### PR TITLE
PIN 1850 - Replaced useHistory with useLocation

### DIFF
--- a/src/components/BodyLogger.tsx
+++ b/src/components/BodyLogger.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useContext, useEffect, useState } from 'react'
 import { DialogProps, ToastContentWithOutcome, ToastProps } from '../../types'
-import { useHistory } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import isEmpty from 'lodash/isEmpty'
 import {
   DialogContext,
@@ -81,7 +81,7 @@ export const WhitePanel: FunctionComponent = ({ children }) => {
 
 export function BodyLogger() {
   const { doesRouteAllowTwoColumnsLayout } = useRoute()
-  const history = useHistory()
+  const location = useLocation()
   const [toast, setToast] = useState<ToastProps | null>(null)
   const [dialog, setDialog] = useState<DialogProps | null>(null)
   const [loadingText, setLoadingText] = useState<string | null>(null)
@@ -96,7 +96,8 @@ export function BodyLogger() {
       setToast(null)
     }
 
-    const locationState: Record<string, unknown> = history.location.state as Record<string, unknown>
+    const locationState: Record<string, unknown> = location.state as Record<string, unknown>
+
     // If there is explicitly a new toast to show on this page, display it
     if (!isEmpty(locationState) && !isEmpty(locationState.toast)) {
       const toastContent = locationState.toast as ToastContentWithOutcome
@@ -107,14 +108,14 @@ export function BodyLogger() {
         },
       })
     }
-  }, [history.location]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [location]) // eslint-disable-line react-hooks/exhaustive-deps
 
   /*
    * Handle data logging (now console.log, in the future might be Analytics)
    */
   useEffect(() => {
-    logAction('Route change', history.location)
-  }, [history.location])
+    logAction('Route change', location)
+  }, [location])
 
   return (
     <TableActionMenuContext.Provider value={{ tableActionMenu, setTableActionMenu }}>
@@ -124,7 +125,7 @@ export function BodyLogger() {
             <RebuildI18N />
             <HeaderWrapper />
 
-            {doesRouteAllowTwoColumnsLayout(history.location) ? (
+            {doesRouteAllowTwoColumnsLayout(location) ? (
               <Box sx={{ flexGrow: 1 }}>
                 <Stack direction="row" sx={{ height: '100%', overflowX: 'hidden' }}>
                   <MainNav />


### PR DESCRIPTION
# PIN 1850 - Replaced useHistory with useLocation

The problem was due to the fact that **the history object returned by useHistory is mutable**.
 
Internally, React Router DOM updates the history object without creating an entirely new one, this means that the reference of that object remains the same. That's the reason useEffect was not triggering on location change despite having history.location in the dependency array.

More info [here](https://v5.reactrouter.com/web/api/history/history-is-mutable) 