### PR TITLE
PIN - 1851 

### DIFF
--- a/src/components/Shared/AsyncTableEservice.tsx
+++ b/src/components/Shared/AsyncTableEservice.tsx
@@ -167,9 +167,6 @@ export const AsyncTableEServiceCatalog = () => {
               name: eservice.name,
               version: eservice.version,
             }),
-            close: () => {
-              setDialog(null)
-            },
           })
         },
         label: t('actions.subscribe', { ns: 'common' }),

--- a/src/hooks/useFeedback.tsx
+++ b/src/hooks/useFeedback.tsx
@@ -191,9 +191,9 @@ export const useFeedback = () => {
 
     if (showConfirmDialog) {
       return await wrapActionInDialog(runBasicAction, request.path.endpoint)
-    } else {
-      return await runBasicAction()
     }
+
+    return await runBasicAction()
   }
   /*
    * End API calls

--- a/src/hooks/useFeedback.tsx
+++ b/src/hooks/useFeedback.tsx
@@ -59,31 +59,25 @@ export const useFeedback = () => {
 
     if (!hasDialog) {
       throw new Error('This action should have a modal')
-    } else {
-      return new Promise<void>((resolve) => {
-        const title = t(`${endpointKey}.title`, { ns: 'dialog' })
-        const description = i18next.exists(`${endpointKey}.description`, { ns: 'dialog' })
-          ? t(`${endpointKey}.description`, { ns: 'dialog' })
-          : undefined
-
-        const proceedCallback = () => {
-          resolve(wrappedAction())
-        }
-
-        const close = () => {
-          closeDialog()
-          resolve()
-        }
-
-        setDialog({
-          type: 'basic',
-          proceedCallback,
-          close,
-          title,
-          description,
-        })
-      })
     }
+
+    return new Promise<void>((resolve) => {
+      const title = t(`${endpointKey}.title`, { ns: 'dialog' })
+      const description = i18next.exists(`${endpointKey}.description`, { ns: 'dialog' })
+        ? t(`${endpointKey}.description`, { ns: 'dialog' })
+        : undefined
+
+      const proceedCallback = () => {
+        resolve(wrappedAction())
+      }
+
+      setDialog({
+        type: 'basic',
+        proceedCallback,
+        title,
+        description,
+      })
+    })
   }
 
   const closeDialog = () => {

--- a/src/views/EServiceRead.tsx
+++ b/src/views/EServiceRead.tsx
@@ -112,9 +112,6 @@ export function EServiceRead() {
         name: data.name,
         version: data.activeDescriptor?.version,
       }),
-      close: () => {
-        setDialog(null)
-      },
     })
   }
 

--- a/types.ts
+++ b/types.ts
@@ -684,7 +684,6 @@ export type DialogContent = {
 }
 
 export type DialogDefaultProps = {
-  close: VoidFunction
   maxWidth?: MUISize
 }
 


### PR DESCRIPTION
This bug was due to the fact that in case an action needed a confirm dialog, the *runAction* function did not "await" the user confirmation but it synchronously just returned void.

```javascript
if (showConfirmDialog) {
  wrapActionInDialog(runBasicAction, request.path.endpoint)
} else {
  return await runBasicAction()
}
// returns void
```
So when an action with the confirmation dialog is fired it instantly resolves, without waiting for the actual async action to resolve.

This led to a crash inside *wrapCreateNewVersionDraft* function (*AsyncTableEservice.tsx*) due to an object decostruction on a function that returns void.

```javascript
const { outcome, response } = (await runAction(
  ...
```


---
The proposed solution transforms *wrapActionInDialog* in an async function that resolves only when the user confirms or cancels the action.