### PR TITLE
Pin 1932 - Redesign e-service details subscriber side

### DIFF
--- a/public/locales/en/eservice.json
+++ b/public/locales/en/eservice.json
@@ -113,6 +113,12 @@
     "sections": {
       "generalInformations": {
         "title": "General informations",
+        "alreadySubscribedField": {
+          "label": "You are a Subscriber of the E-Service",
+          "link": {
+            "label": "Go to the fruition request"
+          }
+        },
         "technology": "Technology"
       },
       "versionInformations": {
@@ -198,12 +204,6 @@
       "title": "Fruition requests",
       "description": "You are about to send a fruition request for the E-Service {{name}}, version {{version}}",
       "proceedLabel": "Subscribe"
-    },
-    "alreadySubscribedField": {
-      "label": "You are a Subscriber of the E-Service",
-      "link": {
-        "label": "Go to the fruition request"
-      }
     },
     "alert": {
       "youAreTheProvider": "You can't subscribe to an E-Service you are a Provider of",

--- a/public/locales/it/eservice.json
+++ b/public/locales/it/eservice.json
@@ -113,6 +113,12 @@
     "sections": {
       "generalInformations": {
         "title": "Informazioni generali",
+        "alreadySubscribedField": {
+          "label": "Sei iscritto all'E-Service",
+          "link": {
+            "label": "Vai alla richiesta di fruizione"
+          }
+        },
         "technology": "Tecnologia"
       },
       "versionInformations": {
@@ -199,12 +205,6 @@
       "title": "Richiesta di fruizione",
       "description": "Stai per inoltrare una richiesta di fruizione per l'E-Service {{name}}, versione {{version}}",
       "proceedLabel": "Iscriviti"
-    },
-    "alreadySubscribedField": {
-      "label": "Sei iscritto all'E-Service",
-      "link": {
-        "label": "Vai alla richiesta di fruizione"
-      }
     },
     "alert": {
       "youAreTheProvider": "Non puoi iscriverti a un E-Service di cui sei Erogatore",

--- a/src/components/InformationRow.tsx
+++ b/src/components/InformationRow.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Box, Typography, Stack, Divider } from '@mui/material'
 
 interface InformationRowProps {
-  label: React.ReactNode | string
+  label: string
   labelDescription?: string
   children: React.ReactNode
   rightContent?: React.ReactNode
@@ -14,6 +14,12 @@ export function InformationRow({
   rightContent,
   children,
 }: InformationRowProps) {
+  /**
+   * If the children passed is a JSX Element, renders the children in a div,
+   * otherwise it's a string and we render it in a p tag.
+   * */
+  const isChildrenAJSXElement = React.isValidElement(children)
+
   return (
     <Stack spacing={4} direction="row">
       <Box sx={{ flexShrink: 0, maxWidth: '200px', flex: 1 }}>
@@ -28,7 +34,11 @@ export function InformationRow({
         )}
       </Box>
       <Box sx={{ flex: 1 }}>
-        <Typography component="div" variant="body2" fontWeight={600}>
+        <Typography
+          component={isChildrenAJSXElement ? 'div' : 'p'}
+          variant="body2"
+          fontWeight={600}
+        >
           {children}
         </Typography>
       </Box>

--- a/src/components/InformationRow.tsx
+++ b/src/components/InformationRow.tsx
@@ -18,7 +18,13 @@ export function InformationRow({
    * If the children passed is a JSX Element, renders the children in a div,
    * otherwise it's a string and we render it in a p tag.
    * */
-  const isChildrenAJSXElement = React.isValidElement(children)
+  let isChildrenAJSXElement = false
+
+  React.Children.forEach(children, (child) => {
+    if (React.isValidElement(child)) {
+      isChildrenAJSXElement = true
+    }
+  })
 
   return (
     <Stack spacing={4} direction="row">

--- a/src/components/Shared/EServiceContentInfo.tsx
+++ b/src/components/Shared/EServiceContentInfo.tsx
@@ -127,7 +127,7 @@ function VersionInfoSection({
         <Stack spacing={2}>
           <InformationRow label={t('actualVersion')}>
             <Stack spacing={1} direction="row" alignItems="center">
-              <Typography component="span">{activeDescriptor.version}</Typography>
+              <span>{activeDescriptor.version}</span>
               {isCurrentVersion && <Chip size="small" label="versione corrente" color="primary" />}
             </Stack>
           </InformationRow>

--- a/src/components/Shared/EServiceContentInfo.tsx
+++ b/src/components/Shared/EServiceContentInfo.tsx
@@ -1,42 +1,180 @@
-import { Box, Chip, Grid, Typography } from '@mui/material'
+import { Chip, Divider, Grid, Stack, Typography } from '@mui/material'
 import { AxiosResponse } from 'axios'
-import has from 'lodash/has'
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useMemo, useState } from 'react'
 import {
-  AttributeKey,
-  BackendAttribute,
   EServiceDescriptorRead,
   EServiceDocumentRead,
   EServiceReadType,
-  GroupBackendAttribute,
-  SingleBackendAttribute,
+  FrontendAttributes,
 } from '../../../types'
 import { RunActionOutput, useFeedback } from '../../hooks/useFeedback'
 import { useRoute } from '../../hooks/useRoute'
 import { secondsToHoursMinutes } from '../../lib/format-utils'
 import { downloadFile } from '../../lib/file-utils'
-import { buildDynamicPath } from '../../lib/router-utils'
-import { DescriptionBlock } from '../DescriptionBlock'
-import { ResourceList } from './ResourceList'
-import { StyledAccordion } from './StyledAccordion'
+import { buildDynamicRoute } from '../../lib/router-utils'
 import { StyledLink } from './StyledLink'
-import sortBy from 'lodash/sortBy'
 import { formatThousands } from '../../lib/format-utils'
 import { useTranslation } from 'react-i18next'
-import { getDownloadDocumentName } from '../../lib/eservice-utils'
+import { getDownloadDocumentName, getLatestActiveVersion } from '../../lib/eservice-utils'
+import { remapBackendAttributesToFrontend } from '../../lib/attributes'
+import { StyledButton } from './StyledButton'
+import { InformationRow } from '../InformationRow'
+import StyledSection from './StyledSection'
+import { useHistory } from 'react-router-dom'
+import { StyledForm } from './StyledForm'
+import { StyledInputControlledSelect } from './StyledInputControlledSelect'
+import { AttributeSection } from '../AttributeSection'
+import { CHIP_COLORS_E_SERVICE, eServiceHelpLink, verifyVoucherHelpLink } from '../../lib/constants'
+import { WELL_KNOWN_URL } from '../../lib/env'
+import { AttachFile as AttachFileIcon, Launch as LaunchIcon } from '@mui/icons-material'
+import { ButtonNaked } from '@pagopa/mui-italia'
 
 type EServiceContentInfoProps = {
   data: EServiceReadType
+  descriptorId: string
 }
 
-export const EServiceContentInfo: FunctionComponent<EServiceContentInfoProps> = ({ data }) => {
-  const { t } = useTranslation(['eservice', 'attribute', 'common'])
-  const { runAction } = useFeedback()
-  const { routes } = useRoute()
+export const EServiceContentInfo: FunctionComponent<EServiceContentInfoProps> = ({
+  data,
+  descriptorId,
+}) => {
+  const frontendAttributes = useMemo(() => {
+    if (!data.attributes) return
+    return remapBackendAttributesToFrontend(data.attributes)
+  }, [data])
+
+  const activeDescriptor = getLatestActiveVersion(data)
+  const isCurrentVersion = activeDescriptor?.id === descriptorId
+
+  return (
+    <React.Fragment>
+      <Grid spacing={2} container>
+        <Grid item xs={7}>
+          <GeneralInfoSection data={data} />
+          <VersionInfoSection data={data} isCurrentVersion={isCurrentVersion} />
+        </Grid>
+        <Grid item xs={5}>
+          <DownloadSection data={data} />
+          <VoucherVerificationSection />
+        </Grid>
+      </Grid>
+
+      {frontendAttributes && <AttributesSection frontendAttributes={frontendAttributes} />}
+
+      <Grid spacing={2} container>
+        <Grid item xs={6}>
+          <VersionHistorySection
+            viewindDescriptorId={descriptorId!}
+            eserviceId={data.id}
+            descriptors={data.descriptors}
+          />
+        </Grid>
+      </Grid>
+    </React.Fragment>
+  )
+}
+
+function GeneralInfoSection({ data }: { data: EServiceReadType }) {
+  const { t } = useTranslation('eservice', {
+    keyPrefix: 'contentInfo.sections.generalInformations',
+  })
+  return (
+    <StyledSection>
+      <StyledSection.Title>{t('title')}</StyledSection.Title>
+      <StyledSection.Content>
+        <InformationRow label={t('technology')}>{data.technology}</InformationRow>
+      </StyledSection.Content>
+    </StyledSection>
+  )
+}
+
+function VersionInfoSection({
+  data,
+  isCurrentVersion,
+}: {
+  data: EServiceReadType
+  isCurrentVersion: boolean
+}) {
+  const { t } = useTranslation('eservice', {
+    keyPrefix: 'contentInfo.sections.versionInformations',
+  })
+  const { t: tCommon } = useTranslation('common')
+
   const activeDescriptor = data.activeDescriptor as EServiceDescriptorRead
 
-  // Get all documents actual URL
-  const wrapDownloadDocument = (document: EServiceDocumentRead) => async () => {
+  const getFormattedVoucherLifespan = () => {
+    const { hours, minutes } = secondsToHoursMinutes(activeDescriptor.voucherLifespan)
+
+    const minutesLabel = tCommon('time.minute', { count: minutes })
+    const hoursLabel = tCommon('time.hour', { count: hours })
+    const and = tCommon('conjunctions.and')
+
+    if (hours === 0) {
+      return `${minutes} ${minutesLabel}`
+    }
+
+    if (minutes === 0) {
+      return `${hours} ${hoursLabel}`
+    }
+
+    return `${hours} ${hoursLabel} ${and} ${minutes} ${minutesLabel}`
+  }
+
+  return (
+    <StyledSection>
+      <StyledSection.Title>{t('title')}</StyledSection.Title>
+      <StyledSection.Content>
+        <Stack spacing={2}>
+          <InformationRow label={t('actualVersion')}>
+            <Stack spacing={1} direction="row" alignItems="center">
+              <Typography component="span">{activeDescriptor.version}</Typography>
+              {isCurrentVersion && <Chip size="small" label="versione corrente" color="primary" />}
+            </Stack>
+          </InformationRow>
+          <InformationRow label={t('versionStatus')}>
+            <Chip
+              size="small"
+              label={tCommon(`status.eservice.${activeDescriptor.state || 'DRAFT'}`)}
+              color={CHIP_COLORS_E_SERVICE[activeDescriptor.state]}
+            />
+          </InformationRow>
+          <InformationRow label={t('description')}>{activeDescriptor?.description}</InformationRow>
+          <InformationRow label={t('audience')} labelDescription={t('audienceDescription')}>
+            {activeDescriptor.audience.join(', ')}
+          </InformationRow>
+          <InformationRow label={t('voucherLifespan')}>
+            {getFormattedVoucherLifespan()}
+          </InformationRow>
+          <InformationRow label={t('dailyCallsPerConsumer')}>
+            {formatThousands(activeDescriptor.dailyCallsPerConsumer)} {t('callsPerDay')}
+          </InformationRow>
+          <InformationRow label={t('dailyCallsTotal')}>
+            {formatThousands(activeDescriptor.dailyCallsTotal)} {t('callsPerDay')}
+          </InformationRow>
+
+          <Divider />
+
+          <Typography variant="body2">
+            {t('doubtsQuestion')}{' '}
+            <StyledLink href={eServiceHelpLink} target="_blank">
+              {t('doubtsLink')}
+            </StyledLink>
+          </Typography>
+        </Stack>
+      </StyledSection.Content>
+    </StyledSection>
+  )
+}
+
+function DownloadSection({ data }: { data: EServiceReadType }) {
+  const { t } = useTranslation('eservice', {
+    keyPrefix: 'contentInfo.sections.download',
+  })
+  const { runAction } = useFeedback()
+
+  const activeDescriptor = data.activeDescriptor as EServiceDescriptorRead
+
+  const handleDownloadDocument = async (document: EServiceDocumentRead) => {
     const { response, outcome } = (await runAction(
       {
         path: {
@@ -58,213 +196,164 @@ export const EServiceContentInfo: FunctionComponent<EServiceContentInfoProps> = 
     }
   }
 
-  const getVerificationRequiredStringMaybe = (
-    explicitAttributeVerification: boolean,
-    attributeKey: AttributeKey
-  ) => {
-    return explicitAttributeVerification && attributeKey === 'verified'
-      ? ` (${t('contentInfo.verificationRequired')})`
-      : ''
-  }
+  const docs = [...activeDescriptor.docs, activeDescriptor.interface]
 
-  const toAccordionEntries = (attributes: Array<BackendAttribute>, attributeKey: AttributeKey) => {
-    return attributes.map((attribute) => {
-      const isSingle = has(attribute, 'single')
+  return (
+    <StyledSection>
+      <StyledSection.Title>{t('title')}</StyledSection.Title>
+      <StyledSection.Content>
+        <Stack spacing={2} alignItems="start">
+          {docs.map((doc) => (
+            <Stack key={doc.id} spacing={2}>
+              <ButtonNaked
+                onClick={handleDownloadDocument.bind(null, doc)}
+                size="large"
+                color="primary"
+                startIcon={<AttachFileIcon />}
+              >
+                {doc.prettyName}
+              </ButtonNaked>
+              {/* TEMP BACKEND - Size data doesn't come from backend (yet) */}
+              {/* <Typography fontWeight={600} sx={{ marginLeft: '30px' }}>
+                {(doc.size / 1024).toFixed(2)}&nbsp;KB
+              </Typography> */}
+            </Stack>
+          ))}
+        </Stack>
+      </StyledSection.Content>
+    </StyledSection>
+  )
+}
 
-      const labels = isSingle
-        ? [(attribute as SingleBackendAttribute).single]
-        : (attribute as GroupBackendAttribute).group
+function VoucherVerificationSection() {
+  const { t } = useTranslation(['eservice', 'common'], {
+    keyPrefix: 'contentInfo.sections.voucherVerification',
+  })
 
-      let summary: string | JSX.Element
-      let details: string | JSX.Element = ''
-      if (labels.length === 1) {
-        const { name, description, explicitAttributeVerification } = labels[0]
-        summary = `${name} ${getVerificationRequiredStringMaybe(
-          explicitAttributeVerification,
-          attributeKey
-        )}`
-
-        details = description
-      } else {
-        const summaryComponent = labels.map(({ name }, i) => {
-          if (i < labels.length - 1) {
-            return (
-              <React.Fragment key={i}>
-                {name}{' '}
-                <Typography component="span" fontWeight={600}>
-                  {t('contentInfo.groupOr')}
-                </Typography>{' '}
-              </React.Fragment>
-            )
-          }
-
-          return name
-        })
-
-        summary = (
-          <React.Fragment>
-            {summaryComponent}{' '}
-            {getVerificationRequiredStringMaybe(
-              labels[0].explicitAttributeVerification,
-              attributeKey
-            )}
-          </React.Fragment>
-        )
-
-        details = (
-          <React.Fragment>
-            {labels.map((label, i) => {
-              return (
-                <Box sx={{ mb: i !== labels.length - 1 ? 2 : 0 }} key={i}>
-                  <Typography component="span" sx={{ fontWeight: 700 }}>
-                    {label.name}
-                  </Typography>
-                  : {label.description}
-                </Box>
-              )
-            })}
-          </React.Fragment>
-        )
-      }
-
-      return { summary, details }
-    })
-  }
-
-  const getFormattedVoucherLifespan = () => {
-    const { hours, minutes } = secondsToHoursMinutes(activeDescriptor.voucherLifespan)
-
-    const minutesLabel = t('time.minute', { count: minutes, ns: 'common' })
-    const hoursLabel = t('time.hour', { count: hours, ns: 'common' })
-    const and = t('conjunctions.and', { ns: 'common' })
-
-    if (hours === 0) {
-      return `${minutes} ${minutesLabel}`
-    }
-
-    if (minutes === 0) {
-      return `${hours} ${hoursLabel}`
-    }
-
-    return `${hours} ${hoursLabel} ${and} ${minutes} ${minutesLabel}`
+  function VoucherLink({ label, href }: { label: string; href: string }) {
+    return (
+      <StyledLink
+        component="a"
+        href={href}
+        target="_blank"
+        variant="body2"
+        underline="hover"
+        sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+      >
+        <LaunchIcon sx={{ mr: 1 }} /> {label}
+      </StyledLink>
+    )
   }
 
   return (
-    <React.Fragment>
-      <DescriptionBlock label={t('contentInfo.provider')} sx={{ mt: 0 }}>
-        <Typography component="span">{data.producer.name}</Typography>
-      </DescriptionBlock>
+    <StyledSection>
+      <StyledSection.Title>{t('title')}</StyledSection.Title>
+      <StyledSection.Content>
+        <Typography>{t('description')}</Typography>
 
-      <DescriptionBlock label={t('contentInfo.version')}>
-        <Typography component="span">{activeDescriptor.version}</Typography>
-      </DescriptionBlock>
+        <Stack sx={{ mt: 2 }} spacing={2}>
+          <VoucherLink label={t('howLink')} href={verifyVoucherHelpLink} />
+          <VoucherLink label={t('wellKnownLink')} href={WELL_KNOWN_URL} />
+        </Stack>
+      </StyledSection.Content>
+    </StyledSection>
+  )
+}
 
-      <DescriptionBlock label={t('contentInfo.versionDescription')}>
-        <Typography component="span">{activeDescriptor.description}</Typography>
-      </DescriptionBlock>
+function AttributesSection({ frontendAttributes }: { frontendAttributes: FrontendAttributes }) {
+  const { t } = useTranslation('eservice', {
+    keyPrefix: 'contentInfo.sections.attributes',
+  })
 
-      <DescriptionBlock label={t('contentInfo.versionStatus')}>
-        <Typography component="span">
-          {t(`status.eservice.${activeDescriptor.state}`, { ns: 'common' })}
-        </Typography>
-      </DescriptionBlock>
+  return (
+    <>
+      <AttributeSection
+        attributeKey="certified"
+        description={t('certified.description')}
+        attributesSubtitle={t('subtitle')}
+        attributes={frontendAttributes.certified}
+        readOnly
+      />
+      <AttributeSection
+        attributeKey="verified"
+        description={t('verified.description')}
+        attributesSubtitle={t('subtitle')}
+        attributes={frontendAttributes.verified}
+        readOnly
+      />
+      <AttributeSection
+        attributeKey="declared"
+        description={t('declared.description')}
+        attributesSubtitle={t('subtitle')}
+        attributes={frontendAttributes.declared}
+        readOnly
+      />
+    </>
+  )
+}
 
-      <DescriptionBlock label={t('contentInfo.audience')}>
-        <Typography component="span">{activeDescriptor.audience.join(', ')}</Typography>
-      </DescriptionBlock>
+function VersionHistorySection({
+  viewindDescriptorId,
+  eserviceId,
+  descriptors,
+}: {
+  viewindDescriptorId: string
+  eserviceId: string
+  descriptors: EServiceDescriptorRead[]
+}) {
+  const { t } = useTranslation(['eservice', 'common'], {
+    keyPrefix: 'contentInfo.sections.versionHistory',
+  })
 
-      <DescriptionBlock label={t('contentInfo.technology')}>
-        <Typography component="span">{data.technology}</Typography>
-      </DescriptionBlock>
+  const history = useHistory()
+  const { routes } = useRoute()
+  const [selectedDescriptorId, setSelectedDescriptorId] = useState(viewindDescriptorId)
 
-      <DescriptionBlock label={t('contentInfo.voucherLifespan')}>
-        <Typography component="span">{getFormattedVoucherLifespan()}</Typography>
-      </DescriptionBlock>
+  const handleVersionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedDescriptorId(e.target.value)
+  }
 
-      <DescriptionBlock label={t('contentInfo.dailyCallsPerConsumer')}>
-        <Typography component="span">
-          {formatThousands(activeDescriptor.dailyCallsPerConsumer)} {t('contentInfo.callsPerDay')}
-        </Typography>
-      </DescriptionBlock>
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    history.push(
+      buildDynamicRoute(routes.PROVIDE_ESERVICE_MANAGE, {
+        eserviceId,
+        descriptorId: selectedDescriptorId,
+      }).PATH
+    )
+  }
 
-      <DescriptionBlock label={t('contentInfo.dailyCallsTotal')}>
-        <Typography component="span">
-          {formatThousands(activeDescriptor.dailyCallsTotal)} {t('contentInfo.callsPerDay')}
-        </Typography>
-      </DescriptionBlock>
+  const shouldNotRender = descriptors.length <= 1
 
-      {(Object.keys(data.attributes) as Array<AttributeKey>).map((key, i) => (
-        <DescriptionBlock
-          key={i}
-          label={`${t('contentInfo.attributes')} ${t(`type.${key}`, {
-            count: 2,
-            ns: 'attribute',
-          })}`}
-        >
-          {data.attributes[key].length > 0 ? (
-            <Grid container>
-              <Grid item xs={8}>
-                <StyledAccordion entries={toAccordionEntries(data.attributes[key], key)} />
-              </Grid>
-            </Grid>
-          ) : (
-            <Typography component="span">{t('contentInfo.noAttributesLabel')}</Typography>
-          )}
-        </DescriptionBlock>
-      ))}
+  if (shouldNotRender) return null
 
-      <DescriptionBlock label={t('contentInfo.documentation')}>
-        <ResourceList
-          resources={[
-            // TEMP PIN-1095 and PIN-1105
-            // {
-            //   label: 'Richiesta di fruizione',
-            //   onClick: () => {
-            //     console.log('download richiesta di fruizione')
-            //   },
-            // },
-            {
-              label: activeDescriptor.interface.prettyName,
-              onClick: wrapDownloadDocument(activeDescriptor.interface),
-            },
-            ...activeDescriptor.docs.map((d) => ({
-              label: d.prettyName,
-              onClick: wrapDownloadDocument(d),
-            })),
-          ]}
-        />
-      </DescriptionBlock>
+  const descriptorsOptions = descriptors.map((descriptor) => ({
+    label: t('historyField.option', { version: descriptor.version }),
+    value: descriptor.id,
+  }))
 
-      {Boolean(data.descriptors.length > 0) && (
-        <DescriptionBlock label={t('contentInfo.versionHistory')} sx={{ mb: 0 }}>
-          {sortBy(data.descriptors, 'version').map((d, i) => {
-            const state = t(`status.eservice.${d.state}`, { ns: 'common' })
-
-            return (
-              <Box key={i} sx={{ pb: 1 }}>
-                {d.id !== data.activeDescriptor?.id ? (
-                  <Box>
-                    <StyledLink
-                      to={buildDynamicPath(routes.PROVIDE_ESERVICE_MANAGE.PATH, {
-                        eserviceId: data.id,
-                        descriptorId: d.id,
-                      })}
-                    >
-                      {t('contentInfo.version')} {d.version}
-                    </StyledLink>{' '}
-                    <Chip size="small" label={state} />
-                  </Box>
-                ) : (
-                  <Typography component="span">
-                    {t('contentInfo.version')} {d.version}{' '}
-                    <Chip size="small" label={state} color="primary" />
-                  </Typography>
-                )}
-              </Box>
-            )
-          })}
-        </DescriptionBlock>
-      )}
-    </React.Fragment>
+  return (
+    <StyledSection>
+      <StyledSection.Title>{t('title')}</StyledSection.Title>
+      <StyledSection.Content>
+        <StyledForm onSubmit={handleSubmit}>
+          <InformationRow label={t('historyField.title')}>
+            <StyledInputControlledSelect
+              label={t('historyField.label')}
+              sx={{ width: '100%' }}
+              emptyLabel=""
+              name="eServiceHistorySelection"
+              onChange={handleVersionChange}
+              value={selectedDescriptorId}
+              options={descriptorsOptions}
+              selectProps={{ MenuProps: { sx: { maxHeight: '160px' } } }}
+            />
+            <StyledButton sx={{ mt: 2 }} size="large" variant="outlined" type="submit">
+              {t('submitBtn')}
+            </StyledButton>
+          </InformationRow>
+        </StyledForm>
+      </StyledSection.Content>
+    </StyledSection>
   )
 }

--- a/src/components/Shared/EServiceContentInfo.tsx
+++ b/src/components/Shared/EServiceContentInfo.tsx
@@ -6,6 +6,7 @@ import {
   EServiceDocumentRead,
   EServiceReadType,
   FrontendAttributes,
+  ProviderOrSubscriber,
 } from '../../../types'
 import { RunActionOutput, useFeedback } from '../../hooks/useFeedback'
 import { useRoute } from '../../hooks/useRoute'
@@ -29,12 +30,14 @@ import { WELL_KNOWN_URL } from '../../lib/env'
 import { AttachFile as AttachFileIcon, Launch as LaunchIcon } from '@mui/icons-material'
 
 type EServiceContentInfoProps = {
+  context: ProviderOrSubscriber
   data: EServiceReadType
   descriptorId: string
   agreementId?: string
 }
 
 export const EServiceContentInfo: FunctionComponent<EServiceContentInfoProps> = ({
+  context,
   data,
   descriptorId,
   agreementId,
@@ -52,11 +55,11 @@ export const EServiceContentInfo: FunctionComponent<EServiceContentInfoProps> = 
       <Grid spacing={2} container>
         <Grid item xs={7}>
           <GeneralInfoSection data={data} agreementId={agreementId} />
-          <VersionInfoSection data={data} isCurrentVersion={isCurrentVersion} />
+          <VersionInfoSection data={data} isCurrentVersion={isCurrentVersion} context={context} />
         </Grid>
         <Grid item xs={5}>
           <DownloadSection data={data} />
-          <VoucherVerificationSection />
+          {context === 'provider' && <VoucherVerificationSection />}
         </Grid>
       </Grid>
 
@@ -113,9 +116,11 @@ function GeneralInfoSection({
 function VersionInfoSection({
   data,
   isCurrentVersion,
+  context,
 }: {
   data: EServiceReadType
   isCurrentVersion: boolean
+  context: ProviderOrSubscriber
 }) {
   const { t } = useTranslation('eservice', {
     keyPrefix: 'contentInfo.sections.versionInformations',
@@ -174,14 +179,18 @@ function VersionInfoSection({
             {formatThousands(activeDescriptor.dailyCallsTotal)} {t('callsPerDay')}
           </InformationRow>
 
-          <Divider />
+          {context === 'provider' && (
+            <>
+              <Divider />
 
-          <Typography variant="body2">
-            {t('doubtsQuestion')}{' '}
-            <StyledLink href={eServiceHelpLink} target="_blank">
-              {t('doubtsLink')}
-            </StyledLink>
-          </Typography>
+              <Typography variant="body2">
+                {t('doubtsQuestion')}{' '}
+                <StyledLink href={eServiceHelpLink} target="_blank">
+                  {t('doubtsLink')}
+                </StyledLink>
+              </Typography>
+            </>
+          )}
         </Stack>
       </StyledSection.Content>
     </StyledSection>

--- a/src/components/Shared/EServiceContentInfo.tsx
+++ b/src/components/Shared/EServiceContentInfo.tsx
@@ -11,7 +11,7 @@ import { RunActionOutput, useFeedback } from '../../hooks/useFeedback'
 import { useRoute } from '../../hooks/useRoute'
 import { secondsToHoursMinutes } from '../../lib/format-utils'
 import { downloadFile } from '../../lib/file-utils'
-import { buildDynamicRoute } from '../../lib/router-utils'
+import { buildDynamicPath, buildDynamicRoute } from '../../lib/router-utils'
 import { StyledLink } from './StyledLink'
 import { formatThousands } from '../../lib/format-utils'
 import { useTranslation } from 'react-i18next'
@@ -32,11 +32,13 @@ import { ButtonNaked } from '@pagopa/mui-italia'
 type EServiceContentInfoProps = {
   data: EServiceReadType
   descriptorId: string
+  agreementId?: string
 }
 
 export const EServiceContentInfo: FunctionComponent<EServiceContentInfoProps> = ({
   data,
   descriptorId,
+  agreementId,
 }) => {
   const frontendAttributes = useMemo(() => {
     if (!data.attributes) return
@@ -50,7 +52,7 @@ export const EServiceContentInfo: FunctionComponent<EServiceContentInfoProps> = 
     <React.Fragment>
       <Grid spacing={2} container>
         <Grid item xs={7}>
-          <GeneralInfoSection data={data} />
+          <GeneralInfoSection data={data} agreementId={agreementId} />
           <VersionInfoSection data={data} isCurrentVersion={isCurrentVersion} />
         </Grid>
         <Grid item xs={5}>
@@ -74,15 +76,36 @@ export const EServiceContentInfo: FunctionComponent<EServiceContentInfoProps> = 
   )
 }
 
-function GeneralInfoSection({ data }: { data: EServiceReadType }) {
+function GeneralInfoSection({
+  data,
+  agreementId,
+}: {
+  data: EServiceReadType
+  agreementId?: string
+}) {
   const { t } = useTranslation('eservice', {
     keyPrefix: 'contentInfo.sections.generalInformations',
   })
+  const { routes } = useRoute()
+
   return (
     <StyledSection>
       <StyledSection.Title>{t('title')}</StyledSection.Title>
       <StyledSection.Content>
-        <InformationRow label={t('technology')}>{data.technology}</InformationRow>
+        <Stack spacing={2}>
+          {agreementId && (
+            <InformationRow label={t('alreadySubscribedField.label')}>
+              <StyledLink
+                to={buildDynamicPath(routes.SUBSCRIBE_AGREEMENT_READ.PATH, {
+                  agreementId,
+                })}
+              >
+                {t('alreadySubscribedField.link.label')}
+              </StyledLink>
+            </InformationRow>
+          )}
+          <InformationRow label={t('technology')}>{data.technology}</InformationRow>
+        </Stack>
       </StyledSection.Content>
     </StyledSection>
   )

--- a/src/components/Shared/EServiceContentInfo.tsx
+++ b/src/components/Shared/EServiceContentInfo.tsx
@@ -27,7 +27,6 @@ import { AttributeSection } from '../AttributeSection'
 import { CHIP_COLORS_E_SERVICE, eServiceHelpLink, verifyVoucherHelpLink } from '../../lib/constants'
 import { WELL_KNOWN_URL } from '../../lib/env'
 import { AttachFile as AttachFileIcon, Launch as LaunchIcon } from '@mui/icons-material'
-import { ButtonNaked } from '@pagopa/mui-italia'
 
 type EServiceContentInfoProps = {
   data: EServiceReadType
@@ -228,14 +227,15 @@ function DownloadSection({ data }: { data: EServiceReadType }) {
         <Stack spacing={2} alignItems="start">
           {docs.map((doc) => (
             <Stack key={doc.id} spacing={2}>
-              <ButtonNaked
+              <StyledLink
                 onClick={handleDownloadDocument.bind(null, doc)}
-                size="large"
-                color="primary"
-                startIcon={<AttachFileIcon />}
+                component="button"
+                variant="body2"
+                underline="hover"
+                sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
               >
-                {doc.prettyName}
-              </ButtonNaked>
+                <AttachFileIcon sx={{ mr: 1 }} /> {doc.prettyName}
+              </StyledLink>
               {/* TEMP BACKEND - Size data doesn't come from backend (yet) */}
               {/* <Typography fontWeight={600} sx={{ marginLeft: '30px' }}>
                 {(doc.size / 1024).toFixed(2)}&nbsp;KB

--- a/src/views/EServiceManage.tsx
+++ b/src/views/EServiceManage.tsx
@@ -1,49 +1,28 @@
-import React, { FormEvent, useMemo, useState } from 'react'
+import React from 'react'
 import { StyledIntro } from '../components/Shared/StyledIntro'
 import {
   ActionProps,
   ApiEndpointKey,
   EServiceDescriptorRead,
-  EServiceDocumentRead,
   EServiceReadType,
   EServiceState,
-  FrontendAttributes,
 } from '../../types'
 import { RunActionOutput, useFeedback } from '../hooks/useFeedback'
 import { useHistory, useParams } from 'react-router-dom'
-import {
-  decorateEServiceWithActiveDescriptor,
-  getDownloadDocumentName,
-  getLatestActiveVersion,
-} from '../lib/eservice-utils'
+import { decorateEServiceWithActiveDescriptor } from '../lib/eservice-utils'
 import { useAsyncFetch } from '../hooks/useAsyncFetch'
 import { NotFound } from './NotFound'
 import { useTranslation } from 'react-i18next'
-import { remapBackendAttributesToFrontend } from '../lib/attributes'
-import { InformationRow } from '../components/InformationRow'
-import { AttributeSection } from '../components/AttributeSection'
-import StyledSection from '../components/Shared/StyledSection'
-import { Box, Chip, Divider, Grid, Stack, Typography } from '@mui/material'
-import { StyledLink } from '../components/Shared/StyledLink'
-import { formatThousands, minutesToSeconds, secondsToHoursMinutes } from '../lib/format-utils'
-import { downloadFile } from '../lib/file-utils'
+import { Box, Stack } from '@mui/material'
+import { minutesToSeconds } from '../lib/format-utils'
 import { AxiosResponse } from 'axios'
-import { ButtonNaked } from '@pagopa/mui-italia'
-import { AttachFile as AttachFileIcon, Launch as LaunchIcon } from '@mui/icons-material'
 import { StyledButton } from '../components/Shared/StyledButton'
-import { StyledForm } from '../components/Shared/StyledForm'
-import {
-  CHIP_COLORS_E_SERVICE,
-  eServiceHelpLink,
-  MAX_WIDTH,
-  verifyVoucherHelpLink,
-} from '../lib/constants'
+import { MAX_WIDTH } from '../lib/constants'
 import { PageBottomActions } from '../components/Shared/PageBottomActions'
 import { useRoute } from '../hooks/useRoute'
-import { buildDynamicPath, buildDynamicRoute } from '../lib/router-utils'
-import { StyledInputControlledSelect } from '../components/Shared/StyledInputControlledSelect'
-import { WELL_KNOWN_URL } from '../lib/env'
+import { buildDynamicPath } from '../lib/router-utils'
 import { ActionMenu } from '../components/Shared/ActionMenu'
+import { EServiceContentInfo } from '../components/Shared/EServiceContentInfo'
 
 export function EServiceManage() {
   const { eserviceId, descriptorId } = useParams<{
@@ -220,17 +199,9 @@ export function EServiceManage() {
     history.push(routes.PROVIDE.PATH)
   }
 
-  const frontendAttributes = useMemo(() => {
-    if (!eserviceData?.attributes) return
-    return remapBackendAttributesToFrontend(eserviceData?.attributes)
-  }, [eserviceData])
-
   if (error) {
     return <NotFound errorType="serverError" />
   }
-
-  const activeDescriptor = getLatestActiveVersion(eserviceData)
-  const isCurrentVersion = activeDescriptor?.id === descriptorId
 
   const availableActions = getAvailableActions()
   let primaryAction: ActionProps | undefined
@@ -255,31 +226,8 @@ export function EServiceManage() {
         </Stack>
       </Stack>
 
-      {eserviceData && (
-        <>
-          <Grid spacing={2} container>
-            <Grid item xs={7}>
-              <GeneralInfoSection data={eserviceData} />
-              <VersionInfoSection data={eserviceData} isCurrentVersion={isCurrentVersion} />
-            </Grid>
-            <Grid item xs={5}>
-              <DownloadSection data={eserviceData} />
-              <VoucherVerificationSection />
-            </Grid>
-          </Grid>
-
-          {frontendAttributes && <AttributesSection frontendAttributes={frontendAttributes} />}
-
-          <Grid spacing={2} container>
-            <Grid item xs={6}>
-              <VersionHistorySection
-                viewindDescriptorId={descriptorId!}
-                eserviceId={eserviceId!}
-                descriptors={eserviceData.descriptors}
-              />
-            </Grid>
-          </Grid>
-        </>
+      {eserviceData && descriptorId && (
+        <EServiceContentInfo data={eserviceData} descriptorId={descriptorId} />
       )}
 
       <Box sx={{ mt: 4 }}>
@@ -290,289 +238,5 @@ export function EServiceManage() {
         </PageBottomActions>
       </Box>
     </Box>
-  )
-}
-
-function GeneralInfoSection({ data }: { data: EServiceReadType }) {
-  const { t } = useTranslation('eservice', {
-    keyPrefix: 'contentInfo.sections.generalInformations',
-  })
-  return (
-    <StyledSection>
-      <StyledSection.Title>{t('title')}</StyledSection.Title>
-      <StyledSection.Content>
-        <InformationRow label={t('technology')}>{data.technology}</InformationRow>
-      </StyledSection.Content>
-    </StyledSection>
-  )
-}
-
-function VersionInfoSection({
-  data,
-  isCurrentVersion,
-}: {
-  data: EServiceReadType
-  isCurrentVersion: boolean
-}) {
-  const { t } = useTranslation('eservice', {
-    keyPrefix: 'contentInfo.sections.versionInformations',
-  })
-  const { t: tCommon } = useTranslation('common')
-
-  const activeDescriptor = data.activeDescriptor as EServiceDescriptorRead
-
-  const getFormattedVoucherLifespan = () => {
-    const { hours, minutes } = secondsToHoursMinutes(activeDescriptor.voucherLifespan)
-
-    const minutesLabel = tCommon('time.minute', { count: minutes })
-    const hoursLabel = tCommon('time.hour', { count: hours })
-    const and = tCommon('conjunctions.and')
-
-    if (hours === 0) {
-      return `${minutes} ${minutesLabel}`
-    }
-
-    if (minutes === 0) {
-      return `${hours} ${hoursLabel}`
-    }
-
-    return `${hours} ${hoursLabel} ${and} ${minutes} ${minutesLabel}`
-  }
-
-  return (
-    <StyledSection>
-      <StyledSection.Title>{t('title')}</StyledSection.Title>
-      <StyledSection.Content>
-        <Stack spacing={2}>
-          <InformationRow label={t('actualVersion')}>
-            <Stack spacing={1} direction="row" alignItems="center">
-              <Typography component="span">{activeDescriptor.version}</Typography>
-              {isCurrentVersion && <Chip size="small" label="versione corrente" color="primary" />}
-            </Stack>
-          </InformationRow>
-          <InformationRow label={t('versionStatus')}>
-            <Chip
-              size="small"
-              label={tCommon(`status.eservice.${activeDescriptor.state || 'DRAFT'}`)}
-              color={CHIP_COLORS_E_SERVICE[activeDescriptor.state]}
-            />
-          </InformationRow>
-          <InformationRow label={t('description')}>{activeDescriptor?.description}</InformationRow>
-          <InformationRow label={t('audience')} labelDescription={t('audienceDescription')}>
-            {activeDescriptor.audience.join(', ')}
-          </InformationRow>
-          <InformationRow label={t('voucherLifespan')}>
-            {getFormattedVoucherLifespan()}
-          </InformationRow>
-          <InformationRow label={t('dailyCallsPerConsumer')}>
-            {formatThousands(activeDescriptor.dailyCallsPerConsumer)} {t('callsPerDay')}
-          </InformationRow>
-          <InformationRow label={t('dailyCallsTotal')}>
-            {formatThousands(activeDescriptor.dailyCallsTotal)} {t('callsPerDay')}
-          </InformationRow>
-
-          <Divider />
-
-          <Typography variant="body2">
-            {t('doubtsQuestion')}{' '}
-            <StyledLink href={eServiceHelpLink} target="_blank">
-              {t('doubtsLink')}
-            </StyledLink>
-          </Typography>
-        </Stack>
-      </StyledSection.Content>
-    </StyledSection>
-  )
-}
-
-function DownloadSection({ data }: { data: EServiceReadType }) {
-  const { t } = useTranslation('eservice', {
-    keyPrefix: 'contentInfo.sections.download',
-  })
-  const { runAction } = useFeedback()
-
-  const activeDescriptor = data.activeDescriptor as EServiceDescriptorRead
-
-  const handleDownloadDocument = async (document: EServiceDocumentRead) => {
-    const { response, outcome } = (await runAction(
-      {
-        path: {
-          endpoint: 'ESERVICE_VERSION_DOWNLOAD_DOCUMENT',
-          endpointParams: {
-            eserviceId: data.id,
-            descriptorId: activeDescriptor.id,
-            documentId: document.id,
-          },
-        },
-        config: { responseType: 'arraybuffer' },
-      },
-      { suppressToast: ['success'] }
-    )) as RunActionOutput
-
-    if (outcome === 'success') {
-      const filename = getDownloadDocumentName(document)
-      downloadFile((response as AxiosResponse).data, filename)
-    }
-  }
-
-  const docs = [...activeDescriptor.docs, activeDescriptor.interface]
-
-  return (
-    <StyledSection>
-      <StyledSection.Title>{t('title')}</StyledSection.Title>
-      <StyledSection.Content>
-        <Stack spacing={2} alignItems="start">
-          {docs.map((doc) => (
-            <Stack key={doc.id} spacing={2}>
-              <ButtonNaked
-                onClick={handleDownloadDocument.bind(null, doc)}
-                size="large"
-                color="primary"
-                startIcon={<AttachFileIcon />}
-              >
-                {doc.prettyName}
-              </ButtonNaked>
-              {/* TEMP BACKEND - Size data doesn't come from backend (yet) */}
-              {/* <Typography fontWeight={600} sx={{ marginLeft: '30px' }}>
-                {(doc.size / 1024).toFixed(2)}&nbsp;KB
-              </Typography> */}
-            </Stack>
-          ))}
-        </Stack>
-      </StyledSection.Content>
-    </StyledSection>
-  )
-}
-
-function VoucherVerificationSection() {
-  const { t } = useTranslation(['eservice', 'common'], {
-    keyPrefix: 'contentInfo.sections.voucherVerification',
-  })
-
-  function VoucherLink({ label, href }: { label: string; href: string }) {
-    return (
-      <StyledLink
-        component="a"
-        href={href}
-        target="_blank"
-        variant="body2"
-        underline="hover"
-        sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
-      >
-        <LaunchIcon sx={{ mr: 1 }} /> {label}
-      </StyledLink>
-    )
-  }
-
-  return (
-    <StyledSection>
-      <StyledSection.Title>{t('title')}</StyledSection.Title>
-      <StyledSection.Content>
-        <Typography>{t('description')}</Typography>
-
-        <Stack sx={{ mt: 2 }} spacing={2}>
-          <VoucherLink label={t('howLink')} href={verifyVoucherHelpLink} />
-          <VoucherLink label={t('wellKnownLink')} href={WELL_KNOWN_URL} />
-        </Stack>
-      </StyledSection.Content>
-    </StyledSection>
-  )
-}
-
-function AttributesSection({ frontendAttributes }: { frontendAttributes: FrontendAttributes }) {
-  const { t } = useTranslation('eservice', {
-    keyPrefix: 'contentInfo.sections.attributes',
-  })
-
-  return (
-    <>
-      <AttributeSection
-        attributeKey="certified"
-        description={t('certified.description')}
-        attributesSubtitle={t('subtitle')}
-        attributes={frontendAttributes.certified}
-        readOnly
-      />
-      <AttributeSection
-        attributeKey="verified"
-        description={t('verified.description')}
-        attributesSubtitle={t('subtitle')}
-        attributes={frontendAttributes.verified}
-        readOnly
-      />
-      <AttributeSection
-        attributeKey="declared"
-        description={t('declared.description')}
-        attributesSubtitle={t('subtitle')}
-        attributes={frontendAttributes.declared}
-        readOnly
-      />
-    </>
-  )
-}
-
-function VersionHistorySection({
-  viewindDescriptorId,
-  eserviceId,
-  descriptors,
-}: {
-  viewindDescriptorId: string
-  eserviceId: string
-  descriptors: EServiceDescriptorRead[]
-}) {
-  const { t } = useTranslation(['eservice', 'common'], {
-    keyPrefix: 'contentInfo.sections.versionHistory',
-  })
-
-  const history = useHistory()
-  const { routes } = useRoute()
-  const [selectedDescriptorId, setSelectedDescriptorId] = useState(viewindDescriptorId)
-
-  const handleVersionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSelectedDescriptorId(e.target.value)
-  }
-
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    history.push(
-      buildDynamicRoute(routes.PROVIDE_ESERVICE_MANAGE, {
-        eserviceId,
-        descriptorId: selectedDescriptorId,
-      }).PATH
-    )
-  }
-
-  const shouldNotRender = descriptors.length <= 1
-
-  if (shouldNotRender) return null
-
-  const descriptorsOptions = descriptors.map((descriptor) => ({
-    label: t('historyField.option', { version: descriptor.version }),
-    value: descriptor.id,
-  }))
-
-  return (
-    <StyledSection>
-      <StyledSection.Title>{t('title')}</StyledSection.Title>
-      <StyledSection.Content>
-        <StyledForm onSubmit={handleSubmit}>
-          <InformationRow label={t('historyField.title')}>
-            <StyledInputControlledSelect
-              label={t('historyField.label')}
-              sx={{ width: '100%' }}
-              emptyLabel=""
-              name="eServiceHistorySelection"
-              onChange={handleVersionChange}
-              value={selectedDescriptorId}
-              options={descriptorsOptions}
-              selectProps={{ MenuProps: { sx: { maxHeight: '160px' } } }}
-            />
-            <StyledButton sx={{ mt: 2 }} size="large" variant="outlined" type="submit">
-              {t('submitBtn')}
-            </StyledButton>
-          </InformationRow>
-        </StyledForm>
-      </StyledSection.Content>
-    </StyledSection>
   )
 }

--- a/src/views/EServiceManage.tsx
+++ b/src/views/EServiceManage.tsx
@@ -227,7 +227,7 @@ export function EServiceManage() {
       </Stack>
 
       {eserviceData && descriptorId && (
-        <EServiceContentInfo data={eserviceData} descriptorId={descriptorId} />
+        <EServiceContentInfo data={eserviceData} descriptorId={descriptorId} context="provider" />
       )}
 
       <Box sx={{ mt: 4 }}>

--- a/src/views/EServiceManage.tsx
+++ b/src/views/EServiceManage.tsx
@@ -23,6 +23,7 @@ import { useRoute } from '../hooks/useRoute'
 import { buildDynamicPath } from '../lib/router-utils'
 import { ActionMenu } from '../components/Shared/ActionMenu'
 import { EServiceContentInfo } from '../components/Shared/EServiceContentInfo'
+import { LoadingWithMessage } from '../components/Shared/LoadingWithMessage'
 
 export function EServiceManage() {
   const { eserviceId, descriptorId } = useParams<{
@@ -226,8 +227,10 @@ export function EServiceManage() {
         </Stack>
       </Stack>
 
-      {eserviceData && descriptorId && (
+      {!isLoading && eserviceData && descriptorId ? (
         <EServiceContentInfo data={eserviceData} descriptorId={descriptorId} context="provider" />
+      ) : (
+        <LoadingWithMessage label={t('loadingSingleLabel')} transparentBackground />
       )}
 
       <Box sx={{ mt: 4 }}>

--- a/src/views/EServiceRead.tsx
+++ b/src/views/EServiceRead.tsx
@@ -155,7 +155,7 @@ export function EServiceRead() {
         </Alert>
       )}
 
-      {data ? (
+      {data && descriptorId ? (
         <React.Fragment>
           <StyledPaper>
             {isSubscribed && (
@@ -169,9 +169,9 @@ export function EServiceRead() {
                 </StyledLink>
               </DescriptionBlock>
             )}
-
-            <EServiceContentInfo data={data} />
           </StyledPaper>
+
+          <EServiceContentInfo data={data} descriptorId={descriptorId} />
 
           <PageBottomActions>
             {/* TEMP PIN-612 */}

--- a/src/views/EServiceRead.tsx
+++ b/src/views/EServiceRead.tsx
@@ -139,21 +139,15 @@ export function EServiceRead() {
         )}
       </Stack>
 
-      {isMine && (
-        <Alert sx={{ mt: 2 }} severity="info">
-          {t('read.alert.youAreTheProvider')}
-        </Alert>
-      )}
-      {!canSubscribeEservice && (
-        <Alert sx={{ mt: 2 }} severity="info">
-          {t('read.alert.missingCertifiedAttributes')}
-        </Alert>
-      )}
-      {flatData?.callerSubscribed && (
-        <Alert sx={{ mt: 2 }} severity="info">
-          {t('read.alert.alreadySubscribed')}
-        </Alert>
-      )}
+      <Stack spacing={2}>
+        {isMine && <Alert severity="info">{t('read.alert.youAreTheProvider')}</Alert>}
+        {!canSubscribeEservice && (
+          <Alert severity="info">{t('read.alert.missingCertifiedAttributes')}</Alert>
+        )}
+        {flatData?.callerSubscribed && (
+          <Alert severity="info">{t('read.alert.alreadySubscribed')}</Alert>
+        )}
+      </Stack>
 
       {data && descriptorId ? (
         <React.Fragment>

--- a/src/views/EServiceRead.tsx
+++ b/src/views/EServiceRead.tsx
@@ -18,7 +18,7 @@ import { DescriptionBlock } from '../components/DescriptionBlock'
 import { StyledLink } from '../components/Shared/StyledLink'
 import { buildDynamicPath } from '../lib/router-utils'
 import { LoadingWithMessage } from '../components/Shared/LoadingWithMessage'
-import { Alert } from '@mui/material'
+import { Alert, Stack } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { useJwt } from '../hooks/useJwt'
 import { StyledPaper } from '../components/StyledPaper'
@@ -120,57 +120,60 @@ export function EServiceRead() {
   }
 
   const isLoading = isEServiceLoading || isFlatEServiceLoading
+  const isSubscribed = flatData && flatData.callerSubscribed && isAdmin
+  const canBeSubsribed =
+    isVersionPublished && !isMine && canSubscribeEservice && !flatData?.callerSubscribed && isAdmin
 
   return (
     <React.Fragment>
-      <StyledIntro isLoading={isLoading}>
-        {{ title: data?.name, description: data?.description }}
-      </StyledIntro>
+      <Stack direction="row" spacing={2}>
+        <StyledIntro sx={{ flex: 1 }} isLoading={isLoading}>
+          {{ title: data?.name, description: data?.description }}
+        </StyledIntro>
+        {canBeSubsribed && (
+          <Stack direction="row" alignItems="center" spacing={2}>
+            <StyledButton variant="outlined" onClick={handleSubscriptionDialog}>
+              {t('actions.subscribe', { ns: 'common' })}
+            </StyledButton>
+          </Stack>
+        )}
+      </Stack>
+
+      {isMine && (
+        <Alert sx={{ mt: 2 }} severity="info">
+          {t('read.alert.youAreTheProvider')}
+        </Alert>
+      )}
+      {!canSubscribeEservice && (
+        <Alert sx={{ mt: 2 }} severity="info">
+          {t('read.alert.missingCertifiedAttributes')}
+        </Alert>
+      )}
+      {flatData?.callerSubscribed && (
+        <Alert sx={{ mt: 2 }} severity="info">
+          {t('read.alert.alreadySubscribed')}
+        </Alert>
+      )}
 
       {data ? (
         <React.Fragment>
           <StyledPaper>
-            {flatData && flatData.callerSubscribed && isAdmin && (
+            {isSubscribed && (
               <DescriptionBlock label={t('read.alreadySubscribedField.label')}>
                 <StyledLink
                   to={buildDynamicPath(routes.SUBSCRIBE_AGREEMENT_READ.PATH, {
-                    agreementId: flatData.callerSubscribed as string,
+                    agreementId: flatData.callerSubscribed,
                   })}
                 >
                   {t('read.alreadySubscribedField.link.label')}
                 </StyledLink>
               </DescriptionBlock>
             )}
-            <EServiceContentInfo data={data} />
 
-            {isMine && (
-              <Alert sx={{ mt: 2 }} severity="info">
-                {t('read.alert.youAreTheProvider')}
-              </Alert>
-            )}
-            {!canSubscribeEservice && (
-              <Alert sx={{ mt: 2 }} severity="info">
-                {t('read.alert.missingCertifiedAttributes')}
-              </Alert>
-            )}
-            {flatData?.callerSubscribed && (
-              <Alert sx={{ mt: 2 }} severity="info">
-                {t('read.alert.alreadySubscribed')}
-              </Alert>
-            )}
+            <EServiceContentInfo data={data} />
           </StyledPaper>
 
           <PageBottomActions>
-            {isVersionPublished &&
-              !isMine &&
-              canSubscribeEservice &&
-              !flatData?.callerSubscribed &&
-              isAdmin && (
-                <StyledButton variant="contained" onClick={handleSubscriptionDialog}>
-                  {t('actions.subscribe', { ns: 'common' })}
-                </StyledButton>
-              )}
-
             {/* TEMP PIN-612 */}
             {/* {!isMine && isAdmin && !canSubscribeEservice && (
           <StyledButton

--- a/src/views/EServiceRead.tsx
+++ b/src/views/EServiceRead.tsx
@@ -15,11 +15,12 @@ import { useLocation } from 'react-router-dom'
 import { NotFound } from './NotFound'
 import { useRoute } from '../hooks/useRoute'
 import { LoadingWithMessage } from '../components/Shared/LoadingWithMessage'
-import { Alert, Stack } from '@mui/material'
+import { Alert, Box, Stack } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { useJwt } from '../hooks/useJwt'
 import { PageBottomActions } from '../components/Shared/PageBottomActions'
 import { AxiosResponse } from 'axios'
+import { MAX_WIDTH } from '../lib/constants'
 
 export function EServiceRead() {
   const { t } = useTranslation(['eservice', 'common'])
@@ -121,7 +122,7 @@ export function EServiceRead() {
     isVersionPublished && !isMine && canSubscribeEservice && !flatData?.callerSubscribed && isAdmin
 
   return (
-    <React.Fragment>
+    <Box sx={{ maxWidth: MAX_WIDTH }}>
       <Stack direction="row" spacing={2}>
         <StyledIntro sx={{ flex: 1 }} isLoading={isLoading}>
           {{ title: data?.name, description: data?.description }}
@@ -174,6 +175,6 @@ export function EServiceRead() {
       ) : (
         <LoadingWithMessage label={t('loadingSingleLabel')} transparentBackground />
       )}
-    </React.Fragment>
+    </Box>
   )
 }

--- a/src/views/EServiceRead.tsx
+++ b/src/views/EServiceRead.tsx
@@ -14,14 +14,10 @@ import {
 import { useLocation } from 'react-router-dom'
 import { NotFound } from './NotFound'
 import { useRoute } from '../hooks/useRoute'
-import { DescriptionBlock } from '../components/DescriptionBlock'
-import { StyledLink } from '../components/Shared/StyledLink'
-import { buildDynamicPath } from '../lib/router-utils'
 import { LoadingWithMessage } from '../components/Shared/LoadingWithMessage'
 import { Alert, Stack } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { useJwt } from '../hooks/useJwt'
-import { StyledPaper } from '../components/StyledPaper'
 import { PageBottomActions } from '../components/Shared/PageBottomActions'
 import { AxiosResponse } from 'axios'
 
@@ -151,21 +147,11 @@ export function EServiceRead() {
 
       {data && descriptorId ? (
         <React.Fragment>
-          <StyledPaper>
-            {isSubscribed && (
-              <DescriptionBlock label={t('read.alreadySubscribedField.label')}>
-                <StyledLink
-                  to={buildDynamicPath(routes.SUBSCRIBE_AGREEMENT_READ.PATH, {
-                    agreementId: flatData.callerSubscribed,
-                  })}
-                >
-                  {t('read.alreadySubscribedField.link.label')}
-                </StyledLink>
-              </DescriptionBlock>
-            )}
-          </StyledPaper>
-
-          <EServiceContentInfo data={data} descriptorId={descriptorId} />
+          <EServiceContentInfo
+            data={data}
+            descriptorId={descriptorId}
+            agreementId={isSubscribed ? flatData.callerSubscribed : undefined}
+          />
 
           <PageBottomActions>
             {/* TEMP PIN-612 */}

--- a/src/views/EServiceRead.tsx
+++ b/src/views/EServiceRead.tsx
@@ -152,6 +152,7 @@ export function EServiceRead() {
             data={data}
             descriptorId={descriptorId}
             agreementId={isSubscribed ? flatData.callerSubscribed : undefined}
+            context="subscriber"
           />
 
           <PageBottomActions>


### PR DESCRIPTION
This branch was created from the [pin-1704 branch](https://github.com/pagopa/pdnd-interop-frontend/tree/pin-1704).

Major changes:

- Brought UI redesign E-Service details ([PIN-1704](https://github.com/pagopa/pdnd-interop-frontend/pull/127)) in the subscriber context. 
- Added InformationRow **content container automatic adaptation** based on the type of its children ("div" if the children contains ReactNodes, else "p").