### PR TITLE
Pin 1764 - Agreement policy field

### DIFF
--- a/public/locales/en/eservice.json
+++ b/public/locales/en/eservice.json
@@ -67,6 +67,9 @@
         "validation": {
           "min": "This value cannot be below the threshold set for the API calls/day for each Subscriber"
         }
+      },
+      "agreementApprovalPolicyField": {
+        "label": "I want to reserve the right to manually check and activate all requests received for this version of the E-Service"
       }
     },
     "step3": {

--- a/public/locales/it/eservice.json
+++ b/public/locales/it/eservice.json
@@ -51,7 +51,7 @@
       },
       "audienceField": {
         "label": "Audience (richiesto)",
-        "infoLabel": "All’nterno dell'access token che il Fruitore ti invierà rappresenterà l’audience (aud), l'id con il quale è dichiarato il servizio richiesto"
+        "infoLabel": "All’interno dell'access token che il Fruitore ti invierà rappresenterà l’audience (aud), l'id con il quale è dichiarato il servizio richiesto"
       },
       "voucherLifespanField": {
         "label": "Durata di validità dell'access token (in minuti - richiesto)",
@@ -67,6 +67,9 @@
         "validation": {
           "min": "Il valore non può essere inferiore alla soglia chiamate API/giorno per Fruitore"
         }
+      },
+      "agreementApprovalPolicyField": {
+        "label": "Voglio riservarmi la facoltà di verificare e attivare manualmente tutte le richieste di fruizione pervenute per questa versione dell’E-Service"
       }
     },
     "step3": {

--- a/src/components/EServiceCreateStep2Version.tsx
+++ b/src/components/EServiceCreateStep2Version.tsx
@@ -22,6 +22,7 @@ import { LoadingWithMessage } from './Shared/LoadingWithMessage'
 import { minutesToSeconds, secondsToMinutes } from '../lib/format-utils'
 import { useTranslation } from 'react-i18next'
 import { StyledPaper } from './StyledPaper'
+import { StyledInputControlledSwitch } from './Shared/StyledInputControlledSwitch'
 
 type VersionData = {
   audience: string
@@ -30,6 +31,7 @@ type VersionData = {
   description: string
   dailyCallsPerConsumer: number
   dailyCallsTotal: number
+  agreementApprovalPolicy: boolean
 }
 
 export function EServiceCreateStep2Version({ forward, back }: StepperStepComponentProps) {
@@ -56,6 +58,7 @@ export function EServiceCreateStep2Version({ forward, back }: StepperStepCompone
     description: '',
     dailyCallsPerConsumer: 1,
     dailyCallsTotal: 1,
+    agreementApprovalPolicy: true,
   }
   const [initialOrFetchedValues, setInitialOrFetchedValues] = useState(initialValues)
 
@@ -79,6 +82,8 @@ export function EServiceCreateStep2Version({ forward, back }: StepperStepCompone
         description,
         dailyCallsPerConsumer: dailyCallsPerConsumer || 1,
         dailyCallsTotal: dailyCallsTotal || 1,
+        // TEMP - BACKEND
+        agreementApprovalPolicy: true,
       })
     }
   }, [fetchedData]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -91,6 +96,7 @@ export function EServiceCreateStep2Version({ forward, back }: StepperStepCompone
       description: data.description,
       dailyCallsPerConsumer: data.dailyCallsPerConsumer,
       dailyCallsTotal: data.dailyCallsTotal,
+      agreementApprovalPolicy: data.agreementApprovalPolicy ? 'MANUAL' : 'AUTOMATIC',
     }
 
     const sureFetchedData = fetchedData as EServiceReadType
@@ -214,6 +220,14 @@ export function EServiceCreateStep2Version({ forward, back }: StepperStepCompone
                     onChange={handleChange}
                     inputProps={{ min: '1' }}
                     sx={{ mb: 3 }}
+                  />
+
+                  <StyledInputControlledSwitch
+                    label={t('create.step2.agreementApprovalPolicyField.label')}
+                    value={values.agreementApprovalPolicy}
+                    vertical
+                    name="agreementApprovalPolicy"
+                    onChange={handleChange}
                   />
                 </StyledPaper>
 

--- a/src/components/EServiceCreateStep2Version.tsx
+++ b/src/components/EServiceCreateStep2Version.tsx
@@ -76,7 +76,6 @@ export function EServiceCreateStep2Version({ forward, back }: StepperStepCompone
         dailyCallsTotal,
         agreementApprovalPolicy,
       } = activeDescriptor
-      console.log(agreementApprovalPolicy)
       setInitialOrFetchedValues({
         version,
         audience: Boolean(audience.length > 0) ? audience[0] : '',

--- a/src/components/EServiceCreateStep2Version.tsx
+++ b/src/components/EServiceCreateStep2Version.tsx
@@ -74,7 +74,9 @@ export function EServiceCreateStep2Version({ forward, back }: StepperStepCompone
         description,
         dailyCallsPerConsumer,
         dailyCallsTotal,
+        agreementApprovalPolicy,
       } = activeDescriptor
+      console.log(agreementApprovalPolicy)
       setInitialOrFetchedValues({
         version,
         audience: Boolean(audience.length > 0) ? audience[0] : '',
@@ -82,8 +84,7 @@ export function EServiceCreateStep2Version({ forward, back }: StepperStepCompone
         description,
         dailyCallsPerConsumer: dailyCallsPerConsumer || 1,
         dailyCallsTotal: dailyCallsTotal || 1,
-        // TEMP - BACKEND
-        agreementApprovalPolicy: true,
+        agreementApprovalPolicy: agreementApprovalPolicy === 'MANUAL',
       })
     }
   }, [fetchedData]) // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/components/Shared/AsyncTableEservice.tsx
+++ b/src/components/Shared/AsyncTableEservice.tsx
@@ -346,6 +346,7 @@ export const AsyncTableEServiceList = () => {
             description: '',
             dailyCallsPerConsumer: 1,
             dailyCallsTotal: 1,
+            agreementApprovalPolicy: 'MANUAL',
           },
         },
       },

--- a/src/components/Shared/StyledInputControlledSwitch.tsx
+++ b/src/components/Shared/StyledInputControlledSwitch.tsx
@@ -1,14 +1,15 @@
 import React, { ChangeEventHandler } from 'react'
-import { Box, FormLabel, Switch, SxProps } from '@mui/material'
+import { Box, FormLabel, Switch, SxProps, Typography } from '@mui/material'
 import { StyledInputWrapper } from './StyledInputWrapper'
 
 export type StyledInputControlledSwitchProps = {
   label: string
   infoLabel?: string | JSX.Element
-  error?: string
-  value: boolean
   name: string
+  value: boolean
+  error?: string
 
+  vertical?: boolean
   onChange: ChangeEventHandler
 
   sx?: SxProps
@@ -19,19 +20,29 @@ export type StyledInputControlledSwitchProps = {
 export function StyledInputControlledSwitch({
   label,
   infoLabel,
-
   name,
   value,
   error,
 
+  vertical = false,
   sx,
 
   onChange,
 }: StyledInputControlledSwitchProps) {
+  let formLabelSxProps: SxProps = {}
+  let typographyLabelSxProps: SxProps = {}
+
+  if (vertical) {
+    formLabelSxProps = { display: 'flex', alignItems: 'center' }
+    typographyLabelSxProps = { order: 2, ml: 2 }
+  }
+
   return (
     <StyledInputWrapper name={name} error={error} sx={sx} infoLabel={infoLabel}>
-      <FormLabel sx={{ color: 'text.primary' }}>
-        {label}
+      <FormLabel sx={{ color: 'text.primary', ...formLabelSxProps }}>
+        <Typography sx={typographyLabelSxProps} component="span" variant="body1">
+          {label}
+        </Typography>
         <Box>
           <Switch checked={value} id={name} name={name} onChange={onChange} />
         </Box>

--- a/src/views/EServiceManage.tsx
+++ b/src/views/EServiceManage.tsx
@@ -132,6 +132,7 @@ export function EServiceManage() {
             description: '',
             dailyCallsPerConsumer: 1,
             dailyCallsTotal: 1,
+            agreementApprovalPolicy: 'MANUAL',
           },
         },
       },

--- a/types.ts
+++ b/types.ts
@@ -323,6 +323,7 @@ export type EServiceDescriptorRead = {
   audience: Array<string>
   dailyCallsPerConsumer: number
   dailyCallsTotal: number
+  agreementApprovalPolicy: 'MANUAL' | 'AUTOMATIC'
 }
 
 export type EServiceDocumentRead = {


### PR DESCRIPTION
This PR solves breaking changes from [PIN-1769](https://pagopa.atlassian.net/browse/PIN-1769).
The `ESERVICE_VERSION_DRAFT_CREATE` api endpoint now requires ```agreementApprovalPolicy``` property.

## Main changes
- Added switch input field in step2 edit/create e-service for agreement policy selection
- Added a prop to ```StyledInputControlledSwitch``` to be able to show the Switch and the label in a horizontal layout.
- Added `agreementApprovalPolicy` property value to every `ESERVICE_VERSION_DRAFT_CREATE` api calls (defaults to _MANUAL_).