### PR TITLE
Pin 1919 - TOS acceptance view

### DIFF
--- a/public/locales/en/pagopa.json
+++ b/public/locales/en/pagopa.json
@@ -1,4 +1,9 @@
 {
+  "tos": {
+    "title": "Interoperability",
+    "description": "Before proceeding, please read and accept the Privacy Policy and Terms and Conditions. You can consult them again whenever you want: you can always find them at the bottom of the page.",
+    "termsDescription": "By entering you declare that you have read and accepted the <1>Privacy Policy</1> and the <1>Terms and Conditions</1> of Interoperability"
+  },
   "footer": {
     "links": {
       "privacy": {

--- a/public/locales/it/pagopa.json
+++ b/public/locales/it/pagopa.json
@@ -1,4 +1,9 @@
 {
+  "tos": {
+    "title": "Interoperabilità",
+    "description": "Prima di entrare, leggi e accetta l’Informativa Privacy e i Termini e condizioni d’uso. Potrai consultarli di nuovo quando vuoi: li trovi sempre in fondo alla pagina.",
+    "termsDescription": "Entrando dichiari di aver letto e accettato l’<1>Informativa Privacy</1> e i <1>Termini e condizioni d’uso</1> di Interoperabilità"
+  },
   "footer": {
     "links": {
       "privacy": {

--- a/src/components/BodyLogger.tsx
+++ b/src/components/BodyLogger.tsx
@@ -15,6 +15,9 @@ import { HeaderWrapper } from './HeaderWrapper'
 import { FooterWrapper } from './FooterWrapper'
 import { Stack, Box } from '@mui/material'
 import { useRebuildI18N } from '../hooks/useRebuildI18n'
+import { useTOSAgreementLocalStorage } from '../hooks/useTOSAgreementLocalStorage'
+import TOSAgreement from '../views/TOSAgreement'
+import { LIGHT_GRAY } from '../lib/constants'
 
 export const WhitePanel: FunctionComponent = ({ children }) => {
   return (
@@ -35,7 +38,7 @@ export const WhitePanel: FunctionComponent = ({ children }) => {
           transform: 'translate(100%, 0)',
         },
       }}
-      bgcolor="#FAFAFA"
+      bgcolor={LIGHT_GRAY}
     >
       {children}
     </Box>
@@ -45,6 +48,8 @@ export const WhitePanel: FunctionComponent = ({ children }) => {
 export function BodyLogger() {
   const { doesRouteAllowTwoColumnsLayout } = useRoute()
   const location = useLocation()
+  const { isRouteProtected } = useRoute()
+  const { isTOSAccepted, acceptTOS } = useTOSAgreementLocalStorage()
   const [toast, setToast] = useState<ToastProps | null>(null)
   const [dialog, setDialog] = useState<DialogProps | null>(null)
   const [loadingText, setLoadingText] = useState<string | null>(null)
@@ -89,6 +94,8 @@ export function BodyLogger() {
     window.scrollTo(0, 0)
   }, [location.pathname])
 
+  const isCurrentRouteProtected = isRouteProtected(location)
+
   return (
     <TableActionMenuContext.Provider value={{ tableActionMenu, setTableActionMenu }}>
       <ToastContext.Provider value={{ toast, setToast }}>
@@ -96,7 +103,9 @@ export function BodyLogger() {
           <LoaderContext.Provider value={{ loadingText, setLoadingText }}>
             <HeaderWrapper />
 
-            {doesRouteAllowTwoColumnsLayout(location) ? (
+            {!isTOSAccepted && isCurrentRouteProtected ? (
+              <TOSAgreement onAcceptAgreement={acceptTOS} />
+            ) : doesRouteAllowTwoColumnsLayout(location) ? (
               <Box sx={{ flexGrow: 1 }}>
                 <Stack direction="row" sx={{ height: '100%', overflowX: 'hidden' }}>
                   <MainNav />
@@ -110,6 +119,7 @@ export function BodyLogger() {
                 <Main />
               </Box>
             )}
+
             <FooterWrapper />
             {toast && <StyledToast {...toast} />}
             {dialog && <StyledDialog {...dialog} />}

--- a/src/components/Shared/StyledTOSAgreementLayout.tsx
+++ b/src/components/Shared/StyledTOSAgreementLayout.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Stack, Typography, Box, Button } from '@mui/material'
+import { SxProps } from '@mui/system'
+
+type StyledTOSAgreementLayoutProps = {
+  productName: string
+  description: React.ReactNode | string
+  children: React.ReactNode
+  onConfirm: VoidFunction
+
+  sx?: SxProps
+  confirmBtnDisabled?: boolean
+  confirmBtnLabel?: string
+}
+
+export function StyledTOSAgreementLayout({
+  productName,
+  description,
+  children,
+  onConfirm,
+
+  sx,
+  confirmBtnDisabled,
+  confirmBtnLabel = 'Entra',
+}: StyledTOSAgreementLayoutProps) {
+  const isDescriptionComponentAString = typeof description === 'string'
+
+  return (
+    <Stack
+      alignItems="center"
+      justifyContent="center"
+      sx={{ py: 16, backgroundColor: 'background.default', ...sx }}
+    >
+      <Stack sx={{ textAlign: 'center', maxWidth: 720, mx: 'auto', px: 4 }} spacing={8}>
+        <Stack spacing={1}>
+          <Typography variant="h3">{productName}</Typography>
+          <Typography component={isDescriptionComponentAString ? 'p' : 'span'}>
+            {description}
+          </Typography>
+        </Stack>
+        <Box>{children}</Box>
+        <Box>
+          <Button onClick={onConfirm} variant="contained" disabled={confirmBtnDisabled}>
+            {confirmBtnLabel}
+          </Button>
+        </Box>
+      </Stack>
+    </Stack>
+  )
+}

--- a/src/hooks/useTOSAgreementLocalStorage.ts
+++ b/src/hooks/useTOSAgreementLocalStorage.ts
@@ -1,0 +1,29 @@
+import React from 'react'
+import { useJwt } from './useJwt'
+
+export function useTOSAgreementLocalStorage(localStorageKey = 'acceptTOS') {
+  const getLocalStorageTOS = React.useCallback(() => {
+    return localStorage.getItem(localStorageKey)
+  }, [localStorageKey])
+
+  const [tosAcceptedId, setTOSAcceptedId] = React.useState<string | null>(getLocalStorageTOS())
+  const { jwt } = useJwt()
+
+  React.useEffect(() => {
+    function listenForStorage() {
+      setTOSAcceptedId(getLocalStorageTOS())
+    }
+    window.addEventListener('storage', listenForStorage)
+    return () => {
+      window.removeEventListener('storage', listenForStorage)
+    }
+  }, [getLocalStorageTOS])
+
+  const acceptTOS = React.useCallback(() => {
+    const id = JSON.stringify({ id: jwt?.uid, timestamp: new Date().toISOString() })
+    setTOSAcceptedId(id)
+    localStorage.setItem(localStorageKey, id)
+  }, [localStorageKey, jwt?.uid])
+
+  return { isTOSAccepted: !!tosAcceptedId, acceptTOS, tosAcceptedId }
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -55,3 +55,5 @@ export const CHIP_COLORS_E_SERVICE: Record<EServiceState, MUIColor> = {
   ARCHIVED: 'info',
   DEPRECATED: 'warning',
 }
+
+export const LIGHT_GRAY = '#FAFAFA'

--- a/src/views/TOSAgreement.tsx
+++ b/src/views/TOSAgreement.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { StyledTOSAgreementLayout } from '../components/Shared/StyledTOSAgreementLayout'
+import { Trans, useTranslation } from 'react-i18next'
+import { StyledLink } from '../components/Shared/StyledLink'
+import { useRoute } from '../hooks/useRoute'
+import { Typography } from '@mui/material'
+import { LIGHT_GRAY } from '../lib/constants'
+
+type TOSAgreementProps = {
+  onAcceptAgreement: VoidFunction
+}
+
+const TOSAgreement: React.FC<TOSAgreementProps> = ({ onAcceptAgreement }) => {
+  const { routes } = useRoute()
+  const { t } = useTranslation('pagopa', { keyPrefix: 'tos', useSuspense: false })
+
+  return (
+    <StyledTOSAgreementLayout
+      productName={t('title')}
+      description={t('description')}
+      onConfirm={onAcceptAgreement}
+      sx={{ backgroundColor: LIGHT_GRAY, flex: 1 }}
+    >
+      <Typography sx={{ px: 8 }} color="text.secondary">
+        <Trans components={{ 1: <StyledLink to={routes.TOS.PATH} underline="hover" /> }}>
+          {t('termsDescription')}
+        </Trans>
+      </Typography>
+    </StyledTOSAgreementLayout>
+  )
+}
+
+export default TOSAgreement


### PR DESCRIPTION
- Added TOS agreement view. It block the render of all the private pages until the user accepts the TOS. The "acceptance" is represented by a record with `acceptTOS` as key inside _localStorage_.
- Added `LIGHT_GRAY` constants that contains the color "#FAFAFA".