### PR TITLE
Pin 1939 - Updated FE risk analysis integration

### DIFF
--- a/src/components/PurposeEditStep2RiskAnalysis.tsx
+++ b/src/components/PurposeEditStep2RiskAnalysis.tsx
@@ -61,8 +61,14 @@ export const PurposeEditStep2RiskAnalysis: FunctionComponent<ActiveStepProps> = 
       const currentAnswersIds = Object.keys(answers)
       // Set them as formik values. This will also trigger the useEffect that
       // depends on formik.values and update the questions accordingly
-      currentAnswersIds.forEach((id) => {
-        const answer = answers[id as keyof PurposeRiskAnalysisFormAnswers]
+      currentAnswersIds.forEach((_id) => {
+        const id = _id as keyof PurposeRiskAnalysisFormAnswers
+        let answer = answers[id]
+        const question = riskAnalysisConfig.questions.find((question) => question.id === id)
+        // Only the checkbox needs the data as Array
+        if (question?.type !== 'checkbox' && answer) {
+          answer = answer[0]
+        }
         formik.setFieldValue(id, answer, false)
       })
     }

--- a/src/data/risk-analysis/pa/v2.0.json
+++ b/src/data/risk-analysis/pa/v2.0.json
@@ -276,6 +276,10 @@
         {
           "id": "legalBasisPublicInterest",
           "value": "RULE_OF_LAW"
+        },
+        {
+          "id": "legalBasis",
+          "value": "PUBLIC_INTEREST"
         }
       ]
     },
@@ -297,6 +301,10 @@
         {
           "id": "legalBasisPublicInterest",
           "value": "ADMINISTRATIVE_ACT"
+        },
+        {
+          "id": "legalBasis",
+          "value": "PUBLIC_INTEREST"
         }
       ]
     },
@@ -485,11 +493,11 @@
       },
       "options": [
         {
-          "label": {"it": "Confermo", "en": "Confirm"},
+          "label": { "it": "Confermo", "en": "Confirm" },
           "value": true
         },
         {
-          "label": {"it": "Nego", "en": "Deny"},
+          "label": { "it": "Nego", "en": "Deny" },
           "value": false,
           "forceUserCheckEServiceCatalog": true
         }
@@ -569,11 +577,11 @@
       },
       "options": [
         {
-          "label": {"it": "Confermo", "en": "Confirm"},
+          "label": { "it": "Confermo", "en": "Confirm" },
           "value": true
         },
         {
-          "label": {"it": "Nego", "en": "Deny"},
+          "label": { "it": "Nego", "en": "Deny" },
           "value": false,
           "forceUserCheckEServiceCatalog": true
         }
@@ -581,7 +589,7 @@
       "defaultValue": false,
       "required": true,
       "dependencies": []
-    }, 
+    },
     {
       "id": "purposePursuit",
       "type": "radio",
@@ -620,11 +628,11 @@
       },
       "options": [
         {
-          "label": {"it": "Confermo", "en": "Confirm"},
+          "label": { "it": "Confermo", "en": "Confirm" },
           "value": true
         },
         {
-          "label": {"it": "Nego", "en": "Deny"},
+          "label": { "it": "Nego", "en": "Deny" },
           "value": false,
           "forceUserCheckEServiceCatalog": true,
           "blockedAlert": {
@@ -737,11 +745,11 @@
       },
       "options": [
         {
-          "label": {"it": "Confermo", "en": "Confirm"},
+          "label": { "it": "Confermo", "en": "Confirm" },
           "value": true
         },
         {
-          "label": {"it": "Nego", "en": "Deny"},
+          "label": { "it": "Nego", "en": "Deny" },
           "value": false
         }
       ],

--- a/src/hooks/useDynamicRiskAnalysisForm.tsx
+++ b/src/hooks/useDynamicRiskAnalysisForm.tsx
@@ -485,9 +485,24 @@ function useDynamicRiskAnalysisForm(
 
   const onSubmit = async (allAnswers: Record<string, unknown>) => {
     const currentQuestions = Object.keys(questions)
+
+    function transformAnswerToArray(answer: unknown) {
+      switch (typeof answer) {
+        case 'object':
+          return answer
+        case 'boolean':
+          return [new Boolean(answer).toString()]
+        case 'string':
+          return [answer]
+      }
+    }
+
     // Send only answers to currently visible questions
     const validAnswers = Object.keys(allAnswers).reduce(
-      (acc, key) => (currentQuestions.includes(key) ? { ...acc, [key]: allAnswers[key] } : acc),
+      (acc, key) =>
+        currentQuestions.includes(key)
+          ? { ...acc, [key]: transformAnswerToArray(allAnswers[key]) }
+          : acc,
       {}
     )
 


### PR DESCRIPTION
In this PR the way FE and BE exchange Risk Analysis data has been changed to `Record<string, Array<string>>`.

- The function that maps all the questions before sending it to BE now transforms all the question values to array of string. 
- The function that takes all the fetched Risk Analysis data and put them into the Formik state has been changed to handle correctly the new data structure.
- Fixed a critical bug inside the logic of Risk Analysis 2.0 that rendered fields that were not supposed to be rendered