### PR TITLE
Pin 1903 - Fix crash on add client dialog render

### DIFF
--- a/src/components/Shared/StyledInputControlledAutocomplete.tsx
+++ b/src/components/Shared/StyledInputControlledAutocomplete.tsx
@@ -52,7 +52,9 @@ export const StyledInputControlledAutocomplete = <T extends unknown>({
   })
   const [isOpen, setIsOpen] = useState(false)
   const [_options, _setOptions] = useState<Array<T>>([])
-  const [value, setValue] = useState<T | Array<T> | null>(defaultValue)
+  const [value, setValue] = useState<T | Array<T> | null>(
+    multiple && !defaultValue ? [] : defaultValue
+  )
 
   const getEmptyOptions = () => {
     return transformFn(options, '')

--- a/types.ts
+++ b/types.ts
@@ -554,6 +554,10 @@ export type Client = {
   operators: Array<SelfCareUser>
   kind: ClientKind
   purposes: Array<ClientPurpose>
+  consumer: {
+    description: string
+    institutionId: string
+  }
 }
 
 export type ClientKind = 'CONSUMER' | 'API'


### PR DESCRIPTION
The crash was due to the `StyledInputControlledAutocomplete` crashing when the internal state value null while the multiple prop is set to true. Internally MUI was trying to iterate on a null value.

Also, added property `consumer` to the `Client` type.