### PR TITLE
Reject agreement

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -29,6 +29,7 @@
   "actions": {
     "suspend": "Suspend",
     "activate": "Activate",
+    "reject": "Reject",
     "upgrade": "Upgrade",
     "delete": "Delete",
     "inspect": "Inspect",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -75,7 +75,8 @@
       "DRAFT": "draft",
       "SUSPENDED": "suspended",
       "PENDING": "awaiting approval",
-      "ARCHIVED": "archived"
+      "ARCHIVED": "archived",
+      "REJECTED": "rejected"
     },
     "purpose": {
       "DRAFT": "draft",

--- a/public/locales/en/toast.json
+++ b/public/locales/en/toast.json
@@ -194,6 +194,12 @@
       "message": "The fruition request could not be activated. Please, make sure all attributes are verified and try again!"
     }
   },
+  "AGREEMENT_REJECT": {
+    "loadingText": "Rejecting fruition request",
+    "error": {
+      "message": "The fruition request could not be rejected. Please, try again!"
+    }
+  },
   "AGREEMENT_SUSPEND": {
     "loadingText": "Suspending fruition request",
     "success": {

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -29,6 +29,7 @@
   "actions": {
     "suspend": "Sospendi",
     "activate": "Attiva",
+    "reject": "Rifiuta",
     "upgrade": "Aggiorna",
     "delete": "Elimina",
     "inspect": "Ispeziona",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -75,7 +75,8 @@
       "DRAFT": "in bozza",
       "SUSPENDED": "sospeso",
       "PENDING": "in attesa di approvazione",
-      "ARCHIVED": "archiviato"
+      "ARCHIVED": "archiviato",
+      "REJECTED": "rifiutato"
     },
     "purpose": {
       "DRAFT": "in bozza",

--- a/public/locales/it/shared-components.json
+++ b/public/locales/it/shared-components.json
@@ -176,6 +176,20 @@
       "confirmLabel": "Conferma"
     }
   },
+  "styledDialogRejectAgreement": {
+    "ariaDescribedBy": "Modale per rifiutare una richiesta di fruizione ad un fruitore",
+    "title": "Rifiuta richiesta di fruizione",
+    "content": {
+      "reason": {
+        "label": "Motivazione",
+        "infoLabel": "Inserisci la motivazione per la quale rifiuti la richiesta di fruizione. Max 1000 caratteri"
+      }
+    },
+    "actions": {
+      "cancelLabel": "Annulla",
+      "confirmLabel": "Rifiuta"
+    }
+  },
   "styledDialogSessionExpired": {
     "ariaDescribedBy": "Modale per segnalare che la sessione attuale è scaduta. È necessario effettuare un nuovo login",
     "title": "La sessione è scaduta",

--- a/public/locales/it/toast.json
+++ b/public/locales/it/toast.json
@@ -194,6 +194,12 @@
       "message": "Non è stato possibile attivare la richiesta. Accertarsi che tutti gli attributi siano stati verificati e riprovare"
     }
   },
+  "AGREEMENT_REJECT": {
+    "loadingText": "Stiamo rifiutando la richiesta",
+    "error": {
+      "message": "Non è stato possibile rifiutare la richiesta. Per favore, riprova!"
+    }
+  },
   "AGREEMENT_SUSPEND": {
     "loadingText": "Stiamo sospendendo la richiesta",
     "success": {

--- a/src/components/EServiceCreateStep1General.tsx
+++ b/src/components/EServiceCreateStep1General.tsx
@@ -184,7 +184,7 @@ export const EServiceCreateStep1General: FunctionComponent<StepperStepComponentP
                   onChange={handleChange}
                   disabled={!isEditable}
                   multiline={true}
-                  inputProps={{ maxLength: 250 }}
+                  inputProps={{ maxLength: 1000 }}
                 />
 
                 <StyledInputControlledRadio

--- a/src/components/Shared/AsyncTableAgreement.tsx
+++ b/src/components/Shared/AsyncTableAgreement.tsx
@@ -81,6 +81,7 @@ export const AsyncTableAgreement = () => {
       PENDING: [],
       ARCHIVED: [],
       DRAFT: [],
+      REJECTED: [],
     }
 
     const subscriberOnlyActionsActive: Array<ActionProps> = []
@@ -100,6 +101,7 @@ export const AsyncTableAgreement = () => {
       PENDING: [],
       ARCHIVED: [],
       DRAFT: [],
+      REJECTED: [],
     }
 
     const providerOnlyActions: AgreementActions = {
@@ -108,6 +110,7 @@ export const AsyncTableAgreement = () => {
       PENDING: [{ onClick: wrapActivate(agreement.id), label: tCommon('actions.activate') }],
       ARCHIVED: [],
       DRAFT: [],
+      REJECTED: [],
     }
 
     const currentActions: AgreementActions = {

--- a/src/components/Shared/StyledDialog.tsx
+++ b/src/components/Shared/StyledDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogExistingAttributeProps,
   DialogNewAttributeProps,
   DialogProps,
+  DialogRejectAgreementProps,
   DialogSessionExpiredProps,
   DialogSetPurposeExpectedApprovalDateProps,
   DialogUpdatePurposeDailyCallsProps,
@@ -24,6 +25,7 @@ import { StyledDialogUpdatePurposeDailyCalls } from './StyledDialogUpdatePurpose
 import { StyledDialogSetPurposeExpectedApprovalDate } from './StyledDialogSetPurposeExpectedApprovalDate'
 import { StyledDialogSessionExpired } from './StyledDialogSessionExpired'
 import { StyledDialogAttributeDetails } from './StyledDialogAttributeDetails'
+import { StyledDialogRejectAgreement } from './StyledDialogRejectAgreement'
 
 function match<T>(
   onBasic: (props: DialogBasicProps) => T,
@@ -36,6 +38,7 @@ function match<T>(
   onAddClients: (props: DialogAddClientsProps) => T,
   onUpdatePurposeDailyCalls: (props: DialogUpdatePurposeDailyCallsProps) => T,
   onSetPurposeExpectedApprovalDate: (props: DialogSetPurposeExpectedApprovalDateProps) => T,
+  onRejectAgreement: (props: DialogRejectAgreementProps) => T,
   onSessionExpired: (props: DialogSessionExpiredProps) => T
 ) {
   return (props: DialogProps) => {
@@ -60,6 +63,8 @@ function match<T>(
         return onUpdatePurposeDailyCalls(props)
       case 'setPurposeExpectedApprovalDate':
         return onSetPurposeExpectedApprovalDate(props)
+      case 'rejectAgreement':
+        return onRejectAgreement(props)
       case 'sessionExpired':
         return onSessionExpired(props)
     }
@@ -77,5 +82,6 @@ export const StyledDialog = match(
   (props) => <StyledDialogAddClients {...props} />,
   (props) => <StyledDialogUpdatePurposeDailyCalls {...props} />,
   (props) => <StyledDialogSetPurposeExpectedApprovalDate {...props} />,
+  (props) => <StyledDialogRejectAgreement {...props} />,
   (props) => <StyledDialogSessionExpired {...props} />
 )

--- a/src/components/Shared/StyledDialogRejectAgreement.tsx
+++ b/src/components/Shared/StyledDialogRejectAgreement.tsx
@@ -47,7 +47,7 @@ export const StyledDialogRejectAgreement: FunctionComponent<DialogRejectAgreemen
                 onChange={handleChange}
                 focusOnMount={true}
                 multiline={true}
-                inputProps={{ maxLength: 250 }}
+                inputProps={{ maxLength: 1000 }}
               />
             </DialogContent>
 

--- a/src/components/Shared/StyledDialogRejectAgreement.tsx
+++ b/src/components/Shared/StyledDialogRejectAgreement.tsx
@@ -1,0 +1,67 @@
+import React, { FunctionComponent } from 'react'
+import { Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material'
+import { Formik } from 'formik'
+import { StyledButton } from './StyledButton'
+import { DialogRejectAgreementProps } from '../../../types'
+import { useCloseDialog } from '../../hooks/useCloseDialog'
+import { StyledForm } from './StyledForm'
+import { StyledInputControlledText } from './StyledInputControlledText'
+import { useTranslation } from 'react-i18next'
+import { LoadingTranslations } from './LoadingTranslations'
+
+export const StyledDialogRejectAgreement: FunctionComponent<DialogRejectAgreementProps> = ({
+  onSubmit,
+  initialValues,
+  validationSchema,
+}) => {
+  const { t, ready } = useTranslation('shared-components', {
+    useSuspense: false,
+    keyPrefix: 'styledDialogRejectAgreement',
+  })
+  const { closeDialog } = useCloseDialog()
+
+  if (!ready) {
+    return <LoadingTranslations />
+  }
+
+  return (
+    <Dialog open onClose={closeDialog} aria-describedby={t('ariaDescribedBy')} fullWidth>
+      <Formik
+        initialValues={initialValues}
+        validationSchema={validationSchema}
+        onSubmit={onSubmit}
+        validateOnChange={false}
+        validateOnBlur={false}
+      >
+        {({ handleSubmit, errors, values, handleChange }) => (
+          <StyledForm onSubmit={handleSubmit}>
+            <DialogTitle>{t('title')}</DialogTitle>
+
+            <DialogContent>
+              <StyledInputControlledText
+                name="reason"
+                label={t('content.reason.label')}
+                infoLabel={t('content.reason.infoLabel')}
+                error={errors.reason}
+                value={values.reason}
+                onChange={handleChange}
+                focusOnMount={true}
+                multiline={true}
+                inputProps={{ maxLength: 250 }}
+              />
+            </DialogContent>
+
+            <DialogActions>
+              <StyledButton variant="outlined" onClick={closeDialog}>
+                {t('actions.cancelLabel')}
+              </StyledButton>
+              <StyledButton variant="contained" type="submit">
+                {t('actions.confirmLabel')}
+              </StyledButton>
+            </DialogActions>
+          </StyledForm>
+        )}
+      </Formik>
+    </Dialog>
+  )
+}

--- a/src/config/api-endpoints.ts
+++ b/src/config/api-endpoints.ts
@@ -136,6 +136,10 @@ export const API: Record<ApiEndpointKey, ApiEndpointContent> = {
     URL: `${BACKEND_FOR_FRONTEND_URL}/agreements/:agreementId/activate`,
     METHOD: 'POST',
   },
+  AGREEMENT_REJECT: {
+    URL: `${BACKEND_FOR_FRONTEND_URL}/agreements/:agreementId/reject`,
+    METHOD: 'POST',
+  },
   AGREEMENT_SUSPEND: {
     URL: `${BACKEND_FOR_FRONTEND_URL}/agreements/:agreementId/suspend`,
     METHOD: 'POST',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -41,6 +41,7 @@ export const CHIP_COLORS_AGREEMENT: Record<AgreementState, MUIColor> = {
   PENDING: 'warning',
   ARCHIVED: 'info',
   DRAFT: 'info',
+  REJECTED: 'error',
 }
 
 export const CHIP_COLORS_USER: Record<UserState, MUIColor> = {

--- a/src/views/AgreementRead.tsx
+++ b/src/views/AgreementRead.tsx
@@ -40,6 +40,7 @@ import {
   remapTenantBackendAttributesToFrontend,
 } from '../lib/attributes'
 import { ActionMenu } from '../components/Shared/ActionMenu'
+import { DialogContext } from '../lib/context'
 
 export function AgreementRead() {
   const { t } = useTranslation(['agreement', 'common'])
@@ -47,6 +48,7 @@ export function AgreementRead() {
   const mode = useMode()
   const agreementId = getLastBit(useLocation())
   const { routes } = useRoute()
+  const { setDialog } = useContext(DialogContext)
 
   const {
     data: agreement,
@@ -80,6 +82,20 @@ export function AgreementRead() {
   const activate = async () => {
     await runAction(
       { path: { endpoint: 'AGREEMENT_ACTIVATE', endpointParams: { agreementId } } },
+      { showConfirmDialog: true }
+    )
+  }
+
+  const wrapReject = () => {
+    setDialog({
+      type: 'rejectAgreement',
+      onSubmit,
+    })
+  }
+
+  const reject = async () => {
+    await runAction(
+      { path: { endpoint: 'AGREEMENT_REJECT', endpointParams: { agreementId } } },
       { showConfirmDialog: true }
     )
   }
@@ -121,7 +137,10 @@ export function AgreementRead() {
     const providerOnlyActions: AgreementActions = {
       ACTIVE: [],
       SUSPENDED: [], // [{ onClick: archive, label: 'Archivia' }],
-      PENDING: [{ onClick: activate, label: t('actions.activate', { ns: 'common' }) }],
+      PENDING: [
+        { onClick: activate, label: t('actions.activate', { ns: 'common' }) },
+        { onClick: reject, label: t('actions.reject', { ns: 'common' }) },
+      ],
       ARCHIVED: [],
       DRAFT: [],
     }

--- a/types.ts
+++ b/types.ts
@@ -40,6 +40,7 @@ export type ApiEndpointKey =
   | 'AGREEMENT_VERIFY_ATTRIBUTE'
   | 'AGREEMENT_REVOKE_VERIFIED_ATTRIBUTE'
   | 'AGREEMENT_ACTIVATE'
+  | 'AGREEMENT_REJECT'
   | 'AGREEMENT_SUSPEND'
   | 'AGREEMENT_UPGRADE'
   | 'AGREEMENT_DOCUMENT_DOWNLOAD'
@@ -729,6 +730,7 @@ export type DialogProps =
   | DialogAddClientsProps
   | DialogUpdatePurposeDailyCallsProps
   | DialogSetPurposeExpectedApprovalDateProps
+  | DialogRejectAgreementProps
   | DialogSessionExpiredProps
 
 export type DialogSessionExpiredProps = {
@@ -741,6 +743,17 @@ export type DialogSetPurposeExpectedApprovalDateProps = {
   versionId: string
   approvalDate?: string
   runAction: RunAction
+}
+
+export type DialogRejectAgreementProps = {
+  type: 'rejectAgreement'
+  onSubmit: (data: DialogRejectAgreementFormInputValues) => void
+  initialValues: DialogRejectAgreementFormInputValues
+  validationSchema: SchemaOf<DialogRejectAgreementFormInputValues>
+}
+
+export type DialogRejectAgreementFormInputValues = {
+  reason: string
 }
 
 export type DialogUpdatePurposeDailyCallsProps = {

--- a/types.ts
+++ b/types.ts
@@ -346,7 +346,7 @@ export type EServiceDocumentRead = {
 /*
  * Agreement
  */
-export type AgreementState = 'ACTIVE' | 'SUSPENDED' | 'PENDING' | 'ARCHIVED' | 'DRAFT'
+export type AgreementState = 'ACTIVE' | 'SUSPENDED' | 'PENDING' | 'ARCHIVED' | 'DRAFT' | 'REJECTED'
 
 export type AgreementVerifiableAttribute = {
   id: string


### PR DESCRIPTION
Implemented feature to reject agreement. When the "reject" button is clicked, a modal is opened. The provider must state the reason for rejecting the agreement and then submit the decision. A "REJECTED" status with an error color is added