### PR TITLE
Pin 2033 - Changed rendering logic of confirm declared attributes button

### DIFF
--- a/src/components/AttributeGroup.tsx
+++ b/src/components/AttributeGroup.tsx
@@ -341,7 +341,7 @@ function AttributesList({
             </>
           ) : (
             <>
-              {onConfirmDeclaredAttribute && (
+              {onConfirmDeclaredAttribute && !isActive && (
                 <ButtonNaked
                   onClick={onConfirmDeclaredAttribute.bind(null, attribute.id)}
                   color="primary"

--- a/src/components/AttributeGroup.tsx
+++ b/src/components/AttributeGroup.tsx
@@ -341,6 +341,15 @@ function AttributesList({
             </>
           ) : (
             <>
+              {onConfirmDeclaredAttribute && (
+                <ButtonNaked
+                  onClick={onConfirmDeclaredAttribute.bind(null, attribute.id)}
+                  color="primary"
+                >
+                  {t('confirmDeclaredAttributeBtn')}
+                </ButtonNaked>
+              )}
+
               {isActive && (
                 <StyledTooltip title={activeTooltipLabel}>
                   <Check color="success" fontSize="small" />
@@ -351,15 +360,6 @@ function AttributesList({
                 <Tooltip title={revokedTooltipLabel}>
                   <CloseIcon fontSize="small" color="error" />
                 </Tooltip>
-              )}
-
-              {onConfirmDeclaredAttribute && (
-                <ButtonNaked
-                  onClick={onConfirmDeclaredAttribute.bind(null, attribute.id)}
-                  color="primary"
-                >
-                  {t('confirmDeclaredAttributeBtn')}
-                </ButtonNaked>
               )}
               <ButtonNaked
                 onClick={openAttributeDetailsDialog.bind(null, attribute)}


### PR DESCRIPTION
This PR updates the rendering logic of the declared attribute button.
It now appears only when the declared attribute is not `ACTIVE`.