### PR TITLE
PIN-2038  - Added delete agreement actions

### DIFF
--- a/src/components/Shared/AsyncTableAgreement.tsx
+++ b/src/components/Shared/AsyncTableAgreement.tsx
@@ -68,6 +68,18 @@ export const AsyncTableAgreement = () => {
       { showConfirmDialog: true }
     )
   }
+
+  const wrapDelete = (agreementId: string) => async () => {
+    await runAction(
+      {
+        path: {
+          endpoint: 'AGREEMENT_DRAFT_DELETE',
+          endpointParams: { agreementId },
+        },
+      },
+      { showConfirmDialog: true }
+    )
+  }
   /*
    * End list of actions
    */
@@ -101,9 +113,11 @@ export const AsyncTableAgreement = () => {
       SUSPENDED: [],
       PENDING: [],
       ARCHIVED: [],
-      DRAFT: [],
+      DRAFT: [{ onClick: wrapDelete(agreement.id), label: tCommon('actions.delete') }],
       REJECTED: [],
-      MISSING_CERTIFIED_ATTRIBUTES: [],
+      MISSING_CERTIFIED_ATTRIBUTES: [
+        { onClick: wrapDelete(agreement.id), label: tCommon('actions.delete') },
+      ],
     }
 
     const providerOnlyActions: AgreementActions = {

--- a/src/views/AgreementRead.tsx
+++ b/src/views/AgreementRead.tsx
@@ -123,6 +123,18 @@ export function AgreementRead() {
     )
   }
 
+  const deleteAgreement = async () => {
+    await runAction(
+      {
+        path: {
+          endpoint: 'AGREEMENT_DRAFT_DELETE',
+          endpointParams: { agreementId },
+        },
+      },
+      { onSuccessDestination: routes.SUBSCRIBE_AGREEMENT_LIST, showConfirmDialog: true }
+    )
+  }
+
   /*
    * End list of actions
    */
@@ -171,9 +183,11 @@ export function AgreementRead() {
       SUSPENDED: [],
       PENDING: [],
       ARCHIVED: [],
-      DRAFT: [],
+      DRAFT: [{ onClick: deleteAgreement, label: t('actions.delete', { ns: 'common' }) }],
       REJECTED: [],
-      MISSING_CERTIFIED_ATTRIBUTES: [],
+      MISSING_CERTIFIED_ATTRIBUTES: [
+        { onClick: deleteAgreement, label: t('actions.delete', { ns: 'common' }) },
+      ],
     }
 
     const currentMode = mode as ProviderOrSubscriber


### PR DESCRIPTION
In this PR the delete agreement action is added to the menus in the agreement list and agreement read. The action is available ONLY when the agreement is `DRAFT` or `MISSING_CERTIFIED_ATTRIBUTES`.