### PR TITLE
PIN-2075 - Submit agreement button must be always active if provider is the same as subscriber

### DIFF
--- a/src/views/AgreementEdit.tsx
+++ b/src/views/AgreementEdit.tsx
@@ -191,19 +191,22 @@ export function AgreementEdit() {
     )
   }
 
-  // REFACTOR
-  const isMissingCertifiedAttributes = agreement?.state === 'MISSING_CERTIFIED_ATTRIBUTES'
-  let isSubmitAgreementButtonDisabled = isMissingCertifiedAttributes
-
-  if (frontendAttributes && !isMissingCertifiedAttributes) {
-    isSubmitAgreementButtonDisabled = !checkOwnershipFrontendAttributes(
+  /** Check if submit agreement button can be enabled */
+  const isProducerSameAsConsumer = agreement?.consumer.id === agreement?.producer.id
+  const hasAllDeclaredAndCertifiedAttributes =
+    agreement?.state !== 'MISSING_CERTIFIED_ATTRIBUTES' &&
+    frontendAttributes &&
+    checkOwnershipFrontendAttributes(
       [...frontendAttributes.certified, ...frontendAttributes.declared],
       [
         ...(ownedCertifiedAttributes || []).map(({ id }) => id),
         ...(ownedDeclaredAttributes || []).map(({ id }) => id),
       ]
     )
-  }
+
+  const isSubmitAgreementButtonEnabled =
+    hasAllDeclaredAndCertifiedAttributes || isProducerSameAsConsumer
+  /** --- */
 
   return (
     <Box sx={{ maxWidth: MAX_WIDTH }}>
@@ -326,7 +329,7 @@ export function AgreementEdit() {
                   {t('edit.bottomPageActionCard.cancelBtn')}
                 </StyledButton>
                 <StyledButton
-                  disabled={isSubmitAgreementButtonDisabled}
+                  disabled={!isSubmitAgreementButtonEnabled}
                   onClick={wrapHandleSendAgreementRequest}
                   variant="contained"
                 >

--- a/src/views/AgreementEdit.tsx
+++ b/src/views/AgreementEdit.tsx
@@ -192,7 +192,7 @@ export function AgreementEdit() {
   }
 
   /** Check if submit agreement button can be enabled */
-  const isProducerSameAsConsumer = agreement?.consumer.id === agreement?.producer.id
+  const isProviderSameAsSubscriber = agreement?.consumer.id === agreement?.producer.id
   const hasAllDeclaredAndCertifiedAttributes =
     agreement?.state !== 'MISSING_CERTIFIED_ATTRIBUTES' &&
     frontendAttributes &&
@@ -205,7 +205,7 @@ export function AgreementEdit() {
     )
 
   const isSubmitAgreementButtonEnabled =
-    hasAllDeclaredAndCertifiedAttributes || isProducerSameAsConsumer
+    hasAllDeclaredAndCertifiedAttributes || isProviderSameAsSubscriber
   /** --- */
 
   return (


### PR DESCRIPTION
Logic for disabling/enabling submit button has been rewritten. 
The button will be always active if the id of the agreement's provider is the same as the id of the agreement's subscriber.