### PR TITLE
PIN-2101 - Implemented download agreement documents

### DIFF
--- a/public/locales/en/shared-components.json
+++ b/public/locales/en/shared-components.json
@@ -209,5 +209,8 @@
   },
   "tableWithLoader": {
     "noDataLabel": "This search bears no results"
+  },
+  "downloadableDocumentListSection": {
+    "noDataLabel": "No documents available"
   }
 }

--- a/public/locales/it/shared-components.json
+++ b/public/locales/it/shared-components.json
@@ -223,5 +223,8 @@
   },
   "tableWithLoader": {
     "noDataLabel": "Questa ricerca non ha prodotto risultati"
+  },
+  "downloadableDocumentListSection": {
+    "noDataLabel": "Nessun documento disponibile"
   }
 }

--- a/src/components/Shared/DownloadableDocumentListSection.tsx
+++ b/src/components/Shared/DownloadableDocumentListSection.tsx
@@ -4,6 +4,7 @@ import { EServiceDocumentRead } from '../../../types'
 import { StyledLink } from './StyledLink'
 import StyledSection from './StyledSection'
 import { AttachFile as AttachFileIcon } from '@mui/icons-material'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   docs: Array<EServiceDocumentRead>
@@ -16,13 +17,17 @@ function DownloadableDocumentListSection({
   docs,
   onDocumentDownload,
   sectionTitle = 'Download',
-  noFilesLabel = 'Nessun download disponibile',
+  noFilesLabel,
 }: Props) {
+  const { t } = useTranslation('shared-components', {
+    keyPrefix: 'downloadableDocumentListSection',
+  })
+
   return (
     <StyledSection>
       <StyledSection.Title>{sectionTitle}</StyledSection.Title>
       <StyledSection.Content>
-        {Boolean(docs.length > 0) ? (
+        {docs.length > 0 ? (
           <Stack spacing={2} alignItems="start">
             {docs.map((doc) => (
               <Stack key={doc.id} spacing={2}>
@@ -48,7 +53,7 @@ function DownloadableDocumentListSection({
             ))}
           </Stack>
         ) : (
-          <Typography variant="body2">{noFilesLabel}</Typography>
+          <Typography variant="body2">{noFilesLabel ?? t('noDataLabel')}</Typography>
         )}
       </StyledSection.Content>
     </StyledSection>

--- a/src/components/Shared/DownloadableDocumentListSection.tsx
+++ b/src/components/Shared/DownloadableDocumentListSection.tsx
@@ -1,53 +1,23 @@
 import React from 'react'
 import { Stack, Typography } from '@mui/material'
-import { AxiosResponse } from 'axios'
 import { EServiceDocumentRead } from '../../../types'
-import { RunActionOutput, useFeedback } from '../../hooks/useFeedback'
-import { getDownloadDocumentName } from '../../lib/eservice-utils'
-import { downloadFile } from '../../lib/file-utils'
 import { StyledLink } from './StyledLink'
 import StyledSection from './StyledSection'
 import { AttachFile as AttachFileIcon } from '@mui/icons-material'
 
 interface Props {
-  descriptorId: string
-  eserviceId: string
   docs: Array<EServiceDocumentRead>
+  onDocumentDownload: (document: EServiceDocumentRead) => void
   sectionTitle?: string
   noFilesLabel?: string
 }
 
 function DownloadableDocumentListSection({
-  descriptorId,
-  eserviceId,
   docs,
+  onDocumentDownload,
   sectionTitle = 'Download',
   noFilesLabel = 'Nessun download disponibile',
 }: Props) {
-  const { runAction } = useFeedback()
-
-  const handleDownloadDocument = async (document: EServiceDocumentRead) => {
-    const { response, outcome } = (await runAction(
-      {
-        path: {
-          endpoint: 'ESERVICE_VERSION_DOWNLOAD_DOCUMENT',
-          endpointParams: {
-            eserviceId,
-            descriptorId,
-            documentId: document.id,
-          },
-        },
-        config: { responseType: 'arraybuffer' },
-      },
-      { suppressToast: ['success'] }
-    )) as RunActionOutput
-
-    if (outcome === 'success') {
-      const filename = getDownloadDocumentName(document)
-      downloadFile((response as AxiosResponse).data, filename)
-    }
-  }
-
   return (
     <StyledSection>
       <StyledSection.Title>{sectionTitle}</StyledSection.Title>
@@ -57,7 +27,7 @@ function DownloadableDocumentListSection({
             {docs.map((doc) => (
               <Stack key={doc.id} spacing={2}>
                 <StyledLink
-                  onClick={handleDownloadDocument.bind(null, doc)}
+                  onClick={onDocumentDownload.bind(null, doc)}
                   component="button"
                   variant="body2"
                   underline="hover"

--- a/src/views/AgreementRead.tsx
+++ b/src/views/AgreementRead.tsx
@@ -271,7 +271,7 @@ export function AgreementRead() {
         },
         config: { responseType: 'arraybuffer' },
       },
-      { suppressToast: ['success'] }
+      { suppressToast: ['success'], silent: true }
     )) as RunActionOutput
 
     if (outcome === 'success') {

--- a/src/views/AgreementRead.tsx
+++ b/src/views/AgreementRead.tsx
@@ -7,9 +7,14 @@ import {
   ProviderOrSubscriber,
   EServiceReadType,
   DialogRejectAgreementFormInputValues,
+  EServiceDocumentRead,
 } from '../../types'
 import { buildDynamicPath, getLastBit } from '../lib/router-utils'
-import { getLatestActiveVersion, mergeActions } from '../lib/eservice-utils'
+import {
+  getDownloadDocumentName,
+  getLatestActiveVersion,
+  mergeActions,
+} from '../lib/eservice-utils'
 import { useMode } from '../hooks/useMode'
 import { StyledIntro } from '../components/Shared/StyledIntro'
 import { useAsyncFetch } from '../hooks/useAsyncFetch'
@@ -257,6 +262,25 @@ export function AgreementRead() {
     // runAction()
   }
 
+  const handleDownloadDocument = async (document: EServiceDocumentRead) => {
+    const { outcome, response } = (await runAction(
+      {
+        path: {
+          endpoint: 'AGREEMENT_DRAFT_DOCUMENT_DOWNLOAD',
+          endpointParams: { agreementId, documentId: document.id },
+        },
+        config: { responseType: 'arraybuffer' },
+      },
+      { suppressToast: ['success'] }
+    )) as RunActionOutput
+
+    if (outcome === 'success') {
+      const data = (response as AxiosResponse).data as string
+      const filename = getDownloadDocumentName(document)
+      downloadFile(data, filename)
+    }
+  }
+
   const availableActions = getAvailableActions()
   let primaryAction: ActionProps | undefined
 
@@ -293,9 +317,8 @@ export function AgreementRead() {
             </Grid>
             <Grid item xs={5}>
               <DownloadableDocumentListSection
-                docs={[]}
-                eserviceId={eservice.id}
-                descriptorId={agreement.descriptorId}
+                docs={agreement.consumerDocuments}
+                onDocumentDownload={handleDownloadDocument}
               />
             </Grid>
           </Grid>


### PR DESCRIPTION
In this PR the component `DownloadableDocumentListSection` has been generalized, making it usable outside the e-service context. It is now used inside the AgreementRead page to handle the agreement's documents.