### PR TITLE
PIN 2061 - Added external link to sidenav and removed "API Operators" page

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -18,7 +18,8 @@
     }
   },
   "mainNav": {
-    "ariaLabel": "Main navigation"
+    "ariaLabel": "Main navigation",
+    "userExternalLinkLabel": "Users"
   },
   "loading": {
     "sessionToken": {

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -18,7 +18,8 @@
     }
   },
   "mainNav": {
-    "ariaLabel": "Navigazione principale"
+    "ariaLabel": "Navigazione principale",
+    "userExternalLinkLabel": "Utenti"
   },
   "loading": {
     "sessionToken": {

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -6,7 +6,9 @@ import {
   List,
   ListItem,
   ListItemButton,
+  ListItemIcon,
   ListItemText,
+  SvgIconTypeMap,
   Typography,
 } from '@mui/material'
 import { MappedRouteConfig, UserProductRole } from '../../types'
@@ -16,6 +18,8 @@ import { useRoute } from '../hooks/useRoute'
 import { useTranslation } from 'react-i18next'
 import { useJwt } from '../hooks/useJwt'
 import { LoadingTranslations } from './Shared/LoadingTranslations'
+import { Email as EmailIcon } from '@mui/icons-material'
+import { OverridableComponent } from '@mui/material/OverridableComponent'
 
 type View = {
   route: MappedRouteConfig
@@ -23,7 +27,16 @@ type View = {
   children?: Array<MappedRouteConfig>
 }
 
-type Views = Record<UserProductRole, Array<View>>
+type MuiIcon = OverridableComponent<SvgIconTypeMap<unknown, 'svg'>> & {
+  muiName: string
+}
+
+type SideNavItemView = View & {
+  StartIcon?: MuiIcon
+  EndIcon?: MuiIcon
+}
+
+type Views = Record<UserProductRole, Array<SideNavItemView>>
 
 const WIDTH = 340
 
@@ -78,7 +91,7 @@ export const MainNav = () => {
     ...(isAdmin ? views['admin'] : []),
     ...(isOperatorAPI ? views['api'] : []),
     ...(isOperatorSecurity ? views['security'] : []),
-    { route: routes.NOTIFICATION },
+    { route: routes.NOTIFICATION, StartIcon: EmailIcon },
   ]
 
   const wrapSetOpenSubmenuId = (newOpenId?: string) => () => {
@@ -101,7 +114,7 @@ export const MainNav = () => {
 }
 
 type MainNavComponentProps = {
-  items: Array<View>
+  items: Array<SideNavItemView>
   isItemSelected: (route: MappedRouteConfig) => boolean
   openSubmenuId: string | null
   wrapSetOpenSubmenuId: (id?: string) => () => void
@@ -119,9 +132,13 @@ const MainNavComponent = ({
 
   const WrappedLink = ({
     route,
+    StartIcon,
+    EndIcon,
     indented = false,
   }: {
     route: MappedRouteConfig
+    StartIcon?: MuiIcon
+    EndIcon?: MuiIcon
     indented?: boolean
   }) => {
     const isSelected = isItemSelected(route)
@@ -134,13 +151,18 @@ const MainNavComponent = ({
         sx={{
           pl: 3,
           py: 2,
-          display: 'block',
+          display: 'flex',
           borderRight: 2,
           borderColor: isSelected ? 'primary.main' : 'transparent',
           backgroundColor: isSelected ? 'rgba(0, 115, 230, 0.08)' : 'transparent',
           color: isSelected ? 'primary.main' : 'text.primary',
         }}
       >
+        {StartIcon && (
+          <ListItemIcon>
+            <StartIcon fontSize="inherit" color={isSelected ? 'primary' : undefined} />
+          </ListItemIcon>
+        )}
         <ListItemText
           disableTypography
           sx={{ color: 'inherit' }}
@@ -153,6 +175,11 @@ const MainNavComponent = ({
             </Typography>
           }
         />
+        {EndIcon && (
+          <ListItemIcon>
+            <EndIcon color="action" />
+          </ListItemIcon>
+        )}
       </ListItemButton>
     )
   }
@@ -200,7 +227,11 @@ const MainNavComponent = ({
               </Box>
             ) : (
               <ListItem sx={{ display: 'block', p: 0 }} key={i}>
-                <WrappedLink route={item.route} />
+                <WrappedLink
+                  route={item.route}
+                  StartIcon={item?.StartIcon}
+                  EndIcon={item?.EndIcon}
+                />
               </ListItem>
             )
           })}

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -39,11 +39,7 @@ export const MainNav = () => {
       {
         route: routes.PROVIDE,
         id: 'provider',
-        children: [
-          routes.PROVIDE_ESERVICE_LIST,
-          routes.PROVIDE_AGREEMENT_LIST,
-          routes.PROVIDE_OPERATOR_LIST,
-        ],
+        children: [routes.PROVIDE_ESERVICE_LIST, routes.PROVIDE_AGREEMENT_LIST],
       },
       {
         route: routes.SUBSCRIBE,

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router'
 import {
   Box,
   Collapse,
+  Divider,
   List,
   ListItem,
   ListItemButton,
@@ -18,7 +19,11 @@ import { useRoute } from '../hooks/useRoute'
 import { useTranslation } from 'react-i18next'
 import { useJwt } from '../hooks/useJwt'
 import { LoadingTranslations } from './Shared/LoadingTranslations'
-import { Email as EmailIcon } from '@mui/icons-material'
+import {
+  Email as EmailIcon,
+  ExitToAppRounded as ExitToAppRoundedIcon,
+  People as PeopleIcon,
+} from '@mui/icons-material'
 import { OverridableComponent } from '@mui/material/OverridableComponent'
 
 type View = {
@@ -237,6 +242,28 @@ const MainNavComponent = ({
           })}
         </List>
       )}
+      <Divider sx={{ my: 1 }} />
+      <List>
+        <ListItem sx={{ display: 'block', p: 0 }}>
+          <ListItemButton
+            component="a"
+            href="#0"
+            sx={{
+              pl: 3,
+              py: 2,
+              display: 'flex',
+            }}
+          >
+            <ListItemIcon>
+              <PeopleIcon fontSize="inherit" />
+            </ListItemIcon>
+            <ListItemText primary={t('mainNav.userExternalLinkLabel')} />
+            <ListItemIcon>
+              <ExitToAppRoundedIcon color="action" />
+            </ListItemIcon>
+          </ListItemButton>
+        </ListItem>
+      </List>
     </Box>
   )
 }

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -71,7 +71,6 @@ export const MainNav = () => {
           routes.SUBSCRIBE_INTEROP_M2M,
         ],
       },
-      { route: routes.PARTY_REGISTRY },
     ],
     api: [
       {
@@ -98,6 +97,7 @@ export const MainNav = () => {
     ...(isOperatorAPI ? views['api'] : []),
     ...(isOperatorSecurity ? views['security'] : []),
     { route: routes.NOTIFICATION, StartIcon: EmailIcon },
+    ...(isAdmin ? [{ route: routes.PARTY_REGISTRY }] : []),
   ]
 
   const wrapSetOpenSubmenuId = (newOpenId?: string) => () => {

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -25,6 +25,7 @@ import {
   People as PeopleIcon,
 } from '@mui/icons-material'
 import { OverridableComponent } from '@mui/material/OverridableComponent'
+import { SELFCARE_BASE_URL } from '../lib/env'
 
 type View = {
   route: MappedRouteConfig
@@ -134,6 +135,10 @@ const MainNavComponent = ({
   shouldRender,
 }: MainNavComponentProps) => {
   const { t, ready } = useTranslation('common', { useSuspense: false })
+  const { jwt, isAdmin } = useJwt()
+
+  const selfcareUsersPageUrl =
+    jwt && `${SELFCARE_BASE_URL}/dashboard/${jwt.selfcareId}/users#prod-interop`
 
   const WrappedLink = ({
     route,
@@ -242,28 +247,33 @@ const MainNavComponent = ({
           })}
         </List>
       )}
-      <Divider sx={{ my: 1 }} />
-      <List>
-        <ListItem sx={{ display: 'block', p: 0 }}>
-          <ListItemButton
-            component="a"
-            href="#0"
-            sx={{
-              pl: 3,
-              py: 2,
-              display: 'flex',
-            }}
-          >
-            <ListItemIcon>
-              <PeopleIcon fontSize="inherit" />
-            </ListItemIcon>
-            <ListItemText primary={t('mainNav.userExternalLinkLabel')} />
-            <ListItemIcon>
-              <ExitToAppRoundedIcon color="action" />
-            </ListItemIcon>
-          </ListItemButton>
-        </ListItem>
-      </List>
+      {isAdmin && (
+        <>
+          <Divider sx={{ my: 1 }} />
+          <List>
+            <ListItem sx={{ display: 'block', p: 0 }}>
+              <ListItemButton
+                component="a"
+                href={selfcareUsersPageUrl}
+                target={selfcareUsersPageUrl && '_blank'}
+                sx={{
+                  pl: 3,
+                  py: 2,
+                  display: 'flex',
+                }}
+              >
+                <ListItemIcon>
+                  <PeopleIcon fontSize="inherit" />
+                </ListItemIcon>
+                <ListItemText primary={t('mainNav.userExternalLinkLabel')} />
+                <ListItemIcon>
+                  <ExitToAppRoundedIcon color="action" />
+                </ListItemIcon>
+              </ListItemButton>
+            </ListItem>
+          </List>
+        </>
+      )}
     </Box>
   )
 }

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -8,7 +8,6 @@ import { EServiceList } from '../views/EServiceList'
 import { Logout } from '../views/Logout'
 import { Notifications } from '../views/Notifications'
 import { UserEdit } from '../views/UserEdit'
-import { UserList } from '../views/UserList'
 import { ClientCreate } from '../views/ClientCreate'
 import { SecurityKeyGuide } from '../views/SecurityKeyGuide'
 import { EmptyComponent } from '../components/Shared/EmptyComponent'
@@ -116,22 +115,6 @@ export const BASIC_ROUTES: Record<string, RouteConfig> = {
     LABEL: { it: 'Richieste di fruizione', en: 'Requests for use' },
     EXACT: true,
     COMPONENT: AgreementList,
-    PUBLIC: false,
-    AUTH_LEVELS: ['admin'],
-  },
-  PROVIDE_OPERATOR_EDIT: {
-    PATH: { it: '/it/erogazione/operatori/:operatorId', en: '/en/provider/operators/:operatorId' },
-    LABEL: { it: 'Gestisci utenza', en: 'Manage user' },
-    EXACT: false,
-    COMPONENT: UserEdit,
-    PUBLIC: false,
-    AUTH_LEVELS: ['admin'],
-  },
-  PROVIDE_OPERATOR_LIST: {
-    PATH: { it: '/it/erogazione/operatori', en: '/en/provider/operators' },
-    LABEL: { it: 'I tuoi operatori API', en: 'Your API operators' },
-    EXACT: true,
-    COMPONENT: UserList,
     PUBLIC: false,
     AUTH_LEVELS: ['admin'],
   },

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -68,3 +68,6 @@ function getWellKnownUrls(wellKnownUrls: string | undefined) {
 }
 
 export const WELL_KNOWN_URLS = isProduction ? getWellKnownUrls(PAGOPA_ENV.WELL_KNOWN_URLS) : ['#']
+
+// TEMP: Backend - This must come from the backend env
+export const SELFCARE_BASE_URL = 'https://selfcare.pagopa.it'

--- a/types.ts
+++ b/types.ts
@@ -209,6 +209,7 @@ export type JwtUser = {
   jti: string
   nbf: number
   organization: JwtOrg
+  selfcareId: string
   uid: string // the relationshipId between the user and the current institution
   name: string
   family_name: string


### PR DESCRIPTION
This PR adds a new nav item to the sidenav that links to the selfcare's users page and removes the _API Operators_ page inside providers sub menu. Plus:

- Added _selfcareId_ property to _JwtUser_ model