### PR TITLE
PIN-2205 - Fixed i18n character escaping

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -14,6 +14,9 @@ i18n
     // In code, see isProviderOrSubscriber in lib/router-utils.ts
     preload: Object.keys(LANGUAGES),
     fallbackLng: DEFAULT_LANG,
+    interpolation: {
+      escapeValue: false,
+    },
     backend: {
       // DANGER DANGER DANGER. The path needs to be prepended with the PUBLIC_URL
       // See: https://stackoverflow.com/a/65396448


### PR DESCRIPTION
Disabled i18next escaping.
Not needed in React.

Related issue:
https://github.com/i18next/react-i18next/issues/277
