### PR TITLE
[FIX] - Added disabling query if jwt is falsy

### DIFF
--- a/src/api/react-query-wrappers.ts
+++ b/src/api/react-query-wrappers.ts
@@ -6,7 +6,7 @@ import { useJwt } from '@/hooks/useJwt'
 import { NotFoundError } from '@/utils/errors.utils'
 
 export const useQueryWrapper: UseQueryWrapper = (key, queryFn, options) => {
-  const { hasSessionExpired } = useJwt()
+  const { hasSessionExpired, jwt } = useJwt()
   const { openDialog } = useDialog()
 
   if (!options?.skipJwtSessionExpirationCheck && hasSessionExpired()) {
@@ -20,6 +20,7 @@ export const useQueryWrapper: UseQueryWrapper = (key, queryFn, options) => {
       }
       return true
     },
+    enabled: !!jwt && (options?.enabled ?? true),
     ...options,
   })
 }


### PR DESCRIPTION
This PR fixes the bug that did not allow the swap request to go through. The `react-query` queries are now disabled if the jwt token is falsy,