### PR TITLE
[PIN-2424] Renamed property type canSubscribe to hasCertifiedAttributes

### DIFF
--- a/src/hooks/useGetEServiceConsumerActions.ts
+++ b/src/hooks/useGetEServiceConsumerActions.ts
@@ -26,7 +26,7 @@ function useGetEServiceConsumerActions<
   // I can subscribe to the eservice only if...
   if (eservice) {
     // ... I own all the certified attributes or...
-    if (eservice?.canSubscribe) {
+    if (eservice.hasCertifiedAttributes) {
       canCreateAgreementDraft = true
     }
 

--- a/src/types/eservice.types.ts
+++ b/src/types/eservice.types.ts
@@ -63,7 +63,7 @@ export type EServiceCatalog = {
     state: AgreementState
   }
   isMine: boolean
-  canSubscribe: boolean
+  hasCertifiedAttributes: boolean
   activeDescriptor: {
     id: string
     state: EServiceState
@@ -114,7 +114,7 @@ export type EServiceDescriptorCatalog = {
       state: AgreementState
     }
     isMine: boolean
-    canSubscribe: boolean
+    hasCertifiedAttributes: boolean
     isSubscribed: boolean
     activeDescriptor?: {
       id: string

--- a/src/types/eservice.types.ts
+++ b/src/types/eservice.types.ts
@@ -58,7 +58,7 @@ export type EServiceCatalog = {
     id: string
     name: string
   }
-  agreement: {
+  agreement?: {
     id: string
     state: AgreementState
   }


### PR DESCRIPTION
This PR adapts the frontend to the backend change of the `canSubscribe` property being renamed `hasCertifiedAttributes`.