### PR TITLE
[PIN-2301] Added pagination to e-service catalog page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-hook-form": "^7.39.5",
         "react-i18next": "^12.0.0",
         "react-router-dom": "latest",
+        "react-test-renderer": "^18.2.0",
         "uuid": "^9.0.0",
         "yup": "^0.32.11"
       },
@@ -49,6 +50,7 @@
         "@types/qs": "^6.9.7",
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
+        "@types/react-test-renderer": "^18.0.0",
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.44.0",
         "@typescript-eslint/parser": "^5.44.0",
@@ -1922,6 +1924,15 @@
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
       "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz",
+      "integrity": "sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -7289,6 +7300,31 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dependencies": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -9858,6 +9894,15 @@
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
       "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz",
+      "integrity": "sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -13605,6 +13650,25 @@
       "requires": {
         "@remix-run/router": "1.0.3",
         "react-router": "6.4.3"
+      }
+    },
+    "react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "requires": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
       }
     },
     "react-transition-group": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "autosuggest-highlight": "^3.3.4",
         "axios": "^1.2.0",
         "date-fns": "^2.29.3",
+        "history": "^5.3.0",
         "i18next": "^22.0.6",
         "i18next-http-backend": "^2.0.1",
         "lodash": "^4.17.21",
@@ -4760,6 +4761,14 @@
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
       "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
       "dev": true
+    },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -11811,6 +11820,14 @@
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
       "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==",
       "dev": true
+    },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-hook-form": "^7.39.5",
     "react-i18next": "^12.0.0",
     "react-router-dom": "latest",
+    "react-test-renderer": "^18.2.0",
     "uuid": "^9.0.0",
     "yup": "^0.32.11"
   },
@@ -51,6 +52,7 @@
     "@types/qs": "^6.9.7",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
+    "@types/react-test-renderer": "^18.0.0",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
     "@typescript-eslint/parser": "^5.44.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "autosuggest-highlight": "^3.3.4",
     "axios": "^1.2.0",
     "date-fns": "^2.29.3",
+    "history": "^5.3.0",
     "i18next": "^22.0.6",
     "i18next-http-backend": "^2.0.1",
     "lodash": "^4.17.21",

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,4 +1,4 @@
-import { expect, afterEach } from 'vitest'
+import { expect, afterEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
 import matchers from '@testing-library/jest-dom/matchers'
 
@@ -9,3 +9,5 @@ expect.extend(matchers)
 afterEach(() => {
   cleanup()
 })
+
+vi.stubGlobal('scroll', vi.fn())

--- a/src/api/comon.api.types.ts
+++ b/src/api/comon.api.types.ts
@@ -82,6 +82,6 @@ export type Paginated<T> = {
   pagination: {
     offset: number
     limit: number
-    totalResults: number
+    totalCount: number
   }
 }

--- a/src/api/eservice/eservice.hooks.ts
+++ b/src/api/eservice/eservice.hooks.ts
@@ -39,9 +39,14 @@ function useGetListFlat(
   )
 }
 
-function useGetCatalogList(params: EServiceGetCatalogListUrlParams) {
-  return useQueryWrapper([EServiceQueryKeys.GetCatalogList, params], () =>
-    EServiceServices.getCatalogList(params)
+function useGetCatalogList(
+  params: EServiceGetCatalogListUrlParams,
+  config?: { suspense?: boolean; keepPreviousData?: boolean }
+) {
+  return useQueryWrapper(
+    [EServiceQueryKeys.GetCatalogList, params],
+    () => EServiceServices.getCatalogList(params),
+    config
   )
 }
 

--- a/src/components/shared/Pagination.tsx
+++ b/src/components/shared/Pagination.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Pagination as MUIPagination, Stack } from '@mui/material'
+import { Pagination as MUIPagination, Stack } from '@mui/material'
 
 type PaginationProps = {
   totalPages: number
@@ -12,8 +12,7 @@ type PaginationProps = {
 export const Pagination: React.FC<PaginationProps> = ({ totalPages, onPageChange, pageNum }) => {
   if (totalPages <= 1) return null
   return (
-    <Stack sx={{ mt: 2 }} direction="row" justifyContent="space-between" alignItems="center">
-      <Box />
+    <Stack sx={{ mt: 2 }} direction="row" justifyContent="end" alignItems="center">
       <MUIPagination
         color="primary"
         page={pageNum}
@@ -22,8 +21,4 @@ export const Pagination: React.FC<PaginationProps> = ({ totalPages, onPageChange
       />
     </Stack>
   )
-}
-
-export const PaginationSkeleton: React.FC<PaginationProps> = () => {
-  return <></>
 }

--- a/src/components/shared/Pagination.tsx
+++ b/src/components/shared/Pagination.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Box, Pagination as MUIPagination, Stack } from '@mui/material'
+
+type PaginationProps = {
+  totalPages: number
+  pageNum: number
+  resultsPerPage: number
+
+  onPageChange: (numPage: number) => void
+}
+
+export const Pagination: React.FC<PaginationProps> = ({ totalPages, onPageChange, pageNum }) => {
+  if (totalPages <= 1) return null
+  return (
+    <Stack sx={{ mt: 2 }} direction="row" justifyContent="space-between" alignItems="center">
+      <Box />
+      <MUIPagination
+        color="primary"
+        page={pageNum}
+        count={totalPages}
+        onChange={(_, page) => onPageChange(page)}
+      />
+    </Stack>
+  )
+}
+
+export const PaginationSkeleton: React.FC<PaginationProps> = () => {
+  return <></>
+}

--- a/src/components/shared/__tests__/Pagination.test.tsx
+++ b/src/components/shared/__tests__/Pagination.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Pagination } from '../Pagination'
+import { vi } from 'vitest'
+import renderer from 'react-test-renderer'
+
+describe('Pagination component', () => {
+  it('Renders correctly', () => {
+    const tree = renderer
+      .create(<Pagination pageNum={1} totalPages={2} resultsPerPage={25} onPageChange={vi.fn()} />)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('Does not render when total pages are equal 1', () => {
+    const tree = renderer
+      .create(<Pagination pageNum={1} totalPages={1} resultsPerPage={25} onPageChange={vi.fn()} />)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/shared/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -1,0 +1,136 @@
+// Vitest Snapshot v1
+
+exports[`Pagination component > Does not render when total pages are equal 1 1`] = `null`;
+
+exports[`Pagination component > Renders correctly 1`] = `
+<div
+  className="css-1wcyao8-MuiStack-root"
+>
+  <nav
+    aria-label="pagination navigation"
+    className="MuiPagination-root MuiPagination-text css-1oj2twp-MuiPagination-root"
+  >
+    <ul
+      className="MuiPagination-ul css-wjh20t-MuiPagination-ul"
+    >
+      <li>
+        <button
+          aria-label="Go to previous page"
+          className="MuiButtonBase-root Mui-disabled MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-text MuiPaginationItem-circular MuiPaginationItem-textPrimary Mui-disabled MuiPaginationItem-previousNext css-1to7aaw-MuiButtonBase-root-MuiPaginationItem-root"
+          disabled={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={-1}
+          type="button"
+        >
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiPaginationItem-icon css-g2z002-MuiSvgIcon-root-MuiPaginationItem-icon"
+            data-testid="NavigateBeforeIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+            />
+          </svg>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="true"
+          aria-label="page 1"
+          className="MuiButtonBase-root MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-text MuiPaginationItem-circular MuiPaginationItem-textPrimary Mui-selected MuiPaginationItem-page css-1to7aaw-MuiButtonBase-root-MuiPaginationItem-root"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          1
+        </button>
+      </li>
+      <li>
+        <button
+          aria-label="Go to page 2"
+          className="MuiButtonBase-root MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-text MuiPaginationItem-circular MuiPaginationItem-textPrimary MuiPaginationItem-page css-1to7aaw-MuiButtonBase-root-MuiPaginationItem-root"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          2
+        </button>
+      </li>
+      <li>
+        <button
+          aria-label="Go to next page"
+          className="MuiButtonBase-root MuiPaginationItem-root MuiPaginationItem-sizeMedium MuiPaginationItem-text MuiPaginationItem-circular MuiPaginationItem-textPrimary MuiPaginationItem-previousNext css-1to7aaw-MuiButtonBase-root-MuiPaginationItem-root"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiPaginationItem-icon css-g2z002-MuiSvgIcon-root-MuiPaginationItem-icon"
+            data-testid="NavigateNextIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+            />
+          </svg>
+        </button>
+      </li>
+    </ul>
+  </nav>
+</div>
+`;

--- a/src/hooks/__tests__/usePagination.test.tsx
+++ b/src/hooks/__tests__/usePagination.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react'
+import usePagination from '../usePagination'
+import { MemoryRouter, Route, Router, Routes } from 'react-router-dom'
+import { act } from 'react-dom/test-utils'
+import { createMemoryHistory } from 'history'
+import { throws } from 'assert'
+
+describe('usePagination tests', () => {
+  it('Should keep the offset param and pageNum prop in sync with the offset url param', () => {
+    const history = createMemoryHistory()
+
+    const { result, rerender } = renderHook(() => usePagination({ limit: 25 }), {
+      wrapper: ({ children }) => (
+        <Router location={history.location} navigator={history}>
+          <Routes>
+            <Route path="/" element={children} />
+          </Routes>
+        </Router>
+      ),
+    })
+
+    history.push('/?offset=50')
+    rerender()
+    expect(result.current.params.offset).toEqual(50)
+    expect(result.current.props.pageNum).toEqual(3)
+
+    history.push('/?offset=100')
+    rerender()
+    expect(result.current.params.offset).toEqual(100)
+    expect(result.current.props.pageNum).toEqual(5)
+
+    history.push('/?offset=150')
+    rerender()
+    expect(result.current.params.offset).toEqual(150)
+    expect(result.current.props.pageNum).toEqual(7)
+  })
+
+  it('Should update the offset url param on page change', () => {
+    const history = createMemoryHistory()
+
+    const { result } = renderHook(() => usePagination({ limit: 25 }), {
+      wrapper: ({ children }) => (
+        <Router location={history.location} navigator={history}>
+          <Routes>
+            <Route path="/" element={children} />
+          </Routes>
+        </Router>
+      ),
+    })
+
+    expect(history.location.search).toEqual('')
+
+    act(() => {
+      result.current.props.onPageChange(2)
+    })
+
+    expect(history.location.search).toEqual('?offset=25')
+
+    act(() => {
+      result.current.props.onPageChange(3)
+    })
+
+    expect(history.location.search).toEqual('?offset=50')
+  })
+
+  it('Should keep the other url params when changing the offset param', () => {
+    const history = createMemoryHistory()
+    history.push('/?test=0')
+
+    const { result } = renderHook(() => usePagination({ limit: 25 }), {
+      wrapper: ({ children }) => (
+        <Router location={history.location} navigator={history}>
+          <Routes>
+            <Route path="/" element={children} />
+          </Routes>
+        </Router>
+      ),
+    })
+
+    expect(history.location.search).toEqual('?test=0')
+
+    act(() => {
+      result.current.props.onPageChange(2)
+    })
+
+    expect(history.location.search).toContain('test=0')
+
+    act(() => {
+      result.current.props.onPageChange(3)
+    })
+
+    expect(history.location.search).toContain('test=0')
+  })
+
+  it('Should handle page changes correctly', () => {
+    const { result } = renderHook(() => usePagination({ limit: 20 }), {
+      wrapper: MemoryRouter,
+    })
+
+    // Record<PageNum, ExpectedResult>
+    const TEST_CASES = {
+      2: 20,
+      1: 0,
+      3: 40,
+      4: 60,
+      99: 1960,
+      1000: 19980,
+      9999: 199960,
+    }
+
+    Object.entries(TEST_CASES).forEach(([pageNum, expectedResult]) => {
+      act(() => {
+        result.current.props.onPageChange(Number(pageNum))
+      })
+      expect(result.current.params.offset).toEqual(expectedResult)
+    })
+
+    throws(() => {
+      result.current.props.onPageChange(0)
+    })
+  })
+
+  it('Should get the correct total page count', () => {
+    const { result } = renderHook(() => usePagination({ limit: 25 }), {
+      wrapper: MemoryRouter,
+    })
+
+    // Record<TotalCount, ExpectedResult>
+    const TEST_CASES = {
+      99: 4,
+      430: 18,
+      10: 1,
+      26: 2,
+      24: 1,
+    }
+
+    Object.entries(TEST_CASES).forEach(([totalCount, expectedResult]) => {
+      expect(result.current.getTotalPageCount(Number(totalCount))).toEqual(expectedResult)
+    })
+  })
+})

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -11,7 +11,7 @@ import omit from 'lodash/omit'
  */
 function usePagination(options: { limit: number }) {
   const [searchParams, setSearchParams] = useSearchParams()
-  const offset = parseInt(searchParams.get('offset') ?? '0')
+  const offset = parseInt(searchParams.get('offset') ?? '0', 10)
 
   const limit = options.limit
 

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -7,21 +7,26 @@ function usePagination({ limit }: { limit: number }) {
 
   const pageNum = Math.ceil(offset / limit) + 1
 
+  const handlePageChange = (newPage: number) => {
+    if (newPage < 1) {
+      throw new Error(`Number of page ${newPage} is not valid`)
+    }
+    window.scroll(0, 0)
+    const newOffset = (newPage - 1) * limit
+    if (newOffset > 0) {
+      setSearchParams(() => ({
+        ...Object.fromEntries(searchParams),
+        offset: newOffset.toString(),
+      }))
+      return
+    }
+    setSearchParams(() => omit(Object.fromEntries(searchParams), 'offset'))
+  }
+
   const props = {
     pageNum,
     resultsPerPage: limit,
-    onPageChange(newPage: number) {
-      window.scroll(0, 0)
-      const newOffset = (newPage - 1) * limit
-      if (newOffset > 0) {
-        setSearchParams(() => ({
-          ...Object.fromEntries(searchParams),
-          offset: newOffset.toString(),
-        }))
-        return
-      }
-      setSearchParams(() => omit(Object.fromEntries(searchParams), 'offset'))
-    },
+    onPageChange: handlePageChange,
   }
 
   const getTotalPageCount = (totalCount: number | undefined) => {

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,33 @@
+import { useSearchParams } from 'react-router-dom'
+import omit from 'lodash/omit'
+
+function usePagination({ limit }: { limit: number }) {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const offset = parseInt(searchParams.get('offset') ?? '0')
+
+  const pageNum = Math.ceil(offset / limit) + 1
+
+  const props = {
+    pageNum,
+    resultsPerPage: limit,
+    onPageChange(newPage: number) {
+      const newOffset = (newPage - 1) * limit
+      if (newOffset > 0) {
+        setSearchParams(() => ({
+          ...Object.fromEntries(searchParams),
+          offset: newOffset.toString(),
+        }))
+        return
+      }
+      setSearchParams(() => omit(Object.fromEntries(searchParams), 'offset'))
+    },
+  }
+
+  const getTotalPageCount = (totalCount: number | undefined) => {
+    return Math.ceil((totalCount ?? 0) / limit)
+  }
+
+  return { props, params: { limit, offset }, getTotalPageCount }
+}
+
+export default usePagination

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,9 +1,19 @@
 import { useSearchParams } from 'react-router-dom'
 import omit from 'lodash/omit'
 
-function usePagination({ limit }: { limit: number }) {
+/**
+ * Contains all the logic needed for the pagination.
+ *
+ * @returns an object with three properties:
+ * - `props` - an object with props to be passed to the `Pagination` component.
+ * - `params` - an object with url param to be passed to the paginated service.
+ * - `getTotalPageCount` - an utility function that given the total records returns the total page count.
+ */
+function usePagination(options: { limit: number }) {
   const [searchParams, setSearchParams] = useSearchParams()
   const offset = parseInt(searchParams.get('offset') ?? '0')
+
+  const limit = options.limit
 
   const pageNum = Math.ceil(offset / limit) + 1
 

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -11,6 +11,7 @@ function usePagination({ limit }: { limit: number }) {
     pageNum,
     resultsPerPage: limit,
     onPageChange(newPage: number) {
+      window.scroll(0, 0)
       const newOffset = (newPage - 1) * limit
       if (newOffset > 0) {
         setSearchParams(() => ({

--- a/src/pages/ConsumerEServiceCatalogPage/ConsumerEServiceCatalog.page.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/ConsumerEServiceCatalog.page.tsx
@@ -1,16 +1,29 @@
+import React from 'react'
 import { PageContainer } from '@/components/layout/containers'
-import React, { Suspense } from 'react'
+import usePagination from '@/hooks/usePagination'
 import { useTranslation } from 'react-i18next'
 import { EServiceCatalogGrid, EServiceCatalogGridSkeleton } from './components'
+import { EServiceQueries } from '@/api/eservice'
+import { Pagination } from '@/components/shared/Pagination'
 
 const ConsumerEServiceCatalogPage: React.FC = () => {
   const { t } = useTranslation('pages', { keyPrefix: 'consumerEServiceCatalog' })
+  const { props, params, getTotalPageCount } = usePagination({
+    limit: 15,
+  })
 
+  const { data, isFetching } = EServiceQueries.useGetCatalogList(
+    {
+      states: ['PUBLISHED'],
+      ...params,
+    },
+    { suspense: false, keepPreviousData: true }
+  )
   return (
     <PageContainer title={t('title')} description={t('description')}>
-      <Suspense fallback={<EServiceCatalogGridSkeleton />}>
-        <EServiceCatalogGrid />
-      </Suspense>
+      {isFetching && <EServiceCatalogGridSkeleton />}
+      {!isFetching && <EServiceCatalogGrid eservices={data?.results} />}
+      <Pagination {...props} totalPages={getTotalPageCount(data?.pagination.totalCount)} />
     </PageContainer>
   )
 }

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogGrid.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogGrid.tsx
@@ -1,23 +1,23 @@
-import { EServiceQueries } from '@/api/eservice'
+import { EServiceCatalog } from '@/types/eservice.types'
 import { Grid } from '@mui/material'
 import React from 'react'
 import { CatalogCard, CatalogCardSkeleton } from './CatalogCard'
 
-export const EServiceCatalogGrid: React.FC = () => {
-  const { data } = EServiceQueries.useGetCatalogList({
-    states: ['PUBLISHED'],
-    offset: 0,
-    limit: 50,
-  })
+type EServiceCatalogGridProps = {
+  eservices: Array<EServiceCatalog> | undefined
+}
 
+export const EServiceCatalogGrid: React.FC<EServiceCatalogGridProps> = ({ eservices }) => {
   return (
-    <Grid container spacing={3}>
-      {data?.results.map((eservice) => (
-        <Grid item key={eservice.id} xs={4}>
-          <CatalogCard key={eservice.activeDescriptor.id} eservice={eservice} />
-        </Grid>
-      ))}
-    </Grid>
+    <>
+      <Grid container spacing={3}>
+        {eservices?.map((eservice) => (
+          <Grid item key={eservice.id} xs={4}>
+            <CatalogCard key={eservice.activeDescriptor.id} eservice={eservice} />
+          </Grid>
+        ))}
+      </Grid>
+    </>
   )
 }
 


### PR DESCRIPTION
In this PR two pagination utilities has been added: 

- `@/components/shared/Pagination.tsx`, a component that renders the MUI's Pagination component only when there are more than 1 pages.
- `@/hooks/usePagination.ts`, contains all the logic needed for the pagination. Accepts Returns an object with three properties:
  - `props` - an object with props to be passed to the `Pagination` component.
  - `params` - an object with url param to be passed to the paginated service.
  - `getTotalPageCount` - utility function that given the total records returns the total page count.

Also:
- 10dabef7eeeb41da2259e5db76655318311d3ebb - Pagination has been added to the e-service catalog page;
- b168a95710b3fe26a6a53ec45a5c02dbabc7a0d0 - Added global test mock to `window.scroll` function;
- 64124676227c85c20a1cd6cf2dc0eb4a469b43f9 - Added `usePagination` hook unit tests;
- 2c76258463b710792c4ce33e88aa1769619dc2ea - Added `Pagination` component snapshot tests.
