### PR TITLE
[PIN-2299] - Redesign producer eservice page

### DIFF
--- a/src/api/eservice/eservice.hooks.ts
+++ b/src/api/eservice/eservice.hooks.ts
@@ -50,9 +50,14 @@ function useGetCatalogList(
   )
 }
 
-function useGetProviderList(params: EServiceGetProviderListUrlParams) {
-  return useQueryWrapper([EServiceQueryKeys.GetProviderList, params], () =>
-    EServiceServices.getProviderList(params)
+function useGetProviderList(
+  params: EServiceGetProviderListUrlParams,
+  config?: { suspense?: boolean; keepPreviousData?: boolean }
+) {
+  return useQueryWrapper(
+    [EServiceQueryKeys.GetProviderList, params],
+    () => EServiceServices.getProviderList(params),
+    config
   )
 }
 

--- a/src/api/eservice/eservice.services.ts
+++ b/src/api/eservice/eservice.services.ts
@@ -43,7 +43,7 @@ async function getCatalogList(params: EServiceGetCatalogListUrlParams) {
 
 async function getProviderList(params: EServiceGetProviderListUrlParams) {
   const response = await axiosInstance.get<Paginated<EServiceProvider>>(
-    `${BACKEND_FOR_FRONTEND_URL}/producer/eservices`,
+    `${BACKEND_FOR_FRONTEND_URL}/producers/eservices`,
     { params }
   )
   return response.data

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -1,7 +1,7 @@
 import { EServiceQueries } from '@/api/eservice'
 import { PageBottomActionsContainer, PageContainer } from '@/components/layout/containers'
 import { EServiceDetails, EServiceDetailsSkeleton } from '@/components/shared/EServiceDetails'
-import useGetEServiceProviderActions from '@/hooks/useGetEServiceProviderActions'
+import useGetEServiceProviderActions from './hooks/useGetEServiceProviderActions'
 import { RouterLink, useRouteParams } from '@/router'
 import { useActiveTab } from '@/hooks/useActiveTab'
 import { formatTopSideActions } from '@/utils/common.utils'
@@ -19,11 +19,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
   const { data: descriptor, isLoading: isLoadingDescriptor } =
     EServiceQueries.useGetDescriptorProvider(eserviceId, descriptorId, { suspense: false })
 
-  const { actions } = useGetEServiceProviderActions({
-    eserviceId,
-    descriptorId,
-    state: descriptor?.state,
-  })
+  const { actions } = useGetEServiceProviderActions(descriptor)
 
   const topSideActions = formatTopSideActions(actions)
 

--- a/src/pages/ProviderEServiceDetailsPage/hooks/__tests__/useGetEServiceProviderActions.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/hooks/__tests__/useGetEServiceProviderActions.test.tsx
@@ -1,0 +1,127 @@
+import { act, fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react'
+import useGetEServiceProviderActions from '../useGetEServiceProviderActions'
+import {
+  createMockEServiceDescriptorProvider,
+  createMockEServiceReadType,
+} from '@/__mocks__/data/eservice.mocks'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { CATALOG_PROCESS_URL } from '@/config/env'
+import { renderHookWithApplicationContext } from '@/__mocks__/mock.utils'
+
+const server = setupServer(
+  rest.post(
+    `${CATALOG_PROCESS_URL}/eservices/:eserviceId/descriptors/:descriptorId/clone`,
+    (_, res, ctx) => {
+      return res(ctx.json(createMockEServiceReadType()))
+    }
+  ),
+  rest.post(`${CATALOG_PROCESS_URL}/eservices/:eserviceId/descriptors`, (req, res, ctx) => {
+    return res(ctx.json(createMockEServiceReadType()))
+  })
+)
+
+beforeAll(() => {
+  server.listen()
+})
+afterAll(() => {
+  server.close()
+})
+
+function renderUseGetEServiceProviderActionsHook(
+  ...hookParams: Parameters<typeof useGetEServiceProviderActions>
+) {
+  return renderHookWithApplicationContext(
+    () => useGetEServiceProviderActions(...(hookParams ?? [])),
+    { withReactQueryContext: true, withRouterContext: true }
+  )
+}
+
+describe('useGetEServiceProviderActions tests', () => {
+  it('should return no actions if no descriptor is given', () => {
+    const { result } = renderUseGetEServiceProviderActionsHook()
+    expect(result.current.actions).toHaveLength(0)
+  })
+
+  it('should return the correct actions if a descriptor with state "PUBLISHED" is given', () => {
+    const descriptorMock = createMockEServiceDescriptorProvider({ state: 'PUBLISHED' })
+    const { result } = renderUseGetEServiceProviderActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(3)
+    expect(result.current.actions[0].label).toBe('suspend')
+    expect(result.current.actions[1].label).toBe('clone')
+    expect(result.current.actions[2].label).toBe('createNewDraft')
+  })
+
+  it('should return the correct actions if a descriptor with state "ARCHIVED" is given', () => {
+    const descriptorMock = createMockEServiceDescriptorProvider({ state: 'ARCHIVED' })
+    const { result } = renderUseGetEServiceProviderActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(0)
+  })
+
+  it('should return the correct actions if a descriptor with state "DEPRECATED" is given', () => {
+    const descriptorMock = createMockEServiceDescriptorProvider({ state: 'DEPRECATED' })
+    const { result } = renderUseGetEServiceProviderActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(1)
+    expect(result.current.actions[0].label).toBe('suspend')
+  })
+
+  it('should return the correct actions if a descriptor with state "DRAFT" is given', () => {
+    const descriptorMock = createMockEServiceDescriptorProvider({ state: 'DRAFT' })
+    const { result } = renderUseGetEServiceProviderActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(2)
+    expect(result.current.actions[0].label).toBe('publish')
+    expect(result.current.actions[1].label).toBe('delete')
+  })
+
+  it('should return the correct actions if a descriptor with state "SUSPENDED" is given', () => {
+    const descriptorMock = createMockEServiceDescriptorProvider({ state: 'SUSPENDED' })
+    const { result } = renderUseGetEServiceProviderActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(3)
+    expect(result.current.actions[0].label).toBe('activate')
+    expect(result.current.actions[1].label).toBe('clone')
+    expect(result.current.actions[2].label).toBe('createNewDraft')
+  })
+
+  it('should redirect to the provider e-service edit page on clone action success', async () => {
+    const descriptorMock = createMockEServiceDescriptorProvider({ state: 'SUSPENDED' })
+    const { result, history } = renderUseGetEServiceProviderActionsHook(descriptorMock)
+    expect(result.current.actions[1].label).toBe('clone')
+    act(() => {
+      result.current.actions[1].action()
+    })
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'confirm' }))
+    })
+
+    await act(() => {
+      waitForElementToBeRemoved(screen.getByRole('progressbar', { hidden: true }))
+    })
+
+    expect(history.location.pathname).toBe(
+      '/it/erogazione/e-service/6dbb7416-8315-4970-a6be-393a03d0a79d/fd09a069-81f8-4cb5-a302-64320e83a033/modifica'
+    )
+  })
+
+  it('should redirect to the provider e-service edit page, on the step 2, on createNewDraft action success', async () => {
+    const descriptorMock = createMockEServiceDescriptorProvider({ state: 'PUBLISHED' })
+    const { result, history } = renderUseGetEServiceProviderActionsHook(descriptorMock)
+    expect(result.current.actions[2].label).toBe('createNewDraft')
+    act(() => {
+      result.current.actions[2].action()
+    })
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'confirm' }))
+    })
+
+    await act(() => {
+      waitForElementToBeRemoved(screen.getByRole('progressbar', { hidden: true }))
+    })
+
+    expect(history.location.pathname).toBe(
+      '/it/erogazione/e-service/4edda5fd-2fed-485c-9ab4-bc7d78a67624/6dbb7416-8315-4970-a6be-393a03d0a79d/modifica'
+    )
+    expect(history.location.state).toStrictEqual({ stepIndexDestination: 1 })
+  })
+})

--- a/src/pages/ProviderEServiceDetailsPage/hooks/useGetEServiceProviderActions.ts
+++ b/src/pages/ProviderEServiceDetailsPage/hooks/useGetEServiceProviderActions.ts
@@ -1,0 +1,104 @@
+import { EServiceMutations } from '@/api/eservice'
+import { useNavigateRouter } from '@/router'
+import { ActionItem } from '@/types/common.types'
+import { EServiceDescriptorProvider, EServiceState } from '@/types/eservice.types'
+import { minutesToSeconds } from '@/utils/format.utils'
+import { useTranslation } from 'react-i18next'
+
+function useGetEServiceProviderActions(descriptor?: EServiceDescriptorProvider) {
+  const { t } = useTranslation('common', { keyPrefix: 'actions' })
+  const { navigate } = useNavigateRouter()
+
+  const { mutate: publishDraft } = EServiceMutations.usePublishVersionDraft()
+  const { mutate: deleteVersionDraft } = EServiceMutations.useDeleteVersionDraft()
+  const { mutate: suspend } = EServiceMutations.useSuspendVersion()
+  const { mutate: reactivate } = EServiceMutations.useReactivateVersion()
+  const { mutate: clone } = EServiceMutations.useCloneFromVersion()
+  const { mutate: createNewDraft } = EServiceMutations.useCreateVersionDraft()
+
+  if (!descriptor) return { actions: [] }
+
+  const descriptorId = descriptor.id
+  const eserviceId = descriptor.eservice.id
+  const state = descriptor.state
+
+  const publishDraftAction = {
+    action: publishDraft.bind(null, { eserviceId, descriptorId }),
+    label: t('publish'),
+  }
+
+  const deleteVersionDraftAction = {
+    action: deleteVersionDraft.bind(null, { eserviceId, descriptorId }),
+    label: t('delete'),
+  }
+  const suspendAction = {
+    action: suspend.bind(null, { eserviceId, descriptorId }),
+    label: t('suspend'),
+  }
+  const reactivateAction = {
+    action: reactivate.bind(null, { eserviceId, descriptorId }),
+    label: t('activate'),
+  }
+
+  function handleClone() {
+    clone(
+      {
+        eserviceId,
+        descriptorId,
+      },
+      {
+        onSuccess({ id, descriptors }) {
+          const descriptorId = descriptors[0]?.id
+          if (!descriptorId) throw new Error('No descriptor returned from clone mutation.')
+          navigate('PROVIDE_ESERVICE_EDIT', {
+            params: { eserviceId: id, descriptorId },
+          })
+        },
+      }
+    )
+  }
+
+  const cloneAction = {
+    action: handleClone,
+    label: t('clone'),
+  }
+
+  function handleCreateNewDraft() {
+    createNewDraft(
+      {
+        eserviceId,
+        voucherLifespan: minutesToSeconds(1),
+        audience: [],
+        description: '',
+        dailyCallsPerConsumer: 1,
+        dailyCallsTotal: 1,
+        agreementApprovalPolicy: 'MANUAL',
+      },
+      {
+        onSuccess({ id }) {
+          navigate('PROVIDE_ESERVICE_EDIT', {
+            params: { eserviceId, descriptorId: id },
+            state: { stepIndexDestination: 1 },
+          })
+        },
+      }
+    )
+  }
+
+  const createNewDraftAction = {
+    action: handleCreateNewDraft,
+    label: t('createNewDraft'),
+  }
+
+  const availableAction: Record<EServiceState, Array<ActionItem>> = {
+    PUBLISHED: [suspendAction, cloneAction, createNewDraftAction],
+    ARCHIVED: [],
+    DEPRECATED: [suspendAction],
+    DRAFT: [publishDraftAction, deleteVersionDraftAction],
+    SUSPENDED: [reactivateAction, cloneAction, createNewDraftAction],
+  }
+
+  return { actions: availableAction[state ?? 'DRAFT'] }
+}
+
+export default useGetEServiceProviderActions

--- a/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
+++ b/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
@@ -1,14 +1,25 @@
-import React, { Suspense } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { EServiceTable, EServiceTableSkeleton } from './components'
 import { PageContainer } from '@/components/layout/containers'
 import { useNavigateRouter } from '@/router'
 import { TopSideActions } from '@/components/layout/containers/PageContainer'
+import { EServiceQueries } from '@/api/eservice'
+import usePagination from '@/hooks/usePagination'
+import { Pagination } from '@/components/shared/Pagination'
 
 const ProviderEServiceListPage: React.FC = () => {
   const { t } = useTranslation('pages', { keyPrefix: 'providerEServiceList' })
   const { t: tCommon } = useTranslation('common')
   const { navigate } = useNavigateRouter()
+  const { props, params, getTotalPageCount } = usePagination({
+    limit: 20,
+  })
+
+  const { data } = EServiceQueries.useGetProviderList(params, {
+    suspense: false,
+    keepPreviousData: true,
+  })
 
   const topSideActions: TopSideActions = {
     buttons: [
@@ -28,11 +39,21 @@ const ProviderEServiceListPage: React.FC = () => {
       description={t('description')}
       topSideActions={topSideActions}
     >
-      <Suspense fallback={<EServiceTableSkeleton />}>
-        <EServiceTable />
-      </Suspense>
+      <EServiceTableWrapper params={params} />
+      <Pagination {...props} totalPages={getTotalPageCount(data?.pagination.totalCount)} />
     </PageContainer>
   )
+}
+
+const EServiceTableWrapper: React.FC<{ params: { limit: number; offset: number } }> = ({
+  params,
+}) => {
+  const { data, isFetching } = EServiceQueries.useGetProviderList(params, {
+    suspense: false,
+  })
+
+  if (!data && isFetching) return <EServiceTableSkeleton />
+  return <EServiceTable eservices={data?.results ?? []} />
 }
 
 export default ProviderEServiceListPage

--- a/src/pages/ProviderEServiceListPage/components/EServiceTable.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTable.tsx
@@ -1,17 +1,15 @@
 import React from 'react'
-import { EServiceQueries } from '@/api/eservice'
-import { useJwt } from '@/hooks/useJwt'
 import { Table } from '@/components/shared/Table'
 import { useTranslation } from 'react-i18next'
 import { EServiceTableRow, EServiceTableRowSkeleton } from './EServiceTableRow'
+import { EServiceProvider } from '@/types/eservice.types'
 
-export const EServiceTable: React.FC = () => {
+type EServiceTableProps = {
+  eservices: Array<EServiceProvider>
+}
+
+export const EServiceTable: React.FC<EServiceTableProps> = ({ eservices }) => {
   const { t } = useTranslation('pages', { keyPrefix: 'providerEServiceList.eserviceTable' })
-  const { jwt } = useJwt()
-  const { data: eservices } = EServiceQueries.useGetListFlat({
-    callerId: jwt?.organizationId,
-    producerId: jwt?.organizationId,
-  })
 
   const headLabels = [t('headLabels.name'), t('headLabels.version'), t('headLabels.status'), '']
 
@@ -20,7 +18,7 @@ export const EServiceTable: React.FC = () => {
   return (
     <Table headLabels={headLabels} isEmpty={isEmpty}>
       {eservices?.map((eservice) => (
-        <EServiceTableRow key={eservice?.descriptorId || eservice.id} eservice={eservice} />
+        <EServiceTableRow key={eservice.id} eservice={eservice} />
       ))}
     </Table>
   )

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableRow.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableRow.tsx
@@ -1,59 +1,71 @@
 import React from 'react'
 import { TableRow } from '@/components/shared/Table'
 import { StatusChip, StatusChipSkeleton } from '@/components/shared/StatusChip'
-import { Box, Button, Skeleton } from '@mui/material'
+import { Box, Button, Skeleton, Stack } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { useNavigateRouter } from '@/router'
 import { URL_FRAGMENTS } from '@/router/router.utils'
 import useCurrentLanguage from '@/hooks/useCurrentLanguage'
-import useGetEServiceProviderActions from '@/hooks/useGetEServiceProviderActions'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
-import { EServiceFlatten } from '@/types/eservice.types'
+import { EServiceProvider } from '@/types/eservice.types'
 import { EServiceQueries } from '@/api/eservice'
 import { ButtonSkeleton } from '@/components/shared/MUISkeletons'
+import useGetProviderEServiceTableActions from '../hooks/useGetProviderEServiceTableActions'
 
 type EServiceTableRow = {
-  eservice: EServiceFlatten
+  eservice: EServiceProvider
 }
 
 export const EServiceTableRow: React.FC<EServiceTableRow> = ({ eservice }) => {
   const { navigate } = useNavigateRouter()
   const { t } = useTranslation('common')
   const lang = useCurrentLanguage()
-  const prefetch = EServiceQueries.usePrefetchDescriptorProvider()
+  const prefetchDescriptor = EServiceQueries.usePrefetchDescriptorProvider()
+  const prefetchEService = EServiceQueries.usePrefetchSingle()
 
-  const { actions } = useGetEServiceProviderActions({
-    eserviceId: eservice.id,
-    descriptorId: eservice?.descriptorId,
-    state: eservice.state,
-  })
+  const { actions } = useGetProviderEServiceTableActions(eservice)
+
+  const isEServiceInDraft = !eservice.activeDescriptor
 
   const handleEditOrInspect = () => {
-    const destPath =
-      !eservice.state || eservice.state === 'DRAFT'
-        ? 'PROVIDE_ESERVICE_EDIT'
-        : 'PROVIDE_ESERVICE_MANAGE'
+    const destPath = isEServiceInDraft ? 'PROVIDE_ESERVICE_EDIT' : 'PROVIDE_ESERVICE_MANAGE'
 
     navigate(destPath, {
       params: {
         eserviceId: eservice.id,
-        descriptorId: eservice.descriptorId || URL_FRAGMENTS.FIRST_DRAFT[lang],
+        descriptorId:
+          eservice?.activeDescriptor?.id ||
+          eservice?.draftDescriptor?.id ||
+          URL_FRAGMENTS.FIRST_DRAFT[lang],
       },
     })
   }
 
   const handlePrefetch = () => {
-    if (!eservice.descriptorId) return
-    prefetch(eservice.id, eservice.descriptorId)
+    if (isEServiceInDraft) {
+      prefetchEService(eservice.id)
+      return
+    }
+    if (!eservice.activeDescriptor) return
+    prefetchDescriptor(eservice.id, eservice.activeDescriptor.id)
   }
 
   return (
     <TableRow
       cellData={[
         { label: eservice.name },
-        { label: eservice.version || '1' },
+        { label: eservice?.activeDescriptor?.version || '1' },
         {
-          custom: <StatusChip for="eservice" state={eservice.state || 'DRAFT'} />,
+          custom: (
+            <Stack direction="row" spacing={1}>
+              {eservice?.activeDescriptor && (
+                <StatusChip for="eservice" state={eservice.activeDescriptor.state} />
+              )}
+              {(isEServiceInDraft || eservice?.draftDescriptor) && (
+                <StatusChip for="eservice" state={'DRAFT'} />
+              )}
+            </Stack>
+          ),
         },
       ]}
     >
@@ -64,7 +76,7 @@ export const EServiceTableRow: React.FC<EServiceTableRow> = ({ eservice }) => {
         size="small"
         onClick={handleEditOrInspect}
       >
-        {t(`actions.${!eservice.state || eservice.state === 'DRAFT' ? 'edit' : 'inspect'}`)}
+        {t(`actions.${isEServiceInDraft ? 'edit' : 'inspect'}`)}
       </Button>
 
       <Box component="span" sx={{ ml: 2, display: 'inline-block' }}>

--- a/src/pages/ProviderEServiceListPage/hooks/__tests__/useGetProviderEServiceTableActions.test.tsx
+++ b/src/pages/ProviderEServiceListPage/hooks/__tests__/useGetProviderEServiceTableActions.test.tsx
@@ -1,0 +1,97 @@
+import { createMockEServiceProvider } from '@/__mocks__/data/eservice.mocks'
+import useGetProviderEServiceTableActions from '../useGetProviderEServiceTableActions'
+import { renderHookWithApplicationContext } from '@/__mocks__/mock.utils'
+
+function renderUseGetProviderEServiceTableActionsHook(
+  ...hookParams: Parameters<typeof useGetProviderEServiceTableActions>
+) {
+  return renderHookWithApplicationContext(
+    () => useGetProviderEServiceTableActions(...(hookParams ?? [])),
+    {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    }
+  )
+}
+
+describe('useGetProviderEServiceTableActions tests', () => {
+  it('should return the correct actions if the e-service has no descriptors', () => {
+    const descriptorMock = createMockEServiceProvider()
+    const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(1)
+    expect(result.current.actions[0].label).toBe('delete')
+  })
+
+  it('should return the correct actions if the e-service has an active descriptor in PUBLISHED state and has no version draft', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+    })
+    const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(3)
+    expect(result.current.actions[0].label).toBe('suspend')
+    expect(result.current.actions[1].label).toBe('clone')
+    expect(result.current.actions[2].label).toBe('createNewDraft')
+  })
+
+  it('should return the correct actions if the e-service has an active descriptor in PUBLISHED state and has a version draft', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+    })
+    const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(3)
+    expect(result.current.actions[0].label).toBe('suspend')
+    expect(result.current.actions[1].label).toBe('clone')
+    expect(result.current.actions[2].label).toBe('editDraft')
+  })
+
+  it('should return no actions if the e-service has an active descriptor in ARCHIVED state', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: '1' },
+    })
+    const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(0)
+  })
+
+  it('should return the correct actions if the e-service has an active descriptor in DEPRECATED state', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
+    })
+    const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(1)
+    expect(result.current.actions[0].label).toBe('suspend')
+  })
+
+  it('should return the correct actions if the e-service has no active descriptor', () => {
+    const descriptorMock = createMockEServiceProvider({
+      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: '1' },
+    })
+    const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(2)
+    expect(result.current.actions[0].label).toBe('publish')
+    expect(result.current.actions[1].label).toBe('delete')
+  })
+
+  it('should return the correct actions if the e-service has an active descriptor in SUSPENDED state and has no version draft', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+    })
+    const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(3)
+    expect(result.current.actions[0].label).toBe('activate')
+    expect(result.current.actions[1].label).toBe('clone')
+    expect(result.current.actions[2].label).toBe('createNewDraft')
+  })
+
+  it('should return the correct actions if the e-service has an active descriptor in SUSPENDED state and has a version draft', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+    })
+    const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
+    expect(result.current.actions).toHaveLength(3)
+    expect(result.current.actions[0].label).toBe('activate')
+    expect(result.current.actions[1].label).toBe('clone')
+    expect(result.current.actions[2].label).toBe('editDraft')
+  })
+})

--- a/src/pages/ProviderEServiceListPage/hooks/useGetProviderEServiceTableActions.ts
+++ b/src/pages/ProviderEServiceListPage/hooks/useGetProviderEServiceTableActions.ts
@@ -1,19 +1,10 @@
 import { EServiceMutations } from '@/api/eservice'
 import { useNavigateRouter } from '@/router'
-import { ActionItem } from '@/types/common.types'
-import { EServiceState } from '@/types/eservice.types'
+import { EServiceProvider } from '@/types/eservice.types'
 import { minutesToSeconds } from '@/utils/format.utils'
 import { useTranslation } from 'react-i18next'
 
-function useGetEServiceProviderActions({
-  eserviceId,
-  descriptorId,
-  state,
-}: {
-  eserviceId: string
-  descriptorId: string | undefined
-  state: EServiceState | undefined
-}) {
+function useGetProviderEServiceTableActions(eservice: EServiceProvider) {
   const { t } = useTranslation('common', { keyPrefix: 'actions' })
   const { navigate } = useNavigateRouter()
 
@@ -25,37 +16,70 @@ function useGetEServiceProviderActions({
   const { mutate: clone } = EServiceMutations.useCloneFromVersion()
   const { mutate: createNewDraft } = EServiceMutations.useCreateVersionDraft()
 
+  const eserviceId = eservice.id
+  const state = eservice.activeDescriptor?.state ?? 'DRAFT'
+  const hasVersionDraft = !!eservice.draftDescriptor
+
   const deleteDraftAction = {
     action: deleteDraft.bind(null, { eserviceId }),
     label: t('delete'),
   }
 
-  if (!descriptorId) {
+  if (!eservice.activeDescriptor && !eservice.draftDescriptor) {
     return {
       actions: [deleteDraftAction],
     }
   }
 
+  function handlePublishDraft() {
+    const descriptorId = eservice?.draftDescriptor?.id
+    if (!descriptorId) return
+    publishDraft({ eserviceId, descriptorId })
+  }
+
   const publishDraftAction = {
-    action: publishDraft.bind(null, { eserviceId, descriptorId }),
+    action: handlePublishDraft,
     label: t('publish'),
   }
 
+  function handleDeleteVersionDraft() {
+    const descriptorId = eservice?.draftDescriptor?.id
+    if (!descriptorId) return
+    deleteVersionDraft({ eserviceId, descriptorId })
+  }
+
   const deleteVersionDraftAction = {
-    action: deleteVersionDraft.bind(null, { eserviceId, descriptorId }),
+    action: handleDeleteVersionDraft,
     label: t('delete'),
   }
+
+  function handleSuspend() {
+    const descriptorId = eservice?.activeDescriptor?.id
+    if (!descriptorId) return
+    suspend({ eserviceId, descriptorId })
+  }
+
   const suspendAction = {
-    action: suspend.bind(null, { eserviceId, descriptorId }),
+    action: handleSuspend,
     label: t('suspend'),
   }
+
+  function handleReactivate() {
+    const descriptorId = eservice?.activeDescriptor?.id
+    if (!descriptorId) return
+    reactivate({ eserviceId, descriptorId })
+  }
+
   const reactivateAction = {
-    action: reactivate.bind(null, { eserviceId, descriptorId }),
+    action: handleReactivate,
     label: t('activate'),
   }
-  const cloneAction = {
-    action: clone.bind(
-      null,
+
+  function handleClone() {
+    const descriptorId = eservice?.activeDescriptor?.id
+    if (!descriptorId) return
+    reactivate({ eserviceId, descriptorId })
+    clone(
       {
         eserviceId,
         descriptorId,
@@ -69,9 +93,14 @@ function useGetEServiceProviderActions({
           })
         },
       }
-    ),
+    )
+  }
+
+  const cloneAction = {
+    action: handleClone,
     label: t('clone'),
   }
+
   const createNewDraftAction = {
     action: createNewDraft.bind(
       null,
@@ -96,15 +125,37 @@ function useGetEServiceProviderActions({
     label: t('createNewDraft'),
   }
 
-  const availableAction: Record<EServiceState, Array<ActionItem>> = {
-    PUBLISHED: [suspendAction, cloneAction, createNewDraftAction],
+  function handleEditDraft() {
+    const descriptorId = eservice.draftDescriptor?.id
+    if (!descriptorId) return
+    navigate('PROVIDE_ESERVICE_EDIT', {
+      params: { eserviceId, descriptorId },
+      state: { stepIndexDestination: 1 },
+    })
+  }
+
+  const editDraftAction = {
+    action: handleEditDraft,
+    label: t('editDraft'),
+  }
+
+  const availableAction = {
+    PUBLISHED: [
+      suspendAction,
+      cloneAction,
+      ...(!hasVersionDraft ? [createNewDraftAction] : [editDraftAction]),
+    ],
     ARCHIVED: [],
     DEPRECATED: [suspendAction],
     DRAFT: [publishDraftAction, deleteVersionDraftAction],
-    SUSPENDED: [reactivateAction, cloneAction, createNewDraftAction],
-  }
+    SUSPENDED: [
+      reactivateAction,
+      cloneAction,
+      ...(!hasVersionDraft ? [createNewDraftAction] : [editDraftAction]),
+    ],
+  }[state]
 
-  return { actions: availableAction[state ?? 'DRAFT'] }
+  return { actions: availableAction }
 }
 
-export default useGetEServiceProviderActions
+export default useGetProviderEServiceTableActions

--- a/src/static/locales/en/common.json
+++ b/src/static/locales/en/common.json
@@ -53,7 +53,8 @@
     "confirm": "Confirm",
     "createNewDraft": "Create new draft version",
     "saveDraft": "Save draft",
-    "backToCatalog": "Back to catalog"
+    "backToCatalog": "Back to catalog",
+    "editDraft": "Edit draft"
   },
   "table": {
     "headData": {

--- a/src/static/locales/it/common.json
+++ b/src/static/locales/it/common.json
@@ -53,7 +53,8 @@
     "confirm": "Conferma",
     "createNewDraft": "Crea bozza nuova versione",
     "saveDraft": "Salva bozza",
-    "backToCatalog": "Torna al catalogo"
+    "backToCatalog": "Torna al catalogo",
+    "editDraft": "Modifica bozza"
   },
   "table": {
     "headData": {


### PR DESCRIPTION
This PR changes the way producer's e-service are fetched and displayed.
The e-service are fetched trought the new BFF's API service /producers/eservices.
Pagination system is also implemented to the provider's e-service table.

NOTE:
This PR breaks the query invalidation for some services due to the new eventual consistency model implemented backend side.