### PR TITLE
[PIN-2228] e-service provider and catalog filters

### DIFF
--- a/src/api/api.types.ts
+++ b/src/api/api.types.ts
@@ -1,0 +1,4 @@
+export type PaginationParams = {
+  limit: number
+  offset: number
+}

--- a/src/api/eservice/eservice.api.types.ts
+++ b/src/api/eservice/eservice.api.types.ts
@@ -24,7 +24,7 @@ export type EServiceGetCatalogListQueryFilters = {
   /** Query to filter e-services by name */
   q?: string
   /** List of producers IDs */
-  producerIds?: Array<string>
+  producersIds?: Array<string>
   /** List of e-service states */
   states?: Array<EServiceState>
 }

--- a/src/api/eservice/eservice.api.types.ts
+++ b/src/api/eservice/eservice.api.types.ts
@@ -6,6 +6,7 @@ import {
   EServiceState,
   EServiceTechnologyType,
 } from '@/types/eservice.types'
+import { PaginationParams } from '../api.types'
 
 /** @deprecated TO BE REMOVED */
 export type EServiceGetListFlatUrlParams = {
@@ -19,38 +20,34 @@ export type EServiceGetListFlatUrlParams = {
 /** @deprecated TO BE REMOVED */
 export type EServiceGetListFlatResponse = Array<EServiceFlatten>
 
-export type EServiceGetCatalogListUrlParams = {
+export type EServiceGetCatalogListQueryFilters = {
   /** Query to filter e-services by name */
   q?: string
   /** List of producers IDs */
   producerIds?: Array<string>
   /** List of e-service states */
   states?: Array<EServiceState>
-  /** Pagination offset, MAX 50 */
-  offset: number
-  /** Pagination limit, MAX 50 */
-  limit: number
 }
 
-export type EServiceGetProviderListUrlParams = {
+export type EServiceGetCatalogListUrlParams = EServiceGetProviderListQueryFilters & PaginationParams
+
+export type EServiceGetProviderListQueryFilters = {
   /** Query to filter e-services by name */
   q?: string
   /** List of consumers IDs */
   consumersIds?: Array<string>
   /** Pagination offset, MAX 50 */
-  offset: number
-  /** Pagination limit, MAX 50 */
-  limit: number
 }
 
-export type EServiceGetConsumersUrlParams = {
+export type EServiceGetProviderListUrlParams = EServiceGetProviderListQueryFilters &
+  PaginationParams
+
+export type EServiceGetConsumersQueryFilters = {
   /** Query to filter consumers by name */
   name?: string
-  /** Pagination offset, MAX 50 */
-  offset: number
-  /** Pagination limit, MAX 50 */
-  limit: number
 }
+
+export type EServiceGetConsumersUrlParams = EServiceGetConsumersQueryFilters & PaginationParams
 
 export type EServiceDraftPayload = {
   name?: string | undefined

--- a/src/api/eservice/eservice.api.types.ts
+++ b/src/api/eservice/eservice.api.types.ts
@@ -52,10 +52,8 @@ export type EServiceGetProducersQueryFilters = {
   name?: string
 }
 
-export type EServiceGetConsumersUrlParams = EServiceGetConsumersQueryFilters &
-  Partial<PaginationParams>
-export type EServiceGetProducersUrlParams = EServiceGetProducersQueryFilters &
-  Partial<PaginationParams>
+export type EServiceGetConsumersUrlParams = EServiceGetConsumersQueryFilters & PaginationParams
+export type EServiceGetProducersUrlParams = EServiceGetProducersQueryFilters & PaginationParams
 
 export type EServiceDraftPayload = {
   name?: string | undefined

--- a/src/api/eservice/eservice.api.types.ts
+++ b/src/api/eservice/eservice.api.types.ts
@@ -43,6 +43,15 @@ export type EServiceGetProviderListUrlParams = {
   limit: number
 }
 
+export type EServiceGetConsumersUrlParams = {
+  /** Query to filter e-services by name */
+  name?: string
+  /** Pagination offset, MAX 50 */
+  offset: number
+  /** Pagination limit, MAX 50 */
+  limit: number
+}
+
 export type EServiceDraftPayload = {
   name?: string | undefined
   description?: string | undefined

--- a/src/api/eservice/eservice.api.types.ts
+++ b/src/api/eservice/eservice.api.types.ts
@@ -29,7 +29,7 @@ export type EServiceGetCatalogListQueryFilters = {
   states?: Array<EServiceState>
 }
 
-export type EServiceGetCatalogListUrlParams = EServiceGetProviderListQueryFilters & PaginationParams
+export type EServiceGetCatalogListUrlParams = EServiceGetCatalogListQueryFilters & PaginationParams
 
 export type EServiceGetProviderListQueryFilters = {
   /** Query to filter e-services by name */

--- a/src/api/eservice/eservice.api.types.ts
+++ b/src/api/eservice/eservice.api.types.ts
@@ -47,7 +47,15 @@ export type EServiceGetConsumersQueryFilters = {
   name?: string
 }
 
-export type EServiceGetConsumersUrlParams = EServiceGetConsumersQueryFilters & PaginationParams
+export type EServiceGetProducersQueryFilters = {
+  /** Query to filter producers by name */
+  name?: string
+}
+
+export type EServiceGetConsumersUrlParams = EServiceGetConsumersQueryFilters &
+  Partial<PaginationParams>
+export type EServiceGetProducersUrlParams = EServiceGetProducersQueryFilters &
+  Partial<PaginationParams>
 
 export type EServiceDraftPayload = {
   name?: string | undefined

--- a/src/api/eservice/eservice.api.types.ts
+++ b/src/api/eservice/eservice.api.types.ts
@@ -44,7 +44,7 @@ export type EServiceGetProviderListUrlParams = {
 }
 
 export type EServiceGetConsumersUrlParams = {
-  /** Query to filter e-services by name */
+  /** Query to filter consumers by name */
   name?: string
   /** Pagination offset, MAX 50 */
   offset: number

--- a/src/api/eservice/eservice.api.types.ts
+++ b/src/api/eservice/eservice.api.types.ts
@@ -44,12 +44,12 @@ export type EServiceGetProviderListUrlParams = EServiceGetProviderListQueryFilte
 
 export type EServiceGetConsumersQueryFilters = {
   /** Query to filter consumers by name */
-  name?: string
+  q?: string
 }
 
 export type EServiceGetProducersQueryFilters = {
   /** Query to filter producers by name */
-  name?: string
+  q?: string
 }
 
 export type EServiceGetConsumersUrlParams = EServiceGetConsumersQueryFilters & PaginationParams

--- a/src/api/eservice/eservice.hooks.ts
+++ b/src/api/eservice/eservice.hooks.ts
@@ -5,6 +5,7 @@ import { useMutationWrapper, useQueryWrapper } from '../react-query-wrappers'
 import EServiceServices from './eservice.services'
 import {
   EServiceGetCatalogListUrlParams,
+  EServiceGetConsumersUrlParams,
   EServiceGetListFlatUrlParams,
   EServiceGetProviderListUrlParams,
   EServiceVersionDraftPayload,
@@ -20,6 +21,7 @@ export enum EServiceQueryKeys {
   GetSingle = 'EServiceGetSingle',
   GetDescriptorCatalog = 'EServiceGetDescriptorCatalog',
   GetDescriptorProvider = 'EServiceGetDescriptorProvider',
+  GetConsumers = 'EServiceGetConsumers',
 }
 
 /** @deprecated TO BE REMOVED */
@@ -58,6 +60,17 @@ function useGetProviderList(
   return useQueryWrapper(
     [EServiceQueryKeys.GetProviderList, params],
     () => EServiceServices.getProviderList(params),
+    config
+  )
+}
+
+function useGetConsumers(
+  params: EServiceGetConsumersUrlParams,
+  config?: { suspense?: boolean; keepPreviousData?: boolean }
+) {
+  return useQueryWrapper(
+    [EServiceQueryKeys.GetConsumers, params],
+    () => EServiceServices.getConsumers(params),
     config
   )
 }
@@ -348,6 +361,7 @@ export const EServiceQueries = {
   useGetDescriptorCatalog,
   useGetDescriptorProvider,
   useGetSingle,
+  useGetConsumers,
   usePrefetchSingle,
   usePrefetchDescriptorCatalog,
   usePrefetchDescriptorProvider,

--- a/src/api/eservice/eservice.hooks.ts
+++ b/src/api/eservice/eservice.hooks.ts
@@ -7,6 +7,7 @@ import {
   EServiceGetCatalogListUrlParams,
   EServiceGetConsumersUrlParams,
   EServiceGetListFlatUrlParams,
+  EServiceGetProducersUrlParams,
   EServiceGetProviderListUrlParams,
   EServiceVersionDraftPayload,
 } from './eservice.api.types'
@@ -22,6 +23,7 @@ export enum EServiceQueryKeys {
   GetDescriptorCatalog = 'EServiceGetDescriptorCatalog',
   GetDescriptorProvider = 'EServiceGetDescriptorProvider',
   GetConsumers = 'EServiceGetConsumers',
+  GetProducers = 'EServiceGetProducers',
 }
 
 /** @deprecated TO BE REMOVED */
@@ -71,6 +73,17 @@ function useGetConsumers(
   return useQueryWrapper(
     [EServiceQueryKeys.GetConsumers, params],
     () => EServiceServices.getConsumers(params),
+    config
+  )
+}
+
+function useGetProducers(
+  params: EServiceGetProducersUrlParams,
+  config?: { suspense?: boolean; keepPreviousData?: boolean }
+) {
+  return useQueryWrapper(
+    [EServiceQueryKeys.GetProducers, params],
+    () => EServiceServices.getProducers(params),
     config
   )
 }
@@ -362,6 +375,7 @@ export const EServiceQueries = {
   useGetDescriptorProvider,
   useGetSingle,
   useGetConsumers,
+  useGetProducers,
   usePrefetchSingle,
   usePrefetchDescriptorCatalog,
   usePrefetchDescriptorProvider,

--- a/src/api/eservice/eservice.services.ts
+++ b/src/api/eservice/eservice.services.ts
@@ -10,6 +10,7 @@ import {
   EServiceGetCatalogListUrlParams,
   EServiceGetProviderListUrlParams,
   EServiceGetConsumersUrlParams,
+  EServiceGetProducersUrlParams,
 } from './eservice.api.types'
 import {
   EServiceCatalog,
@@ -17,6 +18,7 @@ import {
   EServiceDescriptorCatalog,
   EServiceDescriptorProvider,
   EServiceDescriptorRead,
+  EServiceProducer,
   EServiceProvider,
   EServiceRead,
   EServiceReadType,
@@ -73,6 +75,14 @@ async function getDescriptorProvider(eserviceId: string, descriptorId: string) {
 async function getConsumers(params: EServiceGetConsumersUrlParams) {
   const response = await axiosInstance.get<Paginated<EServiceConsumer>>(
     `${BACKEND_FOR_FRONTEND_URL}/consumers`,
+    { params }
+  )
+  return response.data
+}
+
+async function getProducers(params: EServiceGetProducersUrlParams) {
+  const response = await axiosInstance.get<Paginated<EServiceProducer>>(
+    `${BACKEND_FOR_FRONTEND_URL}/producers`,
     { params }
   )
   return response.data
@@ -266,6 +276,7 @@ const EServiceServices = {
   getDescriptorCatalog,
   getDescriptorProvider,
   getConsumers,
+  getProducers,
   createDraft,
   updateDraft,
   deleteDraft,

--- a/src/api/eservice/eservice.services.ts
+++ b/src/api/eservice/eservice.services.ts
@@ -9,9 +9,11 @@ import {
   UpdateEServiceVersionDraftDocumentPayload,
   EServiceGetCatalogListUrlParams,
   EServiceGetProviderListUrlParams,
+  EServiceGetConsumersUrlParams,
 } from './eservice.api.types'
 import {
   EServiceCatalog,
+  EServiceConsumer,
   EServiceDescriptorCatalog,
   EServiceDescriptorProvider,
   EServiceDescriptorRead,
@@ -64,6 +66,14 @@ async function getDescriptorCatalog(eserviceId: string, descriptorId: string) {
 async function getDescriptorProvider(eserviceId: string, descriptorId: string) {
   const response = await axiosInstance.get<EServiceDescriptorProvider>(
     `${BACKEND_FOR_FRONTEND_URL}/producers/eservices/${eserviceId}/descriptors/${descriptorId}`
+  )
+  return response.data
+}
+
+async function getConsumers(params: EServiceGetConsumersUrlParams) {
+  const response = await axiosInstance.get<Paginated<EServiceConsumer>>(
+    `${BACKEND_FOR_FRONTEND_URL}/consumers`,
+    { params }
   )
   return response.data
 }
@@ -255,6 +265,7 @@ const EServiceServices = {
   getSingle,
   getDescriptorCatalog,
   getDescriptorProvider,
+  getConsumers,
   createDraft,
   updateDraft,
   deleteDraft,

--- a/src/components/shared/ReactHookFormInputs/Autocomplete/AutocompleteMultiple.tsx
+++ b/src/components/shared/ReactHookFormInputs/Autocomplete/AutocompleteMultiple.tsx
@@ -1,5 +1,7 @@
 import { Chip } from '@mui/material'
+import { isEqual } from 'lodash'
 import React from 'react'
+import { useFormContext } from 'react-hook-form'
 import { AutocompleteBaseProps, _AutocompleteBase } from './_AutocompleteBase'
 
 type AutocompleteMultipleProps<T> = Omit<
@@ -19,18 +21,30 @@ type AutocompleteMultipleProps<T> = Omit<
 }
 
 export function AutocompleteMultiple<T>(props: AutocompleteMultipleProps<T>) {
+  const { watch } = useFormContext()
+  const selectedValues = watch(props.name) as Array<T>
+
   return (
     <_AutocompleteBase
       multiple
-      getOptionValue={(data) => data.map((d) => d.value)}
-      getOptionLabel={(option) => option.label}
-      renderTags={(value, getTagProps) => (
-        <React.Fragment>
-          {value.map((option, index: number) => (
-            <Chip variant="outlined" label={option.label} {...getTagProps({ index })} /> // eslint-disable-line react/jsx-key
-          ))}
-        </React.Fragment>
-      )}
+      getOptionValue={(data) => data.map((d) => d?.value ?? d)}
+      renderTags={(_, getTagProps) => {
+        const selectedOptions = props.options.filter((option) =>
+          selectedValues.some(isEqual.bind(null, option.value))
+        )
+        return (
+          <React.Fragment>
+            {selectedOptions.map((option, index: number) => (
+              <Chip
+                variant="outlined"
+                label={option.label}
+                {...getTagProps({ index })}
+                key={option.label}
+              />
+            ))}
+          </React.Fragment>
+        )
+      }}
       {...props}
     />
   )

--- a/src/components/shared/ReactHookFormInputs/Autocomplete/AutocompleteSingle.tsx
+++ b/src/components/shared/ReactHookFormInputs/Autocomplete/AutocompleteSingle.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { isEqual } from 'lodash'
 import { AutocompleteBaseProps, _AutocompleteBase } from './_AutocompleteBase'
 
 type AutocompleteSingleProps<T> = Omit<
@@ -21,10 +22,9 @@ export function AutocompleteSingle<T>(props: AutocompleteSingleProps<T>) {
   return (
     <_AutocompleteBase
       multiple={false}
-      getOptionValue={(d) => d?.value || null}
-      getOptionLabel={(option) => option.label}
-      isOptionEqualToValue={(option, value) =>
-        JSON.stringify(option.value) === JSON.stringify(value.value)
+      getOptionValue={(d) => d?.value ?? d}
+      getOptionLabel={(value) =>
+        value?.label ?? props.options.find((option) => isEqual(option.value, value))?.label
       }
       {...props}
     />

--- a/src/components/shared/ReactHookFormInputs/Autocomplete/_AutocompleteBase.tsx
+++ b/src/components/shared/ReactHookFormInputs/Autocomplete/_AutocompleteBase.tsx
@@ -97,7 +97,7 @@ export function _AutocompleteBase<
                 <TextField
                   variant={variant}
                   error={!!error}
-                  placeholder={placeholder || '...'}
+                  placeholder={placeholder ?? '...'}
                   {...params}
                   autoFocus={focusOnMount}
                   InputLabelProps={{ shrink: true, ...params.InputLabelProps }}

--- a/src/components/shared/ReactHookFormInputs/Autocomplete/_AutocompleteBase.tsx
+++ b/src/components/shared/ReactHookFormInputs/Autocomplete/_AutocompleteBase.tsx
@@ -3,7 +3,6 @@ import {
   Autocomplete,
   AutocompleteProps,
   AutocompleteValue,
-  Chip,
   CircularProgress,
   TextField,
   TextFieldProps,
@@ -15,6 +14,7 @@ import parse from 'autosuggest-highlight/parse'
 import match from 'autosuggest-highlight/match'
 import { useTranslation } from 'react-i18next'
 import identity from 'lodash/identity'
+import { isEqual } from 'lodash'
 
 export type AutocompleteBaseProps<
   T,
@@ -47,10 +47,9 @@ export function _AutocompleteBase<
   loading,
   defaultValue,
   variant = 'outlined',
-  getOptionLabel = identity,
   getOptionValue = identity,
   ...props
-}: AutocompleteBaseProps<T, Multiple, DisableClearable, FreeSolo>) {
+}: AutocompleteBaseProps<{ label: string; value: T }, Multiple, DisableClearable, FreeSolo>) {
   const { t } = useTranslation('shared-components', {
     keyPrefix: 'autocompleteMultiple',
   })
@@ -73,10 +72,11 @@ export function _AutocompleteBase<
       <Controller
         control={control}
         name={name}
-        render={({ field: { onChange } }) => (
+        render={({ field: { onChange, value } }) => (
           <Autocomplete
             id={labelId}
             options={options}
+            isOptionEqualToValue={(option, value) => isEqual(option.value, value)}
             loadingText={props.loadingText || t('loadingLabel')}
             noOptionsText={props.noOptionsText || t('noDataLabel')}
             loading={loading}
@@ -91,6 +91,7 @@ export function _AutocompleteBase<
               onChange(newValue)
               return newValue
             }}
+            value={value}
             renderInput={(params) => {
               return (
                 <TextField
@@ -114,7 +115,7 @@ export function _AutocompleteBase<
               )
             }}
             renderOption={(props, value, { inputValue }) => {
-              const label = getOptionLabel(value)
+              const label = value.label
               if (!label) return null
 
               const matches = match(label, inputValue, { insideWords: true })
@@ -136,17 +137,6 @@ export function _AutocompleteBase<
                 </li>
               )
             }}
-            renderTags={(value, getTagProps) => (
-              <React.Fragment>
-                {value.map((option, index: number) => (
-                  <Chip // eslint-disable-line react/jsx-key
-                    variant="outlined"
-                    label={getOptionLabel(option)}
-                    {...getTagProps({ index })}
-                  />
-                ))}
-              </React.Fragment>
-            )}
           />
         )}
       />

--- a/src/hooks/__tests__/useAutocompleteFilterInput.test.ts
+++ b/src/hooks/__tests__/useAutocompleteFilterInput.test.ts
@@ -1,0 +1,34 @@
+import { renderHook, act } from '@testing-library/react'
+import { vi } from 'vitest'
+import { useAutocompleteFilterInput } from '../useAutocompleteFilterInput'
+
+vi.useFakeTimers()
+
+describe('useAutocompleteFilterInput hooks tests', () => {
+  it('should not update the state if an input with length less than 3 is given', async () => {
+    const { result } = renderHook(() => useAutocompleteFilterInput())
+
+    expect(result.current[0]).toBe('')
+    vi.advanceTimersByTime(300)
+    act(() => {
+      result.current[1](undefined, 't')
+      vi.advanceTimersByTime(300)
+    })
+    expect(result.current[0]).toBe('')
+    act(() => {
+      result.current[1](undefined, 'te')
+      vi.advanceTimersByTime(300)
+    })
+    expect(result.current[0]).toBe('')
+    act(() => {
+      result.current[1](undefined, 'tes')
+      vi.advanceTimersByTime(300)
+    })
+    expect(result.current[0]).toEqual('tes')
+    act(() => {
+      result.current[1](undefined, 'test')
+      vi.advanceTimersByTime(300)
+    })
+    expect(result.current[0]).toEqual('test')
+  })
+})

--- a/src/hooks/__tests__/useQueryFilters.test.ts
+++ b/src/hooks/__tests__/useQueryFilters.test.ts
@@ -36,7 +36,7 @@ describe('useQueryFilters testing', () => {
       testFilterArray: ['testArray1', 'testArray2'],
     })
 
-    expect(result.current.filtersFormMethods.getValues()).toEqual({
+    expect(result.current.filtersUseFormMethods.getValues()).toEqual({
       testFilterString: 'test',
       testFilterArray: ['testArray1', 'testArray2'],
     })
@@ -50,7 +50,7 @@ describe('useQueryFilters testing', () => {
       memoryHistory
     )
 
-    expect(result.current.filtersFormMethods.getValues()).toEqual({
+    expect(result.current.filtersUseFormMethods.getValues()).toEqual({
       testFilterString: 'test',
       testFilterArray: ['testArray1', 'testArray2'],
     })
@@ -70,7 +70,7 @@ describe('useQueryFilters testing', () => {
 
     expect(history.location.search).toBe('')
     expect(result.current.queryFilters).toEqual(testFiltersInitialValues)
-    expect(result.current.filtersFormMethods.getValues()).toEqual(testFiltersInitialValues)
+    expect(result.current.filtersUseFormMethods.getValues()).toEqual(testFiltersInitialValues)
   })
 
   it('Should keep the url search params that are not filters related on clearFilters call', () => {
@@ -98,15 +98,15 @@ describe('useQueryFilters testing', () => {
     )
 
     await act(async () => {
-      result.current.filtersFormMethods.setValue('testFilterArray', ['a', 'b'])
-      result.current.filtersFormMethods.setValue('testFilterString', 'testFilter')
+      result.current.filtersUseFormMethods.setValue('testFilterArray', ['a', 'b'])
+      result.current.filtersUseFormMethods.setValue('testFilterString', 'testFilter')
       result.current.enableFilters()
     })
 
     expect(history.location.search).toBe(
       '?testFilterString=testFilter&testFilterArray=a&testFilterArray=b'
     )
-    expect(result.current.queryFilters).toEqual(result.current.filtersFormMethods.getValues())
+    expect(result.current.queryFilters).toEqual(result.current.filtersUseFormMethods.getValues())
   })
 
   it('Should not set url search params that are nullish/empty array on enableFilters call', async () => {
@@ -119,8 +119,8 @@ describe('useQueryFilters testing', () => {
     )
 
     await act(async () => {
-      result.current.filtersFormMethods.setValue('testFilterArray', [])
-      result.current.filtersFormMethods.setValue('testFilterString', '')
+      result.current.filtersUseFormMethods.setValue('testFilterArray', [])
+      result.current.filtersUseFormMethods.setValue('testFilterString', '')
       result.current.enableFilters()
     })
 

--- a/src/hooks/__tests__/useQueryFilters.test.ts
+++ b/src/hooks/__tests__/useQueryFilters.test.ts
@@ -1,0 +1,129 @@
+import { renderHookWithApplicationContext } from '@/__mocks__/mock.utils'
+import { createMemoryHistory } from 'history'
+import { act } from 'react-dom/test-utils'
+import { URLSearchParams } from 'url'
+import { useQueryFilters } from '../useQueryFilters'
+
+type TestFilters = {
+  testFilterString: string
+  testFilterArray: Array<string>
+}
+
+const testFiltersInitialValues = { testFilterString: '', testFilterArray: [] }
+
+function createMemoryHistoryWithTestSearchParams(searchParams: Record<string, string> = {}) {
+  const memoryHistory = createMemoryHistory()
+
+  const additionalSearchParams = new URLSearchParams(searchParams).toString()
+
+  memoryHistory.push(
+    `/?${additionalSearchParams}&testFilterString=test&testFilterArray=testArray1&testFilterArray=testArray2`
+  )
+  return memoryHistory
+}
+
+describe('useQueryFilters testing', () => {
+  it('Should take the filters state from url search params', () => {
+    const memoryHistory = createMemoryHistoryWithTestSearchParams()
+    const { result } = renderHookWithApplicationContext(
+      () => useQueryFilters<TestFilters>(testFiltersInitialValues),
+      { withRouterContext: true },
+      memoryHistory
+    )
+
+    expect(result.current.queryFilters).toEqual({
+      testFilterString: 'test',
+      testFilterArray: ['testArray1', 'testArray2'],
+    })
+
+    expect(result.current.filtersFormMethods.getValues()).toEqual({
+      testFilterString: 'test',
+      testFilterArray: ['testArray1', 'testArray2'],
+    })
+  })
+
+  it('Should not put unrelated filters search params inside form state', () => {
+    const memoryHistory = createMemoryHistoryWithTestSearchParams({ offset: 'test' })
+    const { result } = renderHookWithApplicationContext(
+      () => useQueryFilters<TestFilters>(testFiltersInitialValues),
+      { withRouterContext: true },
+      memoryHistory
+    )
+
+    expect(result.current.filtersFormMethods.getValues()).toEqual({
+      testFilterString: 'test',
+      testFilterArray: ['testArray1', 'testArray2'],
+    })
+  })
+
+  it('Should clear the filters, te form state and the url search params on clearFilters call', () => {
+    const memoryHistory = createMemoryHistoryWithTestSearchParams()
+    const { result, history } = renderHookWithApplicationContext(
+      () => useQueryFilters<TestFilters>(testFiltersInitialValues),
+      { withRouterContext: true },
+      memoryHistory
+    )
+
+    act(() => {
+      result.current.clearFilters()
+    })
+
+    expect(history.location.search).toBe('')
+    expect(result.current.queryFilters).toEqual(testFiltersInitialValues)
+    expect(result.current.filtersFormMethods.getValues()).toEqual(testFiltersInitialValues)
+  })
+
+  it('Should keep the url search params that are not filters related on clearFilters call', () => {
+    const memoryHistory = createMemoryHistoryWithTestSearchParams({ offset: 'test' })
+    const { result, history } = renderHookWithApplicationContext(
+      () => useQueryFilters<TestFilters>(testFiltersInitialValues),
+      { withRouterContext: true },
+      memoryHistory
+    )
+
+    act(() => {
+      result.current.clearFilters()
+    })
+
+    expect(history.location.search).toBe('?offset=test')
+  })
+
+  it('Should sync the form state with the queryFilters state and the url search params on enableFilters call', async () => {
+    const memoryHistory = createMemoryHistoryWithTestSearchParams()
+
+    const { result, history } = renderHookWithApplicationContext(
+      () => useQueryFilters<TestFilters>(testFiltersInitialValues),
+      { withRouterContext: true },
+      memoryHistory
+    )
+
+    await act(async () => {
+      result.current.filtersFormMethods.setValue('testFilterArray', ['a', 'b'])
+      result.current.filtersFormMethods.setValue('testFilterString', 'testFilter')
+      result.current.enableFilters()
+    })
+
+    expect(history.location.search).toBe(
+      '?testFilterString=testFilter&testFilterArray=a&testFilterArray=b'
+    )
+    expect(result.current.queryFilters).toEqual(result.current.filtersFormMethods.getValues())
+  })
+
+  it('Should not set url search params that are nullish/empty array on enableFilters call', async () => {
+    const memoryHistory = createMemoryHistoryWithTestSearchParams()
+
+    const { result, history } = renderHookWithApplicationContext(
+      () => useQueryFilters<TestFilters>(testFiltersInitialValues),
+      { withRouterContext: true },
+      memoryHistory
+    )
+
+    await act(async () => {
+      result.current.filtersFormMethods.setValue('testFilterArray', [])
+      result.current.filtersFormMethods.setValue('testFilterString', '')
+      result.current.enableFilters()
+    })
+
+    expect(history.location.search).toBe('')
+  })
+})

--- a/src/hooks/useAutocompleteFilterInput.ts
+++ b/src/hooks/useAutocompleteFilterInput.ts
@@ -1,8 +1,15 @@
 import React from 'react'
 import debounce from 'lodash/debounce'
 
-export function useAutocompleteFilterInput() {
-  const [autocompleteInput, setAutocompleteInput] = React.useState('')
+/**
+ * This is an utility hook made for the autocomplete filters that calls an API on text input change in order to query the options.
+ * It debounces the state change to limit the API calls, and ignores the text input change when it is less than 3 chars.
+ *
+ * @returns the text input state and the handleAutocompleteInputChange callback to put inside the `onInputChange` of the `AutocompleteMultiple` component.
+ *
+ */
+export function useAutocompleteFilterInput(initialState = '') {
+  const [autocompleteInput, setAutocompleteInput] = React.useState(initialState)
 
   const handleAutocompleteInputChange = React.useMemo(
     () =>

--- a/src/hooks/useAutocompleteFilterInput.ts
+++ b/src/hooks/useAutocompleteFilterInput.ts
@@ -1,0 +1,26 @@
+import React from 'react'
+import debounce from 'lodash/debounce'
+
+export function useAutocompleteFilterInput() {
+  const [autocompleteInput, setAutocompleteInput] = React.useState('')
+
+  const handleAutocompleteInputChange = React.useMemo(
+    () =>
+      debounce((_: unknown, value: string) => {
+        if (value.length >= 3) {
+          setAutocompleteInput(value)
+          return
+        }
+        setAutocompleteInput('')
+      }, 300),
+    []
+  )
+
+  React.useEffect(() => {
+    return () => {
+      handleAutocompleteInputChange.cancel()
+    }
+  }, [handleAutocompleteInputChange])
+
+  return [autocompleteInput, handleAutocompleteInputChange] as const
+}

--- a/src/hooks/useQueryFilters.ts
+++ b/src/hooks/useQueryFilters.ts
@@ -7,7 +7,7 @@ import omit from 'lodash/omit'
 export function useQueryFilters<T extends Record<string, string | string[]>>(_defaultValues: T) {
   const [filtersSearchParams, setFiltersSearchParams] = useSearchParams()
 
-  const decodedSearchParams = React.useMemo(() => {
+  const decodedSearchParams = React.useMemo<T>(() => {
     const filterKeys = getKeys(_defaultValues) as Array<string>
 
     return filterKeys.reduce((prev, filterKey) => {
@@ -17,14 +17,14 @@ export function useQueryFilters<T extends Record<string, string | string[]>>(_de
           ? filtersSearchParams.getAll(filterKey) ?? _defaultValues[filterKey]
           : filtersSearchParams.get(filterKey) ?? _defaultValues[filterKey],
       }
-    }, {})
+    }, {} as T)
   }, [filtersSearchParams, _defaultValues])
 
   const filtersFormMethods = useForm<T>({
     defaultValues: decodedSearchParams as DeepPartial<T>,
   })
 
-  const [queryFilters, setQueryFilters] = React.useState(decodedSearchParams)
+  const [queryFilters, setQueryFilters] = React.useState<T>(decodedSearchParams)
 
   const clearFilters = React.useCallback(() => {
     const filtersKeys = getKeys(_defaultValues)

--- a/src/hooks/useQueryFilters.ts
+++ b/src/hooks/useQueryFilters.ts
@@ -20,7 +20,7 @@ export function useQueryFilters<T extends Record<string, string | string[]>>(def
     }, {} as T)
   }, [filtersSearchParams, defaultValues])
 
-  const filtersFormMethods = useForm<T>({
+  const filtersUseFormMethods = useForm<T>({
     defaultValues: decodedSearchParams as DeepPartial<T>,
   })
 
@@ -33,15 +33,15 @@ export function useQueryFilters<T extends Record<string, string | string[]>>(def
     filtersKeys.forEach((filterKey) => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore
-      filtersFormMethods.setValue(filterKey, defaultValues[filterKey])
+      filtersUseFormMethods.setValue(filterKey, defaultValues[filterKey])
     })
     setQueryFilters(defaultValues)
 
     // Clears the search url params from only the filter related url params
     setFiltersSearchParams(omit(Object.fromEntries(filtersSearchParams), ...filtersKeys))
-  }, [filtersFormMethods, defaultValues, filtersSearchParams, setFiltersSearchParams])
+  }, [filtersUseFormMethods, defaultValues, filtersSearchParams, setFiltersSearchParams])
 
-  const enableFilters = filtersFormMethods.handleSubmit((values) => {
+  const enableFilters = filtersUseFormMethods.handleSubmit((values) => {
     setQueryFilters(values)
 
     // Filters out the falsy/empty values
@@ -54,5 +54,5 @@ export function useQueryFilters<T extends Record<string, string | string[]>>(def
     setFiltersSearchParams(filteredSearchParams)
   })
 
-  return { queryFilters, filtersFormMethods, enableFilters, clearFilters }
+  return { queryFilters, filtersUseFormMethods, enableFilters, clearFilters }
 }

--- a/src/hooks/useQueryFilters.ts
+++ b/src/hooks/useQueryFilters.ts
@@ -1,20 +1,45 @@
+import { getKeys } from '@/utils/array.utils'
 import React from 'react'
 import { DeepPartial, useForm } from 'react-hook-form'
+import { useSearchParams } from 'react-router-dom'
+import omit from 'lodash/omit'
 
-export function useQueryFilters<T extends object>(defaultValues: T) {
+export function useQueryFilters<T extends Record<string, string | string[]>>(_defaultValues: T) {
+  const [filtersSearchParams, setFiltersSearchParams] = useSearchParams()
+
+  const decodedSearchParams = React.useMemo(() => {
+    const filterKeys = getKeys(_defaultValues) as Array<string>
+
+    return filterKeys.reduce((prev, filterKey) => {
+      return {
+        ...prev,
+        [filterKey]: Array.isArray(_defaultValues[filterKey])
+          ? filtersSearchParams.getAll(filterKey) ?? _defaultValues[filterKey]
+          : filtersSearchParams.get(filterKey) ?? _defaultValues[filterKey],
+      }
+    }, {})
+  }, [filtersSearchParams, _defaultValues])
+
   const filtersFormMethods = useForm<T>({
-    defaultValues: defaultValues as DeepPartial<T>,
+    defaultValues: decodedSearchParams as DeepPartial<T>,
   })
 
-  const [queryFilters, setQueryFilters] = React.useState(defaultValues)
+  const [queryFilters, setQueryFilters] = React.useState(decodedSearchParams)
 
   const clearFilters = React.useCallback(() => {
-    filtersFormMethods.reset()
-    setQueryFilters(defaultValues)
-  }, [filtersFormMethods, defaultValues])
+    const filtersKeys = getKeys(_defaultValues)
+    filtersKeys.forEach((filterKey) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      filtersFormMethods.setValue(filterKey, _defaultValues[filterKey])
+    })
+    setQueryFilters(_defaultValues)
+    setFiltersSearchParams(() => omit(Object.fromEntries(filtersSearchParams), ...filtersKeys))
+  }, [filtersFormMethods, _defaultValues, filtersSearchParams, setFiltersSearchParams])
 
   const enableFilters = filtersFormMethods.handleSubmit((values) => {
     setQueryFilters(values)
+    setFiltersSearchParams(() => ({ ...Object.fromEntries(filtersSearchParams), ...values }))
   })
 
   return { queryFilters, filtersFormMethods, enableFilters, clearFilters }

--- a/src/hooks/useQueryFilters.ts
+++ b/src/hooks/useQueryFilters.ts
@@ -3,21 +3,16 @@ import React from 'react'
 import { DeepPartial, useForm } from 'react-hook-form'
 import { useSearchParams } from 'react-router-dom'
 import omit from 'lodash/omit'
+import pick from 'lodash/pick'
+import qs from 'qs'
 
 export function useQueryFilters<T extends Record<string, string | string[]>>(_defaultValues: T) {
   const [filtersSearchParams, setFiltersSearchParams] = useSearchParams()
 
   const decodedSearchParams = React.useMemo<T>(() => {
-    const filterKeys = getKeys(_defaultValues) as Array<string>
+    const parsedSearchParams = qs.parse(filtersSearchParams.toString()) as T
 
-    return filterKeys.reduce((prev, filterKey) => {
-      return {
-        ...prev,
-        [filterKey]: Array.isArray(_defaultValues[filterKey])
-          ? filtersSearchParams.getAll(filterKey) ?? _defaultValues[filterKey]
-          : filtersSearchParams.get(filterKey) ?? _defaultValues[filterKey],
-      }
-    }, {} as T)
+    return pick(parsedSearchParams, ...getKeys(_defaultValues))
   }, [filtersSearchParams, _defaultValues])
 
   const filtersFormMethods = useForm<T>({
@@ -39,6 +34,21 @@ export function useQueryFilters<T extends Record<string, string | string[]>>(_de
 
   const enableFilters = filtersFormMethods.handleSubmit((values) => {
     setQueryFilters(values)
+    /**
+     * {
+     *   q: "",
+     *   consumerIds: ["id1", "id2"]
+     * }
+     */
+
+    /**
+     * {
+     *   consumerIds: ["id1", "id2"]
+     * }
+     */
+
+    // const a: string | Array<string> = []
+    // !!a && a.length > 0
     setFiltersSearchParams(() => ({ ...Object.fromEntries(filtersSearchParams), ...values }))
   })
 

--- a/src/hooks/useQueryFilters.ts
+++ b/src/hooks/useQueryFilters.ts
@@ -1,0 +1,18 @@
+import React from 'react'
+import { useForm } from 'react-hook-form'
+
+export function useQueryFilters<T>(defaultValues: Omit<T, 'offset' | 'limit'>) {
+  const filtersFormMethods = useForm<any>({ defaultValues })
+  const [queryFilters, setQueryFilters] = React.useState(defaultValues)
+
+  const clearFilters = React.useCallback(() => {
+    filtersFormMethods.reset()
+    setQueryFilters(defaultValues)
+  }, [filtersFormMethods, defaultValues])
+
+  const enableFilters = filtersFormMethods.handleSubmit((values) => {
+    setQueryFilters(values)
+  })
+
+  return { queryFilters, filtersFormMethods, enableFilters, clearFilters }
+}

--- a/src/hooks/useQueryFilters.ts
+++ b/src/hooks/useQueryFilters.ts
@@ -34,22 +34,14 @@ export function useQueryFilters<T extends Record<string, string | string[]>>(_de
 
   const enableFilters = filtersFormMethods.handleSubmit((values) => {
     setQueryFilters(values)
-    /**
-     * {
-     *   q: "",
-     *   consumerIds: ["id1", "id2"]
-     * }
-     */
 
-    /**
-     * {
-     *   consumerIds: ["id1", "id2"]
-     * }
-     */
+    const definedFiltersSearchParams = Object.fromEntries(
+      Object.entries({ ...Object.fromEntries(filtersSearchParams), ...values }).filter(
+        (value) => !!value[1] && value[1].length > 0
+      )
+    )
 
-    // const a: string | Array<string> = []
-    // !!a && a.length > 0
-    setFiltersSearchParams(() => ({ ...Object.fromEntries(filtersSearchParams), ...values }))
+    setFiltersSearchParams(() => definedFiltersSearchParams)
   })
 
   return { queryFilters, filtersFormMethods, enableFilters, clearFilters }

--- a/src/hooks/useQueryFilters.ts
+++ b/src/hooks/useQueryFilters.ts
@@ -1,8 +1,11 @@
 import React from 'react'
-import { useForm } from 'react-hook-form'
+import { DeepPartial, useForm } from 'react-hook-form'
 
-export function useQueryFilters<T>(defaultValues: Omit<T, 'offset' | 'limit'>) {
-  const filtersFormMethods = useForm<any>({ defaultValues })
+export function useQueryFilters<T extends object>(defaultValues: T) {
+  const filtersFormMethods = useForm<T>({
+    defaultValues: defaultValues as DeepPartial<T>,
+  })
+
   const [queryFilters, setQueryFilters] = React.useState(defaultValues)
 
   const clearFilters = React.useCallback(() => {

--- a/src/hooks/useQueryFilters.ts
+++ b/src/hooks/useQueryFilters.ts
@@ -4,20 +4,20 @@ import { DeepPartial, useForm } from 'react-hook-form'
 import { useSearchParams } from 'react-router-dom'
 import omit from 'lodash/omit'
 
-export function useQueryFilters<T extends Record<string, string | string[]>>(_defaultValues: T) {
+export function useQueryFilters<T extends Record<string, string | string[]>>(defaultValues: T) {
   const [filtersSearchParams, setFiltersSearchParams] = useSearchParams()
 
   const decodedSearchParams = React.useMemo<T>(() => {
-    const filterKeys = getKeys(_defaultValues) as Array<string>
+    const filterKeys = getKeys(defaultValues) as Array<string>
     return filterKeys.reduce((prev, filterKey) => {
       return {
         ...prev,
-        [filterKey]: Array.isArray(_defaultValues[filterKey])
-          ? filtersSearchParams.getAll(filterKey) ?? _defaultValues[filterKey]
-          : filtersSearchParams.get(filterKey) ?? _defaultValues[filterKey],
+        [filterKey]: Array.isArray(defaultValues[filterKey])
+          ? filtersSearchParams.getAll(filterKey) ?? defaultValues[filterKey]
+          : filtersSearchParams.get(filterKey) ?? defaultValues[filterKey],
       }
     }, {} as T)
-  }, [filtersSearchParams, _defaultValues])
+  }, [filtersSearchParams, defaultValues])
 
   const filtersFormMethods = useForm<T>({
     defaultValues: decodedSearchParams as DeepPartial<T>,
@@ -26,15 +26,15 @@ export function useQueryFilters<T extends Record<string, string | string[]>>(_de
   const [queryFilters, setQueryFilters] = React.useState<T>(decodedSearchParams)
 
   const clearFilters = React.useCallback(() => {
-    const filtersKeys = getKeys(_defaultValues)
+    const filtersKeys = getKeys(defaultValues)
     filtersKeys.forEach((filterKey) => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore
-      filtersFormMethods.setValue(filterKey, _defaultValues[filterKey])
+      filtersFormMethods.setValue(filterKey, defaultValues[filterKey])
     })
-    setQueryFilters(_defaultValues)
+    setQueryFilters(defaultValues)
     setFiltersSearchParams(() => omit(Object.fromEntries(filtersSearchParams), ...filtersKeys))
-  }, [filtersFormMethods, _defaultValues, filtersSearchParams, setFiltersSearchParams])
+  }, [filtersFormMethods, defaultValues, filtersSearchParams, setFiltersSearchParams])
 
   const enableFilters = filtersFormMethods.handleSubmit((values) => {
     setQueryFilters(values)
@@ -45,7 +45,7 @@ export function useQueryFilters<T extends Record<string, string | string[]>>(_de
       )
     )
 
-    setFiltersSearchParams(() => definedFiltersSearchParams)
+    setFiltersSearchParams(definedFiltersSearchParams)
   })
 
   return { queryFilters, filtersFormMethods, enableFilters, clearFilters }

--- a/src/hooks/useQueryFilters.ts
+++ b/src/hooks/useQueryFilters.ts
@@ -7,6 +7,7 @@ import omit from 'lodash/omit'
 export function useQueryFilters<T extends Record<string, string | string[]>>(defaultValues: T) {
   const [filtersSearchParams, setFiltersSearchParams] = useSearchParams()
 
+  // Parses the search url params into a filters object
   const decodedSearchParams = React.useMemo<T>(() => {
     const filterKeys = getKeys(defaultValues) as Array<string>
     return filterKeys.reduce((prev, filterKey) => {
@@ -27,25 +28,30 @@ export function useQueryFilters<T extends Record<string, string | string[]>>(def
 
   const clearFilters = React.useCallback(() => {
     const filtersKeys = getKeys(defaultValues)
+
+    // Sets the default value to all the form value states
     filtersKeys.forEach((filterKey) => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore
       filtersFormMethods.setValue(filterKey, defaultValues[filterKey])
     })
     setQueryFilters(defaultValues)
-    setFiltersSearchParams(() => omit(Object.fromEntries(filtersSearchParams), ...filtersKeys))
+
+    // Clears the search url params from only the filter related url params
+    setFiltersSearchParams(omit(Object.fromEntries(filtersSearchParams), ...filtersKeys))
   }, [filtersFormMethods, defaultValues, filtersSearchParams, setFiltersSearchParams])
 
   const enableFilters = filtersFormMethods.handleSubmit((values) => {
     setQueryFilters(values)
 
-    const definedFiltersSearchParams = Object.fromEntries(
+    // Filters out the falsy/empty values
+    const filteredSearchParams = Object.fromEntries(
       Object.entries({ ...Object.fromEntries(filtersSearchParams), ...values }).filter(
         ([_, value]) => !!value && value.length > 0
       )
     )
 
-    setFiltersSearchParams(definedFiltersSearchParams)
+    setFiltersSearchParams(filteredSearchParams)
   })
 
   return { queryFilters, filtersFormMethods, enableFilters, clearFilters }

--- a/src/pages/ConsumerEServiceCatalogPage/ConsumerEServiceCatalog.page.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/ConsumerEServiceCatalog.page.tsx
@@ -22,7 +22,7 @@ const ConsumerEServiceCatalogPage: React.FC = () => {
   const { queryFilters, filtersFormMethods, enableFilters, clearFilters } =
     useQueryFilters<EServiceGetCatalogListQueryFilters>({
       q: '',
-      producerIds: [],
+      producersIds: [],
     })
 
   const params = { ...queryFilters, ...paginationParams }

--- a/src/pages/ConsumerEServiceCatalogPage/ConsumerEServiceCatalog.page.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/ConsumerEServiceCatalog.page.tsx
@@ -5,12 +5,27 @@ import { useTranslation } from 'react-i18next'
 import { EServiceCatalogGrid, EServiceCatalogGridSkeleton } from './components'
 import { EServiceQueries } from '@/api/eservice'
 import { Pagination } from '@/components/shared/Pagination'
+import { useQueryFilters } from '@/hooks/useQueryFilters'
+import { EServiceGetCatalogListUrlParams } from '@/api/eservice/eservice.api.types'
+import EServiceCatalogFilters from './components/EServiceCatalogFilters'
 
 const ConsumerEServiceCatalogPage: React.FC = () => {
   const { t } = useTranslation('pages', { keyPrefix: 'consumerEServiceCatalog' })
-  const { props, params, getTotalPageCount } = usePagination({
+  const {
+    props,
+    params: paginationParams,
+    getTotalPageCount,
+  } = usePagination({
     limit: 15,
   })
+
+  const { queryFilters, filtersFormMethods, enableFilters, clearFilters } =
+    useQueryFilters<EServiceGetCatalogListUrlParams>({
+      q: '',
+      producerIds: [],
+    })
+
+  const params = { ...queryFilters, ...paginationParams }
 
   const { data } = EServiceQueries.useGetCatalogList(
     {
@@ -22,6 +37,11 @@ const ConsumerEServiceCatalogPage: React.FC = () => {
 
   return (
     <PageContainer title={t('title')} description={t('description')}>
+      <EServiceCatalogFilters
+        filtersFormMethods={filtersFormMethods}
+        enableFilters={enableFilters}
+        clearFilters={clearFilters}
+      />
       <EServiceCatalogWrapper params={params} />
       <Pagination {...props} totalPages={getTotalPageCount(data?.pagination.totalCount)} />
     </PageContainer>

--- a/src/pages/ConsumerEServiceCatalogPage/ConsumerEServiceCatalog.page.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/ConsumerEServiceCatalog.page.tsx
@@ -19,7 +19,7 @@ const ConsumerEServiceCatalogPage: React.FC = () => {
     limit: 15,
   })
 
-  const { queryFilters, filtersFormMethods, enableFilters, clearFilters } =
+  const { queryFilters, filtersUseFormMethods, enableFilters, clearFilters } =
     useQueryFilters<EServiceGetCatalogListQueryFilters>({
       q: '',
       producersIds: [],
@@ -38,7 +38,7 @@ const ConsumerEServiceCatalogPage: React.FC = () => {
   return (
     <PageContainer title={t('title')} description={t('description')}>
       <EServiceCatalogFilters
-        filtersFormMethods={filtersFormMethods}
+        filtersUseFormMethods={filtersUseFormMethods}
         enableFilters={enableFilters}
         clearFilters={clearFilters}
       />

--- a/src/pages/ConsumerEServiceCatalogPage/ConsumerEServiceCatalog.page.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/ConsumerEServiceCatalog.page.tsx
@@ -6,7 +6,7 @@ import { EServiceCatalogGrid, EServiceCatalogGridSkeleton } from './components'
 import { EServiceQueries } from '@/api/eservice'
 import { Pagination } from '@/components/shared/Pagination'
 import { useQueryFilters } from '@/hooks/useQueryFilters'
-import { EServiceGetCatalogListUrlParams } from '@/api/eservice/eservice.api.types'
+import { EServiceGetCatalogListQueryFilters } from '@/api/eservice/eservice.api.types'
 import EServiceCatalogFilters from './components/EServiceCatalogFilters'
 
 const ConsumerEServiceCatalogPage: React.FC = () => {
@@ -20,7 +20,7 @@ const ConsumerEServiceCatalogPage: React.FC = () => {
   })
 
   const { queryFilters, filtersFormMethods, enableFilters, clearFilters } =
-    useQueryFilters<EServiceGetCatalogListUrlParams>({
+    useQueryFilters<EServiceGetCatalogListQueryFilters>({
       q: '',
       producerIds: [],
     })

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
@@ -22,7 +22,7 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
   const [producersAutocompleteText, handleAutocompleteInputChange] = useAutocompleteFilterInput()
 
   const { data: producers, isFetching: isFetchingProducers } = EServiceQueries.useGetProducers(
-    { offset: 0, limit: 50, name: producersAutocompleteText },
+    { offset: 0, limit: 50, q: producersAutocompleteText },
     { suspense: false, keepPreviousData: true }
   )
 

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
@@ -5,6 +5,7 @@ import { AutocompleteMultiple, TextField } from '@/components/shared/ReactHookFo
 import { EServiceQueries } from '@/api/eservice'
 import { useTranslation } from 'react-i18next'
 import { EServiceGetCatalogListQueryFilters } from '@/api/eservice/eservice.api.types'
+import { useAutocompleteFilterInput } from '@/hooks/useAutocompleteFilterInput'
 
 interface EServiceCatalogFiltersProps {
   clearFilters: VoidFunction
@@ -18,11 +19,11 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
   filtersFormMethods,
 }) => {
   const { t } = useTranslation('eservice')
-  const { data: producers, isLoading: isLoadingProducers } = EServiceQueries.useGetProducers(
-    { limit: 50, offset: 0 },
-    {
-      suspense: false,
-    }
+  const [producersAutocompleteText, handleAutocompleteInputChange] = useAutocompleteFilterInput()
+
+  const { data: producers, isInitialLoading: isLoadingProducers } = EServiceQueries.useGetProducers(
+    { name: producersAutocompleteText },
+    { suspense: false }
   )
 
   const producersOptions =
@@ -53,6 +54,7 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
             placeholder=""
             size="small"
             name="producersIds"
+            onInputChange={handleAutocompleteInputChange}
             label={t('list.filters.providerField.label')}
             options={producersOptions}
             loading={isLoadingProducers}

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
@@ -50,6 +50,7 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
           />
           <AutocompleteMultiple
             sx={{ width: '45%' }}
+            placeholder=""
             size="small"
             name="producersIds"
             label={t('list.filters.providerField.label')}

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
@@ -10,13 +10,13 @@ import { useAutocompleteFilterInput } from '@/hooks/useAutocompleteFilterInput'
 interface EServiceCatalogFiltersProps {
   clearFilters: VoidFunction
   enableFilters: VoidFunction
-  filtersFormMethods: UseFormReturn<EServiceGetCatalogListQueryFilters, unknown>
+  filtersUseFormMethods: UseFormReturn<EServiceGetCatalogListQueryFilters, unknown>
 }
 
 const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
   clearFilters,
   enableFilters,
-  filtersFormMethods,
+  filtersUseFormMethods,
 }) => {
   const { t } = useTranslation('eservice')
   const [producersAutocompleteText, handleAutocompleteInputChange] = useAutocompleteFilterInput()
@@ -33,7 +33,7 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
     })) || []
 
   return (
-    <FormProvider {...filtersFormMethods}>
+    <FormProvider {...filtersUseFormMethods}>
       <Stack
         onSubmit={enableFilters}
         component="form"

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
@@ -3,11 +3,13 @@ import { Button, Stack } from '@mui/material'
 import { FormProvider, UseFormReturn } from 'react-hook-form'
 import { AutocompleteMultiple, TextField } from '@/components/shared/ReactHookFormInputs'
 import { EServiceQueries } from '@/api/eservice'
+import { useTranslation } from 'react-i18next'
+import { EServiceGetCatalogListQueryFilters } from '@/api/eservice/eservice.api.types'
 
 interface EServiceCatalogFiltersProps {
   clearFilters: VoidFunction
   enableFilters: VoidFunction
-  filtersFormMethods: UseFormReturn<any, any>
+  filtersFormMethods: UseFormReturn<EServiceGetCatalogListQueryFilters, unknown>
 }
 
 const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
@@ -15,6 +17,7 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
   enableFilters,
   filtersFormMethods,
 }) => {
+  const { t } = useTranslation('eservice')
   const { data: producers, isLoading: isLoadingProducers } = EServiceQueries.useGetProducers(
     { limit: 50, offset: 0 },
     {
@@ -43,13 +46,13 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
             sx={{ m: 0, width: '55%' }}
             size="small"
             name="q"
-            label="Cerca per nome dell’e-service"
+            label={t('list.filters.nameField.label')}
           />
           <AutocompleteMultiple
             sx={{ width: '45%' }}
             size="small"
             name="producersIds"
-            label="producers"
+            label={t('list.filters.providerField.label')}
             options={producersOptions}
             loading={isLoadingProducers}
           />
@@ -57,10 +60,10 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
 
         <Stack direction="row" spacing={2}>
           <Button size="small" variant="outlined" type="submit">
-            Filtra
+            {t('list.filters.filterBtn')}
           </Button>
           <Button size="small" variant="text" type="button" onClick={clearFilters}>
-            Annulla filtri
+            {t('list.filters.cancelFilterBtn')}
           </Button>
         </Stack>
       </Stack>

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
@@ -24,7 +24,7 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
 
   const producersOptions =
     producers?.results.map((o) => ({
-      label: o.name || 'default',
+      label: o.name,
       value: o.id,
     })) || []
 

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { Button, Stack } from '@mui/material'
+import { FormProvider, UseFormReturn } from 'react-hook-form'
+import { AutocompleteMultiple, TextField } from '@/components/shared/ReactHookFormInputs'
+import { EServiceQueries } from '@/api/eservice'
+
+interface EServiceCatalogFiltersProps {
+  clearFilters: VoidFunction
+  enableFilters: VoidFunction
+  filtersFormMethods: UseFormReturn<any, any>
+}
+
+const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
+  clearFilters,
+  enableFilters,
+  filtersFormMethods,
+}) => {
+  const { data: producers, isLoading: isLoadingProducers } = EServiceQueries.useGetProducers(
+    { limit: 50, offset: 0 },
+    {
+      suspense: false,
+    }
+  )
+
+  const producersOptions =
+    producers?.results.map((o) => ({
+      label: o.name || 'default',
+      value: o.id,
+    })) || []
+
+  return (
+    <FormProvider {...filtersFormMethods}>
+      <Stack
+        onSubmit={enableFilters}
+        component="form"
+        direction="row"
+        spacing={2}
+        justifyContent="space-between"
+        sx={{ mb: 4 }}
+      >
+        <Stack direction="row" spacing={2} sx={{ width: '60%' }}>
+          <TextField
+            sx={{ m: 0, width: '55%' }}
+            size="small"
+            name="q"
+            label="Cerca per nome dell’e-service"
+          />
+          <AutocompleteMultiple
+            sx={{ width: '45%' }}
+            size="small"
+            name="producersIds"
+            label="producers"
+            options={producersOptions}
+            loading={isLoadingProducers}
+          />
+        </Stack>
+
+        <Stack direction="row" spacing={2}>
+          <Button size="small" variant="outlined" type="submit">
+            Filtra
+          </Button>
+          <Button size="small" variant="text" type="button" onClick={clearFilters}>
+            Annulla filtri
+          </Button>
+        </Stack>
+      </Stack>
+    </FormProvider>
+  )
+}
+
+export default EServiceCatalogFilters

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
@@ -22,7 +22,7 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
   const [producersAutocompleteText, handleAutocompleteInputChange] = useAutocompleteFilterInput()
 
   const { data: producers, isInitialLoading: isLoadingProducers } = EServiceQueries.useGetProducers(
-    { name: producersAutocompleteText },
+    { offset: 0, limit: 50, name: producersAutocompleteText },
     { suspense: false }
   )
 

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogFilters.tsx
@@ -21,9 +21,9 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
   const { t } = useTranslation('eservice')
   const [producersAutocompleteText, handleAutocompleteInputChange] = useAutocompleteFilterInput()
 
-  const { data: producers, isInitialLoading: isLoadingProducers } = EServiceQueries.useGetProducers(
+  const { data: producers, isFetching: isFetchingProducers } = EServiceQueries.useGetProducers(
     { offset: 0, limit: 50, name: producersAutocompleteText },
-    { suspense: false }
+    { suspense: false, keepPreviousData: true }
   )
 
   const producersOptions =
@@ -57,7 +57,7 @@ const EServiceCatalogFilters: React.FC<EServiceCatalogFiltersProps> = ({
             onInputChange={handleAutocompleteInputChange}
             label={t('list.filters.providerField.label')}
             options={producersOptions}
-            loading={isLoadingProducers}
+            loading={isFetchingProducers}
           />
         </Stack>
 

--- a/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
+++ b/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
@@ -7,14 +7,29 @@ import { TopSideActions } from '@/components/layout/containers/PageContainer'
 import { EServiceQueries } from '@/api/eservice'
 import usePagination from '@/hooks/usePagination'
 import { Pagination } from '@/components/shared/Pagination'
+import { EServiceGetProviderListUrlParams } from '@/api/eservice/eservice.api.types'
+import { useQueryFilters } from '@/hooks/useQueryFilters'
+import EServiceTableFilters from './components/EServiceTableFilters'
 
 const ProviderEServiceListPage: React.FC = () => {
   const { t } = useTranslation('pages', { keyPrefix: 'providerEServiceList' })
   const { t: tCommon } = useTranslation('common')
   const { navigate } = useNavigateRouter()
-  const { props, params, getTotalPageCount } = usePagination({
+  const {
+    props,
+    params: paginationParams,
+    getTotalPageCount,
+  } = usePagination({
     limit: 20,
   })
+
+  const { queryFilters, filtersFormMethods, enableFilters, clearFilters } =
+    useQueryFilters<EServiceGetProviderListUrlParams>({
+      q: '',
+      consumersIds: [],
+    })
+
+  const params = { ...queryFilters, ...paginationParams }
 
   const { data } = EServiceQueries.useGetProviderList(params, {
     suspense: false,
@@ -39,13 +54,18 @@ const ProviderEServiceListPage: React.FC = () => {
       description={t('description')}
       topSideActions={topSideActions}
     >
+      <EServiceTableFilters
+        filtersFormMethods={filtersFormMethods}
+        enableFilters={enableFilters}
+        clearFilters={clearFilters}
+      />
       <EServiceTableWrapper params={params} />
       <Pagination {...props} totalPages={getTotalPageCount(data?.pagination.totalCount)} />
     </PageContainer>
   )
 }
 
-const EServiceTableWrapper: React.FC<{ params: { limit: number; offset: number } }> = ({
+const EServiceTableWrapper: React.FC<{ params: EServiceGetProviderListUrlParams }> = ({
   params,
 }) => {
   const { data, isFetching } = EServiceQueries.useGetProviderList(params, {

--- a/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
+++ b/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
@@ -7,7 +7,10 @@ import { TopSideActions } from '@/components/layout/containers/PageContainer'
 import { EServiceQueries } from '@/api/eservice'
 import usePagination from '@/hooks/usePagination'
 import { Pagination } from '@/components/shared/Pagination'
-import { EServiceGetProviderListUrlParams } from '@/api/eservice/eservice.api.types'
+import {
+  EServiceGetProviderListQueryFilters,
+  EServiceGetProviderListUrlParams,
+} from '@/api/eservice/eservice.api.types'
 import { useQueryFilters } from '@/hooks/useQueryFilters'
 import EServiceTableFilters from './components/EServiceTableFilters'
 
@@ -24,7 +27,7 @@ const ProviderEServiceListPage: React.FC = () => {
   })
 
   const { queryFilters, filtersFormMethods, enableFilters, clearFilters } =
-    useQueryFilters<EServiceGetProviderListUrlParams>({
+    useQueryFilters<EServiceGetProviderListQueryFilters>({
       q: '',
       consumersIds: [],
     })

--- a/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
+++ b/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
@@ -23,6 +23,19 @@ const ProviderEServiceListPage: React.FC = () => {
     limit: 20,
   })
 
+  const consumerParams = { limit: 50, offset: 0 }
+
+  const { data: consumers } = EServiceQueries.useGetConsumers(consumerParams, {
+    suspense: true,
+    keepPreviousData: false,
+  })
+
+  const consumersOptions =
+    consumers?.results.map((o) => ({
+      label: `${o.name || o.id}`,
+      value: o.id,
+    })) || []
+
   const { queryFilters, filtersFormMethods, enableFilters, clearFilters } =
     useQueryFilters<EServiceGetProviderListUrlParams>({
       q: '',
@@ -58,6 +71,7 @@ const ProviderEServiceListPage: React.FC = () => {
         filtersFormMethods={filtersFormMethods}
         enableFilters={enableFilters}
         clearFilters={clearFilters}
+        filterOptions={consumersOptions}
       />
       <EServiceTableWrapper params={params} />
       <Pagination {...props} totalPages={getTotalPageCount(data?.pagination.totalCount)} />

--- a/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
+++ b/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
@@ -26,7 +26,7 @@ const ProviderEServiceListPage: React.FC = () => {
     limit: 20,
   })
 
-  const { queryFilters, filtersFormMethods, enableFilters, clearFilters } =
+  const { queryFilters, filtersUseFormMethods, enableFilters, clearFilters } =
     useQueryFilters<EServiceGetProviderListQueryFilters>({
       q: '',
       consumersIds: [],
@@ -58,7 +58,7 @@ const ProviderEServiceListPage: React.FC = () => {
       topSideActions={topSideActions}
     >
       <EServiceTableFilters
-        filtersFormMethods={filtersFormMethods}
+        filtersUseFormMethods={filtersUseFormMethods}
         enableFilters={enableFilters}
         clearFilters={clearFilters}
       />

--- a/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
+++ b/src/pages/ProviderEServiceListPage/ProviderEServiceList.page.tsx
@@ -23,19 +23,6 @@ const ProviderEServiceListPage: React.FC = () => {
     limit: 20,
   })
 
-  const consumerParams = { limit: 50, offset: 0 }
-
-  const { data: consumers } = EServiceQueries.useGetConsumers(consumerParams, {
-    suspense: true,
-    keepPreviousData: false,
-  })
-
-  const consumersOptions =
-    consumers?.results.map((o) => ({
-      label: `${o.name || o.id}`,
-      value: o.id,
-    })) || []
-
   const { queryFilters, filtersFormMethods, enableFilters, clearFilters } =
     useQueryFilters<EServiceGetProviderListUrlParams>({
       q: '',
@@ -71,7 +58,6 @@ const ProviderEServiceListPage: React.FC = () => {
         filtersFormMethods={filtersFormMethods}
         enableFilters={enableFilters}
         clearFilters={clearFilters}
-        filterOptions={consumersOptions}
       />
       <EServiceTableWrapper params={params} />
       <Pagination {...props} totalPages={getTotalPageCount(data?.pagination.totalCount)} />

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
@@ -10,13 +10,13 @@ import { useAutocompleteFilterInput } from '@/hooks/useAutocompleteFilterInput'
 interface EServiceTableFiltersProps {
   clearFilters: VoidFunction
   enableFilters: VoidFunction
-  filtersFormMethods: UseFormReturn<EServiceGetProviderListQueryFilters, unknown>
+  filtersUseFormMethods: UseFormReturn<EServiceGetProviderListQueryFilters, unknown>
 }
 
 const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
   clearFilters,
   enableFilters,
-  filtersFormMethods,
+  filtersUseFormMethods,
 }) => {
   const { t } = useTranslation('eservice')
   const [consumersAutocompleteText, handleAutocompleteInputChange] = useAutocompleteFilterInput()
@@ -33,7 +33,7 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
     })) || []
 
   return (
-    <FormProvider {...filtersFormMethods}>
+    <FormProvider {...filtersUseFormMethods}>
       <Stack
         onSubmit={enableFilters}
         component="form"

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
@@ -3,11 +3,12 @@ import { Button, Stack } from '@mui/material'
 import { FormProvider, UseFormReturn } from 'react-hook-form'
 import { AutocompleteMultiple, TextField } from '@/components/shared/ReactHookFormInputs'
 import { EServiceQueries } from '@/api/eservice'
+import { EServiceGetProviderListQueryFilters } from '@/api/eservice/eservice.api.types'
 
 interface EServiceTableFiltersProps {
   clearFilters: VoidFunction
   enableFilters: VoidFunction
-  filtersFormMethods: UseFormReturn<any, any>
+  filtersFormMethods: UseFormReturn<EServiceGetProviderListQueryFilters, unknown>
 }
 
 const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Button, Stack } from '@mui/material'
+import { Button, Stack } from '@mui/material'
 import { FormProvider, UseFormReturn } from 'react-hook-form'
 import { AutocompleteMultiple, TextField } from '@/components/shared/ReactHookFormInputs'
 
@@ -7,12 +7,17 @@ interface EServiceTableFiltersProps {
   clearFilters: VoidFunction
   enableFilters: VoidFunction
   filtersFormMethods: UseFormReturn<any, any>
+  filterOptions: Array<{
+    label: string
+    value: unknown
+  }>
 }
 
 const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
   clearFilters,
   enableFilters,
   filtersFormMethods,
+  filterOptions,
 }) => {
   return (
     <FormProvider {...filtersFormMethods}>
@@ -24,28 +29,27 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
         justifyContent="space-between"
         sx={{ mb: 4 }}
       >
-        <TextField sx={{ m: 0 }} size="small" name="q" label="Cerca per nome dell’e-service" />
-        {/* <AutocompleteMultiple
-          size="small"
-          name="consumerIds"
-          label="consumers"
-          options={[
-            { label: 'A', value: 'a' },
-            { label: 'B', value: 'b' },
-          ]}
-        /> */}
+        <Stack direction="row" spacing={2} sx={{ flex: 0.8 }}>
+          <TextField
+            sx={{ m: 0, flex: 0.55 }}
+            size="small"
+            name="q"
+            label="Cerca per nome dell’e-service"
+          />
+          <AutocompleteMultiple
+            sx={{ flex: 0.45 }}
+            size="small"
+            name="consumerIds"
+            label="consumers"
+            options={filterOptions}
+          />
+        </Stack>
 
         <Stack direction="row" spacing={2}>
           <Button size="small" variant="outlined" type="submit">
             Filtra
           </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            sx={{ border: 0, '&:hover': { border: 0 } }}
-            type="button"
-            onClick={clearFilters}
-          >
+          <Button size="small" variant="text" type="button" onClick={clearFilters}>
             Annulla filtri
           </Button>
         </Stack>

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
@@ -2,23 +2,32 @@ import React from 'react'
 import { Button, Stack } from '@mui/material'
 import { FormProvider, UseFormReturn } from 'react-hook-form'
 import { AutocompleteMultiple, TextField } from '@/components/shared/ReactHookFormInputs'
+import { EServiceQueries } from '@/api/eservice'
 
 interface EServiceTableFiltersProps {
   clearFilters: VoidFunction
   enableFilters: VoidFunction
   filtersFormMethods: UseFormReturn<any, any>
-  filterOptions: Array<{
-    label: string
-    value: unknown
-  }>
 }
 
 const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
   clearFilters,
   enableFilters,
   filtersFormMethods,
-  filterOptions,
 }) => {
+  const { data: consumers, isLoading: isLoadingConsumers } = EServiceQueries.useGetConsumers(
+    { limit: 50, offset: 0 },
+    {
+      suspense: false,
+    }
+  )
+
+  const consumersOptions =
+    consumers?.results.map((o) => ({
+      label: o.name || 'default',
+      value: o.id,
+    })) || []
+
   return (
     <FormProvider {...filtersFormMethods}>
       <Stack
@@ -29,19 +38,20 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
         justifyContent="space-between"
         sx={{ mb: 4 }}
       >
-        <Stack direction="row" spacing={2} sx={{ flex: 0.8 }}>
+        <Stack direction="row" spacing={2} sx={{ width: '60%' }}>
           <TextField
-            sx={{ m: 0, flex: 0.55 }}
+            sx={{ m: 0, width: '55%' }}
             size="small"
             name="q"
             label="Cerca per nome dell’e-service"
           />
           <AutocompleteMultiple
-            sx={{ flex: 0.45 }}
+            sx={{ width: '45%' }}
             size="small"
-            name="consumerIds"
+            name="consumersIds"
             label="consumers"
-            options={filterOptions}
+            options={consumersOptions}
+            loading={isLoadingConsumers}
           />
         </Stack>
 

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
@@ -50,6 +50,7 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
           />
           <AutocompleteMultiple
             sx={{ width: '45%' }}
+            placeholder=""
             size="small"
             name="consumersIds"
             label={t('list.filters.consumerField.label')}

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
@@ -4,6 +4,7 @@ import { FormProvider, UseFormReturn } from 'react-hook-form'
 import { AutocompleteMultiple, TextField } from '@/components/shared/ReactHookFormInputs'
 import { EServiceQueries } from '@/api/eservice'
 import { EServiceGetProviderListQueryFilters } from '@/api/eservice/eservice.api.types'
+import { useTranslation } from 'react-i18next'
 
 interface EServiceTableFiltersProps {
   clearFilters: VoidFunction
@@ -16,6 +17,7 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
   enableFilters,
   filtersFormMethods,
 }) => {
+  const { t } = useTranslation('eservice')
   const { data: consumers, isLoading: isLoadingConsumers } = EServiceQueries.useGetConsumers(
     { limit: 50, offset: 0 },
     {
@@ -44,13 +46,13 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
             sx={{ m: 0, width: '55%' }}
             size="small"
             name="q"
-            label="Cerca per nome dell’e-service"
+            label={t('list.filters.nameField.label')}
           />
           <AutocompleteMultiple
             sx={{ width: '45%' }}
             size="small"
             name="consumersIds"
-            label="consumers"
+            label={t('list.filters.consumerField.label')}
             options={consumersOptions}
             loading={isLoadingConsumers}
           />
@@ -58,10 +60,10 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
 
         <Stack direction="row" spacing={2}>
           <Button size="small" variant="outlined" type="submit">
-            Filtra
+            {t('list.filters.filterBtn')}
           </Button>
           <Button size="small" variant="text" type="button" onClick={clearFilters}>
-            Annulla filtri
+            {t('list.filters.cancelFilterBtn')}
           </Button>
         </Stack>
       </Stack>

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
@@ -21,9 +21,9 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
   const { t } = useTranslation('eservice')
   const [consumersAutocompleteText, handleAutocompleteInputChange] = useAutocompleteFilterInput()
 
-  const { data: consumers, isLoading: isLoadingConsumers } = EServiceQueries.useGetConsumers(
+  const { data: consumers, isFetching: isFetchingConsumers } = EServiceQueries.useGetConsumers(
     { offset: 0, limit: 50, name: consumersAutocompleteText },
-    { suspense: false }
+    { suspense: false, keepPreviousData: true }
   )
 
   const consumersOptions =
@@ -57,7 +57,7 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
             onInputChange={handleAutocompleteInputChange}
             label={t('list.filters.consumerField.label')}
             options={consumersOptions}
-            loading={isLoadingConsumers}
+            loading={isFetchingConsumers}
           />
         </Stack>
 

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
@@ -5,6 +5,7 @@ import { AutocompleteMultiple, TextField } from '@/components/shared/ReactHookFo
 import { EServiceQueries } from '@/api/eservice'
 import { EServiceGetProviderListQueryFilters } from '@/api/eservice/eservice.api.types'
 import { useTranslation } from 'react-i18next'
+import { useAutocompleteFilterInput } from '@/hooks/useAutocompleteFilterInput'
 
 interface EServiceTableFiltersProps {
   clearFilters: VoidFunction
@@ -18,11 +19,11 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
   filtersFormMethods,
 }) => {
   const { t } = useTranslation('eservice')
+  const [consumersAutocompleteText, handleAutocompleteInputChange] = useAutocompleteFilterInput()
+
   const { data: consumers, isLoading: isLoadingConsumers } = EServiceQueries.useGetConsumers(
-    { limit: 50, offset: 0 },
-    {
-      suspense: false,
-    }
+    { offset: 0, limit: 50, name: consumersAutocompleteText },
+    { suspense: false }
   )
 
   const consumersOptions =
@@ -53,6 +54,7 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
             placeholder=""
             size="small"
             name="consumersIds"
+            onInputChange={handleAutocompleteInputChange}
             label={t('list.filters.consumerField.label')}
             options={consumersOptions}
             loading={isLoadingConsumers}

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
@@ -22,7 +22,7 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
   const [consumersAutocompleteText, handleAutocompleteInputChange] = useAutocompleteFilterInput()
 
   const { data: consumers, isFetching: isFetchingConsumers } = EServiceQueries.useGetConsumers(
-    { offset: 0, limit: 50, name: consumersAutocompleteText },
+    { offset: 0, limit: 50, q: consumersAutocompleteText },
     { suspense: false, keepPreviousData: true }
   )
 

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
@@ -24,7 +24,7 @@ const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
 
   const consumersOptions =
     consumers?.results.map((o) => ({
-      label: o.name || 'default',
+      label: o.name,
       value: o.id,
     })) || []
 

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableFilters.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { Box, Button, Stack } from '@mui/material'
+import { FormProvider, UseFormReturn } from 'react-hook-form'
+import { AutocompleteMultiple, TextField } from '@/components/shared/ReactHookFormInputs'
+
+interface EServiceTableFiltersProps {
+  clearFilters: VoidFunction
+  enableFilters: VoidFunction
+  filtersFormMethods: UseFormReturn<any, any>
+}
+
+const EServiceTableFilters: React.FC<EServiceTableFiltersProps> = ({
+  clearFilters,
+  enableFilters,
+  filtersFormMethods,
+}) => {
+  return (
+    <FormProvider {...filtersFormMethods}>
+      <Stack
+        onSubmit={enableFilters}
+        component="form"
+        direction="row"
+        spacing={2}
+        justifyContent="space-between"
+        sx={{ mb: 4 }}
+      >
+        <TextField sx={{ m: 0 }} size="small" name="q" label="Cerca per nome dell’e-service" />
+        {/* <AutocompleteMultiple
+          size="small"
+          name="consumerIds"
+          label="consumers"
+          options={[
+            { label: 'A', value: 'a' },
+            { label: 'B', value: 'b' },
+          ]}
+        /> */}
+
+        <Stack direction="row" spacing={2}>
+          <Button size="small" variant="outlined" type="submit">
+            Filtra
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            sx={{ border: 0, '&:hover': { border: 0 } }}
+            type="button"
+            onClick={clearFilters}
+          >
+            Annulla filtri
+          </Button>
+        </Stack>
+      </Stack>
+    </FormProvider>
+  )
+}
+
+export default EServiceTableFilters

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -121,6 +121,9 @@
       "providerField": {
         "label": "Find by provider"
       },
+      "consumerField": {
+        "label": "Find by consumer"
+      },
       "filterBtn": "Filter",
       "cancelFilterBtn": "Cancel filters"
     }

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -121,6 +121,9 @@
       "providerField": {
         "label": "Cerca per erogatore"
       },
+      "consumerField": {
+        "label": "Cerca per fruitore"
+      },
       "filterBtn": "Filtra",
       "cancelFilterBtn": "Annulla filtri"
     }

--- a/src/types/eservice.types.ts
+++ b/src/types/eservice.types.ts
@@ -172,3 +172,8 @@ export type EServiceDescriptorRead = {
   dailyCallsTotal: number
   agreementApprovalPolicy: 'MANUAL' | 'AUTOMATIC'
 }
+
+export type EServiceConsumer = {
+  id: string
+  name: string
+}

--- a/src/types/eservice.types.ts
+++ b/src/types/eservice.types.ts
@@ -177,3 +177,8 @@ export type EServiceConsumer = {
   id: string
   name: string
 }
+
+export type EServiceProducer = {
+  id: string
+  name: string
+}


### PR DESCRIPTION
This PR adds filter for the catalog and the provider's e-service table.
A hook that handles the filters, `useQueryFilters`, has been added.

Also:
- Fixed various problems with the MUI's autocomplete;
- Added `getProducers` and `getConsumers`services;
- Added tests for `useQueryFilters`.