### PR TITLE
[PIN-2404] - Added useActiveStep hook testing

### DIFF
--- a/src/hooks/__tests__/useActiveStep.test.tsx
+++ b/src/hooks/__tests__/useActiveStep.test.tsx
@@ -1,0 +1,51 @@
+import { renderHook } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+import { vi } from 'vitest'
+import { useActiveStep } from '../useActiveStep'
+import * as reactRouterDom from 'react-router-dom'
+
+vi.mock('react-router-dom')
+const useLocationSpy = vi.spyOn(reactRouterDom, 'useLocation')
+
+type UseLocationReturn = ReturnType<typeof reactRouterDom.useLocation>
+
+describe('useActiveStep hook testing', () => {
+  it('should update the state correctly', () => {
+    useLocationSpy.mockImplementation(() => ({} as UseLocationReturn))
+
+    const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => undefined)
+    const { result } = renderHook(() => useActiveStep())
+
+    expect(result.current.activeStep).toBe(0)
+    act(() => {
+      result.current.forward()
+    })
+    expect(scrollSpy).toBeCalledTimes(1)
+    expect(result.current.activeStep).toBe(1)
+    act(() => {
+      result.current.back()
+    })
+    expect(scrollSpy).toBeCalledTimes(1)
+    expect(result.current.activeStep).toBe(0)
+  })
+
+  it('should sync the initial step state with the location state', () => {
+    useLocationSpy.mockImplementation(
+      () => ({ state: { stepIndexDestination: 2 } } as UseLocationReturn)
+    )
+    const { result } = renderHook(() => useActiveStep())
+
+    expect(result.current.activeStep).toBe(2)
+  })
+
+  it('should not set the step index below to zero', () => {
+    useLocationSpy.mockImplementation(() => ({} as UseLocationReturn))
+    const { result } = renderHook(() => useActiveStep())
+
+    expect(result.current.activeStep).toBe(0)
+    act(() => {
+      result.current.back()
+    })
+    expect(result.current.activeStep).toBe(0)
+  })
+})

--- a/src/hooks/useActiveStep.ts
+++ b/src/hooks/useActiveStep.ts
@@ -13,35 +13,27 @@ export function scrollToTop() {
 }
 
 export const useActiveStep = (): ActiveStepProps => {
-  const [activeStep, setActiveStep] = React.useState(0)
   const location = useLocation()
-
-  // Handles which step to go to after a "creation" action has been performed
-  // and a history.replace action has taken place and the whole EServiceCreate
-  // component has rerendered and fetched fresh data
-  React.useEffect(() => {
-    const goToStep = (step: number) => {
-      setActiveStep(step)
-      scrollToTop()
-    }
-    // State has priority since it is a direct order to go to a location
+  const [activeStep, setActiveStep] = React.useState(() => {
     const locationState: Record<string, unknown> = location.state as Record<string, unknown>
+
     if (!isEmpty(locationState) && locationState.stepIndexDestination) {
-      goToStep(locationState.stepIndexDestination as number)
-    } else {
-      // If there is no state, go to first step
-      goToStep(0)
+      return locationState.stepIndexDestination as number
     }
-  }, [location])
+
+    return 0
+  })
 
   /*
    * Stepper actions
    */
   const back = React.useCallback(() => {
-    setActiveStep((prev) => prev - 1)
+    setActiveStep((prev) => Math.max(0, prev - 1))
   }, [])
 
   const forward = React.useCallback(() => {
+    console.debug('FIRED FORWARD')
+
     setActiveStep((prev) => prev + 1)
     scrollToTop()
   }, [])

--- a/src/hooks/useActiveStep.ts
+++ b/src/hooks/useActiveStep.ts
@@ -32,8 +32,6 @@ export const useActiveStep = (): ActiveStepProps => {
   }, [])
 
   const forward = React.useCallback(() => {
-    console.debug('FIRED FORWARD')
-
     setActiveStep((prev) => prev + 1)
     scrollToTop()
   }, [])

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStep1General/EServiceCreateStep1General.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStep1General/EServiceCreateStep1General.tsx
@@ -75,8 +75,8 @@ export const EServiceCreateStep1General: React.FC = () => {
             navigate('PROVIDE_ESERVICE_EDIT', {
               params: { eserviceId: id, descriptorId: URL_FRAGMENTS.FIRST_DRAFT[currentLanguage] },
               replace: true,
-              state: { stepIndexDestination: 1 },
             })
+            forward()
           },
         }
       )

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStep2Version/EServiceCreateStep2Version.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStep2Version/EServiceCreateStep2Version.tsx
@@ -119,8 +119,8 @@ export const EServiceCreateStep2Version: React.FC<ActiveStepProps> = () => {
         navigate('PROVIDE_ESERVICE_EDIT', {
           params: { eserviceId: eservice.id, descriptorId: data.id },
           replace: true,
-          state: { stepIndexDestination: 2 },
         })
+        forward()
       },
     })
   }


### PR DESCRIPTION
This PR adds tests for `useActiveStep` hook.

The way `useActiveStep` syncs with the location state has been changed. 
It does not sync with an useEffect, but with an initialization function inside the `activeStep` useState.

Added logic to the `back` function that does not allow the `activeStep` state to go below 0.