### PR TITLE
[PIN-2658] - Fix missing certified attributes alert

### DIFF
--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -22,10 +22,23 @@ const ConsumerEServiceDetailsPageContent: React.FC = () => {
   const { eserviceId, descriptorId } = useRouteParams<'SUBSCRIBE_CATALOG_VIEW'>()
 
   const { data: descriptor } = EServiceQueries.useGetDescriptorCatalog(eserviceId, descriptorId)
-  const { actions, canCreateAgreementDraft, isMine, isSubscribed, hasAgreementDraft } =
-    useGetEServiceConsumerActions(descriptor?.eservice, descriptor)
+  const { actions, isMine, isSubscribed, hasAgreementDraft } = useGetEServiceConsumerActions(
+    descriptor?.eservice,
+    descriptor
+  )
 
   const topSideActions = formatTopSideActions(actions)
+
+  // Only show missing certified attributes alert when...
+  const shouldShowMissingCertifiedAttributesAlert =
+    // ...the e-service is not owned by the active party...
+    !isMine &&
+    // ... the party doesn't own all the certified attributes required...
+    !descriptor?.eservice.hasCertifiedAttributes &&
+    // ... the e-service'slatest active descriptor is the actual descriptor the user is viewing...
+    descriptor?.eservice.activeDescriptor?.id === descriptor?.id &&
+    /// ... and it is not archived.
+    descriptor?.state !== 'ARCHIVED'
 
   return (
     <PageContainer
@@ -35,7 +48,7 @@ const ConsumerEServiceDetailsPageContent: React.FC = () => {
     >
       <Stack spacing={2}>
         {isMine && <Alert severity="info">{t('read.alert.youAreTheProvider')}</Alert>}
-        {!isMine && !canCreateAgreementDraft && descriptor?.state === 'PUBLISHED' && (
+        {shouldShowMissingCertifiedAttributesAlert && (
           <Alert severity="info">{t('read.alert.missingCertifiedAttributes')}</Alert>
         )}
         {isSubscribed && <Alert severity="info">{t('read.alert.alreadySubscribed')}</Alert>}


### PR DESCRIPTION
This PR fixes the rendering logic of the missing certified attributes alert.

The updated logic now renders the alert only when:
- the e-service is not owned by the active party;
- `descriptor.eservice.hasCertifiedAttributes` property is false;
- the actual viewing descriptor is the e-service active descriptor;
- the descriptor state is not "ARCHIVED". (It is not possible to have an active decriptor in "ARCHIVED" state right now, but it might be i the future)