### PR TITLE
[PIN-2613] - Replaced "access token" strings with "voucher"

### DIFF
--- a/src/pages/ConsumerClientManagePage/components/VoucherInstructions/VoucherInstructionsStep2.tsx
+++ b/src/pages/ConsumerClientManagePage/components/VoucherInstructions/VoucherInstructionsStep2.tsx
@@ -80,15 +80,15 @@ export const VoucherInstructionsStep2: React.FC<VoucherInstructionsStepProps> = 
       <Divider sx={{ mt: 4 }} />
 
       <Typography sx={{ mt: 3 }} component="h3" variant="h6">
-        {t('step2.accessTokenScript.title')}
+        {t('step2.voucherScript.title')}
       </Typography>
       <Typography sx={{ mt: 1 }} component="p" variant="body2" color="text.secondary">
-        {t('step2.accessTokenScript.description')}
+        {t('step2.voucherScript.description')}
       </Typography>
 
       <CodeSnippetPreview
         sx={{ mt: 2 }}
-        title={t('step2.accessTokenScript.exampleLabel')}
+        title={t('step2.voucherScript.exampleLabel')}
         activeLang="curl"
         entries={[{ url: `${FE_URL}/data/it/session_token_curl.txt`, value: 'curl' }]}
         scriptSubstitutionValues={{

--- a/src/static/locales/en/client.json
+++ b/src/static/locales/en/client.json
@@ -31,8 +31,8 @@
   },
   "edit": {
     "tabs": {
-      "ariaLabel": "Three different tabs with the instructions to obtain an access token, for client members and public keys",
-      "voucher": "Access token instructions",
+      "ariaLabel": "Three different tabs with the instructions to obtain a voucher, for client members and public keys",
+      "voucher": "Voucher instructions",
       "clientOperators": "Client members",
       "publicKeys": "Public keys"
     },

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -61,7 +61,7 @@
         "infoLabel": "The content of this field will the audience (aud) that the Subscriber will send you inside the access token. With this id the Subscriber will tell the Provider which service it is looking for. Max 250 chars"
       },
       "voucherLifespanField": {
-        "label": "Access token expiration (in minutes - required)",
+        "label": "Voucher expiration (in minutes - required)",
         "infoLabel": "Max value: 1440 minutes (24 hours)"
       },
       "dailyCallsPerConsumerField": {

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -436,14 +436,14 @@
     "postKey": {
       "loading": "Uploading key",
       "outcome": {
-        "success": "The key was uploaded successfully. It can now be used to sign a client assertion to obtain an access token",
+        "success": "The key was uploaded successfully. It can now be used to sign a client assertion to obtain a voucher",
         "error": "The key could not be uploaded. Please, make sure it is in the right format and with the right algorithm. Warning: the same key cannot be uploaded twice"
       }
     },
     "deleteKey": {
       "loading": "Deleting key",
       "outcome": {
-        "success": "The key was deleted successfully. It can no longer be used to sign a client assertion to obtain an access token",
+        "success": "The key was deleted successfully. It can no longer be used to sign a client assertion to obtain a voucher",
         "error": "The key could not be deleted. Please, try again!"
       },
       "confirmDialog": {

--- a/src/static/locales/en/voucher.json
+++ b/src/static/locales/en/voucher.json
@@ -11,14 +11,14 @@
   "choosePurposeBtn": "associate a purpose",
   "or": "or",
   "choosePurposeLabel": "Choose the purpose to use",
-  "purposeFailureMessage": "Warning! It will not be possible to obtain an access token for this purpose. One or more components are currently suspended. Suspended components:",
+  "purposeFailureMessage": "Warning! It will not be possible to obtain a voucher for this purpose. One or more components are currently suspended. Suspended components:",
   "purposeFailureReason": {
     "eservice": "E-service",
     "agreement": "fruition agreement",
     "purpose": "purpose"
   },
   "uploadKey": {
-    "message": "No keys found, it will not be possible to obtain an access token. To upload your first key, go to",
+    "message": "No keys found, it will not be possible to obtain a voucher. To upload your first key, go to",
     "linkLabel": "the public keys tab"
   },
   "step1": {
@@ -95,11 +95,11 @@
     }
   },
   "step2": {
-    "stepperLabel": "Access token",
-    "title": "Access token",
-    "consumerDescription": "In the previous step, you obtained a JWS signed with your private key. Now it will be used to make an access token request towards the Interoperability authorization server. It all is fine, an access token will be generated. It can be spent on the Provider e-service",
+    "stepperLabel": "Voucher",
+    "title": "Voucher",
+    "consumerDescription": "In the previous step, you obtained a JWS signed with your private key. Now it will be used to make a voucher request towards the Interoperability authorization server. It all is fine, a voucher will be generated. It can be spent on the Provider e-service",
     "apiDescription": {
-      "message": "In the previous step, you obtained a JWS signed with your private key. Now it will be used to make an access token request towards the Interoperability authorization server. It all is fine, an access token will be generated. It can be spent on the Provider e-service"
+      "message": "In the previous step, you obtained a JWS signed with your private key. Now it will be used to make a voucher request towards the Interoperability authorization server. It all is fine, a voucher will be generated. It can be spent on the Provider e-service"
     },
     "authEndpoint": {
       "label": "Authorization server endpoint",
@@ -126,7 +126,7 @@
         "copySuccessFeedbackText": "String copied successfully"
       }
     },
-    "accessTokenScript": {
+    "voucherScript": {
       "title": "cURL example",
       "description": "Replace the placeholder with the assertion obtained at step 1 and run the cURL",
       "exampleLabel": "example cURL"
@@ -137,7 +137,7 @@
     "apiStepperLabel": "API gateway details",
     "consumer": {
       "title": "Access the Provider e-service",
-      "description": "The access token obtained can be spent on the Provider e-service",
+      "description": "The voucher obtained can be spent on the Provider e-service",
       "audField": {
         "label": "AUD",
         "description": "The audience of the Provider e-service",
@@ -149,7 +149,7 @@
     },
     "api": {
       "title": "Interoperability API gateway access",
-      "description": "The access token obtained can be spent on the Interoperability API gateway",
+      "description": "The voucher obtained can be spent on the Interoperability API gateway",
       "apiField": {
         "label": "Link to the document's interface",
         "link": {

--- a/src/static/locales/it/client.json
+++ b/src/static/locales/it/client.json
@@ -31,8 +31,8 @@
   },
   "edit": {
     "tabs": {
-      "ariaLabel": "Tre tab diverse per le istruzioni dell'ottenimento dell'access token, i membri del client e le chiavi pubbliche",
-      "voucher": "Istruzioni ottenimento accesso token",
+      "ariaLabel": "Tre tab diverse per le istruzioni dell'ottenimento del voucher, i membri del client e le chiavi pubbliche",
+      "voucher": "Istruzioni ottenimento voucher",
       "clientOperators": "Membri del client",
       "publicKeys": "Chiavi pubbliche"
     },

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -61,7 +61,7 @@
         "infoLabel": "All’interno dell'access token che il fruitore ti invierà rappresenterà l’audience (aud), l'id con il quale è dichiarato il servizio richiesto. Max 250 caratteri"
       },
       "voucherLifespanField": {
-        "label": "Durata di validità dell'access token (in minuti - richiesto)",
+        "label": "Durata di validità del voucher (in minuti - richiesto)",
         "infoLabel": "Valore massimo: 1440 minuti (24 ore)"
       },
       "dailyCallsPerConsumerField": {

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -437,14 +437,14 @@
     "postKey": {
       "loading": "Stiamo caricando la chiave",
       "outcome": {
-        "success": "La chiave è ora utilizzabile per firmare una client assertion per ottenere un access token",
+        "success": "La chiave è ora utilizzabile per firmare una client assertion per ottenere un voucher",
         "error": "Non è stato possibile caricare la chiave. Assicurarsi sia nel formato corretto e riprovare. Attenzione: la stessa chiave non può essere caricata due volte"
       }
     },
     "deleteKey": {
       "loading": "Stiamo cancellando la chiave",
       "outcome": {
-        "success": "La chiave pubblica è stata cancellata correttamente. Da questo momento non potrà più essere usata per firmare una client assertion per ottenere un access token",
+        "success": "La chiave pubblica è stata cancellata correttamente. Da questo momento non potrà più essere usata per firmare una client assertion per ottenere un voucher",
         "error": "Non è stato possibile cancellare la chiave. Per favore, riprova!"
       },
       "confirmDialog": {

--- a/src/static/locales/it/voucher.json
+++ b/src/static/locales/it/voucher.json
@@ -11,14 +11,14 @@
   "choosePurposeBtn": "scegli la finalità da associare",
   "or": "oppure",
   "choosePurposeLabel": "Scegli la finalità da utilizzare",
-  "purposeFailureMessage": "Attenzione! Non sarà possibile ottenere un access token per questa finalità. In una o più componenti della pipeline è stato sospeso il servizio. Le componenti sospese sono:",
+  "purposeFailureMessage": "Attenzione! Non sarà possibile ottenere un voucher per questa finalità. In una o più componenti della pipeline è stato sospeso il servizio. Le componenti sospese sono:",
   "purposeFailureReason": {
     "eservice": "E-service",
     "agreement": "accordo di fruizione",
     "purpose": "finalità"
   },
   "uploadKey": {
-    "message": "Non ci sono chiavi disponibili, non è possibile ottenere un access token. Per caricare la tua prima chiave, vai alla",
+    "message": "Non ci sono chiavi disponibili, non è possibile ottenere un voucher. Per caricare la tua prima chiave, vai alla",
     "linkLabel": "tab delle chiavi pubbliche"
   },
   "step1": {
@@ -95,11 +95,11 @@
     }
   },
   "step2": {
-    "stepperLabel": "Access token",
-    "title": "Access token",
-    "consumerDescription": "Una volta creato il JWS firmato con la propria chiave privata, bisogna utilizzarlo per fare una richiesta di access token verso l’authorization server di Interoperabilità PDND. Se va a buon fine, verrà restituito un access token spendibile presso l'e-service dell’erogatore",
+    "stepperLabel": "Voucher",
+    "title": "Voucher",
+    "consumerDescription": "Una volta creato il JWS firmato con la propria chiave privata, bisogna utilizzarlo per fare una richiesta di voucher verso l’authorization server di Interoperabilità PDND. Se va a buon fine, verrà restituito un voucher spendibile presso l'e-service dell’erogatore",
     "apiDescription": {
-      "message": "Una volta creato il JWS firmato con la propria chiave privata, bisogna utilizzarlo per fare una richiesta di access token verso l’authorization server di Interoperabilità PDND. Se va a buon fine, verrà restituito un access token spendibile presso l’API gateway di Interoperabilità"
+      "message": "Una volta creato il JWS firmato con la propria chiave privata, bisogna utilizzarlo per fare una richiesta di voucher verso l’authorization server di Interoperabilità PDND. Se va a buon fine, verrà restituito un voucher spendibile presso l’API gateway di Interoperabilità"
     },
     "authEndpoint": {
       "label": "Endpoint authorization server",
@@ -126,7 +126,7 @@
         "copySuccessFeedbackText": "Stringa copiata correttamente"
       }
     },
-    "accessTokenScript": {
+    "voucherScript": {
       "title": "Esempio di cURL",
       "description": "Sostituisci il segnaposto con l’asserzione che hai ottenuto allo step precedente e lancia la cURL",
       "exampleLabel": "cURL di esempio"
@@ -137,7 +137,7 @@
     "apiStepperLabel": "Dettagli API gateway",
     "consumer": {
       "title": "Accesso all’e-service dell’erogatore",
-      "description": "A questo punto l'access token ottenuto è spendibile presso l'e-service dell’erogatore",
+      "description": "A questo punto il voucher ottenuto è spendibile presso l'e-service dell’erogatore",
       "audField": {
         "label": "AUD",
         "description": "L'audience dell'e-service dell'erogatore",
@@ -149,7 +149,7 @@
     },
     "api": {
       "title": "Accesso all’API gateway di Interoperabilità",
-      "description": "A questo punto l'access token ottenuto è spendibile presso l’API gateway di Interoperabilità",
+      "description": "A questo punto il voucher ottenuto è spendibile presso l’API gateway di Interoperabilità",
       "apiField": {
         "label": "Link al documento di interfaccia",
         "link": {


### PR DESCRIPTION
Replaced every "access token" string and localized string reference with "voucher". Only the "access token" in audience field in step-2 of e-service descriptor creation is standing