### PR TITLE
[PIN-2744] - Purpose action hooks ad utils testing

### DIFF
--- a/__mocks__/data/purpose.mocks.ts
+++ b/__mocks__/data/purpose.mocks.ts
@@ -1,0 +1,86 @@
+import { DecoratedPurpose, PurposeListingItem } from '../../src/types/purpose.types'
+import { createMockFactory } from '../../src/utils/testing.utils'
+
+const createMockDecoratedPurpose = createMockFactory<DecoratedPurpose>({
+  agreement: { id: '3ec3875a-cf24-450a-b94b-550ca2ec5e86', state: 'ACTIVE' },
+  clients: [],
+  consumer: { id: '6b16be70-9230-4209-bd1f-7e5ae0eed289', name: 'PagoPa S.p.A.' },
+  description: 'Lorem ipsum dolor sit amet...',
+  eservice: {
+    descriptor: {
+      dailyCalls: 1,
+      id: 'cd80bfe6-54be-493a-aaa1-6bb2b54545f8',
+      state: 'PUBLISHED',
+      version: '1',
+    },
+    id: 'dea4bbf4-df64-4b8a-9ca9-125dd4cd1f5e',
+    name: 'Test Attributi 2 - Ste',
+    producer: { id: '6b16be70-9230-4209-bd1f-7e5ae0eed289', name: 'PagoPa S.p.A.' },
+  },
+  id: 'e46c7d27-18a0-40db-b7f9-ae8652355e8e',
+  riskAnalysisForm: {
+    answers: {
+      checkedExistenceMereCorrectnessInteropCatalogue: ['true'],
+      deliveryMethod: ['CLEARTEXT'],
+      confirmPricipleIntegrityAndDiscretion: ['true'],
+      usesThirdPartyData: ['NO'],
+      purpose: ['INSTITUTIONAL'],
+      doneDpia: ['NO'],
+      personalDataTypes: ['WITH_NON_IDENTIFYING_DATA'],
+      legalBasis: ['CONTRACT'],
+      dataRetentionPeriod: ['true'],
+      knowsDataQuantity: ['NO'],
+      institutionalPurpose: ['test'],
+      policyProvided: ['YES'],
+      declarationConfirmGDPR: ['true'],
+      purposePursuit: ['MERE_CORRECTNESS'],
+    },
+    version: '2.0',
+  },
+  suspendedByConsumer: false,
+  suspendedByProducer: false,
+  title: 'Nuova finalità',
+  versions: [
+    {
+      createdAt: '2023-02-03T07:59:52.458Z',
+      dailyCalls: 1,
+      firstActivationAt: '2023-02-03T08:26:43.139Z',
+      id: '3a5c9422-876c-4de8-828a-66586fd68b55',
+      riskAnalysis: {
+        contentType: 'application/pdf',
+        createdAt: '2023-02-03T08:26:43.049Z',
+        id: '3562b028-0193-45fa-acf9-4bbe1ced352a',
+      },
+      state: 'ACTIVE',
+    },
+  ],
+  waitingForApprovalVersion: null,
+  currentVersion: {
+    createdAt: '2023-02-03T07:59:52.458Z',
+    dailyCalls: 1,
+    firstActivationAt: '2023-02-03T08:26:43.139Z',
+    id: '3a5c9422-876c-4de8-828a-66586fd68b55',
+    riskAnalysis: {
+      contentType: 'application/pdf',
+      createdAt: '2023-02-03T08:26:43.049Z',
+      id: '3562b028-0193-45fa-acf9-4bbe1ced352a',
+    },
+    state: 'ACTIVE',
+  },
+})
+
+const createMockPurposeListingItem = createMockFactory<PurposeListingItem>({
+  consumer: { id: '6b16be70-9230-4209-bd1f-7e5ae0eed289', name: 'PagoPa S.p.A.' },
+  currentVersion: { dailyCalls: 1, id: '3a5c9422-876c-4de8-828a-66586fd68b55', state: 'ACTIVE' },
+  eservice: {
+    id: 'dea4bbf4-df64-4b8a-9ca9-125dd4cd1f5e',
+    name: 'Test Attributi 2 - Ste',
+    producer: { id: '6b16be70-9230-4209-bd1f-7e5ae0eed289', name: 'PagoPa S.p.A.' },
+  },
+  id: 'e46c7d27-18a0-40db-b7f9-ae8652355e8e',
+  suspendedByConsumer: false,
+  suspendedByProducer: false,
+  title: 'Nuova finalità',
+})
+
+export { createMockDecoratedPurpose, createMockPurposeListingItem }

--- a/src/hooks/__tests__/useGetConsumerPurposesActions.test.ts
+++ b/src/hooks/__tests__/useGetConsumerPurposesActions.test.ts
@@ -13,7 +13,7 @@ function renderUseGetConsumerPurposesActionsHook(purpose?: DecoratedPurpose | Pu
   })
 }
 
-describe('', () => {
+describe('check if useGetConsumerPurposesActions returns the correct actions based on the passed purpose', () => {
   it('shoud not return any action if no purpose is given', () => {
     const { result } = renderUseGetConsumerPurposesActionsHook()
     expect(result.current.actions).toHaveLength(0)

--- a/src/hooks/__tests__/useGetConsumerPurposesActions.test.ts
+++ b/src/hooks/__tests__/useGetConsumerPurposesActions.test.ts
@@ -1,0 +1,118 @@
+import { DecoratedPurpose, PurposeListingItem } from '@/types/purpose.types'
+import { renderHookWithApplicationContext } from '@/utils/testing.utils'
+import useGetConsumerPurposesActions from '../useGetConsumerPurposesActions'
+import {
+  createMockDecoratedPurpose,
+  createMockPurposeListingItem,
+} from '__mocks__/data/purpose.mocks'
+
+function renderUseGetConsumerPurposesActionsHook(purpose?: DecoratedPurpose | PurposeListingItem) {
+  return renderHookWithApplicationContext(() => useGetConsumerPurposesActions(purpose), {
+    withReactQueryContext: true,
+    withRouterContext: true,
+  })
+}
+
+describe('', () => {
+  it('shoud not return any action if no purpose is given', () => {
+    const { result } = renderUseGetConsumerPurposesActionsHook()
+    expect(result.current.actions).toHaveLength(0)
+  })
+
+  it('shoud not return any action if an archived purpose is given', () => {
+    const purposeMock = createMockDecoratedPurpose({ currentVersion: { state: 'ARCHIVED' } })
+    const { result } = renderUseGetConsumerPurposesActionsHook(purposeMock)
+    expect(result.current.actions).toHaveLength(0)
+  })
+
+  it('should return the activate and delete functions if the current version is in draft', () => {
+    const purposeMock = createMockPurposeListingItem({ currentVersion: { state: 'DRAFT' } })
+    const { result } = renderUseGetConsumerPurposesActionsHook(purposeMock)
+    expect(result.current.actions).toHaveLength(2)
+
+    const activateAction = result.current.actions.find((action) => action.label === 'activate')
+    const deleteAction = result.current.actions.find((action) => action.label === 'delete')
+
+    expect(activateAction).toBeTruthy()
+    expect(deleteAction).toBeTruthy()
+  })
+
+  it('should return only the delete action if the purpose has only the waiting for approval version', () => {
+    const purposeMock = createMockPurposeListingItem({
+      currentVersion: undefined,
+      waitingForApprovalVersion: {
+        id: 'test-id',
+        state: 'WAITING_FOR_APPROVAL',
+        dailyCalls: 1,
+      },
+    })
+    const { result } = renderUseGetConsumerPurposesActionsHook(purposeMock)
+    expect(result.current.actions).toHaveLength(1)
+
+    const deleteAction = result.current.actions.find((action) => action.label === 'delete')
+    expect(deleteAction).toBeTruthy()
+  })
+
+  it('should return the delete daily calls update action if the purpose has more than one version and a waiting for approval version', () => {
+    const purposeMock = createMockPurposeListingItem({
+      waitingForApprovalVersion: {
+        id: 'test-id',
+        state: 'WAITING_FOR_APPROVAL',
+        dailyCalls: 1,
+      },
+    })
+    const { result } = renderUseGetConsumerPurposesActionsHook(purposeMock)
+    expect(result.current.actions.length).toBeGreaterThanOrEqual(1)
+
+    const deleteDailyCallsUpdateAction = result.current.actions.find(
+      (action) => action.label === 'deleteDailyCallsUpdate'
+    )
+    expect(deleteDailyCallsUpdateAction).toBeTruthy()
+  })
+
+  it('should return the updated daily calls update action if the purpose has more than one version and no waiting for approval version', () => {
+    const purposeMock = createMockPurposeListingItem({ waitingForApprovalVersion: undefined })
+    const { result } = renderUseGetConsumerPurposesActionsHook(purposeMock)
+    expect(result.current.actions.length).toBeGreaterThanOrEqual(1)
+
+    const updateDailyCallsAction = result.current.actions.find(
+      (action) => action.label === 'updateDailyCalls'
+    )
+    expect(updateDailyCallsAction).toBeTruthy()
+  })
+
+  it('should return the suspend action if the purpose is active', () => {
+    const purposeMock = createMockPurposeListingItem({
+      currentVersion: { state: 'ACTIVE' },
+    })
+    const { result } = renderUseGetConsumerPurposesActionsHook(purposeMock)
+    expect(result.current.actions.length).toBeGreaterThanOrEqual(1)
+
+    const suspendAction = result.current.actions.find((action) => action.label === 'suspend')
+    expect(suspendAction).toBeTruthy()
+  })
+
+  it('should return the suspend action if the purpose is suspended by the provider', () => {
+    const purposeMock = createMockPurposeListingItem({
+      currentVersion: { state: 'SUSPENDED' },
+      suspendedByConsumer: false,
+    })
+    const { result } = renderUseGetConsumerPurposesActionsHook(purposeMock)
+    expect(result.current.actions.length).toBeGreaterThanOrEqual(1)
+
+    const suspendAction = result.current.actions.find((action) => action.label === 'suspend')
+    expect(suspendAction).toBeTruthy()
+  })
+
+  it('should return the activate action if the purpose is suspended by the consumer', () => {
+    const purposeMock = createMockPurposeListingItem({
+      currentVersion: { state: 'SUSPENDED' },
+      suspendedByConsumer: true,
+    })
+    const { result } = renderUseGetConsumerPurposesActionsHook(purposeMock)
+    expect(result.current.actions.length).toBeGreaterThanOrEqual(1)
+
+    const activateAction = result.current.actions.find((action) => action.label === 'activate')
+    expect(activateAction).toBeTruthy()
+  })
+})

--- a/src/hooks/__tests__/useGetProviderPurposesActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderPurposesActions.test.ts
@@ -1,0 +1,76 @@
+import { DecoratedPurpose, PurposeListingItem } from '@/types/purpose.types'
+import { renderHookWithApplicationContext } from '@/utils/testing.utils'
+import useGetProviderPurposesActions from '../useGetProviderPurposesActions'
+import {
+  createMockDecoratedPurpose,
+  createMockPurposeListingItem,
+} from '__mocks__/data/purpose.mocks'
+
+function renderUseGetProviderPurposesActionsHook(purpose?: DecoratedPurpose | PurposeListingItem) {
+  return renderHookWithApplicationContext(() => useGetProviderPurposesActions(purpose), {
+    withReactQueryContext: true,
+    withRouterContext: true,
+  })
+}
+
+describe('', () => {
+  it('shoud not return any action if no purpose is given', () => {
+    const { result } = renderUseGetProviderPurposesActionsHook()
+    expect(result.current.actions).toHaveLength(0)
+  })
+
+  it('shoud not return any action if an archived purpose is given', () => {
+    const purposeMock = createMockDecoratedPurpose({ currentVersion: { state: 'ARCHIVED' } })
+    const { result } = renderUseGetProviderPurposesActionsHook(purposeMock)
+    expect(result.current.actions).toHaveLength(0)
+  })
+
+  it('should return the suspend function if the current version is active', () => {
+    const purposeMock = createMockPurposeListingItem({ currentVersion: { state: 'ACTIVE' } })
+    const { result } = renderUseGetProviderPurposesActionsHook(purposeMock)
+
+    const suspendAction = result.current.actions.find((action) => action.label === 'suspend')
+    expect(suspendAction).toBeTruthy()
+  })
+
+  it('shoud have action to update completion date and active the waiting for approval version if the purpose has one', () => {
+    const purposeMock = createMockPurposeListingItem({
+      waitingForApprovalVersion: {
+        id: 'test-id',
+        dailyCalls: 2,
+        state: 'WAITING_FOR_APPROVAL',
+      },
+    })
+    const { result } = renderUseGetProviderPurposesActionsHook(purposeMock)
+    const activateVersionAction = result.current.actions.find(
+      (action) => action.label === 'confirmUpdate'
+    )
+    const updateCompletionDateAction = result.current.actions.find(
+      (action) => action.label === 'updateCompletionDate'
+    )
+    expect(activateVersionAction).toBeTruthy()
+    expect(updateCompletionDateAction).toBeTruthy()
+  })
+
+  it('shoud have the suspend action if the purpose is suspended but not suspended by the provider ', () => {
+    const purposeMock = createMockPurposeListingItem({
+      currentVersion: { state: 'SUSPENDED' },
+      suspendedByProducer: false,
+    })
+
+    const { result } = renderUseGetProviderPurposesActionsHook(purposeMock)
+    const suspendAction = result.current.actions.find((action) => action.label === 'suspend')
+    expect(suspendAction).toBeTruthy()
+  })
+
+  it('shoud have the activate action if the purpose is suspended by the provider ', () => {
+    const purposeMock = createMockPurposeListingItem({
+      currentVersion: { state: 'SUSPENDED' },
+      suspendedByProducer: true,
+    })
+
+    const { result } = renderUseGetProviderPurposesActionsHook(purposeMock)
+    const suspendAction = result.current.actions.find((action) => action.label === 'activate')
+    expect(suspendAction).toBeTruthy()
+  })
+})

--- a/src/hooks/__tests__/useGetProviderPurposesActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderPurposesActions.test.ts
@@ -13,7 +13,7 @@ function renderUseGetProviderPurposesActionsHook(purpose?: DecoratedPurpose | Pu
   })
 }
 
-describe('', () => {
+describe('check if useGetProviderPurposesActions returns the correct actions based on the passed purpose', () => {
   it('shoud not return any action if no purpose is given', () => {
     const { result } = renderUseGetProviderPurposesActionsHook()
     expect(result.current.actions).toHaveLength(0)

--- a/src/hooks/__tests__/useGetProviderPurposesActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderPurposesActions.test.ts
@@ -70,7 +70,7 @@ describe('check if useGetProviderPurposesActions returns the correct actions bas
     })
 
     const { result } = renderUseGetProviderPurposesActionsHook(purposeMock)
-    const suspendAction = result.current.actions.find((action) => action.label === 'activate')
-    expect(suspendAction).toBeTruthy()
+    const activateAction = result.current.actions.find((action) => action.label === 'activate')
+    expect(activateAction).toBeTruthy()
   })
 })

--- a/src/hooks/useGetConsumerPurposesActions.ts
+++ b/src/hooks/useGetConsumerPurposesActions.ts
@@ -93,7 +93,6 @@ function useGetConsumerPurposesActions(purpose?: DecoratedPurpose | PurposeListi
     action: handleUpdateDailyCalls,
   }
 
-  // TODO: commento
   if (!purpose.currentVersion && purpose.waitingForApprovalVersion) {
     return { actions: [deleteAction] }
   }

--- a/src/utils/__tests__/purpose.utils.test.ts
+++ b/src/utils/__tests__/purpose.utils.test.ts
@@ -1,0 +1,110 @@
+import { checkPurposeSuspendedByConsumer, getPurposeFailureReasons } from '../purpose.utils'
+import { createMockDecoratedPurpose } from '__mocks__/data/purpose.mocks'
+
+describe('checks if the getPurposeFailureReasons purpose util function work as expected', () => {
+  it('should have no failure if the e-service is published, the agreement and the purpose current version are active', () => {
+    const mockPurpose = createMockDecoratedPurpose({
+      eservice: { descriptor: { state: 'PUBLISHED' } },
+      agreement: { state: 'ACTIVE' },
+      currentVersion: { state: 'ACTIVE' },
+    })
+    const failureReasons = getPurposeFailureReasons(mockPurpose)
+    expect(failureReasons).toHaveLength(0)
+  })
+
+  it('should have no failure if the e-service is deprecated, the agreement and the purpose current version are active', () => {
+    const mockPurpose = createMockDecoratedPurpose({
+      eservice: { descriptor: { state: 'DEPRECATED' } },
+      agreement: { state: 'ACTIVE' },
+      currentVersion: { state: 'ACTIVE' },
+    })
+    const failureReasons = getPurposeFailureReasons(mockPurpose)
+    expect(failureReasons).toHaveLength(0)
+  })
+
+  it('should have e-service failure reason if the e-service is neither deprecated or published', () => {
+    const mockPurpose = createMockDecoratedPurpose({
+      eservice: { descriptor: { state: 'DRAFT' } },
+      agreement: { state: 'ACTIVE' },
+      currentVersion: { state: 'ACTIVE' },
+    })
+    const failureReasons = getPurposeFailureReasons(mockPurpose)
+    expect(failureReasons.length).toBeGreaterThanOrEqual(1)
+    expect(failureReasons).toContain('eservice')
+  })
+
+  it('should have agreement failure reason if the agreement is not active', () => {
+    const mockPurpose = createMockDecoratedPurpose({
+      eservice: { descriptor: { state: 'PUBLISHED' } },
+      agreement: { state: 'SUSPENDED' },
+      currentVersion: { state: 'ACTIVE' },
+    })
+    const failureReasons = getPurposeFailureReasons(mockPurpose)
+    expect(failureReasons.length).toBeGreaterThanOrEqual(1)
+    expect(failureReasons).toContain('agreement')
+  })
+
+  it('should have purpose failure reason if the purpose current version is not active', () => {
+    const mockPurpose = createMockDecoratedPurpose({
+      eservice: { descriptor: { state: 'PUBLISHED' } },
+      agreement: { state: 'ACTIVE' },
+      currentVersion: { state: 'SUSPENDED' },
+    })
+    const failureReasons = getPurposeFailureReasons(mockPurpose)
+    expect(failureReasons.length).toBeGreaterThanOrEqual(1)
+    expect(failureReasons).toContain('purpose')
+  })
+
+  it('should have puspoe, agreement and e-servive failure reasons if the purpose current version and the agreement are not active and the eservice is neither published or deprecated ', () => {
+    const mockPurpose = createMockDecoratedPurpose({
+      eservice: { descriptor: { state: 'DRAFT' } },
+      agreement: { state: 'SUSPENDED' },
+      currentVersion: { state: 'SUSPENDED' },
+    })
+    const failureReasons = getPurposeFailureReasons(mockPurpose)
+    expect(failureReasons).toHaveLength(3)
+    expect(failureReasons).toContain('eservice')
+    expect(failureReasons).toContain('agreement')
+    expect(failureReasons).toContain('purpose')
+  })
+})
+
+describe('checks if the checkPurposeSuspendedByConsumer purpose util function work as expected', () => {
+  it("should return false if the purpose's current version is not suspended", () => {
+    const mockPurpose = createMockDecoratedPurpose({
+      currentVersion: { state: 'ACTIVE' },
+    })
+    const isSuspendedByConsumer = checkPurposeSuspendedByConsumer(mockPurpose)
+    expect(isSuspendedByConsumer).toBe(false)
+  })
+
+  it('should return false if the suspendedByConsumer flag is false', () => {
+    const mockPurpose = createMockDecoratedPurpose({
+      currentVersion: { state: 'SUSPENDED' },
+      suspendedByConsumer: false,
+    })
+    const isSuspendedByConsumer = checkPurposeSuspendedByConsumer(mockPurpose)
+    expect(isSuspendedByConsumer).toBe(false)
+  })
+
+  it('should return true if the suspendedByConsumer flag is true', () => {
+    const mockPurpose = createMockDecoratedPurpose({
+      currentVersion: { state: 'SUSPENDED' },
+      suspendedByConsumer: true,
+    })
+    const isSuspendedByConsumer = checkPurposeSuspendedByConsumer(mockPurpose, 'test-id')
+    expect(isSuspendedByConsumer).toBe(true)
+  })
+
+  it('should return true if the suspendedByConsumer flag is false, the suspendedByProducer is true and the passed party id is equal to the e-service producer id and the purpose producer id', () => {
+    const mockPurpose = createMockDecoratedPurpose({
+      currentVersion: { state: 'SUSPENDED' },
+      suspendedByProducer: true,
+      suspendedByConsumer: false,
+      eservice: { producer: { id: 'test-id' } },
+      consumer: { id: 'test-id' },
+    })
+    const isSuspendedByConsumer = checkPurposeSuspendedByConsumer(mockPurpose, 'test-id')
+    expect(isSuspendedByConsumer).toBe(true)
+  })
+})

--- a/src/utils/__tests__/purpose.utils.test.ts
+++ b/src/utils/__tests__/purpose.utils.test.ts
@@ -96,7 +96,7 @@ describe('checks if the checkPurposeSuspendedByConsumer purpose util function wo
     expect(isSuspendedByConsumer).toBe(true)
   })
 
-  it('should return true if the suspendedByConsumer flag is false, the suspendedByProducer is true and the passed party id is equal to the e-service producer id and the purpose producer id', () => {
+  it('should return true if the active party is both the e-service producer and purpose consumer and the purpose is supended by the party itself.', () => {
     const mockPurpose = createMockDecoratedPurpose({
       currentVersion: { state: 'SUSPENDED' },
       suspendedByProducer: true,

--- a/src/utils/purpose.utils.ts
+++ b/src/utils/purpose.utils.ts
@@ -31,12 +31,14 @@ export function checkPurposeSuspendedByConsumer(
   purpose: DecoratedPurpose | PurposeListingItem,
   partyId?: string
 ) {
+  if (purpose?.currentVersion?.state !== 'SUSPENDED') return false
+  if (purpose.suspendedByConsumer) return true
+
   const isPurposeSuspendedByProvider = purpose.suspendedByProducer
   const isActualPartyEServiceProvider = partyId === purpose.eservice.producer.id
   const isActualPartyPurposeConsumer = partyId === purpose.consumer.id
 
   return (
-    purpose.suspendedByConsumer ||
-    (isPurposeSuspendedByProvider && isActualPartyPurposeConsumer && isActualPartyEServiceProvider)
+    isPurposeSuspendedByProvider && isActualPartyPurposeConsumer && isActualPartyEServiceProvider
   )
 }

--- a/src/utils/testing.utils.tsx
+++ b/src/utils/testing.utils.tsx
@@ -48,15 +48,16 @@ export function createPaginatedMockData<T>(
   }
 }
 
+type RecursivePartial<T> = {
+  [P in keyof T]?: RecursivePartial<T[P]>
+}
+
 /**
  * Create and returns a mock factory function
  */
 export function createMockFactory<T>(defaultValue: T) {
-  return (overwrites: Partial<T> = {}) => {
-    return cloneDeep({
-      ...defaultValue,
-      ...overwrites,
-    }) as T
+  return (overwrites: RecursivePartial<T> = {}) => {
+    return deepmerge(cloneDeep(defaultValue), overwrites) as T
   }
 }
 


### PR DESCRIPTION
This PR adds testing for `useGetConsumerPurposesActions`, `useGetProviderPurposesActions` hooks and `purpose.utils.ts` file.

Also:
- Changed the way factory mocks function produces data, it now deep merges the passed data overwrite object.