### PR TITLE
[PIN-2781] - Update eservice services paths from CATALOG to BFF

### DIFF
--- a/src/api/eservice/eservice.services.ts
+++ b/src/api/eservice/eservice.services.ts
@@ -17,7 +17,6 @@ import {
   EServiceConsumer,
   EServiceDescriptorCatalog,
   EServiceDescriptorProvider,
-  EServiceDescriptorRead,
   EServiceProducer,
   EServiceProvider,
   EServiceRead,
@@ -132,8 +131,8 @@ async function createVersionDraft({
 }: {
   eserviceId: string
 } & EServiceVersionDraftPayload) {
-  const response = await axiosInstance.post<EServiceDescriptorRead>(
-    `${CATALOG_PROCESS_URL}/eservices/${eserviceId}/descriptors`,
+  const response = await axiosInstance.post<{ id: string }>(
+    `${BACKEND_FOR_FRONTEND_URL}/eservices/${eserviceId}/descriptors`,
     payload
   )
   return response.data
@@ -147,8 +146,8 @@ async function updateVersionDraft({
   eserviceId: string
   descriptorId: string
 } & EServiceVersionDraftPayload) {
-  const response = await axiosInstance.put<EServiceDescriptorRead>(
-    `${CATALOG_PROCESS_URL}/eservices/${eserviceId}/descriptors/${descriptorId}`,
+  const response = await axiosInstance.put<{ id: string }>(
+    `${BACKEND_FOR_FRONTEND_URL}/eservices/${eserviceId}/descriptors/${descriptorId}`,
     payload
   )
   return response.data
@@ -162,7 +161,7 @@ function publishVersionDraft({
   descriptorId: string
 }) {
   return axiosInstance.post(
-    `${CATALOG_PROCESS_URL}/eservices/${eserviceId}/descriptors/${descriptorId}/publish`
+    `${BACKEND_FOR_FRONTEND_URL}/eservices/${eserviceId}/descriptors/${descriptorId}/publish`
   )
 }
 
@@ -174,7 +173,7 @@ function suspendVersion({
   descriptorId: string
 }) {
   return axiosInstance.post(
-    `${CATALOG_PROCESS_URL}/eservices/${eserviceId}/descriptors/${descriptorId}/suspend`
+    `${BACKEND_FOR_FRONTEND_URL}/eservices/${eserviceId}/descriptors/${descriptorId}/suspend`
   )
 }
 
@@ -186,7 +185,7 @@ function reactivateVersion({
   descriptorId: string
 }) {
   return axiosInstance.post(
-    `${CATALOG_PROCESS_URL}/eservices/${eserviceId}/descriptors/${descriptorId}/activate`
+    `${BACKEND_FOR_FRONTEND_URL}/eservices/${eserviceId}/descriptors/${descriptorId}/activate`
   )
 }
 

--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -7,7 +7,7 @@ import { renderHookWithApplicationContext } from '@/utils/testing.utils'
 import { EServiceProvider } from '@/types/eservice.types'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
-import { CATALOG_PROCESS_URL } from '@/config/env'
+import { BACKEND_FOR_FRONTEND_URL, CATALOG_PROCESS_URL } from '@/config/env'
 import { act } from 'react-dom/test-utils'
 import { fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react'
 
@@ -19,7 +19,7 @@ const server = setupServer(
     }
   ),
   rest.post(
-    `${CATALOG_PROCESS_URL}/eservices/ad474d35-7939-4bee-bde9-4e469cca1030/descriptors`,
+    `${BACKEND_FOR_FRONTEND_URL}/eservices/ad474d35-7939-4bee-bde9-4e469cca1030/descriptors`,
     (_, res, ctx) => {
       return res(ctx.json({ id: 'test-id' }))
     }

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -102,7 +102,7 @@ export function useGetProviderEServiceActions(
         eserviceId,
         voucherLifespan: minutesToSeconds(1),
         audience: [],
-        description: '',
+        description: 'Descrizione nuova versione...',
         dailyCallsPerConsumer: 1,
         dailyCallsTotal: 1,
         agreementApprovalPolicy: 'MANUAL',


### PR DESCRIPTION
This PR changes the path from CATALOG to BFF to:

- `POST /eservices/{eserviceId}/descriptors`
- `PUT /eservices/{eserviceId}/descriptors/${descriptorId}`
- `POST /eservices/{eserviceId}/descriptors/{descriptorId}/publish`
- `POST /eservices/{eserviceId}/descriptors/{descriptorId}/suspend`
- `POST /eservices/{eserviceId}/descriptors/{descriptorId}/activate`