### PR TITLE
[PIN-2849] - Added isContractPresent flag

### DIFF
--- a/src/components/shared/AgreementDetails/components/AgreementDocumentsListSection.tsx
+++ b/src/components/shared/AgreementDetails/components/AgreementDocumentsListSection.tsx
@@ -22,7 +22,9 @@ export const AgreementDocumentListSection: React.FC = () => {
 
   let docs = agreement.consumerDocuments
 
-  if (agreement.state !== 'DRAFT' && agreement.state !== 'PENDING') {
+  // If request agreement contract is available to download...
+  if (agreement.isContractPresent) {
+    // Add it to the document list.
     docs = [
       {
         id: 'contract',

--- a/src/types/agreement.types.ts
+++ b/src/types/agreement.types.ts
@@ -89,4 +89,5 @@ export type AgreementSummary = {
   createdAt: string
   updatedAt?: string
   rejectionReason?: string
+  isContractPresent: boolean
 }


### PR DESCRIPTION
This PR removes the client logic that checks the presence of the contact for the agreement request.
The logic now it is handled backend side. The `isContractPresent` flag is exposed inside the get single agreement service.