### PR TITLE
Feature: PIN-2878 - Updated url params serialization 

### DIFF
--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -20,9 +20,7 @@ const deepTrim = (object: any) => {
 /** This function helps to serialize correctly arrays in url params  */
 const serializeParams = (query: Record<string, unknown>) => {
   return Object.entries(query)
-    .map(([key, value]) =>
-      Array.isArray(value) ? `${key}=${value.join('&' + key + '=')}` : `${key}=${value}`
-    )
+    .map(([key, value]) => (Array.isArray(value) ? `${key}=${value.join(',')}` : `${key}=${value}`))
     .join('&')
 }
 


### PR DESCRIPTION
This PR changes the way arrays are serialized to url params. 
From repeated param to comma separated param.

`{ param: ["a", "b"] }`

serializes from: 
`?param=a&param=b`
to:
`?param=a,b`