### PR TITLE
Feature: PIN-2781 - CATALOG_PROCESS to BFF

### DIFF
--- a/src/api/eservice/eservice.services.ts
+++ b/src/api/eservice/eservice.services.ts
@@ -20,7 +20,6 @@ import type {
   EServiceProducer,
   EServiceProvider,
   EServiceRead,
-  EServiceReadType,
 } from '@/types/eservice.types'
 import type { DocumentRead } from '@/types/common.types'
 import type { Paginated } from '../react-query-wrappers/react-query-wrappers.types'
@@ -89,7 +88,7 @@ async function getProducers(params: EServiceGetProducersUrlParams) {
 
 async function createDraft(payload: EServiceDraftPayload) {
   const response = await axiosInstance.post<{ id: string }>(
-    `${CATALOG_PROCESS_URL}/eservices`,
+    `${BACKEND_FOR_FRONTEND_URL}/eservices`,
     payload
   )
   return response.data
@@ -101,15 +100,15 @@ async function updateDraft({
 }: {
   eserviceId: string
 } & EServiceDraftPayload) {
-  const response = await axiosInstance.put<EServiceReadType>(
-    `${CATALOG_PROCESS_URL}/eservices/${eserviceId}`,
+  const response = await axiosInstance.put<{ id: string }>(
+    `${BACKEND_FOR_FRONTEND_URL}/eservices/${eserviceId}`,
     payload
   )
   return response.data
 }
 
 function deleteDraft({ eserviceId }: { eserviceId: string }) {
-  return axiosInstance.delete(`${CATALOG_PROCESS_URL}/eservices/${eserviceId}`)
+  return axiosInstance.delete(`${BACKEND_FOR_FRONTEND_URL}/eservices/${eserviceId}`)
 }
 
 async function cloneFromVersion({
@@ -119,8 +118,8 @@ async function cloneFromVersion({
   eserviceId: string
   descriptorId: string
 }) {
-  const response = await axiosInstance.post<EServiceReadType>(
-    `${CATALOG_PROCESS_URL}/eservices/${eserviceId}/descriptors/${descriptorId}/clone`
+  const response = await axiosInstance.post<{ id: string; descriptorId: string }>(
+    `${BACKEND_FOR_FRONTEND_URL}/eservices/${eserviceId}/descriptors/${descriptorId}/clone`
   )
   return response.data
 }
@@ -197,7 +196,7 @@ function deleteVersionDraft({
   descriptorId: string
 }) {
   return axiosInstance.delete(
-    `${CATALOG_PROCESS_URL}/eservices/${eserviceId}/descriptors/${descriptorId}`
+    `${BACKEND_FOR_FRONTEND_URL}/eservices/${eserviceId}/descriptors/${descriptorId}`
   )
 }
 

--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -7,15 +7,20 @@ import { renderHookWithApplicationContext } from '@/utils/testing.utils'
 import type { EServiceProvider } from '@/types/eservice.types'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
-import { BACKEND_FOR_FRONTEND_URL, CATALOG_PROCESS_URL } from '@/config/env'
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
 import { act } from 'react-dom/test-utils'
 import { fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react'
 
 const server = setupServer(
   rest.post(
-    `${CATALOG_PROCESS_URL}/eservices/ad474d35-7939-4bee-bde9-4e469cca1030/descriptors/test-1/clone`,
+    `${BACKEND_FOR_FRONTEND_URL}/eservices/ad474d35-7939-4bee-bde9-4e469cca1030/descriptors/test-1/clone`,
     (_, res, ctx) => {
-      return res(ctx.json(createMockEServiceReadType()))
+      return res(
+        ctx.json({
+          id: '6dbb7416-8315-4970-a6be-393a03d0a79d',
+          descriptorId: 'fd09a069-81f8-4cb5-a302-64320e83a033',
+        })
+      )
     }
   ),
   rest.post(

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -81,8 +81,7 @@ export function useGetProviderEServiceActions(
           descriptorId: activeDescriptorId,
         },
         {
-          onSuccess({ id, descriptors }) {
-            const descriptorId = descriptors[0]!.id
+          onSuccess({ id, descriptorId }) {
             navigate('PROVIDE_ESERVICE_EDIT', {
               params: { eserviceId: id, descriptorId },
             })


### PR DESCRIPTION
This PR brings the last CATALOG_PROCESS services to the BFF.

- `POST /eservices`
- `PUT /eservices/{eserviceId}`
- `DELETE /eservices/{eserviceId}`
- `POST /eservices/{eserviceId}/descriptors/{descriptorId}/clone`
- `DELETE /eservices/{eserviceId}/descriptors/{descriptorId}`