### PR TITLE
Feature: Area Riservata in header products selector and pre-release fixes

### DIFF
--- a/src/api/client/client.services.ts
+++ b/src/api/client/client.services.ts
@@ -1,4 +1,4 @@
-import { AUTHORIZATION_PROCESS_URL, BACKEND_FOR_FRONTEND_URL } from '@/config/env'
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
 import axiosInstance from '@/config/axios'
 import type {
   Client,

--- a/src/api/react-query-wrappers/__tests__/react-query-wrappers.utils.test.ts
+++ b/src/api/react-query-wrappers/__tests__/react-query-wrappers.utils.test.ts
@@ -12,7 +12,7 @@ describe('setExponentialInterval tests', () => {
     setExponentialInterval(testFn, 20 * 1000)
 
     for (let i = 1; i <= 6; i++) {
-      expect(testFn).toBeCalledTimes(i)
+      expect(testFn).toBeCalledTimes(i - 1)
       expect(setTimeout).toBeCalledTimes(i)
       expect(vitest.getTimerCount()).toBe(1)
       vitest.advanceTimersByTime(2 ** (i + 1) * 100)
@@ -22,7 +22,7 @@ describe('setExponentialInterval tests', () => {
     }
 
     expect(setTimeout).toBeCalledTimes(6)
-    expect(testFn).toBeCalledTimes(7)
+    expect(testFn).toBeCalledTimes(6)
   })
 
   it('successfully cancels', async () => {
@@ -34,6 +34,6 @@ describe('setExponentialInterval tests', () => {
       await new Promise(process.nextTick)
     }
     expect(setTimeout).toBeCalledTimes(1)
-    expect(testFn).toBeCalledTimes(1)
+    expect(testFn).toBeCalledTimes(0)
   })
 })

--- a/src/api/react-query-wrappers/react-query-wrappers.utils.ts
+++ b/src/api/react-query-wrappers/react-query-wrappers.utils.ts
@@ -21,7 +21,6 @@ class ExponentialInterval {
   }
 
   async #start() {
-    this.#action()
     while (this.#isActive && this.#totalWaitTime < this.#duration) {
       const timeoutMs = this.#getTimeoutMs()
       this.#totalWaitTime += timeoutMs

--- a/src/api/react-query-wrappers/useMutationWrapper.ts
+++ b/src/api/react-query-wrappers/useMutationWrapper.ts
@@ -75,8 +75,8 @@ export const useMutationWrapper: UseMutationWrapper = (mutationFn, options) => {
 
       showToast(successLabel, 'success')
     }
-    requestPolling()
     options?.onSuccess?.(...args)
+    requestPolling()
   }
 
   /**

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -29,23 +29,30 @@ const getPartyList = (parties: Array<SelfcareInstitution> | undefined, t: TFunct
 }
 
 const getProductList = (products?: Array<{ id: string; name: string }>): ProductSwitchItem[] => {
-  const currentProduct: ProductSwitchItem[] = [
-    {
-      id: SELFCARE_INTEROP_PROD_ID,
-      title: `Interoperabilità${STAGE === 'TEST' ? ' Collaudo' : ''}`,
-      productUrl: '',
-      linkType: 'internal',
-    },
-  ]
+  const selfcareProduct: ProductSwitchItem = {
+    id: 'selfcare',
+    title: 'Area Riservata',
+    productUrl: '',
+    linkType: 'internal',
+  }
 
-  if (!products) return currentProduct
+  const interopProduct: ProductSwitchItem = {
+    id: SELFCARE_INTEROP_PROD_ID,
+    title: `Interoperabilità${STAGE === 'TEST' ? ' Collaudo' : ''}`,
+    productUrl: '',
+    linkType: 'internal',
+  }
 
-  return products.map((product) => ({
+  if (!products) return [selfcareProduct, interopProduct]
+
+  const productsFromBE: ProductSwitchItem[] = products.map((product) => ({
     id: product.id,
     title: product.name,
     productUrl: '',
     linkType: 'internal',
   }))
+
+  return [selfcareProduct, ...productsFromBE]
 }
 
 export const Header = () => {
@@ -82,6 +89,12 @@ export const Header = () => {
 
   const handleSelectProduct = (product: ProductSwitchItem) => {
     if (!jwt?.selfcareId) return
+
+    if (product.id === 'selfcare') {
+      window.location.assign(SELFCARE_BASE_URL)
+      return
+    }
+
     window.location.assign(
       `${SELFCARE_BASE_URL}/token-exchange?institutionId=${jwt.selfcareId}&productId=${product.id}`
     )

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -47,10 +47,6 @@ export const BACKEND_FOR_FRONTEND_URL = getEnvVar(
   'BACKEND_FOR_FRONTEND_URL',
   `backend-for-frontend/${SERVICE_VERSION}`
 )
-export const AUTHORIZATION_PROCESS_URL = getEnvVar(
-  'AUTHORIZATION_PROCESS_URL',
-  `authorization-process/${SERVICE_VERSION}`
-)
 export const AUTHORIZATION_SERVER_ACCESS_TOKEN_URL = getEnvVar(
   'AUTHORIZATION_SERVER_TOKEN_CREATION_URL',
   'authorization-server/token.oauth2'

--- a/src/hooks/__tests__/useGetClientActions.test.ts
+++ b/src/hooks/__tests__/useGetClientActions.test.ts
@@ -3,7 +3,6 @@ import useGetClientActions from '../useGetClientActions'
 import { renderHookWithApplicationContext } from '@/utils/testing.utils'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
-import { AUTHORIZATION_PROCESS_URL } from '@/config/env'
 import { act } from 'react-dom/test-utils'
 import { fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
@@ -11,6 +10,7 @@ import { routes } from '@/router/routes'
 import { vi } from 'vitest'
 import * as hooks from '@/hooks/useJwt'
 import type { Client } from '@/api/api.generatedTypes'
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
 
 const useJwtReturnDataMock = {
   currentRoles: ['admin'],
@@ -21,7 +21,7 @@ vi.spyOn(hooks, 'useJwt').mockImplementation(() => useJwtReturnDataMock)
 
 const server = setupServer(
   rest.delete(
-    `${AUTHORIZATION_PROCESS_URL}/clients/85ceaa96-a95e-4cf9-b1f9-b85be1e09369`,
+    `${BACKEND_FOR_FRONTEND_URL}/clients/85ceaa96-a95e-4cf9-b1f9-b85be1e09369`,
     (_, res) => {
       return res()
     }

--- a/src/hooks/__tests__/useResolveError.test.tsx
+++ b/src/hooks/__tests__/useResolveError.test.tsx
@@ -60,7 +60,6 @@ describe('', () => {
 
     expect(screen.getByText('default.title')).toBeInTheDocument()
     expect(screen.getByText('default.description')).toBeInTheDocument()
-    screen.debug()
     expect(screen.getByRole('button', { name: 'actions.reloadPage' })).toBeInTheDocument()
   })
 

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -8,6 +8,7 @@ import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useGetProviderEServiceActions } from '@/hooks/useGetProviderEServiceActions'
 import type { ProducerEServiceDescriptor } from '@/api/api.generatedTypes'
+import { useJwt } from '@/hooks/useJwt'
 
 const ProviderEServiceDetailsPage: React.FC = () => {
   const { t } = useTranslation('eservice')
@@ -53,8 +54,9 @@ const HasDraftDescriptorAlert: React.FC<{ descriptor: ProducerEServiceDescriptor
   descriptor,
 }) => {
   const { t } = useTranslation('eservice')
+  const { isAdmin } = useJwt()
 
-  if (!descriptor.eservice.draftDescriptor) return null
+  if (!descriptor.eservice.draftDescriptor || !isAdmin) return null
 
   return (
     <Alert sx={{ mt: 2 }} severity="info">

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -2,7 +2,6 @@ import type { LANGUAGES } from '@/config/constants'
 
 export type PagoPAEnvVars = {
   STAGE: 'DEV' | 'PROD' | 'TEST'
-  AUTHORIZATION_PROCESS_URL: string
   AUTHORIZATION_SERVER_TOKEN_CREATION_URL: string
   BACKEND_FOR_FRONTEND_URL: string
   SELFCARE_LOGIN_URL: string

--- a/src/utils/__tests__/common.utils.test.tsx
+++ b/src/utils/__tests__/common.utils.test.tsx
@@ -66,7 +66,6 @@ describe('testing truncate utility function', () => {
 
   it('should trim the text before truncating it', () => {
     const result = truncate('tes t-string', 5)
-    console.debug(result)
     expect(result).toBe('tes…')
   })
 })


### PR DESCRIPTION
In this PR:

- Added `Area Riservata` product in the header's products selector;
- Removed unused `AUTHORIZATION_PROCESS` values;
- Fixes race-condition between route redirect and refetching logic that caused 404 BE errors when deleting a record from its details page;
- Removed "has draft descriptor" alert for non-admin users.
