### PR TITLE
Feature: PIN-3255 - Added coverage files exclusion

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,6 +54,19 @@ export default defineConfig(({ mode }) => {
       setupFiles: './setupTests.js',
       coverage: {
         reporter: ['text', 'lcov'],
+        exclude: [
+          '**/node_modules/**',
+          '**/__tests__/**',
+          '**/__test__/**',
+          '**/__mocks__/**',
+          '**/api/agreement/**',
+          '**/api/attribute/**',
+          '**/api/auth/**',
+          '**/api/client/**',
+          '**/api/eservice/**',
+          '**/api/party/**',
+          '**/api/purpose/**',
+        ],
       },
     },
   }


### PR DESCRIPTION
This PR adds coverage file exclusion config to `vite.config.ts`.
