### PR TITLE
Feature: PIN-3484 - Redesign form analisi del rischio

### DIFF
--- a/src/components/shared/StepActions.tsx
+++ b/src/components/shared/StepActions.tsx
@@ -38,8 +38,18 @@ export function StepActions({ back, forward }: StepActionsProps) {
   const backProps =
     back && back.type === 'link' ? { component: Link, to: back.to } : { onClick: back?.onClick }
 
+  const getJustifyContentProp = () => {
+    if (back && forward) return 'space-between'
+
+    if (!back && forward) return 'end'
+
+    if (back && !forward) return 'start'
+
+    return undefined
+  }
+
   return (
-    <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
+    <Stack direction="row" justifyContent={getJustifyContentProp()} spacing={2} sx={{ mt: 5 }}>
       {back && (
         <Button variant="outlined" {...backProps}>
           {back.label}

--- a/src/components/shared/Stepper.tsx
+++ b/src/components/shared/Stepper.tsx
@@ -9,7 +9,7 @@ type StepperProps = {
 
 export function Stepper({ steps, activeIndex }: StepperProps) {
   return (
-    <Box bgcolor="background.paper" sx={{ py: 3 }}>
+    <Box sx={{ py: 3 }}>
       <MUIStepper activeStep={activeIndex} alternativeLabel>
         {steps.map(({ label }) => (
           <Step key={label}>

--- a/src/components/shared/__tests__/__snapshots__/StepActions.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/StepActions.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Checks that StepActions snapshots didn't change > renders StepActions w
 <body>
   <div>
     <div
-      class="css-9v4aab-MuiStack-root"
+      class="css-1tghqnf-MuiStack-root"
     >
       <button
         class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium css-1rwt2y5-MuiButtonBase-root-MuiButton-root"
@@ -25,7 +25,7 @@ exports[`Checks that StepActions snapshots didn't change > renders StepActions w
 <body>
   <div>
     <div
-      class="css-9v4aab-MuiStack-root"
+      class="css-1tghqnf-MuiStack-root"
     >
       <a
         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium css-i4i1vz-MuiTypography-root-MuiLink-root-MuiButtonBase-root-MuiButton-root"
@@ -46,7 +46,7 @@ exports[`Checks that StepActions snapshots didn't change > renders StepActions w
 <body>
   <div>
     <div
-      class="css-9v4aab-MuiStack-root"
+      class="css-1tghqnf-MuiStack-root"
     >
       <a
         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium css-i4i1vz-MuiTypography-root-MuiLink-root-MuiButtonBase-root-MuiButton-root"
@@ -67,7 +67,7 @@ exports[`Checks that StepActions snapshots didn't change > renders StepActions w
 <body>
   <div>
     <div
-      class="css-9v4aab-MuiStack-root"
+      class="css-jojnym-MuiStack-root"
     >
       <button
         class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium css-1rwt2y5-MuiButtonBase-root-MuiButton-root"
@@ -96,7 +96,7 @@ exports[`Checks that StepActions snapshots didn't change > renders StepActions w
 <body>
   <div>
     <div
-      class="css-9v4aab-MuiStack-root"
+      class="css-rhtjtj-MuiStack-root"
     >
       <button
         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-sghohy-MuiButtonBase-root-MuiButton-root"
@@ -117,7 +117,7 @@ exports[`Checks that StepActions snapshots didn't change > renders StepActions w
 <body>
   <div>
     <div
-      class="css-9v4aab-MuiStack-root"
+      class="css-rhtjtj-MuiStack-root"
     >
       <button
         class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-sghohy-MuiButtonBase-root-MuiButton-root"

--- a/src/components/shared/__tests__/__snapshots__/Stepper.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/Stepper.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Checks that Stepper snapshots didn't change > renders correctly step 1 
 <body>
   <div>
     <div
-      class="MuiBox-root css-1jru5tr"
+      class="MuiBox-root css-1phy807"
     >
       <div
         class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"
@@ -149,7 +149,7 @@ exports[`Checks that Stepper snapshots didn't change > renders correctly step 2 
 <body>
   <div>
     <div
-      class="MuiBox-root css-1jru5tr"
+      class="MuiBox-root css-1phy807"
     >
       <div
         class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"
@@ -284,7 +284,7 @@ exports[`Checks that Stepper snapshots didn't change > renders correctly step 3 
 <body>
   <div>
     <div
-      class="MuiBox-root css-1jru5tr"
+      class="MuiBox-root css-1phy807"
     >
       <div
         class="MuiStepper-root MuiStepper-horizontal MuiStepper-alternativeLabel css-10mg1vw-MuiStepper-root"

--- a/src/components/shared/react-hook-form-inputs/RHFCheckboxGroup.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFCheckboxGroup.tsx
@@ -9,7 +9,7 @@ import { mapValidationErrorMessages } from '@/utils/validation.utils'
 
 export type RHFCheckboxGroupProps = {
   sx?: SxProps
-  label: string
+  label?: string
   options: Array<InputOption & { disabled?: boolean }>
   name: string
   infoLabel?: string
@@ -37,7 +37,7 @@ export const RHFCheckboxGroup: React.FC<RHFCheckboxGroupProps> = ({
 
   return (
     <InputWrapper error={error} sx={sx} infoLabel={infoLabel}>
-      <FormLabel component="legend">{label}</FormLabel>
+      {label && <FormLabel component="legend">{label}</FormLabel>}
       <FormGroup>
         <Controller
           name={name}

--- a/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from 'react-i18next'
 import { mapValidationErrorMessages } from '@/utils/validation.utils'
 
 export type RHFRadioGroupProps = Omit<MUIRadioGroupProps, 'onChange'> & {
-  label: string
+  label?: string
   options: Array<InputOption & { disabled?: boolean }>
   name: string
   infoLabel?: string
@@ -46,7 +46,7 @@ export const RHFRadioGroup: React.FC<RHFRadioGroupProps> = ({
 
   return (
     <InputWrapper error={error} sx={sx} infoLabel={infoLabel}>
-      <FormLabel id={labelId}>{label}</FormLabel>
+      {label && <FormLabel id={labelId}>{label}</FormLabel>}
       <Controller
         name={name}
         rules={mapValidationErrorMessages(rules, t)}

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFCheckboxGroup.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFCheckboxGroup.test.tsx
@@ -107,4 +107,24 @@ describe('determine whether the integration between react-hook-form and MUI’s 
 
     expect(checkboxResult.queryByRole('checkbox')).toBeNull()
   })
+
+  it('should not render label if no label prop is given', () => {
+    const checkboxResult = render(
+      <TestInputWrapper>
+        <RHFCheckboxGroup {...checkboxGroupProps.standard} label={undefined} />
+      </TestInputWrapper>
+    )
+
+    expect(checkboxResult.baseElement).toMatchSnapshot()
+  })
+
+  it('should render correctly with label if label prop is given', () => {
+    const checkboxResult = render(
+      <TestInputWrapper>
+        <RHFCheckboxGroup {...checkboxGroupProps.standard} />
+      </TestInputWrapper>
+    )
+
+    expect(checkboxResult.baseElement).toMatchSnapshot()
+  })
 })

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFRadioGroup.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFRadioGroup.test.tsx
@@ -88,4 +88,24 @@ describe('determine whether the integration between react-hook-form and MUI’s 
     expect(onValueChange).toHaveBeenCalledTimes(1)
     expect(onValueChange).toHaveBeenCalledWith('option1')
   })
+
+  it('should not render label if no label prop is given', () => {
+    const radioGroupResult = render(
+      <TestInputWrapper>
+        <RHFRadioGroup {...radioGroupProps.standard} label={undefined} />
+      </TestInputWrapper>
+    )
+
+    expect(radioGroupResult.baseElement).toMatchSnapshot()
+  })
+
+  it('should render correctly with label if label prop is given', () => {
+    const radioGroupResult = render(
+      <TestInputWrapper>
+        <RHFRadioGroup {...radioGroupProps.standard} />
+      </TestInputWrapper>
+    )
+
+    expect(radioGroupResult.baseElement).toMatchSnapshot()
+  })
 })

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFTextField.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFTextField.test.tsx
@@ -78,4 +78,24 @@ describe('determine whether the integration between react-hook-form and MUI’s 
       expect(onValueChange).toHaveBeenCalledWith(testValues.first)
     })
   })
+
+  it('should not render label if no label prop is given', () => {
+    const radioGroupResult = render(
+      <TestInputWrapper>
+        <RHFTextField label={undefined} name={'testText'} />
+      </TestInputWrapper>
+    )
+
+    expect(radioGroupResult.baseElement).toMatchSnapshot()
+  })
+
+  it('should render correctly with label if label prop is given', () => {
+    const radioGroupResult = render(
+      <TestInputWrapper>
+        <RHFTextField label={'input label'} name={'testText'} />
+      </TestInputWrapper>
+    )
+
+    expect(radioGroupResult.baseElement).toMatchSnapshot()
+  })
 })

--- a/src/components/shared/react-hook-form-inputs/__tests__/__snapshots__/RHFCheckboxGroup.test.tsx.snap
+++ b/src/components/shared/react-hook-form-inputs/__tests__/__snapshots__/RHFCheckboxGroup.test.tsx.snap
@@ -1,0 +1,240 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`determine whether the integration between react-hook-form and MUI’s Checkbox works > should not render label if no label prop is given 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-zitybv"
+    >
+      <div
+        class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
+      >
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              data-indeterminate="false"
+              name="option1"
+              type="checkbox"
+              value="option1"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option1
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              data-indeterminate="false"
+              name="option2"
+              type="checkbox"
+              value="option2"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option2
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              data-indeterminate="false"
+              name="option3"
+              type="checkbox"
+              value="option3"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option3
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`determine whether the integration between react-hook-form and MUI’s Checkbox works > should render correctly with label if label prop is given 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-zitybv"
+    >
+      <legend
+        class="MuiFormLabel-root MuiFormLabel-colorPrimary css-u4tvz2-MuiFormLabel-root"
+      >
+        label
+      </legend>
+      <div
+        class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
+      >
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              data-indeterminate="false"
+              name="option1"
+              type="checkbox"
+              value="option1"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option1
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              data-indeterminate="false"
+              name="option2"
+              type="checkbox"
+              value="option2"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option2
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              data-indeterminate="false"
+              name="option3"
+              type="checkbox"
+              value="option3"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option3
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/components/shared/react-hook-form-inputs/__tests__/__snapshots__/RHFRadioGroup.test.tsx.snap
+++ b/src/components/shared/react-hook-form-inputs/__tests__/__snapshots__/RHFRadioGroup.test.tsx.snap
@@ -1,0 +1,329 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`determine whether the integration between react-hook-form and MUI’s RadioGroup works > should not render label if no label prop is given 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-zitybv"
+    >
+      <div
+        aria-labelledby=":r5:"
+        class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
+        role="radiogroup"
+      >
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-vqmohf-MuiButtonBase-root-MuiRadio-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              name="testText"
+              type="radio"
+              value="option1"
+            />
+            <span
+              class="css-hyxlzm"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hhw7if-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option1
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-vqmohf-MuiButtonBase-root-MuiRadio-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              name="testText"
+              type="radio"
+              value="option2"
+            />
+            <span
+              class="css-hyxlzm"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hhw7if-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option2
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-vqmohf-MuiButtonBase-root-MuiRadio-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              name="testText"
+              type="radio"
+              value="option3"
+            />
+            <span
+              class="css-hyxlzm"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hhw7if-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option3
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`determine whether the integration between react-hook-form and MUI’s RadioGroup works > should render correctly with label if label prop is given 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-zitybv"
+    >
+      <label
+        class="MuiFormLabel-root MuiFormLabel-colorPrimary css-u4tvz2-MuiFormLabel-root"
+        id=":r7:"
+      >
+        label
+      </label>
+      <div
+        aria-labelledby=":r7:"
+        class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
+        role="radiogroup"
+      >
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-vqmohf-MuiButtonBase-root-MuiRadio-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              name="testText"
+              type="radio"
+              value="option1"
+            />
+            <span
+              class="css-hyxlzm"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hhw7if-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option1
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-vqmohf-MuiButtonBase-root-MuiRadio-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              name="testText"
+              type="radio"
+              value="option2"
+            />
+            <span
+              class="css-hyxlzm"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hhw7if-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option2
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-5g7fen-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-vqmohf-MuiButtonBase-root-MuiRadio-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-1m9pwf3"
+              name="testText"
+              type="radio"
+              value="option3"
+            />
+            <span
+              class="css-hyxlzm"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hhw7if-MuiSvgIcon-root"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+          >
+            option3
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/components/shared/react-hook-form-inputs/__tests__/__snapshots__/RHFTextField.test.tsx.snap
+++ b/src/components/shared/react-hook-form-inputs/__tests__/__snapshots__/RHFTextField.test.tsx.snap
@@ -1,0 +1,89 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`determine whether the integration between react-hook-form and MUI’s TextField works > should not render label if no label prop is given 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-zitybv"
+    >
+      <div
+        class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      >
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":r4:"
+            name="testText"
+            type="text"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ihdtdm"
+            >
+              <span
+                class="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`determine whether the integration between react-hook-form and MUI’s TextField works > should render correctly with label if label prop is given 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-zitybv"
+    >
+      <div
+        class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+          for=":r5:"
+          id=":r5:-label"
+        >
+          input label
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":r5:"
+            name="testText"
+            type="text"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-14lo706"
+            >
+              <span>
+                input label
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/RiskAnalysisForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/RiskAnalysisForm.tsx
@@ -75,10 +75,10 @@ export const RiskAnalysisForm: React.FC<RiskAnalysisFormProps> = ({
           <Alert sx={{ mt: 2, mb: -1 }} severity="warning">
             {t('step2.personalInfoAlert')}
           </Alert>
-          <Stack spacing={5}>
-            <RiskAnalysisFormComponents questions={questions} />
-          </Stack>
         </SectionContainer>
+        <Stack spacing={2}>
+          <RiskAnalysisFormComponents questions={questions} />
+        </Stack>
         <StepActions
           back={{ label: t('backWithoutSaveBtn'), type: 'button', onClick: onCancel }}
           forward={{

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/RiskAnalysisFormComponents.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/RiskAnalysisFormComponents.tsx
@@ -8,14 +8,16 @@ import {
   RHFSelect,
   RHFTextField,
 } from '@/components/shared/react-hook-form-inputs'
-import { RiskAnalysisSwitch } from './RiskAnalysisSwitch'
+import { RiskAnalysisSwitch } from './components/RiskAnalysisSwitch'
 import { useTranslation } from 'react-i18next'
 import useCurrentLanguage from '@/hooks/useCurrentLanguage'
 import {
   formatRiskAnalysisInputInfoLabel,
   formatRiskAnalysisInputLabel,
+  formatRiskAnalysisInputValidationInfoLabel,
   getRiskAnalysisInputOptions,
 } from '@/pages/ConsumerPurposeEditPage/utils/risk-analysis-form.utils'
+import RiskAnalysisFormSection from './components/RiskAnalysisFormSection'
 
 /**
  * Returns the updated form components.
@@ -29,63 +31,104 @@ export const RiskAnalysisFormComponents: React.FC<{ questions: Questions }> = ({
   const answers = useFormContext<Answers>().watch()
 
   return React.useMemo(() => {
-    function buildFormQuestionComponents(question: FormConfigQuestion, isLast: boolean) {
+    function buildFormQuestionComponents(question: FormConfigQuestion) {
       const questionComponents: Array<React.ReactNode> = []
 
       const maxLength = question?.validation?.maxLength
 
       const inputOptions = getRiskAnalysisInputOptions(question, answers, lang)
       const label = formatRiskAnalysisInputLabel(question, lang, t)
-      const infoLabel = formatRiskAnalysisInputInfoLabel(question, lang, t)
+      const infoLabel = formatRiskAnalysisInputInfoLabel(question, lang)
 
-      const sx = isLast ? { mb: 0 } : {}
-      const commonProps = { key: question.id, name: question.id, label, infoLabel, sx }
+      const validationInfoLabel = formatRiskAnalysisInputValidationInfoLabel(question, t)
+
+      const sx = { mb: 0 }
+      const commonProps = {
+        key: question.id,
+        name: question.id,
+        infoLabel: validationInfoLabel,
+        sx,
+      }
 
       switch (question.visualType) {
         case 'text':
           questionComponents.push(
-            <RHFTextField {...commonProps} inputProps={{ maxLength }} rules={{ required: true }} />
+            <RiskAnalysisFormSection
+              title={label}
+              description={infoLabel}
+              formFieldName={question.id}
+            >
+              <RHFTextField
+                {...commonProps}
+                inputProps={{ maxLength }}
+                rules={{ required: true }}
+              />
+            </RiskAnalysisFormSection>
           )
           break
         case 'select-one':
           questionComponents.push(
-            <RHFSelect
-              {...commonProps}
-              options={inputOptions}
-              emptyLabel={t('edit.step2.emptyLabel')}
-              rules={{ required: true }}
-            />
+            <RiskAnalysisFormSection
+              title={label}
+              description={infoLabel}
+              formFieldName={question.id}
+            >
+              <RHFSelect
+                {...commonProps}
+                options={inputOptions}
+                emptyLabel={t('edit.step2.emptyLabel')}
+                rules={{ required: true }}
+              />
+            </RiskAnalysisFormSection>
           )
           break
         case 'checkbox':
           questionComponents.push(
-            <RHFCheckboxGroup
-              {...commonProps}
-              options={inputOptions}
-              rules={{
-                validate: (value) =>
-                  (typeof value !== 'undefined' && value.length > 0) ||
-                  t('edit.step2.multiCheckboxField.validation.mixed.required'),
-              }}
-            />
+            <RiskAnalysisFormSection
+              title={label}
+              description={infoLabel}
+              formFieldName={question.id}
+            >
+              <RHFCheckboxGroup
+                {...commonProps}
+                options={inputOptions}
+                rules={{
+                  validate: (value) =>
+                    (typeof value !== 'undefined' && value.length > 0) ||
+                    t('edit.step2.multiCheckboxField.validation.mixed.required'),
+                }}
+              />
+            </RiskAnalysisFormSection>
           )
           break
         case 'radio':
           questionComponents.push(
-            <RHFRadioGroup {...commonProps} options={inputOptions} rules={{ required: true }} />
+            <RiskAnalysisFormSection
+              title={label}
+              description={infoLabel}
+              formFieldName={question.id}
+            >
+              <RHFRadioGroup {...commonProps} options={inputOptions} rules={{ required: true }} />
+            </RiskAnalysisFormSection>
           )
           break
         case 'switch':
           questionComponents.push(
-            <RiskAnalysisSwitch
-              {...commonProps}
-              options={inputOptions}
-              rules={{
-                validate: (value) =>
-                  (typeof value === 'boolean' && value === true) ||
-                  t('edit.step2.riskAnalysisSwitch.validation.boolean.isValue'),
-              }}
-            />
+            <RiskAnalysisFormSection
+              title={label}
+              description={infoLabel}
+              formFieldName={question.id}
+            >
+              <RiskAnalysisSwitch
+                {...commonProps}
+                options={inputOptions}
+                rules={{
+                  validate: (value) =>
+                    (typeof value === 'boolean' && value === true) ||
+                    t('edit.step2.riskAnalysisSwitch.validation.boolean.isValue'),
+                }}
+              />
+            </RiskAnalysisFormSection>
           )
           break
       }
@@ -96,9 +139,9 @@ export const RiskAnalysisFormComponents: React.FC<{ questions: Questions }> = ({
     const formComponents: Array<React.ReactNode> = []
     const questionIds = Object.keys(questions)
 
-    questionIds.forEach((questionId, i) => {
+    questionIds.forEach((questionId) => {
       const question = questions[questionId]
-      formComponents.push(...buildFormQuestionComponents(question, questionIds.length - 1 === i))
+      formComponents.push(...buildFormQuestionComponents(question))
     })
 
     return <>{formComponents}</>

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/__tests__/RiskAnalysisForm.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/__tests__/RiskAnalysisForm.test.tsx
@@ -28,9 +28,7 @@ describe('RiskAnalysisForm', () => {
       />
     )
 
-    expect(
-      screen.queryByRole('textbox', { name: 'Question 2 (edit.step2.validation.required)' })
-    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('textbox', { name: '' })).not.toBeInTheDocument()
 
     fireEvent.click(
       screen.getByRole('radio', {
@@ -38,9 +36,7 @@ describe('RiskAnalysisForm', () => {
       })
     )
 
-    expect(
-      screen.getByRole('textbox', { name: 'Question 2 (edit.step2.validation.required)' })
-    ).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument()
   })
 
   it('should submit the form with the correct values', async () => {
@@ -62,10 +58,7 @@ describe('RiskAnalysisForm', () => {
       })
     )
 
-    await user.type(
-      screen.getByRole('textbox', { name: 'Question 2 (edit.step2.validation.required)' }),
-      'Some text'
-    )
+    await user.type(screen.getByRole('textbox', { name: '' }), 'Some text')
 
     fireEvent.click(screen.getByRole('button', { name: 'forwardWithSaveBtn' }))
 

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/__tests__/__snapshots__/RiskAnalysisForm.test.tsx.snap
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/__tests__/__snapshots__/RiskAnalysisForm.test.tsx.snap
@@ -51,18 +51,32 @@ exports[`RiskAnalysisForm > should match the snapshot 1`] = `
               step2.personalInfoAlert
             </div>
           </div>
+        </div>
+      </section>
+      <div
+        class="css-1p5q5e5-MuiStack-root"
+      >
+        <section
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1w5x330-MuiPaper-root"
+        >
           <div
-            class="css-pnq1z9-MuiStack-root"
+            class="css-1okj3ks-MuiStack-root"
+          />
+          <div
+            class="MuiBox-root css-zv7ju9"
           >
+            <div
+              class="css-1okj3ks-MuiStack-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-sidenav css-d2mesl-MuiTypography-root"
+              >
+                Question 1 (edit.step2.validation.required)
+              </span>
+            </div>
             <div
               class="MuiBox-root css-1hhytss"
             >
-              <label
-                class="MuiFormLabel-root MuiFormLabel-colorPrimary css-u4tvz2-MuiFormLabel-root"
-                id=":r0:"
-              >
-                Question 1 (edit.step2.validation.required)
-              </label>
               <div
                 aria-labelledby=":r0:"
                 class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -168,10 +182,10 @@ exports[`RiskAnalysisForm > should match the snapshot 1`] = `
               </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
       <div
-        class="css-9v4aab-MuiStack-root"
+        class="css-jojnym-MuiStack-root"
       >
         <button
           class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium css-1rwt2y5-MuiButtonBase-root-MuiButton-root"

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/__tests__/__snapshots__/RiskAnalysisFormComponents.test.tsx.snap
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/__tests__/__snapshots__/RiskAnalysisFormComponents.test.tsx.snap
@@ -3,164 +3,263 @@
 exports[`RiskAnalysisFormComponents > should match the snapshot 1`] = `
 <body>
   <div>
-    <div
-      class="MuiBox-root css-zitybv"
+    <section
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1w5x330-MuiPaper-root"
     >
       <div
-        class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
-      >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
-          data-shrink="true"
-          for=":r0:"
-          id=":r0:-label"
-        >
-          test (edit.step2.validation.required)
-        </label>
-        <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
-        >
-          <input
-            aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
-            id=":r0:"
-            name="1"
-            type="text"
-            value=""
-          />
-          <fieldset
-            aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-          >
-            <legend
-              class="css-14lo706"
-            >
-              <span>
-                test (edit.step2.validation.required)
-              </span>
-            </legend>
-          </fieldset>
-        </div>
-      </div>
-      <p
-        class="MuiTypography-root MuiTypography-caption css-6n3pnq-MuiTypography-root"
-      >
-        test
-      </p>
-    </div>
-    <div
-      class="MuiBox-root css-zitybv"
-    >
+        class="css-1okj3ks-MuiStack-root"
+      />
       <div
-        class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
+        class="MuiBox-root css-zv7ju9"
       >
-        <label
-          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
-          data-shrink="true"
-          id=":r1:"
-        >
-          test (edit.step2.validation.required)
-        </label>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  css-1yk1gt9-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
-        >
-          <div
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-labelledby=":r1: mui-component-select-2"
-            class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
-            id="mui-component-select-2"
-            role="button"
-            tabindex="0"
-          >
-            <span
-              class="notranslate"
-            >
-              ​
-            </span>
-          </div>
-          <input
-            aria-hidden="true"
-            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-            name="2"
-            tabindex="-1"
-            value=""
-          />
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
-            data-testid="ArrowDropDownIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M7 10l5 5 5-5z"
-            />
-          </svg>
-          <fieldset
-            aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-          >
-            <legend
-              class="css-yjsfm1"
-            >
-              <span>
-                test (edit.step2.validation.required)
-              </span>
-            </legend>
-          </fieldset>
-        </div>
-      </div>
-      <p
-        class="MuiTypography-root MuiTypography-caption css-6n3pnq-MuiTypography-root"
-      >
-        test
-      </p>
-    </div>
-    <div
-      class="MuiBox-root css-zitybv"
-    >
-      <label
-        class="MuiFormLabel-root MuiFormLabel-colorPrimary css-l38uzw-MuiFormLabel-root"
-      >
-        <span
-          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-        >
-          test (edit.step2.validation.required)
-        </span>
-        <div
-          class="css-1npm2ob-MuiStack-root"
+          class="css-1okj3ks-MuiStack-root"
         >
           <span
-            class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+            class="MuiTypography-root MuiTypography-sidenav css-d2mesl-MuiTypography-root"
           >
-            <span
-              class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-5ryogn-MuiButtonBase-root-MuiSwitch-switchBase"
-            >
-              <input
-                class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
-                name="4"
-                type="checkbox"
-              />
-              <span
-                class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
-              />
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
-            </span>
-            <span
-              class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
-            />
+            test (edit.step2.validation.required)
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
+          >
+            test
           </span>
         </div>
-      </label>
-      <p
-        class="MuiTypography-root MuiTypography-caption css-6n3pnq-MuiTypography-root"
+        <div
+          class="MuiBox-root css-1hhytss"
+        >
+          <div
+            class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+          >
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+                id=":r0:"
+                name="1"
+                type="text"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-ihdtdm"
+                >
+                  <span
+                    class="notranslate"
+                  >
+                    ​
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1w5x330-MuiPaper-root"
+    >
+      <div
+        class="css-1okj3ks-MuiStack-root"
+      />
+      <div
+        class="MuiBox-root css-zv7ju9"
       >
-        test
-      </p>
-    </div>
+        <div
+          class="css-1okj3ks-MuiStack-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-sidenav css-d2mesl-MuiTypography-root"
+          >
+            test (edit.step2.validation.required)
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
+          >
+            test
+          </span>
+        </div>
+        <div
+          class="MuiBox-root css-1hhytss"
+        >
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-1sumxir-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="true"
+              id=":r1:"
+            />
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl  css-1yk1gt9-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+            >
+              <div
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby=":r1: mui-component-select-2"
+                class="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input css-11u53oe-MuiSelect-select-MuiInputBase-input-MuiOutlinedInput-input"
+                id="mui-component-select-2"
+                role="button"
+                tabindex="0"
+              >
+                <span
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </div>
+              <input
+                aria-hidden="true"
+                class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+                name="2"
+                tabindex="-1"
+                value=""
+              />
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined css-hfutr2-MuiSvgIcon-root-MuiSelect-icon"
+                data-testid="ArrowDropDownIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7 10l5 5 5-5z"
+                />
+              </svg>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-ihdtdm"
+                >
+                  <span
+                    class="notranslate"
+                  >
+                    ​
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1w5x330-MuiPaper-root"
+    >
+      <div
+        class="css-1okj3ks-MuiStack-root"
+      />
+      <div
+        class="MuiBox-root css-zv7ju9"
+      >
+        <div
+          class="css-1okj3ks-MuiStack-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-sidenav css-d2mesl-MuiTypography-root"
+          >
+            test (edit.step2.validation.required)
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
+          >
+            test
+          </span>
+        </div>
+      </div>
+    </section>
+    <section
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1w5x330-MuiPaper-root"
+    >
+      <div
+        class="css-1okj3ks-MuiStack-root"
+      />
+      <div
+        class="MuiBox-root css-zv7ju9"
+      >
+        <div
+          class="css-1okj3ks-MuiStack-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-sidenav css-d2mesl-MuiTypography-root"
+          >
+            test (edit.step2.validation.required)
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
+          >
+            test
+          </span>
+        </div>
+        <div
+          class="MuiBox-root css-1hhytss"
+        >
+          <label
+            class="MuiFormLabel-root MuiFormLabel-colorPrimary css-l38uzw-MuiFormLabel-root"
+          >
+            <div
+              class="css-1npm2ob-MuiStack-root"
+            >
+              <span
+                class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+              >
+                <span
+                  class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-5ryogn-MuiButtonBase-root-MuiSwitch-switchBase"
+                >
+                  <input
+                    class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                    name="4"
+                    type="checkbox"
+                  />
+                  <span
+                    class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+                  />
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </span>
+                <span
+                  class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+                />
+              </span>
+            </div>
+          </label>
+        </div>
+      </div>
+    </section>
+    <section
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1w5x330-MuiPaper-root"
+    >
+      <div
+        class="css-1okj3ks-MuiStack-root"
+      />
+      <div
+        class="MuiBox-root css-zv7ju9"
+      >
+        <div
+          class="css-1okj3ks-MuiStack-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-sidenav css-d2mesl-MuiTypography-root"
+          >
+            test (edit.step2.validation.required, edit.step2.validation.multipleChoice)
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
+          >
+            test
+          </span>
+        </div>
+      </div>
+    </section>
   </div>
 </body>
 `;

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/RiskAnalysisFormSection.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/RiskAnalysisFormSection.tsx
@@ -1,0 +1,39 @@
+import { SectionContainer } from '@/components/layout/containers'
+import { Stack, Typography } from '@mui/material'
+import React from 'react'
+import { useFormContext } from 'react-hook-form'
+
+type RiskAnalysisFormSectionProps = {
+  children: React.ReactNode
+  title: string
+  description?: string
+  formFieldName: string
+}
+
+const RiskAnalysisFormSection: React.FC<RiskAnalysisFormSectionProps> = ({
+  children,
+  title,
+  description,
+  formFieldName,
+}) => {
+  const { formState } = useFormContext()
+  const error = formState.errors[formFieldName]?.message as string | undefined
+
+  return (
+    <SectionContainer>
+      <Stack spacing={1}>
+        <Typography variant="sidenav" color={error ? 'error.dark' : 'text.primary'} width={600}>
+          {title}
+        </Typography>
+        {description && (
+          <Typography variant="caption" color="text.secondary">
+            {description}
+          </Typography>
+        )}
+      </Stack>
+      {children}
+    </SectionContainer>
+  )
+}
+
+export default RiskAnalysisFormSection

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/RiskAnalysisSwitch.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/RiskAnalysisSwitch.tsx
@@ -9,7 +9,7 @@ import type { ControllerProps } from 'react-hook-form/dist/types'
 import type { InputOption } from '@/types/common.types'
 
 type RiskAnalysisSwitchProps = Omit<MUISwitchProps, 'checked' | 'onChange'> & {
-  label: string
+  label?: string
   infoLabel?: string | JSX.Element
   options: Array<InputOption>
   name: string
@@ -33,9 +33,11 @@ export const RiskAnalysisSwitch: React.FC<RiskAnalysisSwitchProps> = ({
   return (
     <InputWrapper error={error} sx={sx} infoLabel={infoLabel}>
       <FormLabel sx={{ color: 'text.primary' }}>
-        <Typography component="span" variant="body1">
-          {label}
-        </Typography>
+        {label && (
+          <Typography component="span" variant="body1">
+            {label}
+          </Typography>
+        )}
         <Stack sx={{ mt: 2, mb: 1 }} direction="row" alignItems="center" spacing={0.25}>
           <Controller
             name={name}

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/__tests__/RiskAnalysisFormSection.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/__tests__/RiskAnalysisFormSection.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import RiskAnalysisFormSection from '../RiskAnalysisFormSection'
+import { render } from '@testing-library/react'
+import { Typography } from '@mui/material'
+import { vi } from 'vitest'
+
+describe('RiskAnalysisFormSection testing', () => {
+  it('should be render correclty without description and error', () => {
+    vi.mock('react-hook-form', async () => ({
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      ...(await vi.importActual('react-hook-form')),
+      useFormContext: () => ({
+        formState: {
+          errors: {},
+        },
+      }),
+    }))
+
+    const screen = render(
+      <RiskAnalysisFormSection title={'Test title'} formFieldName={'test'}>
+        <Typography>Test children for snapshot</Typography>
+      </RiskAnalysisFormSection>
+    )
+
+    expect(screen.baseElement).toMatchSnapshot()
+  })
+
+  it('should be render correclty with description and without error', () => {
+    vi.mock('react-hook-form', async () => ({
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      ...(await vi.importActual('react-hook-form')),
+      useFormContext: () => ({
+        formState: {
+          errors: {},
+        },
+      }),
+    }))
+
+    const screen = render(
+      <RiskAnalysisFormSection
+        title={'Test title'}
+        formFieldName={'test'}
+        description="Test description"
+      >
+        <Typography>Test children for snapshot</Typography>
+      </RiskAnalysisFormSection>
+    )
+
+    expect(screen.baseElement).toMatchSnapshot()
+  })
+
+  it('should be render correclty with error and without description', () => {
+    vi.mock('react-hook-form', async () => ({
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      ...(await vi.importActual('react-hook-form')),
+      useFormContext: () => ({
+        formState: {
+          errors: {
+            test: {
+              message: 'test error',
+              type: 'required',
+            },
+          },
+        },
+      }),
+    }))
+
+    const screen = render(
+      <RiskAnalysisFormSection title={'Test title'} formFieldName={'test'}>
+        <Typography>Test children for snapshot</Typography>
+      </RiskAnalysisFormSection>
+    )
+
+    expect(screen.baseElement).toMatchSnapshot()
+  })
+
+  it('should be render correclty with description and error', () => {
+    vi.mock('react-hook-form', async () => ({
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      ...(await vi.importActual('react-hook-form')),
+      useFormContext: () => ({
+        formState: {
+          errors: {
+            test: {
+              message: 'test error',
+              type: 'required',
+            },
+          },
+        },
+      }),
+    }))
+
+    const screen = render(
+      <RiskAnalysisFormSection
+        title={'Test title'}
+        formFieldName={'test'}
+        description="Test description"
+      >
+        <Typography>Test children for snapshot</Typography>
+      </RiskAnalysisFormSection>
+    )
+
+    expect(screen.baseElement).toMatchSnapshot()
+  })
+})

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/__tests__/RiskAnalysisSwitch.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/__tests__/RiskAnalysisSwitch.test.tsx
@@ -36,6 +36,14 @@ describe('RiskAnalysisSwitch', () => {
     expect(baseElement).toMatchSnapshot()
   })
 
+  it('should match snapshot if there is no label', () => {
+    const { baseElement } = renderRiskAnalysisSwitch({
+      label: undefined,
+      options: [{ label: 'test', value: 'test' }],
+    })
+    expect(baseElement).toMatchSnapshot()
+  })
+
   it('should change value when clicked', () => {
     const { getByRole } = renderRiskAnalysisSwitch()
     const checkbox = getByRole('checkbox')

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/__tests__/__snapshots__/RiskAnalysisFormSection.test.tsx.snap
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/__tests__/__snapshots__/RiskAnalysisFormSection.test.tsx.snap
@@ -1,0 +1,139 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`RiskAnalysisFormSection testing > should be render correclty with description and error 1`] = `
+<body>
+  <div>
+    <section
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1w5x330-MuiPaper-root"
+    >
+      <div
+        class="css-1okj3ks-MuiStack-root"
+      />
+      <div
+        class="MuiBox-root css-zv7ju9"
+      >
+        <div
+          class="css-1okj3ks-MuiStack-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-sidenav css-z6k39g-MuiTypography-root"
+          >
+            Test title
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
+          >
+            Test description
+          </span>
+        </div>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+        >
+          Test children for snapshot
+        </p>
+      </div>
+    </section>
+  </div>
+</body>
+`;
+
+exports[`RiskAnalysisFormSection testing > should be render correclty with description and without error 1`] = `
+<body>
+  <div>
+    <section
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1w5x330-MuiPaper-root"
+    >
+      <div
+        class="css-1okj3ks-MuiStack-root"
+      />
+      <div
+        class="MuiBox-root css-zv7ju9"
+      >
+        <div
+          class="css-1okj3ks-MuiStack-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-sidenav css-z6k39g-MuiTypography-root"
+          >
+            Test title
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-caption css-ol7wxs-MuiTypography-root"
+          >
+            Test description
+          </span>
+        </div>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+        >
+          Test children for snapshot
+        </p>
+      </div>
+    </section>
+  </div>
+</body>
+`;
+
+exports[`RiskAnalysisFormSection testing > should be render correclty with error and without description 1`] = `
+<body>
+  <div>
+    <section
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1w5x330-MuiPaper-root"
+    >
+      <div
+        class="css-1okj3ks-MuiStack-root"
+      />
+      <div
+        class="MuiBox-root css-zv7ju9"
+      >
+        <div
+          class="css-1okj3ks-MuiStack-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-sidenav css-z6k39g-MuiTypography-root"
+          >
+            Test title
+          </span>
+        </div>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+        >
+          Test children for snapshot
+        </p>
+      </div>
+    </section>
+  </div>
+</body>
+`;
+
+exports[`RiskAnalysisFormSection testing > should be render correclty without description and error 1`] = `
+<body>
+  <div>
+    <section
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1w5x330-MuiPaper-root"
+    >
+      <div
+        class="css-1okj3ks-MuiStack-root"
+      />
+      <div
+        class="MuiBox-root css-zv7ju9"
+      >
+        <div
+          class="css-1okj3ks-MuiStack-root"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-sidenav css-z6k39g-MuiTypography-root"
+          >
+            Test title
+          </span>
+        </div>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+        >
+          Test children for snapshot
+        </p>
+      </div>
+    </section>
+  </div>
+</body>
+`;

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/__tests__/__snapshots__/RiskAnalysisSwitch.test.tsx.snap
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/RiskAnalysisForm/components/__tests__/__snapshots__/RiskAnalysisSwitch.test.tsx.snap
@@ -50,3 +50,49 @@ exports[`RiskAnalysisSwitch > should match snapshot 1`] = `
   </div>
 </body>
 `;
+
+exports[`RiskAnalysisSwitch > should match snapshot if there is no label 1`] = `
+<body>
+  <div>
+    <div
+      class="MuiBox-root css-zitybv"
+    >
+      <label
+        class="MuiFormLabel-root MuiFormLabel-colorPrimary css-l38uzw-MuiFormLabel-root"
+      >
+        <div
+          class="css-1npm2ob-MuiStack-root"
+        >
+          <span
+            class="MuiSwitch-root MuiSwitch-sizeMedium css-julti5-MuiSwitch-root"
+          >
+            <span
+              class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary css-5ryogn-MuiButtonBase-root-MuiSwitch-switchBase"
+            >
+              <input
+                class="PrivateSwitchBase-input MuiSwitch-input css-1m9pwf3"
+                name="RiskAnalysisSwitch"
+                type="checkbox"
+              />
+              <span
+                class="MuiSwitch-thumb css-jsexje-MuiSwitch-thumb"
+              />
+              <span
+                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+              />
+            </span>
+            <span
+              class="MuiSwitch-track css-1yjjitx-MuiSwitch-track"
+            />
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body2 css-hoiwr4-MuiTypography-root"
+          >
+            test
+          </span>
+        </div>
+      </label>
+    </div>
+  </div>
+</body>
+`;

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/__tests__/__snapshots__/PurposeEditStep2RiskAnalysis.test.tsx.snap
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStep2RiskAnalysis/__tests__/__snapshots__/PurposeEditStep2RiskAnalysis.test.tsx.snap
@@ -51,18 +51,32 @@ exports[`PurposeEditStep2RiskAnalysis > should match snapshot 1`] = `
               step2.personalInfoAlert
             </div>
           </div>
+        </div>
+      </section>
+      <div
+        class="css-1p5q5e5-MuiStack-root"
+      >
+        <section
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1w5x330-MuiPaper-root"
+        >
           <div
-            class="css-pnq1z9-MuiStack-root"
+            class="css-1okj3ks-MuiStack-root"
+          />
+          <div
+            class="MuiBox-root css-zv7ju9"
           >
+            <div
+              class="css-1okj3ks-MuiStack-root"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-sidenav css-d2mesl-MuiTypography-root"
+              >
+                Question 1 (edit.step2.validation.required)
+              </span>
+            </div>
             <div
               class="MuiBox-root css-1hhytss"
             >
-              <label
-                class="MuiFormLabel-root MuiFormLabel-colorPrimary css-u4tvz2-MuiFormLabel-root"
-                id=":r0:"
-              >
-                Question 1 (edit.step2.validation.required)
-              </label>
               <div
                 aria-labelledby=":r0:"
                 class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
@@ -168,10 +182,10 @@ exports[`PurposeEditStep2RiskAnalysis > should match snapshot 1`] = `
               </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
       <div
-        class="css-9v4aab-MuiStack-root"
+        class="css-jojnym-MuiStack-root"
       >
         <button
           class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium css-1rwt2y5-MuiButtonBase-root-MuiButton-root"

--- a/src/pages/ConsumerPurposeEditPage/utils/__tests__/risk-analysis-form.utils.test.ts
+++ b/src/pages/ConsumerPurposeEditPage/utils/__tests__/risk-analysis-form.utils.test.ts
@@ -2,6 +2,7 @@ import type { Dependency, FormConfigQuestion } from '@/api/api.generatedTypes'
 import {
   formatRiskAnalysisInputInfoLabel,
   formatRiskAnalysisInputLabel,
+  formatRiskAnalysisInputValidationInfoLabel,
   getBackendAnswerValue,
   getFrontendAnswerValue,
   getRiskAnalysisDefaultValues,
@@ -252,34 +253,42 @@ describe('Risk analysis form utils', () => {
   })
 
   describe('formatRiskAnalysisInputInfoLabel', () => {
-    it('should return undefined if no infoLabel has been set and the question has no max length validation', () => {
+    it('should return undefined if no infoLabel has been set', () => {
       const question = {
         infoLabel: undefined,
-        validation: undefined,
       } as FormConfigQuestion
 
-      const result = formatRiskAnalysisInputInfoLabel(question, 'it', tPurposeMock)
+      const result = formatRiskAnalysisInputInfoLabel(question, 'it')
       expect(result).toBeUndefined()
-    })
-
-    it("should return only the max length validation string if the question doesn't have an infoLabel but has a max lenght validation rule", () => {
-      const question = {
-        infoLabel: undefined,
-        validation: { maxLength: 40 },
-      } as FormConfigQuestion
-
-      const result = formatRiskAnalysisInputInfoLabel(question, 'it', tPurposeMock)
-      expect(result).toEqual('edit.step2.validation.maxLength')
     })
 
     it("should format correctly the infoLabel if it's present", () => {
       const question = {
         infoLabel: { it: 'test' },
+      } as FormConfigQuestion
+
+      const result = formatRiskAnalysisInputInfoLabel(question, 'it')
+      expect(result).toEqual('test')
+    })
+  })
+
+  describe('formatRiskAnalysisInputValidationInfoLabel', () => {
+    it('should return undefined if the question has no max length validation', () => {
+      const question = {
+        validation: undefined,
+      } as FormConfigQuestion
+
+      const result = formatRiskAnalysisInputValidationInfoLabel(question, tPurposeMock)
+      expect(result).toBeUndefined()
+    })
+
+    it("should format correctly the validationInfoLabel if it's present", () => {
+      const question = {
         validation: { maxLength: 40 },
       } as FormConfigQuestion
 
-      const result = formatRiskAnalysisInputInfoLabel(question, 'it', tPurposeMock)
-      expect(result).toEqual('test. edit.step2.validation.maxLength')
+      const result = formatRiskAnalysisInputValidationInfoLabel(question, tPurposeMock)
+      expect(result).toEqual('edit.step2.validation.maxLength')
     })
   })
 

--- a/src/pages/ConsumerPurposeEditPage/utils/risk-analysis-form.utils.ts
+++ b/src/pages/ConsumerPurposeEditPage/utils/risk-analysis-form.utils.ts
@@ -190,9 +190,7 @@ export function formatRiskAnalysisInputLabel(
  * @returns the formatted info label for the risk analysis input
  */
 export function formatRiskAnalysisInputInfoLabel(question: FormConfigQuestion, lang: LangCode) {
-  const infoLabel = question.infoLabel && question.infoLabel[lang]
-
-  return infoLabel
+  return question.infoLabel && question.infoLabel[lang]
 }
 
 /**
@@ -212,8 +210,6 @@ export function formatRiskAnalysisInputValidationInfoLabel(
   if (maxLength) {
     return t('edit.step2.validation.maxLength', { num: maxLength })
   }
-
-  return undefined
 }
 
 /**

--- a/src/pages/ConsumerPurposeEditPage/utils/risk-analysis-form.utils.ts
+++ b/src/pages/ConsumerPurposeEditPage/utils/risk-analysis-form.utils.ts
@@ -183,32 +183,37 @@ export function formatRiskAnalysisInputLabel(
 
 /**
  * Returns the formatted info label for the risk analysis input.
- * The info label is the text that appears below the input.
+ * The info label is the text that appears below section title.
  *
  * @param question - the question
  * @param lang - the current active language
- * @param t - the translation function
  * @returns the formatted info label for the risk analysis input
  */
-export function formatRiskAnalysisInputInfoLabel(
-  question: FormConfigQuestion,
-  lang: LangCode,
-  t: TFunction<'purpose'>
-) {
-  const maxLength = question?.validation?.maxLength
-
-  let infoLabel = question.infoLabel && question.infoLabel[lang]
-
-  if (maxLength) {
-    const maxLengthLabel = t('edit.step2.validation.maxLength', { num: maxLength })
-    if (infoLabel) {
-      infoLabel += `. ${maxLengthLabel}`
-    } else {
-      infoLabel = maxLengthLabel
-    }
-  }
+export function formatRiskAnalysisInputInfoLabel(question: FormConfigQuestion, lang: LangCode) {
+  const infoLabel = question.infoLabel && question.infoLabel[lang]
 
   return infoLabel
+}
+
+/**
+ * Returns the formatted validation info label for the risk analysis input.
+ * The info label is the text that appears below the input.
+ *
+ * @param question - the question
+ * @param t - the translation function
+ * @returns the formatted validatio info label for the risk analysis input
+ */
+export function formatRiskAnalysisInputValidationInfoLabel(
+  question: FormConfigQuestion,
+  t: TFunction<'purpose'>
+) {
+  const maxLength = question.validation?.maxLength
+
+  if (maxLength) {
+    return t('edit.step2.validation.maxLength', { num: maxLength })
+  }
+
+  return undefined
 }
 
 /**


### PR DESCRIPTION
- Implemented component `RiskAnalysisFormSection`
- Updated `RiskAnalysisFormComponents` with `RiskAnalysisFormSection` around all the input components
- Updated `RHFCheckboxGroup`, `RHFRadioGroup`, `RHFTextField` and `RiskAnalysisSwitch` setting the label optional
- Removed `backgroundColor` from `Stepper`
- Added new `justifyContent` prop to `StepActions`
- Separate `formatRiskAnalysisInputInfoLabel` into two functions (`formatRiskAnalysisInputInfoLabel`, `formatRiskAnalysisInputValidationInfoLabel`) that format the infoLabel and the validationInfoLabel
- Updated tests and snapshots