### PR TITLE
Feature: Fix team operations access

### DIFF
--- a/src/hooks/useLoginAttempt.ts
+++ b/src/hooks/useLoginAttempt.ts
@@ -27,11 +27,12 @@ export function useLoginAttempt() {
     }
 
     // 2. See if we are coming from Self Care and have a new token
-    const newSelfCareIdentityToken = window.location.hash.replace('#id=', '')
-    if (newSelfCareIdentityToken) {
+    const hasSelfCareIdentityToken = window.location.hash.includes('#id=')
+    if (hasSelfCareIdentityToken) {
+      const selfCareIdentityToken = window.location.hash.replace('#id=', '')
       // Remove token from hash
       history.replaceState({}, document.title, window.location.href.split('#')[0])
-      const response = await swapTokens(newSelfCareIdentityToken)
+      const response = await swapTokens(selfCareIdentityToken)
       if (response.session_token) {
         setSessionToken(response.session_token)
         return

--- a/src/hooks/useLoginAttempt.ts
+++ b/src/hooks/useLoginAttempt.ts
@@ -8,7 +8,7 @@ import { TokenExchangeError } from '@/utils/errors.utils'
 import { useAuth } from '@/stores'
 
 export function useLoginAttempt() {
-  const { mutateAsync: swapTokens } = AuthServicesHooks.useSwapTokens()
+  const { mutate: swapTokens } = AuthServicesHooks.useSwapTokens()
   const { sessionToken, setSessionToken, setIsLoadingSessionToken } = useAuth()
   const [error, setError] = React.useState<Error | null>(null)
 
@@ -32,24 +32,35 @@ export function useLoginAttempt() {
       const selfCareIdentityToken = window.location.hash.replace('#id=', '')
       // Remove token from hash
       history.replaceState({}, document.title, window.location.href.split('#')[0])
-      const response = await swapTokens(selfCareIdentityToken)
-      if (response.session_token) {
-        setSessionToken(response.session_token)
-        return
-      }
+      swapTokens(selfCareIdentityToken, {
+        onSuccess({ session_token }) {
+          setSessionToken(session_token)
+        },
+      })
+      return
     }
 
-    // 3. Check if there is a valid token in the storage already
+    // 3. See if we are trying to login as support operator
+    // If the url has contains saml2 and jwt, we are trying to login as support operator
+    const hasSupportOperatorToken =
+      window.location.hash.includes('#saml2=') && window.location.hash.includes('jwt=')
+    if (hasSupportOperatorToken) {
+      const supportOperatorToken = window.location.hash.split('jwt=')[1]
+      setSessionToken(supportOperatorToken)
+      return
+    }
+
+    // 4. Check if there is a valid token in the storage already
     const sessionStorageToken = window.localStorage.getItem(STORAGE_KEY_SESSION_TOKEN)
     if (sessionStorageToken) {
       setSessionToken(sessionStorageToken)
       return
     }
 
-    // 4. Check if the route is public
+    // 5. Check if the route is public
     if (isPublic) return
 
-    // 5. If all else fails, logout
+    // 6. If all else fails, logout
     navigate('LOGOUT')
   }, [navigate, isPublic, setSessionToken, swapTokens])
 

--- a/src/pages/AssistanceTenantSelectionPage/AssistanceTenantSelection.page.tsx
+++ b/src/pages/AssistanceTenantSelectionPage/AssistanceTenantSelection.page.tsx
@@ -8,19 +8,6 @@ import { useAuth } from '@/stores'
 import type { CompactTenant } from '@/api/api.generatedTypes'
 import { useNavigate } from '@/router'
 
-function getJWTAndSAML2FromURLFragment() {
-  const hashParams = window.location.hash.split('#')[1]
-  if (!hashParams) throw new AssistencePartySelectionError(`Missing jwt and saml2 query param`)
-
-  const splittedHashParams = hashParams.split('&')
-  const saml2 = splittedHashParams[0].split('=')[1]
-  const jwt = splittedHashParams[1].split('=')[1]
-
-  if (!jwt || !saml2)
-    throw new AssistencePartySelectionError(`Missing jwt (${jwt}) or saml2 (${saml2}) query param`)
-  return { jwt, saml2 }
-}
-
 const AssistanceTenantSelectionPage: React.FC = () => {
   const { t } = useTranslation('assistance', { keyPrefix: 'tenantSelection' })
 
@@ -30,11 +17,8 @@ const AssistanceTenantSelectionPage: React.FC = () => {
   const [selectedTenant, setSelectedTenant] = React.useState<CompactTenant | null>(null)
   const { mutate: swapSAMLToken } = AuthServicesHooks.useSwapSAMLTokens()
 
-  const { jwt, saml2 } = getJWTAndSAML2FromURLFragment()
-
-  React.useEffect(() => {
-    setSessionToken(jwt)
-  }, [setSessionToken, jwt])
+  const saml2 = window.location.hash.split('#saml2=')[1]?.split('&')[0]
+  if (!saml2) throw new AssistencePartySelectionError(`Missing saml2 (${saml2}) from query param`)
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()


### PR DESCRIPTION
The bug was caused by the `useLoginAttempt` hook removing the url fragment that is crucial to the team operations access flow. The fix is about checking first if the selfcare token is in the url fragment, if yes it can be removed safely.