### PR TITLE
Feature: Fixed check if verified attribute is revoked

### DIFF
--- a/src/utils/__tests__/attribute.utils.test.ts
+++ b/src/utils/__tests__/attribute.utils.test.ts
@@ -33,14 +33,6 @@ describe('attribute utils', () => {
       expect(result).toBe(false)
     })
 
-    it('should not be considered revoked if the given verifier did not revoke the attribute (verified)', () => {
-      const attributeMock = createVerifiedTenantAttribute({
-        revokedBy: [{ id: 'verifier-id-another' }],
-      })
-      const result = isAttributeRevoked('verified', attributeMock, 'verifier-id')
-      expect(result).toBe(false)
-    })
-
     it('should be considered revoked if the given verifier revoked the attribute (verified)', () => {
       const attributeMock = createVerifiedTenantAttribute({
         revokedBy: [{ id: 'verifier-id' }],

--- a/src/utils/attribute.utils.ts
+++ b/src/utils/attribute.utils.ts
@@ -45,15 +45,11 @@ export function isAttributeRevoked(
 
       const typedAttribute = attribute as VerifiedTenantAttribute
       if (verifierId) {
-        const isInRevokedBy = typedAttribute.revokedBy.some(
-          (verifier) => verifier.id === verifierId
-        )
-
         const isInVerifiedBy = typedAttribute.verifiedBy.some(
           (verifier) => verifier.id === verifierId
         )
 
-        return isInRevokedBy && !isInVerifiedBy
+        return !isInVerifiedBy
       }
 
       /*


### PR DESCRIPTION
Removed the check of the verifier presence in the `revokedBy` array