### PR TITLE
Feature: PIN-4181 - QA UI Frontend

### DIFF
--- a/src/pages/ConsumerClientManagePage/components/VoucherInstructions/VoucherInstructionsStep2.tsx
+++ b/src/pages/ConsumerClientManagePage/components/VoucherInstructions/VoucherInstructionsStep2.tsx
@@ -139,15 +139,23 @@ export const VoucherInstructionsStep2: React.FC = () => {
       </SectionContainer>
       <SectionContainer newDesign title={t('step2.assertionScript.title')}>
         <Box sx={{ pl: 2 }} component="ol">
-          <Typography component="li">{t('step2.assertionScript.steps.1')}</Typography>
-          <Typography component="li">
+          <Typography component="li" variant="body2">
+            {t('step2.assertionScript.steps.1')}
+          </Typography>
+          <Typography component="li" variant="body2">
             <Trans components={{ 1: <Link download href={downloadUrl} /> }}>
               {t('step2.assertionScript.steps.2', { filename })}
             </Trans>
           </Typography>
-          <Typography component="li">{t('step2.assertionScript.steps.3')}</Typography>
-          <Typography component="li">{t('step2.assertionScript.steps.4')}</Typography>
-          <Typography component="li">{t('step2.assertionScript.steps.5')}</Typography>
+          <Typography component="li" variant="body2">
+            {t('step2.assertionScript.steps.3')}
+          </Typography>
+          <Typography component="li" variant="body2">
+            {t('step2.assertionScript.steps.4')}
+          </Typography>
+          <Typography component="li" variant="body2">
+            {t('step2.assertionScript.steps.5')}
+          </Typography>
         </Box>
 
         <CodeSnippetPreview
@@ -172,7 +180,9 @@ export const VoucherInstructionsStep2: React.FC = () => {
             INSERISCI_VALORE_PUR: selectedPurposeId ?? '',
           }}
         />
-        <Typography>{t('step2.assertionScript.steps.result')}</Typography>
+        <Typography sx={{ mt: 2 }} variant="body2">
+          {t('step2.assertionScript.steps.result')}
+        </Typography>
       </SectionContainer>
       <StepActions
         back={{

--- a/src/pages/ConsumerDebugVoucherPage/ConsumerDebugVoucher.page.tsx
+++ b/src/pages/ConsumerDebugVoucherPage/ConsumerDebugVoucher.page.tsx
@@ -5,6 +5,7 @@ import { DebugVoucherForm } from './components/DebugVoucherForm'
 import { DebugVoucherResults } from './components/DebugVoucherResults'
 import { DebugVoucherContextProvider } from './DebugVoucherContext'
 import type { AccessTokenRequest, TokenGenerationValidationResult } from '@/api/api.generatedTypes'
+import { Grid } from '@mui/material'
 
 const ConsumerDebugVoucherPage: React.FC = () => {
   const { t } = useTranslation('pages', { keyPrefix: 'consumerDebugVoucher' })
@@ -20,17 +21,21 @@ const ConsumerDebugVoucherPage: React.FC = () => {
 
   return (
     <PageContainer title={t('title')} description={t('description')}>
-      {!debugVoucherValues ? (
-        <DebugVoucherForm setDebugVoucherValues={setDebugVoucherValues} />
-      ) : (
-        <DebugVoucherContextProvider
-          request={debugVoucherValues.request}
-          response={debugVoucherValues.response}
-          onResetDebugVoucherValues={onResetDebugVoucherValues}
-        >
-          <DebugVoucherResults />
-        </DebugVoucherContextProvider>
-      )}
+      <Grid container>
+        <Grid item xs={8}>
+          {!debugVoucherValues ? (
+            <DebugVoucherForm setDebugVoucherValues={setDebugVoucherValues} />
+          ) : (
+            <DebugVoucherContextProvider
+              request={debugVoucherValues.request}
+              response={debugVoucherValues.response}
+              onResetDebugVoucherValues={onResetDebugVoucherValues}
+            >
+              <DebugVoucherResults />
+            </DebugVoucherContextProvider>
+          )}
+        </Grid>
+      </Grid>
     </PageContainer>
   )
 }

--- a/src/pages/ConsumerDebugVoucherPage/__test__/__snapshots__/ConsumerDebugVoucher.page.test.tsx.snap
+++ b/src/pages/ConsumerDebugVoucherPage/__test__/__snapshots__/ConsumerDebugVoucher.page.test.tsx.snap
@@ -38,333 +38,341 @@ exports[`ConsumerDebugVoucherPage testing > should render correctly when the deb
         class="MuiBox-root css-164r41r"
       >
         <div
-          class="MuiStack-root css-8mcjw0-MuiStack-root"
+          class="MuiGrid-root MuiGrid-container css-11lq3yg-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-standardSuccess MuiAlert-standard css-wnkddu-MuiPaper-root-MuiAlert-root"
-            role="alert"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-8 css-vok43g-MuiGrid-root"
           >
             <div
-              class="MuiAlert-icon css-1ytlwq5-MuiAlert-icon"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
-                data-testid="SuccessOutlinedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M20,12A8,8 0 0,1 12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4C12.76,4 13.5,4.11 14.2, 4.31L15.77,2.74C14.61,2.26 13.34,2 12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0, 0 22,12M7.91,10.08L6.5,11.5L11,16L21,6L19.59,4.58L11,13.17L7.91,10.08Z"
-                />
-              </svg>
-            </div>
-            <div
-              class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+              class="MuiStack-root css-8mcjw0-MuiStack-root"
             >
               <div
-                class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-1ssz9t4-MuiTypography-root-MuiAlertTitle-root"
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-standardSuccess MuiAlert-standard css-wnkddu-MuiPaper-root-MuiAlert-root"
+                role="alert"
               >
-                alert.title
+                <div
+                  class="MuiAlert-icon css-1ytlwq5-MuiAlert-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1vooibu-MuiSvgIcon-root"
+                    data-testid="SuccessOutlinedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20,12A8,8 0 0,1 12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4C12.76,4 13.5,4.11 14.2, 4.31L15.77,2.74C14.61,2.26 13.34,2 12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0, 0 22,12M7.91,10.08L6.5,11.5L11,16L21,6L19.59,4.58L11,13.17L7.91,10.08Z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message css-1pxa9xg-MuiAlert-message"
+                >
+                  <div
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-gutterBottom MuiAlertTitle-root css-1ssz9t4-MuiTypography-root-MuiAlertTitle-root"
+                  >
+                    alert.title
+                  </div>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                  >
+                    alert.description.apiSuccess
+                  </p>
+                </div>
               </div>
-              <p
-                class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+              <section
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-u52cu0-MuiPaper-root"
               >
-                alert.description.apiSuccess
-              </p>
+                <div
+                  class="MuiStack-root css-jfdv4h-MuiStack-root"
+                >
+                  <div
+                    class="MuiStack-root css-3y1137-MuiStack-root"
+                  >
+                    <h2
+                      class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                    >
+                      title
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root css-1yuhvjn"
+                >
+                  <div
+                    class="MuiStack-root css-1sazv7p-MuiStack-root"
+                  >
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium css-1eu001z-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 css-1qqynwt-MuiTypography-root"
+                      >
+                        label.clientAssertionValidation
+                      </span>
+                      <div
+                        class="MuiStack-root css-1p3wpnr-MuiStack-root"
+                      >
+                        <div
+                          class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-113qj4u-MuiChip-root"
+                        >
+                          <span
+                            class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                          >
+                            chipLabel.passed
+                          </span>
+                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="ChevronRightIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium css-1eu001z-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 css-1qqynwt-MuiTypography-root"
+                      >
+                        label.publicKeyRetrieve
+                      </span>
+                      <div
+                        class="MuiStack-root css-1p3wpnr-MuiStack-root"
+                      >
+                        <div
+                          class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-113qj4u-MuiChip-root"
+                        >
+                          <span
+                            class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                          >
+                            chipLabel.passed
+                          </span>
+                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="ChevronRightIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium css-1eu001z-MuiButtonBase-root-MuiButton-root"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 css-1qqynwt-MuiTypography-root"
+                      >
+                        label.clientAssertionSignatureVerification
+                      </span>
+                      <div
+                        class="MuiStack-root css-1p3wpnr-MuiStack-root"
+                      >
+                        <div
+                          class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-113qj4u-MuiChip-root"
+                        >
+                          <span
+                            class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
+                          >
+                            chipLabel.passed
+                          </span>
+                        </div>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                          data-testid="ChevronRightIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                          />
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </section>
+              <section
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-u52cu0-MuiPaper-root"
+              >
+                <div
+                  class="MuiStack-root css-jfdv4h-MuiStack-root"
+                >
+                  <div
+                    class="MuiStack-root css-3y1137-MuiStack-root"
+                  >
+                    <h2
+                      class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                    >
+                      title
+                    </h2>
+                  </div>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
+                  >
+                    description
+                  </p>
+                </div>
+                <div
+                  class="MuiBox-root css-1yuhvjn"
+                >
+                  <div
+                    class="MuiStack-root css-8mcjw0-MuiStack-root"
+                  >
+                    <div
+                      class="MuiStack-root css-1xcvc1q-MuiStack-root"
+                    >
+                      <div
+                        class="MuiBox-root css-iuqs4u"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                        >
+                          clientId.label
+                        </p>
+                      </div>
+                      <div
+                        class="MuiBox-root css-1rr4qq7"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-1vn33h7-MuiTypography-root"
+                        >
+                          <span
+                            class="MuiBox-root css-13o7eu2"
+                          >
+                            test client Id
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiStack-root css-1xcvc1q-MuiStack-root"
+                    >
+                      <div
+                        class="MuiBox-root css-iuqs4u"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                        >
+                          clientAssertion.label
+                        </p>
+                      </div>
+                      <div
+                        class="MuiBox-root css-1rr4qq7"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-1vn33h7-MuiTypography-root"
+                        >
+                          <span
+                            class="MuiBox-root css-13o7eu2"
+                          >
+                            test client assertion
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiStack-root css-1xcvc1q-MuiStack-root"
+                    >
+                      <div
+                        class="MuiBox-root css-iuqs4u"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                        >
+                          clientAssertionType.label
+                        </p>
+                        <hr
+                          class="MuiDivider-root MuiDivider-fullWidth css-159wgzx-MuiDivider-root"
+                        />
+                        <span
+                          class="MuiTypography-root MuiTypography-caption css-g171c3-MuiTypography-root"
+                        >
+                          clientAssertionType.description
+                        </span>
+                      </div>
+                      <div
+                        class="MuiBox-root css-1rr4qq7"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-1vn33h7-MuiTypography-root"
+                        >
+                          <span
+                            class="MuiBox-root css-13o7eu2"
+                          >
+                            urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiStack-root css-1xcvc1q-MuiStack-root"
+                    >
+                      <div
+                        class="MuiBox-root css-iuqs4u"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                        >
+                          grantType.label
+                        </p>
+                        <hr
+                          class="MuiDivider-root MuiDivider-fullWidth css-159wgzx-MuiDivider-root"
+                        />
+                        <span
+                          class="MuiTypography-root MuiTypography-caption css-g171c3-MuiTypography-root"
+                        >
+                          grantType.description
+                        </span>
+                      </div>
+                      <div
+                        class="MuiBox-root css-1rr4qq7"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-1vn33h7-MuiTypography-root"
+                        >
+                          <span
+                            class="MuiBox-root css-13o7eu2"
+                          >
+                            client_credentials
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+            </div>
+            <div
+              class="MuiBox-root css-a6ohpv"
+            >
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-sghohy-MuiButtonBase-root-MuiButton-root"
+                tabindex="0"
+                type="button"
+              >
+                newRequestBtn
+              </button>
             </div>
           </div>
-          <section
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-u52cu0-MuiPaper-root"
-          >
-            <div
-              class="MuiStack-root css-jfdv4h-MuiStack-root"
-            >
-              <div
-                class="MuiStack-root css-3y1137-MuiStack-root"
-              >
-                <h2
-                  class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
-                >
-                  title
-                </h2>
-              </div>
-            </div>
-            <div
-              class="MuiBox-root css-1yuhvjn"
-            >
-              <div
-                class="MuiStack-root css-1sazv7p-MuiStack-root"
-              >
-                <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium css-1eu001z-MuiButtonBase-root-MuiButton-root"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1qqynwt-MuiTypography-root"
-                  >
-                    label.clientAssertionValidation
-                  </span>
-                  <div
-                    class="MuiStack-root css-1p3wpnr-MuiStack-root"
-                  >
-                    <div
-                      class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-113qj4u-MuiChip-root"
-                    >
-                      <span
-                        class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
-                      >
-                        chipLabel.passed
-                      </span>
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                      data-testid="ChevronRightIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
-                      />
-                    </svg>
-                  </div>
-                </button>
-                <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium css-1eu001z-MuiButtonBase-root-MuiButton-root"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1qqynwt-MuiTypography-root"
-                  >
-                    label.publicKeyRetrieve
-                  </span>
-                  <div
-                    class="MuiStack-root css-1p3wpnr-MuiStack-root"
-                  >
-                    <div
-                      class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-113qj4u-MuiChip-root"
-                    >
-                      <span
-                        class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
-                      >
-                        chipLabel.passed
-                      </span>
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                      data-testid="ChevronRightIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
-                      />
-                    </svg>
-                  </div>
-                </button>
-                <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium MuiButton-root MuiButton-naked MuiButton-nakedPrimary MuiButton-sizeMedium MuiButton-nakedSizeMedium css-1eu001z-MuiButtonBase-root-MuiButton-root"
-                  tabindex="0"
-                  type="button"
-                >
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 css-1qqynwt-MuiTypography-root"
-                  >
-                    label.clientAssertionSignatureVerification
-                  </span>
-                  <div
-                    class="MuiStack-root css-1p3wpnr-MuiStack-root"
-                  >
-                    <div
-                      class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorSuccess MuiChip-filledSuccess css-113qj4u-MuiChip-root"
-                    >
-                      <span
-                        class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"
-                      >
-                        chipLabel.passed
-                      </span>
-                    </div>
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                      data-testid="ChevronRightIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
-                      />
-                    </svg>
-                  </div>
-                </button>
-              </div>
-            </div>
-          </section>
-          <section
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-u52cu0-MuiPaper-root"
-          >
-            <div
-              class="MuiStack-root css-jfdv4h-MuiStack-root"
-            >
-              <div
-                class="MuiStack-root css-3y1137-MuiStack-root"
-              >
-                <h2
-                  class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
-                >
-                  title
-                </h2>
-              </div>
-              <p
-                class="MuiTypography-root MuiTypography-body2 css-r40f8v-MuiTypography-root"
-              >
-                description
-              </p>
-            </div>
-            <div
-              class="MuiBox-root css-1yuhvjn"
-            >
-              <div
-                class="MuiStack-root css-8mcjw0-MuiStack-root"
-              >
-                <div
-                  class="MuiStack-root css-1xcvc1q-MuiStack-root"
-                >
-                  <div
-                    class="MuiBox-root css-iuqs4u"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                    >
-                      clientId.label
-                    </p>
-                  </div>
-                  <div
-                    class="MuiBox-root css-1rr4qq7"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body2 css-1vn33h7-MuiTypography-root"
-                    >
-                      <span
-                        class="MuiBox-root css-13o7eu2"
-                      >
-                        test client Id
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="MuiStack-root css-1xcvc1q-MuiStack-root"
-                >
-                  <div
-                    class="MuiBox-root css-iuqs4u"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                    >
-                      clientAssertion.label
-                    </p>
-                  </div>
-                  <div
-                    class="MuiBox-root css-1rr4qq7"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body2 css-1vn33h7-MuiTypography-root"
-                    >
-                      <span
-                        class="MuiBox-root css-13o7eu2"
-                      >
-                        test client assertion
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="MuiStack-root css-1xcvc1q-MuiStack-root"
-                >
-                  <div
-                    class="MuiBox-root css-iuqs4u"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                    >
-                      clientAssertionType.label
-                    </p>
-                    <hr
-                      class="MuiDivider-root MuiDivider-fullWidth css-159wgzx-MuiDivider-root"
-                    />
-                    <span
-                      class="MuiTypography-root MuiTypography-caption css-g171c3-MuiTypography-root"
-                    >
-                      clientAssertionType.description
-                    </span>
-                  </div>
-                  <div
-                    class="MuiBox-root css-1rr4qq7"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body2 css-1vn33h7-MuiTypography-root"
-                    >
-                      <span
-                        class="MuiBox-root css-13o7eu2"
-                      >
-                        urn:ietf:params:oauth:client-assertion-type:jwt-bearer
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="MuiStack-root css-1xcvc1q-MuiStack-root"
-                >
-                  <div
-                    class="MuiBox-root css-iuqs4u"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                    >
-                      grantType.label
-                    </p>
-                    <hr
-                      class="MuiDivider-root MuiDivider-fullWidth css-159wgzx-MuiDivider-root"
-                    />
-                    <span
-                      class="MuiTypography-root MuiTypography-caption css-g171c3-MuiTypography-root"
-                    >
-                      grantType.description
-                    </span>
-                  </div>
-                  <div
-                    class="MuiBox-root css-1rr4qq7"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body2 css-1vn33h7-MuiTypography-root"
-                    >
-                      <span
-                        class="MuiBox-root css-13o7eu2"
-                      >
-                        client_credentials
-                      </span>
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-        <div
-          class="MuiBox-root css-a6ohpv"
-        >
-          <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-sghohy-MuiButtonBase-root-MuiButton-root"
-            tabindex="0"
-            type="button"
-          >
-            newRequestBtn
-          </button>
         </div>
       </div>
     </div>
@@ -409,138 +417,146 @@ exports[`ConsumerDebugVoucherPage testing > should render correctly when the deb
       <div
         class="MuiBox-root css-164r41r"
       >
-        <form
-          class="MuiBox-root css-0"
-          novalidate=""
+        <div
+          class="MuiGrid-root MuiGrid-container css-11lq3yg-MuiGrid-root"
         >
-          <section
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-u52cu0-MuiPaper-root"
-          >
-            <div
-              class="MuiStack-root css-jfdv4h-MuiStack-root"
-            >
-              <div
-                class="MuiStack-root css-3y1137-MuiStack-root"
-              >
-                <h2
-                  class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
-                >
-                  title
-                </h2>
-              </div>
-            </div>
-            <div
-              class="MuiBox-root css-1yuhvjn"
-            >
-              <div
-                class="MuiFormControl-root MuiFormControl-fullWidth css-cq5a0p-MuiFormControl-root"
-              >
-                <div
-                  class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
-                >
-                  <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
-                    data-shrink="true"
-                    for="clientAssertion"
-                    id="clientAssertion-label"
-                  >
-                    clientAssertionLabel
-                  </label>
-                  <div
-                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-multiline css-1qxw4jt-MuiInputBase-root-MuiOutlinedInput-root"
-                  >
-                    <textarea
-                      aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline MuiInputBase-inputSizeSmall css-12tl3rr-MuiInputBase-input-MuiOutlinedInput-input"
-                      id="clientAssertion"
-                      name="clientAssertion"
-                      rows="2.5"
-                      style="height: 0px; overflow: hidden;"
-                    />
-                    <textarea
-                      aria-hidden="true"
-                      class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline MuiInputBase-inputSizeSmall css-12tl3rr-MuiInputBase-input-MuiOutlinedInput-input"
-                      readonly=""
-                      style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
-                      tabindex="-1"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                    >
-                      <legend
-                        class="css-14lo706"
-                      >
-                        <span>
-                          clientAssertionLabel
-                        </span>
-                      </legend>
-                    </fieldset>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiFormControl-root MuiFormControl-fullWidth css-cq5a0p-MuiFormControl-root"
-              >
-                <div
-                  class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
-                >
-                  <label
-                    class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1pysi21-MuiFormLabel-root-MuiInputLabel-root"
-                    data-shrink="false"
-                    for="clientId"
-                    id="clientId-label"
-                  >
-                    clientIdLabel
-                  </label>
-                  <div
-                    class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
-                  >
-                    <input
-                      aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
-                      id="clientId"
-                      name="clientId"
-                      type="text"
-                      value=""
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
-                    >
-                      <legend
-                        class="css-yjsfm1"
-                      >
-                        <span>
-                          clientIdLabel
-                        </span>
-                      </legend>
-                    </fieldset>
-                  </div>
-                </div>
-              </div>
-              <p
-                class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-              >
-                description
-              </p>
-            </div>
-          </section>
           <div
-            class="MuiBox-root css-a6ohpv"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-8 css-vok43g-MuiGrid-root"
           >
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-sghohy-MuiButtonBase-root-MuiButton-root"
-              tabindex="0"
-              type="submit"
+            <form
+              class="MuiBox-root css-0"
+              novalidate=""
             >
-              submitBtn
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
-            </button>
+              <section
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-u52cu0-MuiPaper-root"
+              >
+                <div
+                  class="MuiStack-root css-jfdv4h-MuiStack-root"
+                >
+                  <div
+                    class="MuiStack-root css-3y1137-MuiStack-root"
+                  >
+                    <h2
+                      class="MuiTypography-root MuiTypography-h6 css-2ulfj5-MuiTypography-root"
+                    >
+                      title
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root css-1yuhvjn"
+                >
+                  <div
+                    class="MuiFormControl-root MuiFormControl-fullWidth css-cq5a0p-MuiFormControl-root"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1jy569b-MuiFormLabel-root-MuiInputLabel-root"
+                        data-shrink="true"
+                        for="clientAssertion"
+                        id="clientAssertion-label"
+                      >
+                        clientAssertionLabel
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-focused MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-multiline css-1qxw4jt-MuiInputBase-root-MuiOutlinedInput-root"
+                      >
+                        <textarea
+                          aria-invalid="false"
+                          class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline MuiInputBase-inputSizeSmall css-12tl3rr-MuiInputBase-input-MuiOutlinedInput-input"
+                          id="clientAssertion"
+                          name="clientAssertion"
+                          rows="2.5"
+                          style="height: 0px; overflow: hidden;"
+                        />
+                        <textarea
+                          aria-hidden="true"
+                          class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline MuiInputBase-inputSizeSmall css-12tl3rr-MuiInputBase-input-MuiOutlinedInput-input"
+                          readonly=""
+                          style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); padding-top: 0px; padding-bottom: 0px; width: 100%;"
+                          tabindex="-1"
+                        />
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                        >
+                          <legend
+                            class="css-14lo706"
+                          >
+                            <span>
+                              clientAssertionLabel
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiFormControl-root MuiFormControl-fullWidth css-cq5a0p-MuiFormControl-root"
+                  >
+                    <div
+                      class="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+                    >
+                      <label
+                        class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1pysi21-MuiFormLabel-root-MuiInputLabel-root"
+                        data-shrink="false"
+                        for="clientId"
+                        id="clientId-label"
+                      >
+                        clientIdLabel
+                      </label>
+                      <div
+                        class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+                      >
+                        <input
+                          aria-invalid="false"
+                          class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1n4twyu-MuiInputBase-input-MuiOutlinedInput-input"
+                          id="clientId"
+                          name="clientId"
+                          type="text"
+                          value=""
+                        />
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+                        >
+                          <legend
+                            class="css-yjsfm1"
+                          >
+                            <span>
+                              clientIdLabel
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                  >
+                    description
+                  </p>
+                </div>
+              </section>
+              <div
+                class="MuiBox-root css-a6ohpv"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-sghohy-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="submit"
+                >
+                  submitBtn
+                  <span
+                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </form>
           </div>
-        </form>
+        </div>
       </div>
     </div>
   </div>

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsGeneralInfoSection.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsGeneralInfoSection.tsx
@@ -1,13 +1,12 @@
 import type { Purpose } from '@/api/api.generatedTypes'
 import { SectionContainer } from '@/components/layout/containers'
 import { Link, useGeneratePath } from '@/router'
-import { Divider, Stack } from '@mui/material'
+import { Stack } from '@mui/material'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
 import React from 'react'
 import LinkIcon from '@mui/icons-material/Link'
 import { PurposeDownloads } from '@/api/purpose'
 import { useTranslation } from 'react-i18next'
-import { IconLink } from '@/components/shared/IconLink'
 import DownloadIcon from '@mui/icons-material/Download'
 
 type ConsumerPurposeDetailsGeneralInfoSectionProps = {
@@ -38,7 +37,26 @@ export const ConsumerPurposeDetailsGeneralInfoSection: React.FC<
   }
 
   return (
-    <SectionContainer title={t('title')} newDesign>
+    <SectionContainer
+      title={t('title')}
+      newDesign
+      bottomActions={[
+        {
+          startIcon: <DownloadIcon fontSize="small" />,
+          label: t('riskAnalysis.link.label'),
+          component: 'button',
+          type: 'button',
+          onClick: { handleDownloadDocument },
+        },
+        {
+          startIcon: <LinkIcon fontSize="small" />,
+          label: t('agreementLink.label'),
+          href:
+            '/ui' + generatePath('SUBSCRIBE_AGREEMENT_READ', { agreementId: purpose.agreement.id }),
+          target: '_blank',
+        },
+      ]}
+    >
       <Stack spacing={2}>
         <InformationContainer
           label={t('eServiceField.label')}
@@ -66,24 +84,6 @@ export const ConsumerPurposeDetailsGeneralInfoSection: React.FC<
           direction="column"
           content={purpose.description}
         />
-        <Divider />
-        <IconLink
-          onClick={handleDownloadDocument}
-          component="button"
-          startIcon={<DownloadIcon />}
-          alignSelf="start"
-        >
-          {t('riskAnalysis.link.label')}
-        </IconLink>
-        <IconLink
-          href={
-            '/ui' + generatePath('SUBSCRIBE_AGREEMENT_READ', { agreementId: purpose.agreement.id })
-          }
-          startIcon={<LinkIcon />}
-          alignSelf="start"
-        >
-          {t('agreementLink.label')}
-        </IconLink>
       </Stack>
     </SectionContainer>
   )

--- a/src/pages/ConsumerPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
+++ b/src/pages/ConsumerPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
@@ -21,7 +21,7 @@ function useGetPurposeStateAlertProps(purpose: Purpose | undefined):
   if (!purpose) return undefined
 
   const isPurposeSuspended = purpose.currentVersion?.state === 'SUSPENDED'
-  const isPurposeWaintingForApproval =
+  const isFirstVersionPending =
     Boolean(purpose.waitingForApprovalVersion) && Boolean(!purpose.currentVersion)
   const isPurposeActive = purpose.currentVersion?.state === 'ACTIVE'
   const isPurposeArchived = purpose.currentVersion?.state === 'ARCHIVED'
@@ -33,7 +33,7 @@ function useGetPurposeStateAlertProps(purpose: Purpose | undefined):
     }
   }
 
-  if (isPurposeWaintingForApproval) {
+  if (isFirstVersionPending) {
     return {
       severity: 'warning',
       content: t('waitingForApprovalAlert'),

--- a/src/pages/ConsumerPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
+++ b/src/pages/ConsumerPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
@@ -20,9 +20,10 @@ function useGetPurposeStateAlertProps(purpose: Purpose | undefined):
 
   if (!purpose) return undefined
 
-  const isPurposeSuspended = purpose?.currentVersion?.state === 'SUSPENDED'
-  const isPurposeWaintingForApproval = Boolean(purpose?.waitingForApprovalVersion)
-  const isPurposeActive = purpose?.currentVersion?.state === 'ACTIVE'
+  const isPurposeSuspended = purpose.currentVersion?.state === 'SUSPENDED'
+  const isPurposeWaintingForApproval =
+    Boolean(purpose.waitingForApprovalVersion) && Boolean(!purpose.currentVersion)
+  const isPurposeActive = purpose.currentVersion?.state === 'ACTIVE'
   const isPurposeArchived = purpose.currentVersion?.state === 'ARCHIVED'
 
   if (isPurposeSuspended) {

--- a/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsGeneralInfoSection/ProviderAgreementDetailsGeneralInfoSection.tsx
+++ b/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsGeneralInfoSection/ProviderAgreementDetailsGeneralInfoSection.tsx
@@ -1,7 +1,6 @@
 import { SectionContainer, SectionContainerSkeleton } from '@/components/layout/containers'
-import { IconLink } from '@/components/shared/IconLink'
 import { Link } from '@/router'
-import { Divider, Stack } from '@mui/material'
+import { Stack } from '@mui/material'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -58,9 +57,50 @@ export const ProviderAgreementDetailsGeneralInfoSection: React.FC = () => {
     downloadContract({ agreementId: agreement.id }, `${t('documentation.fileName')}.pdf`)
   }
 
+  const actions = []
+
+  if (agreement.isContractPresent) {
+    actions.push({
+      startIcon: <DownloadIcon fontSize="small" />,
+      label: t('documentation.link.label'),
+      component: 'button',
+      type: 'button',
+      onClick: handleDownloadDocument,
+    })
+  }
+
+  if (agreement.state === 'PENDING') {
+    actions.push(
+      {
+        startIcon: <RuleIcon fontSize="small" />,
+        label: t('certifiedAttributeLink.label'),
+        component: 'button',
+        type: 'button',
+        onClick: handleOpenAttributesDrawer.bind(null, 'certified'),
+      },
+      {
+        startIcon: <RuleIcon fontSize="small" />,
+        label: t('declaredAttributeLink.label'),
+        component: 'button',
+        type: 'button',
+        onClick: handleOpenAttributesDrawer.bind(null, 'declared'),
+      }
+    )
+  }
+
+  if (agreement.consumer.contactMail) {
+    actions.push({
+      startIcon: <ContactMailIcon fontSize="small" />,
+      label: t('consumerDetailsLink.label'),
+      component: 'button',
+      type: 'button',
+      onClick: handleOpenContactDrawer,
+    })
+  }
+
   return (
     <>
-      <SectionContainer title={t('title')} newDesign>
+      <SectionContainer title={t('title')} newDesign bottomActions={actions}>
         <Stack spacing={2}>
           <InformationContainer
             label={t('eServiceField.label')}
@@ -89,47 +129,6 @@ export const ProviderAgreementDetailsGeneralInfoSection: React.FC = () => {
               direction="column"
               content={agreement.rejectionReason}
             />
-          )}
-          <Divider />
-          {agreement.isContractPresent && (
-            <IconLink
-              onClick={handleDownloadDocument}
-              component="button"
-              startIcon={<DownloadIcon />}
-              alignSelf="start"
-            >
-              {t('documentation.link.label')}
-            </IconLink>
-          )}
-          {agreement.state === 'PENDING' && (
-            <>
-              <IconLink
-                onClick={handleOpenAttributesDrawer.bind(null, 'certified')}
-                component="button"
-                startIcon={<RuleIcon />}
-                alignSelf="start"
-              >
-                {t('certifiedAttributeLink.label')}
-              </IconLink>
-              <IconLink
-                onClick={handleOpenAttributesDrawer.bind(null, 'declared')}
-                component="button"
-                startIcon={<RuleIcon />}
-                alignSelf="start"
-              >
-                {t('declaredAttributeLink.label')}
-              </IconLink>
-            </>
-          )}
-          {agreement.consumer.contactMail && (
-            <IconLink
-              onClick={handleOpenContactDrawer}
-              component="button"
-              startIcon={<ContactMailIcon />}
-              alignSelf="start"
-            >
-              {t('consumerDetailsLink.label')}
-            </IconLink>
           )}
         </Stack>
       </SectionContainer>

--- a/src/pages/ProviderPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
+++ b/src/pages/ProviderPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
@@ -9,9 +9,10 @@ function useGetPurposeStateAlertProps(
 
   if (!purpose) return undefined
 
-  const isSuspended = purpose?.currentVersion?.state === 'SUSPENDED'
-  const isWaintingForApproval = Boolean(purpose?.waitingForApprovalVersion)
-  const isArchived = purpose?.currentVersion?.state === 'ARCHIVED'
+  const isSuspended = purpose.currentVersion?.state === 'SUSPENDED'
+  const isWaintingForApproval =
+    Boolean(purpose.waitingForApprovalVersion) && Boolean(purpose.currentVersion)
+  const isArchived = purpose.currentVersion?.state === 'ARCHIVED'
 
   if (isSuspended) {
     return {

--- a/src/pages/ProviderPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
+++ b/src/pages/ProviderPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
@@ -10,7 +10,7 @@ function useGetPurposeStateAlertProps(
   if (!purpose) return undefined
 
   const isSuspended = purpose.currentVersion?.state === 'SUSPENDED'
-  const isWaintingForApproval =
+  const isUpgradePending =
     Boolean(purpose.waitingForApprovalVersion) && Boolean(purpose.currentVersion)
   const isArchived = purpose.currentVersion?.state === 'ARCHIVED'
 
@@ -21,7 +21,7 @@ function useGetPurposeStateAlertProps(
     }
   }
 
-  if (isWaintingForApproval) {
+  if (isUpgradePending) {
     return {
       severity: 'warning',
       content: t('waitingForApprovalAlert'),


### PR DESCRIPTION
- Changed `Typography` variant from `body1` to `body2` in `VoucherInstructionsStep2`
- Added `Grid `with `xs=8` to `ConsumerDebugVoucher` page
- Fixed when warning alert apperared in ConsumerPurposeDetails page and ProviderPurposeDetails
- Replaced `IconLink` with `SectionContainer` bottomActions
- Updated snapshot