### PR TITLE
Added generate token command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "interop-dashboard-frontend",
-  "version": "1.0.40",
+  "version": "1.0.45",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "interop-dashboard-frontend",
-      "version": "1.0.40",
+      "version": "1.0.45",
       "dependencies": {
         "@date-io/date-fns": "^2.17.0",
         "@emotion/react": "^11.11.1",
@@ -31,10 +31,11 @@
         "react-error-boundary": "^4.0.11",
         "react-hook-form": "^7.46.1",
         "react-i18next": "^13.2.2",
-        "react-router-dom": "*",
+        "react-router-dom": "latest",
         "zustand": "^4.4.1"
       },
       "devDependencies": {
+        "@aws-sdk/client-kms": "^3.509.0",
         "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -51,6 +52,7 @@
         "@vitejs/plugin-react": "^4.0.4",
         "@vitest/coverage-v8": "^0.34.4",
         "cheerio": "^1.0.0-rc.12",
+        "dotenv": "^16.4.1",
         "eslint": "^8.49.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -66,6 +68,7 @@
         "rollup-plugin-visualizer": "^5.9.2",
         "swagger-typescript-api": "^13.0.3",
         "typescript": "^5.2.2",
+        "uuid": "^9.0.1",
         "vite": "^4.4.9",
         "vitest": "^0.34.4"
       }
@@ -96,6 +99,657 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/client-kms": {
+      "version": "3.509.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.509.0.tgz",
+      "integrity": "sha512-fylEmfN7k9laDcmqQunlmwAJ2582K1E2w9GnTgZ2tSyFyqlq7/DiKgpAANTA88Cmk25BJHjXSQRd+M8GGK9zbw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.507.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/credential-provider-node": "3.509.0",
+        "@aws-sdk/middleware-host-header": "3.502.0",
+        "@aws-sdk/middleware-logger": "3.502.0",
+        "@aws-sdk/middleware-recursion-detection": "3.502.0",
+        "@aws-sdk/middleware-signing": "3.502.0",
+        "@aws-sdk/middleware-user-agent": "3.502.0",
+        "@aws-sdk/region-config-resolver": "3.502.0",
+        "@aws-sdk/types": "3.502.0",
+        "@aws-sdk/util-endpoints": "3.502.0",
+        "@aws-sdk/util-user-agent-browser": "3.502.0",
+        "@aws-sdk/util-user-agent-node": "3.502.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.507.0.tgz",
+      "integrity": "sha512-pFeaKwqv4tXD6QVxWC2V4N62DUoP3bPSm/mCe2SPhaNjNsmwwA53viUHz/nwxIbs8w4vV44UQsygb0AgKm+HoQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.502.0",
+        "@aws-sdk/middleware-logger": "3.502.0",
+        "@aws-sdk/middleware-recursion-detection": "3.502.0",
+        "@aws-sdk/middleware-user-agent": "3.502.0",
+        "@aws-sdk/region-config-resolver": "3.502.0",
+        "@aws-sdk/types": "3.502.0",
+        "@aws-sdk/util-endpoints": "3.502.0",
+        "@aws-sdk/util-user-agent-browser": "3.502.0",
+        "@aws-sdk/util-user-agent-node": "3.502.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.507.0.tgz",
+      "integrity": "sha512-ms5CH2ImhqqCIbo5irxayByuPOlVAmSiqDVfjZKwgIziqng2bVgNZMeKcT6t0bmrcgScEAVnZwY7j/iZTIw73g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.507.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.502.0",
+        "@aws-sdk/middleware-logger": "3.502.0",
+        "@aws-sdk/middleware-recursion-detection": "3.502.0",
+        "@aws-sdk/middleware-signing": "3.502.0",
+        "@aws-sdk/middleware-user-agent": "3.502.0",
+        "@aws-sdk/region-config-resolver": "3.502.0",
+        "@aws-sdk/types": "3.502.0",
+        "@aws-sdk/util-endpoints": "3.502.0",
+        "@aws-sdk/util-user-agent-browser": "3.502.0",
+        "@aws-sdk/util-user-agent-node": "3.502.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.507.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.507.0.tgz",
+      "integrity": "sha512-TOWBe0ApEh32QOib0R+irWGjd1F9wnhbGV5PcB9SakyRwvqwG5MKOfYxG7ocoDqLlaRwzZMidcy/PV8/OEVNKg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.502.0",
+        "@aws-sdk/middleware-logger": "3.502.0",
+        "@aws-sdk/middleware-recursion-detection": "3.502.0",
+        "@aws-sdk/middleware-user-agent": "3.502.0",
+        "@aws-sdk/region-config-resolver": "3.502.0",
+        "@aws-sdk/types": "3.502.0",
+        "@aws-sdk/util-endpoints": "3.502.0",
+        "@aws-sdk/util-user-agent-browser": "3.502.0",
+        "@aws-sdk/util-user-agent-node": "3.502.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.507.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
+      "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/core": "^1.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.502.0.tgz",
+      "integrity": "sha512-KIB8Ae1Z7domMU/jU4KiIgK4tmYgvuXlhR54ehwlVHxnEoFPoPuGHFZU7oFn79jhhSLUFQ1lRYMxP0cEwb7XeQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.503.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.503.1.tgz",
+      "integrity": "sha512-rTdlFFGoPPFMF2YjtlfRuSgKI+XsF49u7d98255hySwhsbwd3Xp+utTTPquxP+CwDxMHbDlI7NxDzFiFdsoZug==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.507.0.tgz",
+      "integrity": "sha512-2CnyduoR9COgd7qH1LPYK8UggGqVs8R4ASDMB5bwGxbg9ZerlStDiHpqvJNNg1k+VlejBr++utxfmHd236XgmQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.507.0",
+        "@aws-sdk/credential-provider-env": "3.502.0",
+        "@aws-sdk/credential-provider-process": "3.502.0",
+        "@aws-sdk/credential-provider-sso": "3.507.0",
+        "@aws-sdk/credential-provider-web-identity": "3.507.0",
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.509.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.509.0.tgz",
+      "integrity": "sha512-uXT8wIq1k+m0mS/pC9U1cUTIjUB7/4PgxyiYsTxYPIULtWnQXltAlcPU3QzKTJMP60sqftRYZ2jFDLAVsipQxw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.502.0",
+        "@aws-sdk/credential-provider-http": "3.503.1",
+        "@aws-sdk/credential-provider-ini": "3.507.0",
+        "@aws-sdk/credential-provider-process": "3.502.0",
+        "@aws-sdk/credential-provider-sso": "3.507.0",
+        "@aws-sdk/credential-provider-web-identity": "3.507.0",
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.502.0.tgz",
+      "integrity": "sha512-fJJowOjQ4infYQX0E1J3xFVlmuwEYJAFk0Mo1qwafWmEthsBJs+6BR2RiWDELHKrSK35u4Pf3fu3RkYuCtmQFw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.507.0.tgz",
+      "integrity": "sha512-6WBjou52QukFpDi4ezb19bcAx/bM8ge8qnJnRT02WVRmU6zFQ5yLD2fW1MFsbX3cwbey+wSqKd5FGE1Hukd5wQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.507.0",
+        "@aws-sdk/token-providers": "3.507.0",
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.507.0.tgz",
+      "integrity": "sha512-f+aGMfazBimX7S06224JRYzGTaMh1uIhfj23tZylPJ05KxTVi5IO1RoqeI/uHLJ+bDOx+JHBC04g/oCdO4kHvw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.507.0",
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.502.0.tgz",
+      "integrity": "sha512-EjnG0GTYXT/wJBmm5/mTjDcAkzU8L7wQjOzd3FTXuTCNNyvAvwrszbOj5FlarEw5XJBbQiZtBs+I5u9+zy560w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.502.0.tgz",
+      "integrity": "sha512-FDyv6K4nCoHxbjLGS2H8ex8I0KDIiu4FJgVRPs140ZJy6gE5Pwxzv6YTzZGLMrnqcIs9gh065Lf6DjwMelZqaw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.502.0.tgz",
+      "integrity": "sha512-hvbyGJbxeuezxOu8VfFmcV4ql1hKXLxHTe5FNYfEBat2KaZXVhc1Hg+4TvB06/53p+E8J99Afmumkqbxs2esUA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.502.0.tgz",
+      "integrity": "sha512-4hF08vSzJ7L6sB+393gOFj3s2N6nLusYS0XrMW6wYNFU10IDdbf8Z3TZ7gysDJJHEGQPmTAesPEDBsasGWcMxg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.502.0.tgz",
+      "integrity": "sha512-TxbBZbRiXPH0AUxegqiNd9aM9zNSbfjtBs5MEfcBsweeT/B2O7K1EjP9+CkB8Xmk/5FLKhAKLr19b1TNoE27rw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@aws-sdk/util-endpoints": "3.502.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.502.0.tgz",
+      "integrity": "sha512-mxmsX2AGgnSM+Sah7mcQCIneOsJQNiLX0COwEttuf8eO+6cLMAZvVudH3BnWTfea4/A9nuri9DLCqBvEmPrilg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.507.0.tgz",
+      "integrity": "sha512-ehOINGjoGJc6Puzon7ev4bXckkaZx18WNgMTNttYJhj3vTpj5LPSQbI/5SS927bEbpGMFz1+hJ6Ra5WGfbTcEQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.507.0",
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+      "integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.502.0.tgz",
+      "integrity": "sha512-6LKFlJPp2J24r1Kpfoz5ESQn+1v5fEjDB3mtUKRdpwarhm3syu7HbKlHCF3KbcCOyahobvLvhoedT78rJFEeeg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.495.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.495.0.tgz",
+      "integrity": "sha512-MfaPXT0kLX2tQaR90saBT9fWQq2DHqSSJRzW+MZWsmF+y5LGCOhO22ac/2o6TKSQm7h0HRc2GaADqYYYor62yg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.502.0.tgz",
+      "integrity": "sha512-v8gKyCs2obXoIkLETAeEQ3AM+QmhHhst9xbM1cJtKUGsRlVIak/XyyD+kVE6kmMm1cjfudHpHKABWk9apQcIZQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.502.0.tgz",
+      "integrity": "sha512-9RjxpkGZKbTdl96tIJvAo+vZoz4P/cQh36SBUt9xfRfW0BtsaLyvSrvlR5wyUYhvRcC12Axqh/8JtnAPq//+Vw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1815,6 +2469,577 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+      "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+      "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.2.tgz",
+      "integrity": "sha512-tYDmTp0f2TZVE18jAOH1PnmkngLQ+dOGUlMd1u67s87ieueNeyqhja6z/Z4MxhybEiXKOWFOmGjfTZWFxljwJw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+      "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+      "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+      "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+      "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+      "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+      "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+      "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+      "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+      "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+      "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+      "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+      "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+      "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+      "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+      "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.1.1",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+      "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+      "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+      "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+      "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+      "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+      "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+      "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.0.tgz",
+      "integrity": "sha512-iFJp/N4EtkanFpBUtSrrIbtOIBf69KNuve03ic1afhJ9/korDxdM0c6cCH4Ehj/smI9pDCfVv+bqT3xZjF2WaA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+      "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+      "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@tanstack/match-sorter-utils": {
       "version": "8.7.6",
       "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.7.6.tgz",
@@ -3038,6 +4263,12 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true
+    },
     "node_modules/bplist-parser": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
@@ -3904,6 +5135,18 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.485",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.485.tgz",
@@ -4640,6 +5883,28 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -8476,6 +9741,12 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -9026,6 +10297,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -9593,6 +10877,586 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/client-kms": {
+      "version": "3.509.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.509.0.tgz",
+      "integrity": "sha512-fylEmfN7k9laDcmqQunlmwAJ2582K1E2w9GnTgZ2tSyFyqlq7/DiKgpAANTA88Cmk25BJHjXSQRd+M8GGK9zbw==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.507.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/credential-provider-node": "3.509.0",
+        "@aws-sdk/middleware-host-header": "3.502.0",
+        "@aws-sdk/middleware-logger": "3.502.0",
+        "@aws-sdk/middleware-recursion-detection": "3.502.0",
+        "@aws-sdk/middleware-signing": "3.502.0",
+        "@aws-sdk/middleware-user-agent": "3.502.0",
+        "@aws-sdk/region-config-resolver": "3.502.0",
+        "@aws-sdk/types": "3.502.0",
+        "@aws-sdk/util-endpoints": "3.502.0",
+        "@aws-sdk/util-user-agent-browser": "3.502.0",
+        "@aws-sdk/util-user-agent-node": "3.502.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.507.0.tgz",
+      "integrity": "sha512-pFeaKwqv4tXD6QVxWC2V4N62DUoP3bPSm/mCe2SPhaNjNsmwwA53viUHz/nwxIbs8w4vV44UQsygb0AgKm+HoQ==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.502.0",
+        "@aws-sdk/middleware-logger": "3.502.0",
+        "@aws-sdk/middleware-recursion-detection": "3.502.0",
+        "@aws-sdk/middleware-user-agent": "3.502.0",
+        "@aws-sdk/region-config-resolver": "3.502.0",
+        "@aws-sdk/types": "3.502.0",
+        "@aws-sdk/util-endpoints": "3.502.0",
+        "@aws-sdk/util-user-agent-browser": "3.502.0",
+        "@aws-sdk/util-user-agent-node": "3.502.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.507.0.tgz",
+      "integrity": "sha512-ms5CH2ImhqqCIbo5irxayByuPOlVAmSiqDVfjZKwgIziqng2bVgNZMeKcT6t0bmrcgScEAVnZwY7j/iZTIw73g==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.507.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.502.0",
+        "@aws-sdk/middleware-logger": "3.502.0",
+        "@aws-sdk/middleware-recursion-detection": "3.502.0",
+        "@aws-sdk/middleware-signing": "3.502.0",
+        "@aws-sdk/middleware-user-agent": "3.502.0",
+        "@aws-sdk/region-config-resolver": "3.502.0",
+        "@aws-sdk/types": "3.502.0",
+        "@aws-sdk/util-endpoints": "3.502.0",
+        "@aws-sdk/util-user-agent-browser": "3.502.0",
+        "@aws-sdk/util-user-agent-node": "3.502.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.507.0.tgz",
+      "integrity": "sha512-TOWBe0ApEh32QOib0R+irWGjd1F9wnhbGV5PcB9SakyRwvqwG5MKOfYxG7ocoDqLlaRwzZMidcy/PV8/OEVNKg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.502.0",
+        "@aws-sdk/middleware-logger": "3.502.0",
+        "@aws-sdk/middleware-recursion-detection": "3.502.0",
+        "@aws-sdk/middleware-user-agent": "3.502.0",
+        "@aws-sdk/region-config-resolver": "3.502.0",
+        "@aws-sdk/types": "3.502.0",
+        "@aws-sdk/util-endpoints": "3.502.0",
+        "@aws-sdk/util-user-agent-browser": "3.502.0",
+        "@aws-sdk/util-user-agent-node": "3.502.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/core": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
+      "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
+      "dev": true,
+      "requires": {
+        "@smithy/core": "^1.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.502.0.tgz",
+      "integrity": "sha512-KIB8Ae1Z7domMU/jU4KiIgK4tmYgvuXlhR54ehwlVHxnEoFPoPuGHFZU7oFn79jhhSLUFQ1lRYMxP0cEwb7XeQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-http": {
+      "version": "3.503.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.503.1.tgz",
+      "integrity": "sha512-rTdlFFGoPPFMF2YjtlfRuSgKI+XsF49u7d98255hySwhsbwd3Xp+utTTPquxP+CwDxMHbDlI7NxDzFiFdsoZug==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.507.0.tgz",
+      "integrity": "sha512-2CnyduoR9COgd7qH1LPYK8UggGqVs8R4ASDMB5bwGxbg9ZerlStDiHpqvJNNg1k+VlejBr++utxfmHd236XgmQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sts": "3.507.0",
+        "@aws-sdk/credential-provider-env": "3.502.0",
+        "@aws-sdk/credential-provider-process": "3.502.0",
+        "@aws-sdk/credential-provider-sso": "3.507.0",
+        "@aws-sdk/credential-provider-web-identity": "3.507.0",
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.509.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.509.0.tgz",
+      "integrity": "sha512-uXT8wIq1k+m0mS/pC9U1cUTIjUB7/4PgxyiYsTxYPIULtWnQXltAlcPU3QzKTJMP60sqftRYZ2jFDLAVsipQxw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.502.0",
+        "@aws-sdk/credential-provider-http": "3.503.1",
+        "@aws-sdk/credential-provider-ini": "3.507.0",
+        "@aws-sdk/credential-provider-process": "3.502.0",
+        "@aws-sdk/credential-provider-sso": "3.507.0",
+        "@aws-sdk/credential-provider-web-identity": "3.507.0",
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.502.0.tgz",
+      "integrity": "sha512-fJJowOjQ4infYQX0E1J3xFVlmuwEYJAFk0Mo1qwafWmEthsBJs+6BR2RiWDELHKrSK35u4Pf3fu3RkYuCtmQFw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.507.0.tgz",
+      "integrity": "sha512-6WBjou52QukFpDi4ezb19bcAx/bM8ge8qnJnRT02WVRmU6zFQ5yLD2fW1MFsbX3cwbey+wSqKd5FGE1Hukd5wQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sso": "3.507.0",
+        "@aws-sdk/token-providers": "3.507.0",
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.507.0.tgz",
+      "integrity": "sha512-f+aGMfazBimX7S06224JRYzGTaMh1uIhfj23tZylPJ05KxTVi5IO1RoqeI/uHLJ+bDOx+JHBC04g/oCdO4kHvw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sts": "3.507.0",
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.502.0.tgz",
+      "integrity": "sha512-EjnG0GTYXT/wJBmm5/mTjDcAkzU8L7wQjOzd3FTXuTCNNyvAvwrszbOj5FlarEw5XJBbQiZtBs+I5u9+zy560w==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.502.0.tgz",
+      "integrity": "sha512-FDyv6K4nCoHxbjLGS2H8ex8I0KDIiu4FJgVRPs140ZJy6gE5Pwxzv6YTzZGLMrnqcIs9gh065Lf6DjwMelZqaw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.502.0.tgz",
+      "integrity": "sha512-hvbyGJbxeuezxOu8VfFmcV4ql1hKXLxHTe5FNYfEBat2KaZXVhc1Hg+4TvB06/53p+E8J99Afmumkqbxs2esUA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.502.0.tgz",
+      "integrity": "sha512-4hF08vSzJ7L6sB+393gOFj3s2N6nLusYS0XrMW6wYNFU10IDdbf8Z3TZ7gysDJJHEGQPmTAesPEDBsasGWcMxg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.502.0.tgz",
+      "integrity": "sha512-TxbBZbRiXPH0AUxegqiNd9aM9zNSbfjtBs5MEfcBsweeT/B2O7K1EjP9+CkB8Xmk/5FLKhAKLr19b1TNoE27rw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@aws-sdk/util-endpoints": "3.502.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/region-config-resolver": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.502.0.tgz",
+      "integrity": "sha512-mxmsX2AGgnSM+Sah7mcQCIneOsJQNiLX0COwEttuf8eO+6cLMAZvVudH3BnWTfea4/A9nuri9DLCqBvEmPrilg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.507.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.507.0.tgz",
+      "integrity": "sha512-ehOINGjoGJc6Puzon7ev4bXckkaZx18WNgMTNttYJhj3vTpj5LPSQbI/5SS927bEbpGMFz1+hJ6Ra5WGfbTcEQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.507.0",
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.502.0.tgz",
+      "integrity": "sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.502.0.tgz",
+      "integrity": "sha512-6LKFlJPp2J24r1Kpfoz5ESQn+1v5fEjDB3mtUKRdpwarhm3syu7HbKlHCF3KbcCOyahobvLvhoedT78rJFEeeg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.495.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.495.0.tgz",
+      "integrity": "sha512-MfaPXT0kLX2tQaR90saBT9fWQq2DHqSSJRzW+MZWsmF+y5LGCOhO22ac/2o6TKSQm7h0HRc2GaADqYYYor62yg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.502.0.tgz",
+      "integrity": "sha512-v8gKyCs2obXoIkLETAeEQ3AM+QmhHhst9xbM1cJtKUGsRlVIak/XyyD+kVE6kmMm1cjfudHpHKABWk9apQcIZQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.502.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.502.0.tgz",
+      "integrity": "sha512-9RjxpkGZKbTdl96tIJvAo+vZoz4P/cQh36SBUt9xfRfW0BtsaLyvSrvlR5wyUYhvRcC12Axqh/8JtnAPq//+Vw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.502.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
       }
     },
     "@babel/code-frame": {
@@ -10623,6 +12487,471 @@
       "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
       "dev": true
     },
+    "@smithy/abort-controller": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+      "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/config-resolver": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+      "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
+      "dev": true,
+      "requires": {
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/core": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.2.tgz",
+      "integrity": "sha512-tYDmTp0f2TZVE18jAOH1PnmkngLQ+dOGUlMd1u67s87ieueNeyqhja6z/Z4MxhybEiXKOWFOmGjfTZWFxljwJw==",
+      "dev": true,
+      "requires": {
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+      "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
+      "dev": true,
+      "requires": {
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/eventstream-codec": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+      "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
+      "dev": true,
+      "requires": {
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+      "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+      "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/is-array-buffer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+      "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
+      "dev": true,
+      "requires": {
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-endpoint": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+      "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
+      "dev": true,
+      "requires": {
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-retry": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+      "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
+      "dev": true,
+      "requires": {
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
+    "@smithy/middleware-serde": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+      "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/middleware-stack": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+      "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/node-config-provider": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+      "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
+      "dev": true,
+      "requires": {
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+      "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
+      "dev": true,
+      "requires": {
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/property-provider": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+      "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/protocol-http": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+      "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/querystring-builder": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+      "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/querystring-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+      "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/service-error-classification": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1"
+      }
+    },
+    "@smithy/shared-ini-file-loader": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
+      "dev": true,
+      "requires": {
+        "@smithy/eventstream-codec": "^2.1.1",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/smithy-client": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+      "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
+      "dev": true,
+      "requires": {
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/types": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/url-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+      "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
+      "dev": true,
+      "requires": {
+        "@smithy/querystring-parser": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-base64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+      "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
+      "dev": true,
+      "requires": {
+        "@smithy/util-buffer-from": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-browser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+      "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-body-length-node": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+      "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
+      "dev": true,
+      "requires": {
+        "@smithy/is-array-buffer": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-config-provider": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+      "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-defaults-mode-browser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+      "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
+      "dev": true,
+      "requires": {
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-defaults-mode-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.0.tgz",
+      "integrity": "sha512-iFJp/N4EtkanFpBUtSrrIbtOIBf69KNuve03ic1afhJ9/korDxdM0c6cCH4Ehj/smI9pDCfVv+bqT3xZjF2WaA==",
+      "dev": true,
+      "requires": {
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-endpoints": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+      "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
+      "dev": true,
+      "requires": {
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-hex-encoding": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-middleware": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-retry": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
+      "dev": true,
+      "requires": {
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-stream": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+      "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-uri-escape": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-utf8": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
+      "dev": true,
+      "requires": {
+        "@smithy/util-buffer-from": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
     "@tanstack/match-sorter-utils": {
       "version": "8.7.6",
       "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.7.6.tgz",
@@ -11491,6 +13820,12 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true
+    },
     "bplist-parser": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
@@ -12108,6 +14443,12 @@
         "domhandler": "^5.0.1"
       }
     },
+    "dotenv": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+      "integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
+      "dev": true
+    },
     "electron-to-chromium": {
       "version": "1.4.485",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.485.tgz",
@@ -12660,6 +15001,15 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "dev": true,
+      "requires": {
+        "strnum": "^1.0.5"
+      }
     },
     "fastq": {
       "version": "1.13.0",
@@ -15378,6 +17728,12 @@
         "acorn": "^8.8.2"
       }
     },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
+    },
     "stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -15765,6 +18121,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "dev": true
     },
     "v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "coverage": "vitest run --coverage",
     "generate-types": "node scripts/open-api-type-generator.js",
-    "crawling-guide-links": "node scripts/guide-crawl/index.js"
+    "crawling-guide-links": "node scripts/guide-crawl/index.js",
+    "generate-token": "node scripts/generate-interop-token.js"
   },
   "dependencies": {
     "@date-io/date-fns": "^2.17.0",
@@ -40,6 +41,7 @@
     "zustand": "^4.4.1"
   },
   "devDependencies": {
+    "@aws-sdk/client-kms": "^3.509.0",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
@@ -56,6 +58,7 @@
     "@vitejs/plugin-react": "^4.0.4",
     "@vitest/coverage-v8": "^0.34.4",
     "cheerio": "^1.0.0-rc.12",
+    "dotenv": "^16.4.1",
     "eslint": "^8.49.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
@@ -71,6 +74,7 @@
     "rollup-plugin-visualizer": "^5.9.2",
     "swagger-typescript-api": "^13.0.3",
     "typescript": "^5.2.2",
+    "uuid": "^9.0.1",
     "vite": "^4.4.9",
     "vitest": "^0.34.4"
   }

--- a/scripts/generate-interop-token.js
+++ b/scripts/generate-interop-token.js
@@ -1,0 +1,838 @@
+/**
+ * This script generates a session token for the Interop application.
+ *
+ * Usage:
+ * You must be logged in to AWS with the correct permissions and requires the
+ * `REMOTE_WELLKNOWN_URL` environment variable to be set.
+ *
+ * `npm run generate-token [tenant] [role]`
+ * where:
+ * - [tenant] is the tenant for which to generate the token. Possible values are: GSP, PA1, PA2, PRIVATO. Default is GSP.
+ * - [role] is the role for which to generate the token. Possible values are: ADMIN, API, SECURITY, API,SECURITY, SUPPORT. Default is ADMIN.
+ *
+ * The token will be written to the .env.development.local file in the REACT_APP_MOCK_TOKEN variable.
+ *
+ * Example:
+ * `npm run generate-token PA1 API` // Generates a token for the PA1 tenant with the API role.
+ */
+
+import { config as dotenvConfig } from 'dotenv'
+import * as http from 'http'
+import * as https from 'https'
+import { v4 as uuidv4 } from 'uuid'
+import _ from 'lodash'
+import { VerifyCommand, KMSClient, SignCommand } from '@aws-sdk/client-kms'
+import { readFileSync, write, writeFileSync } from 'fs'
+
+const SESSION_TOKENS_DURATION_SECONDS = 60 * 60 * 24 // 24 hours
+const ENV_FILE_PATH = '.env.development.local'
+const ENV_TOKEN_KEY = 'REACT_APP_MOCK_TOKEN'
+const ALL_TENANTS = {
+  GSP: {
+    ADMIN: {
+      externalId: {
+        origin: 'IPA',
+        value: '5N2TR557',
+      },
+      'user-roles': 'admin',
+      selfcareId: '1962d21c-c701-4805-93f6-53a877898756',
+      organizationId: '69e2865e-65ab-4e48-a638-2037a9ee2ee7',
+      organization: {
+        id: '1962d21c-c701-4805-93f6-53a877898756',
+        name: 'PagoPA S.p.A.',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'admin',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'f07ddb8f-17f9-47d4-b31e-35d1ac10e521',
+    },
+    API: {
+      externalId: {
+        origin: 'IPA',
+        value: '5N2TR557',
+      },
+      'user-roles': 'api',
+      selfcareId: '1962d21c-c701-4805-93f6-53a877898756',
+      organizationId: '69e2865e-65ab-4e48-a638-2037a9ee2ee7',
+      organization: {
+        id: '69e2865e-65ab-4e48-a638-2037a9ee2ee7',
+        name: 'PagoPA S.p.A.',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'api',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: '17a84b7b-dce6-4b8f-a1ae-85926c55f02e',
+    },
+    SECURITY: {
+      externalId: {
+        origin: 'IPA',
+        value: '5N2TR557',
+      },
+      'user-roles': 'security',
+      selfcareId: '1962d21c-c701-4805-93f6-53a877898756',
+      organizationId: '69e2865e-65ab-4e48-a638-2037a9ee2ee7',
+      organization: {
+        id: '69e2865e-65ab-4e48-a638-2037a9ee2ee7',
+        name: 'PagoPA S.p.A.',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'security',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'e0477bcc-3baf-4755-aa31-375c051acb44',
+    },
+    'API,SECURITY': {
+      externalId: {
+        origin: 'IPA',
+        value: '5N2TR557',
+      },
+      'user-roles': 'api,security',
+      selfcareId: '1962d21c-c701-4805-93f6-53a877898756',
+      organizationId: '69e2865e-65ab-4e48-a638-2037a9ee2ee7',
+      organization: {
+        id: '69e2865e-65ab-4e48-a638-2037a9ee2ee7',
+        name: 'PagoPA S.p.A.',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'api',
+          },
+          {
+            partyRole: 'MANAGER',
+            role: 'security',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'e490f02e-9429-4b38-bb11-ddb8a561fb62',
+    },
+    SUPPORT: {
+      externalId: {
+        origin: 'IPA',
+        value: '5N2TR557',
+      },
+      'user-roles': 'support',
+      selfcareId: '1962d21c-c701-4805-93f6-53a877898756',
+      organizationId: '69e2865e-65ab-4e48-a638-2037a9ee2ee7',
+      organization: {
+        id: '69e2865e-65ab-4e48-a638-2037a9ee2ee7',
+        name: 'PagoPA S.p.A.',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'support',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'e0477bcc-3baf-4755-aa31-375c051acb44',
+    },
+  },
+  PA1: {
+    ADMIN: {
+      externalId: {
+        origin: 'IPA',
+        value: 'c_f205',
+      },
+      'user-roles': 'admin',
+      selfcareId: '026e8c72-7944-4dcd-8668-f596447fec6d',
+      organizationId: 'e79a24cd-8edc-441e-ae8d-e87c3aea0059',
+      organization: {
+        id: 'e79a24cd-8edc-441e-ae8d-e87c3aea0059',
+        name: 'Comune di Milano',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'admin',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'f07ddb8f-17f9-47d4-b31e-35d1ac10e521',
+    },
+    API: {
+      externalId: {
+        origin: 'IPA',
+        value: 'c_f205',
+      },
+      'user-roles': 'api',
+      selfcareId: '026e8c72-7944-4dcd-8668-f596447fec6d',
+      organizationId: 'e79a24cd-8edc-441e-ae8d-e87c3aea0059',
+      organization: {
+        id: 'e79a24cd-8edc-441e-ae8d-e87c3aea0059',
+        name: 'Comune di Milano',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'api',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'c7dc1a86-31f6-4fe9-89cd-184201e29d75',
+    },
+    SECURITY: {
+      externalId: {
+        origin: 'IPA',
+        value: 'c_f205',
+      },
+      'user-roles': 'security',
+      selfcareId: '026e8c72-7944-4dcd-8668-f596447fec6d',
+      organizationId: 'e79a24cd-8edc-441e-ae8d-e87c3aea0059',
+      organization: {
+        id: 'e79a24cd-8edc-441e-ae8d-e87c3aea0059',
+        name: 'Comune di Milano.',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'security',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: '17a84b7b-dce6-4b8f-a1ae-85926c55f02e',
+    },
+    'API,SECURITY': {
+      externalId: {
+        origin: 'IPA',
+        value: 'c_f205',
+      },
+      'user-roles': 'api,security',
+      selfcareId: '026e8c72-7944-4dcd-8668-f596447fec6d',
+      organizationId: 'e79a24cd-8edc-441e-ae8d-e87c3aea0059',
+      organization: {
+        id: 'e79a24cd-8edc-441e-ae8d-e87c3aea0059',
+        name: 'Comune di Milano',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'security',
+          },
+          {
+            partyRole: 'MANAGER',
+            role: 'api',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'f3d14e3c-d51d-420f-8f47-5a5cbc469143',
+    },
+    SUPPORT: {
+      externalId: {
+        origin: 'IPA',
+        value: 'c_f205',
+      },
+      'user-roles': 'support',
+      selfcareId: '026e8c72-7944-4dcd-8668-f596447fec6d',
+      organizationId: 'e79a24cd-8edc-441e-ae8d-e87c3aea0059',
+      organization: {
+        id: 'e79a24cd-8edc-441e-ae8d-e87c3aea0059',
+        name: 'Comune di Milano',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'support',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: '17a84b7b-dce6-4b8f-a1ae-85926c55f02e',
+    },
+  },
+  PA2: {
+    ADMIN: {
+      externalId: {
+        origin: 'IPA',
+        value: 'agid',
+      },
+      'user-roles': 'admin',
+      selfcareId: '83e6fc9d-7f60-4a62-8cec-785524b6a0a5',
+      organizationId: '0e9e2dab-2e93-4f24-ba59-38d9f11198ca',
+      organization: {
+        id: '0e9e2dab-2e93-4f24-ba59-38d9f11198ca',
+        name: "Agenzia per L'Italia Digitale",
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'admin',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: '4ea722c3-defd-4372-a0c4-b4613072b632',
+    },
+    API: {
+      externalId: {
+        origin: 'IPA',
+        value: 'agid',
+      },
+      'user-roles': 'api',
+      selfcareId: '83e6fc9d-7f60-4a62-8cec-785524b6a0a5',
+      organizationId: '0e9e2dab-2e93-4f24-ba59-38d9f11198ca',
+      organization: {
+        id: '0e9e2dab-2e93-4f24-ba59-38d9f11198ca',
+        name: "Agenzia per L'Italia Digitale",
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'api',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: '34f3b33a-afac-421c-8044-690469f15cc5',
+    },
+    SECURITY: {
+      externalId: {
+        origin: 'IPA',
+        value: 'agid',
+      },
+      'user-roles': 'security',
+      selfcareId: '83e6fc9d-7f60-4a62-8cec-785524b6a0a5',
+      organizationId: '0e9e2dab-2e93-4f24-ba59-38d9f11198ca',
+      organization: {
+        id: '0e9e2dab-2e93-4f24-ba59-38d9f11198ca',
+        name: "Agenzia per L'Italia Digitale",
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'security',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'e490f02e-9429-4b38-bb11-ddb8a561fb62',
+    },
+    'API,SECURITY': {
+      externalId: {
+        origin: 'IPA',
+        value: 'agid',
+      },
+      'user-roles': 'api,security',
+      selfcareId: '83e6fc9d-7f60-4a62-8cec-785524b6a0a5',
+      organizationId: '0e9e2dab-2e93-4f24-ba59-38d9f11198ca',
+      organization: {
+        id: '0e9e2dab-2e93-4f24-ba59-38d9f11198ca',
+        name: "Agenzia per L'Italia Digitale",
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'security',
+          },
+          {
+            partyRole: 'MANAGER',
+            role: 'api',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: '78b9aa62-a472-4c87-8173-3f73bb2e04b5',
+    },
+    SUPPORT: {
+      externalId: {
+        origin: 'IPA',
+        value: 'agid',
+      },
+      'user-roles': 'support',
+      selfcareId: '83e6fc9d-7f60-4a62-8cec-785524b6a0a5',
+      organizationId: '0e9e2dab-2e93-4f24-ba59-38d9f11198ca',
+      organization: {
+        id: '0e9e2dab-2e93-4f24-ba59-38d9f11198ca',
+        name: "Agenzia per L'Italia Digitale",
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'support',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: '78b9aa62-a472-4c87-8173-3f73bb2e04b5',
+    },
+  },
+  PRIVATO: {
+    ADMIN: {
+      externalId: {
+        origin: 'IVASS',
+        value: '07160010968',
+      },
+      'user-roles': 'admin',
+      selfcareId: '335a4117-5044-4d28-9473-70b74d3bf072',
+      organizationId: 'a7a87b2c-5742-43fb-a847-6304bb0414b4',
+      organization: {
+        id: 'a7a87b2c-5742-43fb-a847-6304bb0414b4',
+        name: 'SOGECAP',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'admin',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'c27e3508-3d26-4b6b-9c73-54cb38e6fe1b',
+    },
+    API: {
+      externalId: {
+        origin: 'IVASS',
+        value: '07160010968',
+      },
+      'user-roles': 'api',
+      selfcareId: '335a4117-5044-4d28-9473-70b74d3bf072',
+      organizationId: 'a7a87b2c-5742-43fb-a847-6304bb0414b4',
+      organization: {
+        id: 'a7a87b2c-5742-43fb-a847-6304bb0414b4',
+        name: 'SOGECAP',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'api',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'e0477bcc-3baf-4755-aa31-375c051acb44',
+    },
+    'API,SECURITY': {
+      externalId: {
+        origin: 'IVASS',
+        value: '07160010968',
+      },
+      'user-roles': 'api,security',
+      selfcareId: '335a4117-5044-4d28-9473-70b74d3bf072',
+      organizationId: 'a7a87b2c-5742-43fb-a847-6304bb0414b4',
+      organization: {
+        id: 'a7a87b2c-5742-43fb-a847-6304bb0414b4',
+        name: 'SOGECAP',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'api,security',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: '17a84b7b-dce6-4b8f-a1ae-85926c55f02e',
+    },
+    SECURITY: {
+      externalId: {
+        origin: 'IVASS',
+        value: '07160010968',
+      },
+      'user-roles': 'security',
+      selfcareId: '335a4117-5044-4d28-9473-70b74d3bf072',
+      organizationId: 'a7a87b2c-5742-43fb-a847-6304bb0414b4',
+      organization: {
+        id: 'a7a87b2c-5742-43fb-a847-6304bb0414b4',
+        name: 'SOGECAP',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'security',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'e490f02e-9429-4b38-bb11-ddb8a561fb62',
+    },
+    SUPPORT: {
+      externalId: {
+        origin: 'IVASS',
+        value: '07160010968',
+      },
+      'user-roles': 'support',
+      selfcareId: '335a4117-5044-4d28-9473-70b74d3bf072',
+      organizationId: 'a7a87b2c-5742-43fb-a847-6304bb0414b4',
+      organization: {
+        id: 'a7a87b2c-5742-43fb-a847-6304bb0414b4',
+        name: 'SOGECAP',
+        roles: [
+          {
+            partyRole: 'MANAGER',
+            role: 'support',
+          },
+        ],
+        fiscal_code: '15376371009',
+        ipaCode: '5N2TR557',
+      },
+      uid: 'e490f02e-9429-4b38-bb11-ddb8a561fb62',
+    },
+  },
+}
+
+dotenvConfig({ path: ENV_FILE_PATH })
+
+if (!process.env.REMOTE_WELLKNOWN_URL) {
+  console.log('REMOTE_WELLKNOWN_URL not found, please set it in the environment variables')
+  process.exit(1)
+}
+
+const possibleTenants = Object.keys(ALL_TENANTS)
+const possibleRoles = Object.keys(ALL_TENANTS.GSP)
+
+let chosenTenant = process.argv[2]?.toUpperCase() || possibleTenants[0]
+let chosenRole = process.argv[3]?.toUpperCase() || possibleRoles[0]
+
+if (!possibleTenants.includes(chosenTenant)) {
+  console.log(
+    `Invalid tenant: ${chosenTenant}\nPossible tenants: \n- ${possibleTenants.join('\n- ')}`
+  )
+  process.exit(1)
+}
+
+if (!possibleRoles.includes(chosenRole)) {
+  console.log(`Invalid role: ${chosenRole}\nPossible roles: \n- ${possibleRoles.join('\n- ')}`)
+  process.exit(1)
+}
+
+console.log(`> Generating token for ${chosenTenant} tenant with role ${chosenRole}...`)
+
+const tenant = {
+  [chosenTenant]: {
+    [chosenRole]: ALL_TENANTS[chosenTenant][chosenRole],
+  },
+}
+
+const sessionTokenHeaderTemplate = {
+  typ: 'at+jwt',
+  alg: 'WELL_KNOWN_ALG',
+  use: 'sig',
+  kid: 'WELL_KNOWN_KID',
+}
+const sessionTokenPayloadTemplate = {
+  externalId: {
+    origin: 'VALUES_EXT_ID_ORIGIN',
+    value: 'VALUES_EXT_ID_VALUE',
+  },
+  'user-roles': 'VALUES_USER_ROLES',
+  selfcareId: 'VALUES_SELFCARE_ID',
+  organizationId: 'VALUES_ORG_ID',
+  uid: 'VALUES_UID',
+  iss: '{{ENVIRONMENT}}.interop.pagopa.it',
+  aud: '{{ENVIRONMENT}}.interop.pagopa.it/ui',
+  nbf: 123,
+  iat: 123,
+  exp: 456,
+  jti: 'uuid',
+}
+
+const kmsClient = new KMSClient()
+
+const config = {
+  kms: {
+    kid: null,
+    alg: 'RSASSA_PKCS1_V1_5_SHA_256',
+  },
+}
+
+/**
+ *
+ * @param {*} stPayloadValuesFilePath File contenente i payload values dei tenant per cui bisogna generare i Session Token
+ * @returns stOutputTokens SessionTokens JSON Object - A token for each tenant/role
+ */
+async function generateSessionTokens() {
+  logInfo('## Step 1. Parse well known ##')
+
+  const wellKnownUrl = new URL(process.env.REMOTE_WELLKNOWN_URL)
+  const { kid, alg } = await fetchWellKnown(
+    wellKnownUrl.protocol.indexOf('https') >= 0,
+    wellKnownUrl.toString()
+  )
+  if (!kid || !alg) {
+    console.error('\tKid or alg not found.')
+    return
+  }
+  config.kms.kid = kid
+  logInfo(`\tGot kid ${kid} and alg ${alg}`)
+
+  // Step 3. Generate STs header - Populate Session Token header from template
+  logInfo('## Step 2. Generate STs header - Populate Session Token header from template ##')
+  const stHeaderCompiled = Object.assign({}, sessionTokenHeaderTemplate, {
+    kid,
+    alg,
+  })
+  logInfo(`\tST Header Compiled: ${JSON.stringify(stHeaderCompiled)}`)
+
+  // Step 4. Generate STs payload
+  logInfo('## Step 3. Generate STs payload ##')
+  logInfo('\tDefine time in seconds since epoch')
+  const epochTimeSeconds = Math.round(new Date().getTime() / 1000)
+  logInfo(`\tTime in seconds since epoch: ${epochTimeSeconds}`)
+
+  logInfo('\tDefine token expiration time in seconds')
+  const epochTimeExpSeconds = epochTimeSeconds + Number(SESSION_TOKENS_DURATION_SECONDS)
+  logInfo(`\tExpiration Time in seconds: ${epochTimeExpSeconds}`)
+
+  logInfo('\tDefine random UUID')
+  const randomUUID = uuidv4()
+  logInfo(`\tRandom UUID:: ${randomUUID}`)
+
+  logInfo(`Populate Session Token payload from template`)
+  let stPayloadCompiled = Object.assign({}, sessionTokenPayloadTemplate, {
+    nbf: epochTimeSeconds,
+    iat: epochTimeSeconds,
+    exp: epochTimeExpSeconds,
+    jti: randomUUID,
+  })
+  stPayloadCompiled = JSON.parse(
+    JSON.stringify(stPayloadCompiled).replaceAll('{{ENVIRONMENT}}', 'dev')
+  )
+  logInfo(`\tST Payload Compiled: ${JSON.stringify(stPayloadCompiled)}`)
+
+  logInfo('## Step 4. Generate unsigned STs ##')
+  const unsignedSTs = unsignedStsGeneration(stHeaderCompiled, stPayloadCompiled, tenant)
+  logInfo(`\tUnsigned STs: ${JSON.stringify(unsignedSTs)}`)
+
+  logInfo('## Step 5. Generate signed STs ##')
+  const stOutputTokens = await signedStsGeneration(unsignedSTs)
+
+  return stOutputTokens
+}
+
+function logInfo(message) {
+  // console.log(message)
+}
+
+async function fetchWellKnown(isSecure, wellKnownUrl) {
+  const jwksObj = await new Promise((resolve, reject) => {
+    const httpMod = isSecure ? https : http
+
+    httpMod
+      .get(wellKnownUrl, (res) => {
+        const { statusCode } = res
+        const contentType = res.headers['content-type']
+
+        let error
+        // Any 2xx status code signals a successful response but
+        // here we're only checking for 200.
+        if (statusCode !== 200) {
+          error = new Error('Request Failed.\n' + `Status Code: ${statusCode}`)
+        } else if (!/^application\/json/.test(contentType)) {
+          error = new Error(
+            'Invalid content-type.\n' + `Expected application/json but received ${contentType}`
+          )
+        }
+        if (error) {
+          console.error(error.message)
+          // Consume response data to free up memory
+          res.resume()
+          reject(error)
+          return
+        }
+
+        let rawData = ''
+
+        res.setEncoding('utf8')
+        res.on('data', (chunk) => {
+          rawData += chunk
+        })
+        res.on('end', () => {
+          try {
+            const parsedData = JSON.parse(rawData)
+            resolve(parsedData)
+          } catch (e) {
+            console.error(e.message)
+            reject(e)
+          }
+        })
+      })
+      .on('error', (e) => {
+        reject(e)
+      })
+  })
+
+  if (typeof jwksObj != 'undefined' && jwksObj.keys && jwksObj.keys[0]) {
+    return _.pick(jwksObj.keys[0], ['kid', 'alg'])
+  }
+
+  return null
+}
+
+// Generate signed tokens from unsigned ones
+async function signedStsGeneration(unsignedStValues) {
+  const signedTokens = {}
+  logInfo(`SignedTokenGeneration::START`)
+  for (const tenant of Object.keys(unsignedStValues)) {
+    logInfo(`\tBuilding token for tenant ${tenant}`)
+    signedTokens[tenant] = {}
+
+    for (const tenantRole of Object.keys(unsignedStValues[tenant])) {
+      logInfo(`\tBuilding token for role ${tenantRole}`)
+
+      const currentUnsignedJwt = unsignedStValues[tenant][tenantRole]
+      const { signedToken, signature } = await kmsSign(currentUnsignedJwt)
+
+      if (!(await kmsVerify(currentUnsignedJwt, signature))) {
+        throw Error('\tSigned Token generation process failed to verify signature')
+      }
+
+      signedTokens[tenant][tenantRole] = signedToken
+    }
+  }
+  logInfo(`SignedTokenGeneration::END`)
+
+  return signedTokens
+}
+
+function unsignedStsGeneration(stHeaderCompiled, stPayloadCompiled, stPayloadValues) {
+  try {
+    logInfo(`unsignedStsGeneration::Phase1:START: Build roles dynamic substitutions`)
+    const stsSubOutput = {}
+    for (const tenant of Object.keys(stPayloadValues)) {
+      logInfo(`\tunsignedStsGeneration::Phase1: Build roles substitutions for tenant ${tenant}`)
+      stsSubOutput[tenant] = {}
+
+      for (const interopRole of Object.keys(stPayloadValues[tenant])) {
+        logInfo(`\tunsignedStsGeneration::Phase1: Start dynamic substition for role ${interopRole}`)
+        stsSubOutput[tenant][interopRole] = Object.assign(
+          {},
+          stPayloadCompiled,
+          stPayloadValues[tenant][interopRole]
+        )
+      }
+    }
+    logInfo(`unsignedStsGeneration::Phase1:END: Build roles dynamic substitutions`)
+
+    logInfo(
+      `unsignedStsGeneration::Phase2:START: Build base64 header and body for each tenant/role`
+    )
+    const base64Header = b64UrlEncode(JSON.stringify(stHeaderCompiled))
+    logInfo('\tunsignedStsGeneration::Phase2: Build base64 header done')
+
+    const stOutputIntermediate = {}
+    for (const tenant of Object.keys(stsSubOutput)) {
+      logInfo(`\tunsignedStsGeneration::Phase2: Build partial JWT for ${tenant}`)
+      stOutputIntermediate[tenant] = {}
+
+      for (const interopRole of Object.keys(stsSubOutput[tenant])) {
+        logInfo(
+          `\tunsignedStsGeneration::Phase2: Build partial JWT for tenant ${tenant} role ${interopRole}`
+        )
+        const base64Role = b64UrlEncode(JSON.stringify(stsSubOutput[tenant][interopRole]))
+        const poJwtForRole = `${base64Header}.${base64Role}`
+
+        stOutputIntermediate[tenant][interopRole] = poJwtForRole
+      }
+    }
+    logInfo(`unsignedStsGeneration::Phase2:END: Build base64 header and body for each tenant/role`)
+
+    return stOutputIntermediate
+  } catch (ex) {
+    console.error(ex)
+    throw ex
+  }
+}
+
+// KMS Wrappers
+async function kmsSign(serializedToken) {
+  if (!serializedToken) {
+    throw Error(`kmsSign: invalid input - missing`)
+  }
+
+  // SignCommandInput
+  const signCommandParams = {
+    KeyId: config.kms.kid,
+    Message: new TextEncoder().encode(serializedToken),
+    SigningAlgorithm: config.kms.alg,
+  }
+
+  const signCommand = new SignCommand(signCommandParams)
+  const response = await kmsClient.send(signCommand)
+  const responseSignature = response.Signature
+
+  if (!responseSignature) {
+    throw Error('JWT Signature failed. Empty signature returned')
+  }
+
+  const kmsSignature = b64ByteUrlEncode(responseSignature)
+
+  return {
+    signedToken: `${serializedToken}.${kmsSignature}`,
+    signature: responseSignature,
+  }
+}
+
+async function kmsVerify(unsignedToken, signature) {
+  if (!unsignedToken || !signature) {
+    throw Error(`kmsVerify: invalid input - missing`)
+  }
+
+  // VerifyCommandInput
+  const commandParams = {
+    KeyId: config.kms.kid,
+    Message: new TextEncoder().encode(unsignedToken),
+    SigningAlgorithm: config.kms.alg,
+    Signature: signature,
+  }
+  const verifyCommand = new VerifyCommand(commandParams)
+  const response = await kmsClient.send(verifyCommand)
+
+  if (!response.SignatureValid) {
+    throw Error('JWT Verify Signature failed')
+  }
+
+  return response.SignatureValid
+}
+
+// Encoding utilities
+/**
+ * Encode a byte array to a url encoded base64 string, as specified in RFC 7515 Appendix C
+ */
+function b64ByteUrlEncode(b) {
+  return bufferB64UrlEncode(Buffer.from(b))
+}
+
+/**
+ * Encode a string to a url encoded base64 string, as specified in RFC 7515 Appendix C
+ */
+function b64UrlEncode(str) {
+  return bufferB64UrlEncode(Buffer.from(str, 'binary'))
+}
+
+function bufferB64UrlEncode(b) {
+  return b.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+}
+
+const token = (await generateSessionTokens())[chosenTenant][chosenRole]
+
+console.log(`> Token retrieved: \n${token}\n\n`)
+console.log(`> Writing token to ${ENV_FILE_PATH}...`)
+
+const envFile = readFileSync(ENV_FILE_PATH, 'utf8')
+  .split('\n')
+  .map((line) => (line.startsWith(ENV_TOKEN_KEY) ? `${ENV_TOKEN_KEY}=${token}` : line))
+  .join('\n')
+
+writeFileSync(ENV_FILE_PATH, envFile)
+
+console.log('> Done!')

--- a/scripts/generate-interop-token.js
+++ b/scripts/generate-interop-token.js
@@ -24,6 +24,15 @@ import _ from 'lodash'
 import { VerifyCommand, KMSClient, SignCommand } from '@aws-sdk/client-kms'
 import { readFileSync, write, writeFileSync } from 'fs'
 
+const config = {
+  kms: {
+    kid: null,
+    alg: 'RSASSA_PKCS1_V1_5_SHA_256',
+  },
+}
+
+const kmsClient = new KMSClient()
+
 const SESSION_TOKENS_DURATION_SECONDS = 60 * 60 * 24 // 24 hours
 const ENV_FILE_PATH = '.env.development.local'
 const ENV_TOKEN_KEY = 'REACT_APP_MOCK_TOKEN'
@@ -517,52 +526,26 @@ if (!possibleRoles.includes(chosenRole)) {
 
 console.log(`> Generating token for ${chosenTenant} tenant with role ${chosenRole}...`)
 
-const tenant = {
-  [chosenTenant]: {
-    [chosenRole]: ALL_TENANTS[chosenTenant][chosenRole],
-  },
-}
+const token = await generateSessionToken(chosenTenant, chosenRole)
 
-const sessionTokenHeaderTemplate = {
-  typ: 'at+jwt',
-  alg: 'WELL_KNOWN_ALG',
-  use: 'sig',
-  kid: 'WELL_KNOWN_KID',
-}
-const sessionTokenPayloadTemplate = {
-  externalId: {
-    origin: 'VALUES_EXT_ID_ORIGIN',
-    value: 'VALUES_EXT_ID_VALUE',
-  },
-  'user-roles': 'VALUES_USER_ROLES',
-  selfcareId: 'VALUES_SELFCARE_ID',
-  organizationId: 'VALUES_ORG_ID',
-  uid: 'VALUES_UID',
-  iss: '{{ENVIRONMENT}}.interop.pagopa.it',
-  aud: '{{ENVIRONMENT}}.interop.pagopa.it/ui',
-  nbf: 123,
-  iat: 123,
-  exp: 456,
-  jti: 'uuid',
-}
+console.log(`> Token retrieved: \n${token}\n\n`)
+console.log(`> Writing token to ${ENV_FILE_PATH}...`)
 
-const kmsClient = new KMSClient()
+const envFile = readFileSync(ENV_FILE_PATH, 'utf8')
+  .split('\n')
+  .map((line) => (line.startsWith(ENV_TOKEN_KEY) ? `${ENV_TOKEN_KEY}=${token}` : line))
+  .join('\n')
 
-const config = {
-  kms: {
-    kid: null,
-    alg: 'RSASSA_PKCS1_V1_5_SHA_256',
-  },
-}
+writeFileSync(ENV_FILE_PATH, envFile)
+
+console.log('> Done!')
 
 /**
  *
  * @param {*} stPayloadValuesFilePath File contenente i payload values dei tenant per cui bisogna generare i Session Token
  * @returns stOutputTokens SessionTokens JSON Object - A token for each tenant/role
  */
-async function generateSessionTokens() {
-  logInfo('## Step 1. Parse well known ##')
-
+async function generateSessionToken(tenant, role) {
   const wellKnownUrl = new URL(process.env.REMOTE_WELLKNOWN_URL)
   const { kid, alg } = await fetchWellKnown(
     wellKnownUrl.protocol.indexOf('https') >= 0,
@@ -573,31 +556,40 @@ async function generateSessionTokens() {
     return
   }
   config.kms.kid = kid
-  logInfo(`\tGot kid ${kid} and alg ${alg}`)
-
   // Step 3. Generate STs header - Populate Session Token header from template
-  logInfo('## Step 2. Generate STs header - Populate Session Token header from template ##')
+  const sessionTokenHeaderTemplate = {
+    typ: 'at+jwt',
+    alg: 'WELL_KNOWN_ALG',
+    use: 'sig',
+    kid: 'WELL_KNOWN_KID',
+  }
   const stHeaderCompiled = Object.assign({}, sessionTokenHeaderTemplate, {
     kid,
     alg,
   })
-  logInfo(`\tST Header Compiled: ${JSON.stringify(stHeaderCompiled)}`)
 
   // Step 4. Generate STs payload
-  logInfo('## Step 3. Generate STs payload ##')
-  logInfo('\tDefine time in seconds since epoch')
   const epochTimeSeconds = Math.round(new Date().getTime() / 1000)
-  logInfo(`\tTime in seconds since epoch: ${epochTimeSeconds}`)
-
-  logInfo('\tDefine token expiration time in seconds')
   const epochTimeExpSeconds = epochTimeSeconds + Number(SESSION_TOKENS_DURATION_SECONDS)
-  logInfo(`\tExpiration Time in seconds: ${epochTimeExpSeconds}`)
-
-  logInfo('\tDefine random UUID')
   const randomUUID = uuidv4()
-  logInfo(`\tRandom UUID:: ${randomUUID}`)
 
-  logInfo(`Populate Session Token payload from template`)
+  const sessionTokenPayloadTemplate = {
+    externalId: {
+      origin: 'VALUES_EXT_ID_ORIGIN',
+      value: 'VALUES_EXT_ID_VALUE',
+    },
+    'user-roles': 'VALUES_USER_ROLES',
+    selfcareId: 'VALUES_SELFCARE_ID',
+    organizationId: 'VALUES_ORG_ID',
+    uid: 'VALUES_UID',
+    iss: '{{ENVIRONMENT}}.interop.pagopa.it',
+    aud: '{{ENVIRONMENT}}.interop.pagopa.it/ui',
+    nbf: 123,
+    iat: 123,
+    exp: 456,
+    jti: 'uuid',
+  }
+
   let stPayloadCompiled = Object.assign({}, sessionTokenPayloadTemplate, {
     nbf: epochTimeSeconds,
     iat: epochTimeSeconds,
@@ -607,20 +599,14 @@ async function generateSessionTokens() {
   stPayloadCompiled = JSON.parse(
     JSON.stringify(stPayloadCompiled).replaceAll('{{ENVIRONMENT}}', 'dev')
   )
-  logInfo(`\tST Payload Compiled: ${JSON.stringify(stPayloadCompiled)}`)
 
-  logInfo('## Step 4. Generate unsigned STs ##')
-  const unsignedSTs = unsignedStsGeneration(stHeaderCompiled, stPayloadCompiled, tenant)
-  logInfo(`\tUnsigned STs: ${JSON.stringify(unsignedSTs)}`)
+  const unsignedSTs = unsignedStsGeneration(stHeaderCompiled, stPayloadCompiled, {
+    [tenant]: {
+      [role]: ALL_TENANTS[tenant][role],
+    },
+  })
 
-  logInfo('## Step 5. Generate signed STs ##')
-  const stOutputTokens = await signedStsGeneration(unsignedSTs)
-
-  return stOutputTokens
-}
-
-function logInfo(message) {
-  // console.log(message)
+  return (await signedStsGeneration(unsignedSTs))[tenant][role]
 }
 
 async function fetchWellKnown(isSecure, wellKnownUrl) {
@@ -681,14 +667,10 @@ async function fetchWellKnown(isSecure, wellKnownUrl) {
 // Generate signed tokens from unsigned ones
 async function signedStsGeneration(unsignedStValues) {
   const signedTokens = {}
-  logInfo(`SignedTokenGeneration::START`)
   for (const tenant of Object.keys(unsignedStValues)) {
-    logInfo(`\tBuilding token for tenant ${tenant}`)
     signedTokens[tenant] = {}
 
     for (const tenantRole of Object.keys(unsignedStValues[tenant])) {
-      logInfo(`\tBuilding token for role ${tenantRole}`)
-
       const currentUnsignedJwt = unsignedStValues[tenant][tenantRole]
       const { signedToken, signature } = await kmsSign(currentUnsignedJwt)
 
@@ -699,21 +681,16 @@ async function signedStsGeneration(unsignedStValues) {
       signedTokens[tenant][tenantRole] = signedToken
     }
   }
-  logInfo(`SignedTokenGeneration::END`)
-
   return signedTokens
 }
 
 function unsignedStsGeneration(stHeaderCompiled, stPayloadCompiled, stPayloadValues) {
   try {
-    logInfo(`unsignedStsGeneration::Phase1:START: Build roles dynamic substitutions`)
     const stsSubOutput = {}
     for (const tenant of Object.keys(stPayloadValues)) {
-      logInfo(`\tunsignedStsGeneration::Phase1: Build roles substitutions for tenant ${tenant}`)
       stsSubOutput[tenant] = {}
 
       for (const interopRole of Object.keys(stPayloadValues[tenant])) {
-        logInfo(`\tunsignedStsGeneration::Phase1: Start dynamic substition for role ${interopRole}`)
         stsSubOutput[tenant][interopRole] = Object.assign(
           {},
           stPayloadCompiled,
@@ -721,30 +698,18 @@ function unsignedStsGeneration(stHeaderCompiled, stPayloadCompiled, stPayloadVal
         )
       }
     }
-    logInfo(`unsignedStsGeneration::Phase1:END: Build roles dynamic substitutions`)
-
-    logInfo(
-      `unsignedStsGeneration::Phase2:START: Build base64 header and body for each tenant/role`
-    )
     const base64Header = b64UrlEncode(JSON.stringify(stHeaderCompiled))
-    logInfo('\tunsignedStsGeneration::Phase2: Build base64 header done')
-
     const stOutputIntermediate = {}
     for (const tenant of Object.keys(stsSubOutput)) {
-      logInfo(`\tunsignedStsGeneration::Phase2: Build partial JWT for ${tenant}`)
       stOutputIntermediate[tenant] = {}
 
       for (const interopRole of Object.keys(stsSubOutput[tenant])) {
-        logInfo(
-          `\tunsignedStsGeneration::Phase2: Build partial JWT for tenant ${tenant} role ${interopRole}`
-        )
         const base64Role = b64UrlEncode(JSON.stringify(stsSubOutput[tenant][interopRole]))
         const poJwtForRole = `${base64Header}.${base64Role}`
 
         stOutputIntermediate[tenant][interopRole] = poJwtForRole
       }
     }
-    logInfo(`unsignedStsGeneration::Phase2:END: Build base64 header and body for each tenant/role`)
 
     return stOutputIntermediate
   } catch (ex) {
@@ -822,17 +787,3 @@ function b64UrlEncode(str) {
 function bufferB64UrlEncode(b) {
   return b.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
 }
-
-const token = (await generateSessionTokens())[chosenTenant][chosenRole]
-
-console.log(`> Token retrieved: \n${token}\n\n`)
-console.log(`> Writing token to ${ENV_FILE_PATH}...`)
-
-const envFile = readFileSync(ENV_FILE_PATH, 'utf8')
-  .split('\n')
-  .map((line) => (line.startsWith(ENV_TOKEN_KEY) ? `${ENV_TOKEN_KEY}=${token}` : line))
-  .join('\n')
-
-writeFileSync(ENV_FILE_PATH, envFile)
-
-console.log('> Done!')


### PR DESCRIPTION
This PR adds a new package.json script `npm run generate-token`.
This command allows us to easily retrieve a valid token in order to start the FE locally.

In order to use the script:
- `REMOTE_WELLKNOWN_URL` must be set in the env variables;
- It is required to have a valid aws session with the correct KMS permissions.

Usage:
```bash
npm run generate-token [tenant] [role]
```

[tenant] must be one of the following: `GSP`,`PA1`, `PA2`, `PRIVATO`. Case-insensitive. Default is `GSP`.
[role] must be one of the following: `ADMIN`,`API`, `SECURITY`, `API,SECURITY`, `SUPPORT`. Case-insensitive. Default is `ADMIN`.