### PR TITLE
Feature: PIN-4331 - Fix bug same value error in ConsumerPurposeDetailsDailyCallsUpdateDrawer

### DIFF
--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsUpdateDrawer.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsUpdateDrawer.tsx
@@ -14,12 +14,11 @@ type ConsumerPurposeDetailsDailyCallsUpdateDrawerProps = {
   purpose: Purpose
   isOpen: boolean
   onClose: VoidFunction
-  dailyCalls?: number
 }
 
 export const ConsumerPurposeDetailsDailyCallsUpdateDrawer: React.FC<
   ConsumerPurposeDetailsDailyCallsUpdateDrawerProps
-> = ({ purpose, isOpen, onClose, dailyCalls = 1 }) => {
+> = ({ purpose, isOpen, onClose }) => {
   const { t } = useTranslation('purpose', {
     keyPrefix: 'consumerView.sections.loadEstimate.drawer',
   })
@@ -30,7 +29,7 @@ export const ConsumerPurposeDetailsDailyCallsUpdateDrawer: React.FC<
   const { mutate: updateDailyCalls } = PurposeMutations.useUpdateDailyCalls()
 
   const defaultValues: UpdateDailyCallsFormValues = {
-    dailyCalls,
+    dailyCalls: purpose.currentVersion?.dailyCalls ?? 1,
   }
 
   const formMethods = useForm<UpdateDailyCallsFormValues>({
@@ -76,7 +75,13 @@ export const ConsumerPurposeDetailsDailyCallsUpdateDrawer: React.FC<
           infoLabel={t('dailyCallsFormField.infoLable')}
           focusOnMount={true}
           inputProps={{ min: '1' }}
-          rules={{ required: true, min: 1 }}
+          rules={{
+            required: true,
+            min: 1,
+            validate: (value) =>
+              value !== purpose.currentVersion?.dailyCalls ||
+              t('dailyCallsFormField.validation.sameValue'),
+          }}
         />
       </Drawer>
     </FormProvider>

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -287,7 +287,10 @@
           "subtitle": "Your current estimate is <strong>{{dailyCalls}} API calls/day</strong>. If the new value exceeds at least one of the thresholds imposed by the provider, it must be approved before becoming active. Do you have any doubts? <1>Read the guide</1>.",
           "dailyCallsFormField": {
             "label": "New load estimate",
-            "infoLable": "Estimated number of API calls/day"
+            "infoLable": "Estimated number of API calls/day",
+            "validation": {
+              "sameValue": "The number of API calls/day requested must be different than the current one"
+            }
           }
         },
         "thresholdsCard": {

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -287,7 +287,10 @@
           "subtitle": "La tua stima attuale è di <strong>{{dailyCalls}} chiamate API/giorno</strong>. Se il nuovo valore supera almeno una delle soglie imposte dall’erogatore, dovrà essere approvata prima di divenire attiva. Hai dubbi? <1>Consulta la guida</1>.",
           "dailyCallsFormField": {
             "label": "Nuova stima di carico",
-            "infoLable": "Numero di chiamate API/giorno stimate"
+            "infoLable": "Numero di chiamate API/giorno stimate",
+            "validation": {
+              "sameValue": "Il numero di chiamate API/giorno richiesto deve essere diverso da quello attuale"
+            }
           }
         },
         "thresholdsCard": {


### PR DESCRIPTION
- Added `currentVersion.dailyCalls` as default value in `ConsumerPurposeDetailsDailyCallsUpdateDrawer`
- Added validation for `dailyCalls` form value to be different from `currentVersion.dailyCalls`
- Added error strings