### PR TITLE
Feature: PIN-4713-4714 - Implemented new logic to delete eservice or descriptor draft

### DIFF
--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -111,7 +111,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
     expect(result.current.actions).toHaveLength(2)
     expect(result.current.actions[0].label).toBe('publishDraft')
-    expect(result.current.actions[1].label).toBe('deleteDraft')
+    expect(result.current.actions[1].label).toBe('delete')
   })
 
   it('should return the correct actions if the e-service has an active descriptor in SUSPENDED state and has no version draft', () => {

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -45,12 +45,6 @@ export function useGetProviderEServiceActions(
     color: 'error',
   }
 
-  if (!activeDescriptorId && !draftDescriptorId) {
-    return {
-      actions: [deleteDraftAction],
-    }
-  }
-
   const handlePublishDraft = () => {
     if (draftDescriptorId) publishDraft({ eserviceId, descriptorId: draftDescriptorId })
   }
@@ -150,11 +144,11 @@ export function useGetProviderEServiceActions(
   }
 
   const handleEditDraft = () => {
-    if (draftDescriptorId)
-      navigate('PROVIDE_ESERVICE_EDIT', {
+    if (draftDescriptorId) {
+      navigate('PROVIDE_ESERVICE_SUMMARY', {
         params: { eserviceId, descriptorId: draftDescriptorId },
-        state: { stepIndexDestination: mode === 'RECEIVE' ? 2 : 1 },
       })
+    }
   }
 
   const editDraftAction: ActionItemButton = {
@@ -163,33 +157,35 @@ export function useGetProviderEServiceActions(
     icon: PendingActionsIcon,
   }
 
+  const deleteAction = !activeDescriptorId ? deleteDraftAction : deleteVersionDraftAction
+
   const adminActions: Record<EServiceDescriptorState, Array<ActionItemButton>> = {
     PUBLISHED: [
       cloneAction,
-      ...(!hasVersionDraft ? [createNewDraftAction] : [editDraftAction, deleteVersionDraftAction]),
+      ...(!hasVersionDraft ? [createNewDraftAction] : [editDraftAction, deleteAction]),
       suspendAction,
     ],
     ARCHIVED: [],
     DEPRECATED: [suspendAction],
-    DRAFT: [publishDraftAction, deleteVersionDraftAction],
+    DRAFT: !hasVersionDraft ? [deleteAction] : [publishDraftAction, deleteAction],
     SUSPENDED: [
       reactivateAction,
       cloneAction,
-      ...(!hasVersionDraft ? [createNewDraftAction] : [editDraftAction, deleteVersionDraftAction]),
+      ...(!hasVersionDraft ? [createNewDraftAction] : [editDraftAction, deleteAction]),
     ],
   }
 
   const operatorAPIActions: Record<EServiceDescriptorState, Array<ActionItemButton>> = {
     PUBLISHED: [
       cloneAction,
-      ...(!hasVersionDraft ? [createNewDraftAction] : [editDraftAction, deleteVersionDraftAction]),
+      ...(!hasVersionDraft ? [createNewDraftAction] : [editDraftAction, deleteAction]),
     ],
     ARCHIVED: [],
     DEPRECATED: [],
-    DRAFT: [publishDraftAction, deleteVersionDraftAction],
+    DRAFT: !hasVersionDraft ? [deleteAction] : [publishDraftAction, deleteAction],
     SUSPENDED: [
       cloneAction,
-      ...(!hasVersionDraft ? [createNewDraftAction] : [editDraftAction, deleteVersionDraftAction]),
+      ...(!hasVersionDraft ? [createNewDraftAction] : [editDraftAction, deleteAction]),
     ],
   }
 

--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -44,17 +44,23 @@ const ProviderEServiceSummaryPage: React.FC = () => {
     })
 
   const handleDeleteDraft = () => {
-    if (descriptor) {
-      deleteVersion(
-        { eserviceId: descriptor.eservice.id, descriptorId: descriptor.id },
+    const hasNoDescriptors = !descriptor
+    const hasOnlyOneDraft =
+      descriptor && descriptor.state === 'DRAFT' && descriptor.eservice.descriptors.length === 0
+    const hasMoreDescriptorsWithLastDraft =
+      descriptor && descriptor.state === 'DRAFT' && descriptor.eservice.descriptors.length > 0
+
+    if (eservice && (hasNoDescriptors || hasOnlyOneDraft)) {
+      deleteDraft(
+        { eserviceId: eservice.id },
         { onSuccess: () => navigate('PROVIDE_ESERVICE_LIST') }
       )
       return
     }
 
-    if (eservice) {
-      deleteDraft(
-        { eserviceId: eservice.id },
+    if (hasMoreDescriptorsWithLastDraft) {
+      deleteVersion(
+        { eserviceId: descriptor.eservice.id, descriptorId: descriptor.id },
         { onSuccess: () => navigate('PROVIDE_ESERVICE_LIST') }
       )
       return
@@ -68,6 +74,7 @@ const ProviderEServiceSummaryPage: React.FC = () => {
           eserviceId: descriptor.eservice.id,
           descriptorId: descriptor.id,
         },
+        state: { stepIndexDestination: 1 },
       })
       return
     }


### PR DESCRIPTION
- Added new logic to delete eservice or descriptor draft in `useGetProviderEServiceActions`
- Added new logic to delete eservice or descriptor draft in `ProviderEServiceSummaryPage`
- Navigation for editing eservices in draft has been standardized. Now they always open summary and then open the eservice step if there is no description otherwise open descriptor step or riskAnalysis step (if mode RECEIVE) if there is a descriptor.
- Update test
