### PR TITLE
Fixed handling the current product in the PagoPA product selection dropdown

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useNavigate } from '@/router'
 import { assistanceLink, documentationLink, pagoPaLink } from '@/config/constants'
 import { HeaderAccount, HeaderProduct, type ProductSwitchItem } from '@pagopa/mui-italia'
-import { FE_LOGIN_URL, SELFCARE_BASE_URL, SELFCARE_INTEROP_PROD_ID, STAGE } from '@/config/env'
+import { FE_LOGIN_URL, SELFCARE_BASE_URL, STAGE } from '@/config/env'
 import { PartyQueries } from '@/api/party/party.hooks'
 import type { PartySwitchItem } from '@pagopa/mui-italia/dist/components/PartySwitch'
 import { useTranslation } from 'react-i18next'
@@ -10,6 +10,7 @@ import type { TFunction } from 'i18next'
 import type { SelfcareInstitution } from '@/api/api.generatedTypes'
 import type { JwtUser, UserProductRole } from '@/types/party.types'
 import { UnauthorizedError } from '@/utils/errors.utils'
+import { getCurrentSelfCareProductId } from '@/utils/common.utils'
 
 /**
  * Generate the party list to be used in the HeaderProduct component to show the party switcher
@@ -61,7 +62,7 @@ const getProductList = (products?: Array<{ id: string; name: string }>): Product
   }
 
   const interopProduct: ProductSwitchItem = {
-    id: SELFCARE_INTEROP_PROD_ID,
+    id: getCurrentSelfCareProductId(),
     title: `Interoperabilità${STAGE === 'UAT' ? ' Collaudo' : ''}`,
     productUrl: '',
     linkType: 'internal',
@@ -113,7 +114,9 @@ export const Header: React.FC<HeaderProps> = ({ jwt, isSupport }) => {
 
   const handleSelectParty = (party: PartySwitchItem) => {
     window.location.assign(
-      `${SELFCARE_BASE_URL}/token-exchange?institutionId=${party.id}&productId=${SELFCARE_INTEROP_PROD_ID}`
+      `${SELFCARE_BASE_URL}/token-exchange?institutionId=${
+        party.id
+      }&productId=${getCurrentSelfCareProductId()}`
     )
   }
 
@@ -161,7 +164,7 @@ export const Header: React.FC<HeaderProps> = ({ jwt, isSupport }) => {
         onSelectedParty={handleSelectParty}
         onSelectedProduct={handleSelectProduct}
         partyId={selfcareId}
-        productId={SELFCARE_INTEROP_PROD_ID}
+        productId={getCurrentSelfCareProductId()}
         productsList={productList}
         partyList={partyList}
         {...headerChipProps}

--- a/src/components/layout/SideNav/SideNav.tsx
+++ b/src/components/layout/SideNav/SideNav.tsx
@@ -13,13 +13,14 @@ import ExitToAppRoundedIcon from '@mui/icons-material/ExitToAppRounded'
 import PeopleIcon from '@mui/icons-material/People'
 import SupervisedUserCircleIcon from '@mui/icons-material/SupervisedUserCircle'
 import { useTranslation } from 'react-i18next'
-import { SELFCARE_BASE_URL, SELFCARE_INTEROP_PROD_ID } from '@/config/env'
+import { SELFCARE_BASE_URL } from '@/config/env'
 import { type RouteKey, useCurrentRoute, getParentRoutes } from '@/router'
 import { SIDENAV_WIDTH } from '@/config/constants'
 import { SideNavItemLink, SideNavItemLinkSkeleton } from './SideNavItemLink'
 import { CollapsableSideNavItem, CollapsableSideNavItemSkeleton } from './CollapsableSideNavItem'
 import { useGetSideNavItems } from './hooks/useGetSideNavItems'
 import { AuthHooks } from '@/api/auth'
+import { getCurrentSelfCareProductId } from '@/utils/common.utils'
 
 type View = {
   routeKey: RouteKey
@@ -57,7 +58,7 @@ const _SideNav = () => {
   const [openId, setOpenId] = useState<string | null>(isActive)
 
   const selfcareUsersPageUrl =
-    jwt && `${SELFCARE_BASE_URL}/dashboard/${jwt.selfcareId}/users#${SELFCARE_INTEROP_PROD_ID}`
+    jwt && `${SELFCARE_BASE_URL}/dashboard/${jwt.selfcareId}/users#${getCurrentSelfCareProductId()}`
 
   const selfcareGroupsPageUrl = jwt && `${SELFCARE_BASE_URL}/dashboard/${jwt.selfcareId}/groups`
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,4 @@
-import { SELFCARE_INTEROP_PROD_ID } from './env'
+import { getCurrentSelfCareProductId } from '@/utils/common.utils'
 
 export const DEFAULT_LANG = 'it'
 export const STORAGE_KEY_SESSION_TOKEN = 'token'
@@ -19,7 +19,7 @@ export const pagoPaLink = {
 }
 
 export const documentationLink = 'https://docs.pagopa.it/interoperabilita-1'
-export const assistanceLink = `https://selfcare.pagopa.it/assistenza?productId=${SELFCARE_INTEROP_PROD_ID}`
+export const assistanceLink = `https://selfcare.pagopa.it/assistenza?productId=${getCurrentSelfCareProductId()}`
 export const attributesHelpLink = `${documentationLink}/manuale-operativo/attributi`
 export const verifyVoucherGuideLink = `${documentationLink}/manuale-operativo/utilizzare-i-voucher`
 export const manageEServiceGuideLink = `${documentationLink}/manuale-operativo/e-service`

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -64,7 +64,15 @@ export const SELFCARE_BASE_URL =
 
 export const STAGE = PAGOPA_ENV?.STAGE ?? 'DEV'
 
-export const SELFCARE_INTEROP_PROD_ID = `prod-interop${STAGE === 'UAT' ? '-coll' : ''}`
+export const SELFCARE_INTEROP_PROD_ID = {
+  UAT: 'prod-interop-coll',
+  PROD: 'prod-interop',
+  ATT: 'prod-interop-atst',
+  // DEV and QA are actually irrelevant. They are set to "prod-interop"
+  // just to avoid breaking the product dropdown in the UI
+  DEV: 'prod-interop',
+  QA: 'prod-interop',
+}[STAGE]
 
 export const PRODUCER_ALLOWED_ORIGINS = PAGOPA_ENV?.PRODUCER_ALLOWED_ORIGINS.split(',')
   .map((o) => o.trim())

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,5 +1,4 @@
 import type { ExtendedWindow, PagoPAEnvVars } from '@/types/common.types'
-import { getCurrentSelfCareProduct } from '@/utils/common.utils'
 
 export const PAGOPA_ENV = (window as unknown as ExtendedWindow).pagopa_env
 
@@ -64,8 +63,6 @@ export const SELFCARE_BASE_URL =
   isProduction && PAGOPA_ENV ? PAGOPA_ENV.SELFCARE_BASE_URL : 'https://uat.selfcare.pagopa.it'
 
 export const STAGE = PAGOPA_ENV?.STAGE ?? 'DEV'
-
-export const SELFCARE_INTEROP_PROD_ID = getCurrentSelfCareProduct()
 
 export const PRODUCER_ALLOWED_ORIGINS = PAGOPA_ENV?.PRODUCER_ALLOWED_ORIGINS.split(',')
   .map((o) => o.trim())

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,4 +1,5 @@
 import type { ExtendedWindow, PagoPAEnvVars } from '@/types/common.types'
+import { getCurrentSelfCareProduct } from '@/utils/common.utils'
 
 export const PAGOPA_ENV = (window as unknown as ExtendedWindow).pagopa_env
 
@@ -64,15 +65,7 @@ export const SELFCARE_BASE_URL =
 
 export const STAGE = PAGOPA_ENV?.STAGE ?? 'DEV'
 
-export const SELFCARE_INTEROP_PROD_ID = {
-  UAT: 'prod-interop-coll',
-  PROD: 'prod-interop',
-  ATT: 'prod-interop-atst',
-  // DEV and QA are actually irrelevant. They are set to "prod-interop"
-  // just to avoid breaking the product dropdown in the UI
-  DEV: 'prod-interop',
-  QA: 'prod-interop',
-}[STAGE]
+export const SELFCARE_INTEROP_PROD_ID = getCurrentSelfCareProduct()
 
 export const PRODUCER_ALLOWED_ORIGINS = PAGOPA_ENV?.PRODUCER_ALLOWED_ORIGINS.split(',')
   .map((o) => o.trim())

--- a/src/utils/common.utils.ts
+++ b/src/utils/common.utils.ts
@@ -2,6 +2,7 @@ import React from 'react'
 import type { OneTrustContent } from '@/types/common.types'
 import { getKeys } from '@/utils/array.utils'
 import isEqual from 'lodash/isEqual'
+import { STAGE } from '@/config/env'
 
 /**
  * Check if the session has expired.
@@ -153,5 +154,26 @@ export function clearExponentialInterval(instanceId: string | undefined) {
   if (instance) {
     instance.cancel()
     exponentialIntervalInstances.delete(instanceId)
+  }
+}
+
+export function getCurrentSelfCareProduct() {
+  switch (STAGE) {
+    case 'PROD':
+      return 'prod-interop'
+    case 'ATT':
+      return 'prod-interop-atst'
+    case 'UAT':
+      return 'prod-interop-coll'
+    // DEV and QA are actually irrelevant. They are set to "prod-interop"
+    // just to avoid breaking the product dropdown in the UI
+    case 'DEV':
+    case 'QA':
+      return 'prod-interop'
+    // If the STAGE value is unmapped here, log a warning and
+    // set the value to "prod-interop" to avoid breaking the UI
+    default:
+      console.warn(`The value "${STAGE}" of STAGE is not mapped`)
+      return 'prod-interop'
   }
 }

--- a/src/utils/common.utils.ts
+++ b/src/utils/common.utils.ts
@@ -157,7 +157,7 @@ export function clearExponentialInterval(instanceId: string | undefined) {
   }
 }
 
-export function getCurrentSelfCareProduct() {
+export function getCurrentSelfCareProductId() {
   switch (STAGE) {
     case 'PROD':
       return 'prod-interop'


### PR DESCRIPTION
This PR could have been done in several ways. I chose to have an object so that every time a new environment is created, the frontend is forced to update its config as well. This way, we are forced to set all the `STAGE` values that are allowed. 

`STAGE` values set to `QA` and `DEV` are actually irrelevant, they are there just to avoid breaking the UI, and a comment was put there to remind us