### PR TITLE
Feature: PIN-4610 - Check if risk analysis is obsolete 

### DIFF
--- a/src/hooks/useGetConsumerPurposesActions.ts
+++ b/src/hooks/useGetConsumerPurposesActions.ts
@@ -1,4 +1,4 @@
-import { PurposeMutations } from '@/api/purpose'
+import { PurposeMutations, PurposeQueries } from '@/api/purpose'
 import { useTranslation } from 'react-i18next'
 import type { ActionItemButton } from '@/types/common.types'
 import { checkPurposeSuspendedByConsumer } from '@/utils/purpose.utils'
@@ -22,6 +22,10 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
   const { mutate: clonePurpose } = PurposeMutations.useClone()
   const { mutate: activatePurpose } = PurposeMutations.useActivateVersion()
   const { mutate: deletePurposeDraft } = PurposeMutations.useDeleteDraft()
+
+  const { data: riskAnalysis } = PurposeQueries.useGetRiskAnalysisLatest({
+    suspense: false,
+  })
 
   if (!purpose || !isAdmin) return { actions: [] }
 
@@ -107,7 +111,11 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
   }
 
   if (purpose?.currentVersion?.state === 'DRAFT') {
-    return { actions: [activateAction, deleteAction] }
+    const actions = [deleteAction]
+    if (purpose.riskAnalysisForm?.version === riskAnalysis?.version) {
+      actions.push(activateAction)
+    }
+    return { actions }
   }
 
   // If the currentVestion is not ARCHIVED or in DRAFT...

--- a/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
@@ -15,7 +15,7 @@ import {
   ConsumerPurposeSummaryGeneralInformationAccordion,
   ConsumerPurposeSummaryRiskAnalysisAccordion,
 } from './components'
-import useGetRiskAnalysisVersionAlertProps from './hooks/useGetRiskAnalysisVersionAlertProps'
+import useGetPurposeSummaryAlertProps from './hooks/useGetRiskAnalysisVersionAlertProps'
 
 const ConsumerPurposeSummaryPage: React.FC = () => {
   const { t } = useTranslation('purpose')
@@ -29,21 +29,7 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
     suspense: false,
   })
 
-  const { data: riskAnalysis } = PurposeQueries.useGetRiskAnalysisLatest({
-    suspense: false,
-  })
-
-  const alertListProps = useGetRiskAnalysisVersionAlertProps({
-    purposeRiskAnalysisVersion: purpose?.riskAnalysisForm?.version,
-    latestRiskAnalysisVersion: riskAnalysis?.version,
-  })
-
-  /* 
-    If latestRiskAnalysisVersion is not the same of purpose risk analysis version, this mean that riskAnalysis is obsolete 
-    so ui need disabled edit and publish buttons
-  */
-  const isRiskAnlysisObsolete =
-    riskAnalysis && purpose && riskAnalysis?.version !== purpose?.riskAnalysisForm?.version
+  const alertProps = useGetPurposeSummaryAlertProps(purposeId)
 
   const { mutate: deleteDraft } = PurposeMutations.useDeleteDraft()
   const { mutate: publishDraft } = PurposeMutations.useActivateVersion()
@@ -95,18 +81,17 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
       isLoading={isInitialLoading}
       statusChip={purpose ? { for: 'purpose', purpose: purpose } : undefined}
     >
-      {alertListProps &&
-        alertListProps.map((alert, index) => (
-          <Alert key={index} severity={alert.severity} sx={{ mb: 3 }}>
-            <Trans
-              components={{
-                strong: <Typography component="span" variant="inherit" fontWeight={600} />,
-              }}
-            >
-              {alert.content}
-            </Trans>
-          </Alert>
-        ))}
+      {alertProps && (
+        <Alert severity={alertProps.severity} sx={{ mb: 3 }}>
+          <Trans
+            components={{
+              strong: <Typography component="span" variant="inherit" fontWeight={600} />,
+            }}
+          >
+            {alertProps.content}
+          </Trans>
+        </Alert>
+      )}
       {!purpose && isInitialLoading ? (
         <Stack spacing={3}>
           <SummaryAccordionSkeleton />
@@ -135,7 +120,7 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
           startIcon={<CreateIcon />}
           variant="text"
           onClick={handleEditDraft}
-          disabled={isRiskAnlysisObsolete}
+          disabled={!alertProps || alertProps?.isRiskAnalysisVersionObsolete}
         >
           {tCommon('editDraft')}
         </Button>
@@ -143,7 +128,7 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
           startIcon={<PublishIcon />}
           variant="contained"
           onClick={handlePublishDraft}
-          disabled={isRiskAnlysisObsolete}
+          disabled={!alertProps || alertProps?.isRiskAnalysisVersionObsolete}
         >
           {tCommon('publish')}
         </Button>

--- a/src/pages/ConsumerPurposeSummaryPage/hooks/useGetRiskAnalysisVersionAlertProps.ts
+++ b/src/pages/ConsumerPurposeSummaryPage/hooks/useGetRiskAnalysisVersionAlertProps.ts
@@ -2,12 +2,13 @@ import { PurposeQueries } from '@/api/purpose'
 import type { AlertProps } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
-type AlertResponse = {
-  severity: AlertProps['severity']
-  content: AlertProps['children']
-  isRiskAnalysisVersionObsolete?: boolean
-}
-function useGetPurposeSummaryAlertProps(purposeId: string): AlertResponse | undefined {
+function useGetPurposeSummaryAlertProps(purposeId: string):
+  | {
+      severity: AlertProps['severity']
+      content: AlertProps['children']
+      isRiskAnalysisVersionObsolete?: boolean
+    }
+  | undefined {
   const { t } = useTranslation('purpose', { keyPrefix: 'summary' })
 
   const { data: purpose, isInitialLoading } = PurposeQueries.useGetSingle(purposeId, {

--- a/src/pages/ConsumerPurposeSummaryPage/hooks/useGetRiskAnalysisVersionAlertProps.ts
+++ b/src/pages/ConsumerPurposeSummaryPage/hooks/useGetRiskAnalysisVersionAlertProps.ts
@@ -1,0 +1,38 @@
+import type { AlertProps } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+
+type AlertResponse = {
+  severity: AlertProps['severity']
+  content: AlertProps['children']
+}
+function useGetRiskAnalysisVersionAlertProps({
+  purposeRiskAnalysisVersion,
+  latestRiskAnalysisVersion,
+}: {
+  purposeRiskAnalysisVersion?: string
+  latestRiskAnalysisVersion?: string
+}): Array<AlertResponse> {
+  const { t } = useTranslation('purpose', { keyPrefix: 'summary' })
+  let alertProps: Array<AlertResponse> = [
+    {
+      severity: 'info',
+      content: t('clientsAlert'),
+    },
+  ]
+
+  if (!purposeRiskAnalysisVersion || !latestRiskAnalysisVersion) return alertProps
+
+  if (purposeRiskAnalysisVersion !== latestRiskAnalysisVersion) {
+    alertProps = [
+      ...alertProps,
+      {
+        severity: 'warning',
+        content: t('obsoleteRiskAnalysisAlert'),
+      },
+    ]
+  }
+
+  return alertProps
+}
+
+export default useGetRiskAnalysisVersionAlertProps

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -85,6 +85,7 @@
   "summary": {
     "title": "Summary",
     "clientsAlert": "<strong>The client association was removed</strong> within the process. It will be possible to associate one or more clients only after the activation of the purpose.",
+    "obsoleteRiskAnalysisAlert": "Risk analysis is outdated. It is not possible activate this purpose. Delete draft purpose and create a new purpose",
     "generalInformationSection": {
       "title": "General informations",
       "eservice": {

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -85,6 +85,7 @@
   "summary": {
     "title": "Riepilogo",
     "clientsAlert": "All’interno del processo <strong>è stata rimossa l’associazione del client</strong>. Sarà possibile associare uno o più client solo dopo l’attivazione della finalità.",
+    "obsoleteRiskAnalysisAlert": "La versione del rischio compilata è obsoleta. Non è possibile pubblicare questa finalità. Elimina la bozza e crea una nuova finalità",
     "generalInformationSection": {
       "title": "Informazioni generali",
       "eservice": {


### PR DESCRIPTION
This PR include a new check on purpose detail. If risk analysis version is bigger than risky analysis version contained on purposeDetail response, an alert will show to the user and he can't activate the purpose as well.