### PR TITLE
Feature: PIN-4604 - Implementing alert no purposes in agreement

### DIFF
--- a/src/pages/ConsumerAgreementDetailsPage/ConsumerAgreementDetails.page.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/ConsumerAgreementDetails.page.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { AgreementQueries } from '@/api/agreement'
 import { PageContainer } from '@/components/layout/containers'
 import useGetAgreementsActions from '@/hooks/useGetAgreementsActions'
-import { useParams } from '@/router'
+import { Link, useParams } from '@/router'
 import { canAgreementBeUpgraded } from '@/utils/agreement.utils'
 import { Alert, Grid, Stack, Typography } from '@mui/material'
 import { Trans, useTranslation } from 'react-i18next'
@@ -19,6 +19,7 @@ import {
   ConsumerAgreementDetailsAttributesSectionsListSkeleton,
 } from './components/ConsumerAgreementDetailsAttributesSectionsList/ConsumerAgreementDetailsAttributesSectionsList'
 import { useDialog } from '@/stores'
+import { useGetConsumerAgreementAlertProps } from './hooks/useGetConsumerAgreementAlertProps'
 
 const ConsumerAgreementDetailsPage: React.FC = () => {
   return (
@@ -40,11 +41,7 @@ const ConsumerAgreementDetailsPageContent: React.FC = () => {
 
   const { actions } = useGetAgreementsActions(agreement)
 
-  const suspendedBy = React.useMemo(() => {
-    if (agreement?.suspendedByProducer) return 'byProducer'
-    if (agreement?.suspendedByConsumer) return 'byConsumer'
-    if (agreement?.suspendedByPlatform) return 'byPlatform'
-  }, [agreement])
+  const alertProps = useGetConsumerAgreementAlertProps(agreement)
 
   const isEserviceMine = agreement?.consumer.id === agreement?.producer.id
   const { hasAllCertifiedAttributes, hasAllDeclaredAttributes, hasAllVerifiedAttributes } =
@@ -90,14 +87,23 @@ const ConsumerAgreementDetailsPageContent: React.FC = () => {
           : undefined
       }
     >
-      {agreement && agreement.state === 'SUSPENDED' && suspendedBy && (
-        <Alert sx={{ mb: 3 }} severity="error">
+      {alertProps && (
+        <Alert sx={{ mb: 3 }} severity={alertProps.severity}>
           <Trans
             components={{
-              strong: <Typography component="span" variant="inherit" fontWeight={700} />,
+              1: alertProps.link ? (
+                <Link
+                  to={alertProps.link.to}
+                  params={alertProps.link.params}
+                  options={alertProps.link.options}
+                />
+              ) : (
+                <Typography component="span" variant="inherit" />
+              ),
+              strong: <Typography component="span" variant="inherit" fontWeight={600} />,
             }}
           >
-            {t(`consumerRead.suspendedAlert.${suspendedBy}`)}
+            {alertProps.content}
           </Trans>
         </Alert>
       )}

--- a/src/pages/ConsumerAgreementDetailsPage/hooks/__test__/useGetConsumerAgreementAlertProps.test.ts
+++ b/src/pages/ConsumerAgreementDetailsPage/hooks/__test__/useGetConsumerAgreementAlertProps.test.ts
@@ -1,0 +1,176 @@
+import type { Agreement, Purpose } from '@/api/api.generatedTypes'
+import { renderHookWithApplicationContext } from '@/utils/testing.utils'
+import { useGetConsumerAgreementAlertProps } from '../useGetConsumerAgreementAlertProps'
+import { createMockAgreement } from '../../../../../__mocks__/data/agreement.mocks'
+import { waitFor } from '@testing-library/react'
+import { PurposeQueries } from '@/api/purpose'
+import { createMockPurpose } from '../../../../../__mocks__/data/purpose.mocks'
+
+const mockUseGetConsumersList = (purposes: Array<Purpose>) => {
+  vi.spyOn(PurposeQueries, 'useGetConsumersList').mockReturnValue({
+    data: {
+      results: purposes,
+      pagination: {
+        limit: 50,
+        offset: 0,
+        totalCount: purposes.length,
+      },
+    },
+  } as unknown as ReturnType<typeof PurposeQueries.useGetConsumersList>)
+}
+
+function renderUseGetConsumerAgreementAlertPropsHook(agreementMock?: Agreement) {
+  return renderHookWithApplicationContext(() => useGetConsumerAgreementAlertProps(agreementMock), {
+    withReactQueryContext: true,
+  })
+}
+
+describe('check if useGetConsumerAgreementAlertProps returns the correct alertProps based on the passed agreement - no agreement', () => {
+  it('shoud not return any alertProps if no agreement is given', () => {
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook()
+    expect(result.current).toBeUndefined()
+  })
+
+  it('shoud return the correct alertProps if suspended agreement with suspendedByProducer is given', () => {
+    const agreement = createMockAgreement({
+      state: 'SUSPENDED',
+      suspendedByProducer: true,
+      suspendedByConsumer: false,
+      suspendedByPlatform: false,
+    })
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+    expect(result.current?.severity).toBe('error')
+    expect(result.current?.content).toBe('consumerRead.suspendedAlert.byProducer')
+  })
+
+  it('shoud return the correct alertProps if suspended agreement with suspendedByConsumer is given', () => {
+    const agreement = createMockAgreement({
+      state: 'SUSPENDED',
+      suspendedByProducer: false,
+      suspendedByConsumer: true,
+      suspendedByPlatform: false,
+    })
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+    expect(result.current?.severity).toBe('error')
+    expect(result.current?.content).toBe('consumerRead.suspendedAlert.byConsumer')
+  })
+
+  it('shoud return the correct alertProps if suspended agreement with suspendedByPlatform is given', () => {
+    const agreement = createMockAgreement({
+      state: 'SUSPENDED',
+      suspendedByProducer: false,
+      suspendedByConsumer: false,
+      suspendedByPlatform: true,
+    })
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+    expect(result.current?.severity).toBe('error')
+    expect(result.current?.content).toBe('consumerRead.suspendedAlert.byPlatform')
+  })
+
+  it('shoud return the correct alertProps if suspended agreement with every suspendedBy is given', () => {
+    const agreement = createMockAgreement({
+      state: 'SUSPENDED',
+      suspendedByProducer: true,
+      suspendedByConsumer: true,
+      suspendedByPlatform: true,
+    })
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+    expect(result.current?.severity).toBe('error')
+    expect(result.current?.content).toBe('consumerRead.suspendedAlert.byProducer')
+  })
+
+  it('shoud return the correct alertProps if suspended agreement with only suspendedByProducer and suspendedByPlatform is given', () => {
+    const agreement = createMockAgreement({
+      state: 'SUSPENDED',
+      suspendedByProducer: true,
+      suspendedByConsumer: false,
+      suspendedByPlatform: true,
+    })
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+    expect(result.current?.severity).toBe('error')
+    expect(result.current?.content).toBe('consumerRead.suspendedAlert.byProducer')
+  })
+
+  it('shoud return the correct alertProps if suspended agreement with only suspendedByProducer and suspendedByConsumer is given', () => {
+    const agreement = createMockAgreement({
+      state: 'SUSPENDED',
+      suspendedByProducer: true,
+      suspendedByConsumer: true,
+      suspendedByPlatform: false,
+    })
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+    expect(result.current?.severity).toBe('error')
+    expect(result.current?.content).toBe('consumerRead.suspendedAlert.byProducer')
+  })
+
+  it('shoud return the correct alertProps if suspended agreement with only suspendedByConsumer and suspendedByPlatform is given', () => {
+    const agreement = createMockAgreement({
+      state: 'SUSPENDED',
+      suspendedByProducer: false,
+      suspendedByConsumer: true,
+      suspendedByPlatform: true,
+    })
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+    expect(result.current?.severity).toBe('error')
+    expect(result.current?.content).toBe('consumerRead.suspendedAlert.byConsumer')
+  })
+
+  it('shoud return the correct alertProps if not suspended agreement is given and that agreement has not purposes', async () => {
+    const agreement = createMockAgreement({
+      state: 'ACTIVE',
+    })
+    mockUseGetConsumersList([])
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+    await waitFor(() => {
+      expect(result.current?.severity).toBe('info')
+      expect(result.current?.content).toBe('consumerRead.noPurposeAlert')
+      expect(result.current?.link?.to).toBe('SUBSCRIBE_PURPOSE_CREATE')
+    })
+  })
+
+  it('shoud return the correct alertProps if not suspended agreement is given and that agreement has only archived purposes', async () => {
+    const agreement = createMockAgreement({
+      state: 'ACTIVE',
+    })
+    const purpose = createMockPurpose({
+      id: 'test-purpose-1',
+      currentVersion: {
+        state: 'ARCHIVED',
+      },
+    })
+    const purpose2 = createMockPurpose({
+      id: 'test-purpose-2',
+      currentVersion: {
+        state: 'ARCHIVED',
+      },
+    })
+    mockUseGetConsumersList([purpose, purpose2])
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+    await waitFor(() => {
+      expect(result.current?.severity).toBe('info')
+      expect(result.current?.content).toBe('consumerRead.noPurposeAlert')
+      expect(result.current?.link?.to).toBe('SUBSCRIBE_PURPOSE_CREATE')
+    })
+  })
+
+  it('shoud not return any alertProps if not suspended agreement is given and the agreement has purposes that are not all archived', () => {
+    const agreement = createMockAgreement({
+      state: 'ACTIVE',
+    })
+    const purpose = createMockPurpose({
+      id: 'test-purpose-1',
+      currentVersion: {
+        state: 'ARCHIVED',
+      },
+    })
+    const purpose2 = createMockPurpose({
+      id: 'test-purpose-2',
+      currentVersion: {
+        state: 'ACTIVE',
+      },
+    })
+    mockUseGetConsumersList([purpose, purpose2])
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+    expect(result.current).toBeUndefined()
+  })
+})

--- a/src/pages/ConsumerAgreementDetailsPage/hooks/useGetConsumerAgreementAlertProps.ts
+++ b/src/pages/ConsumerAgreementDetailsPage/hooks/useGetConsumerAgreementAlertProps.ts
@@ -31,9 +31,9 @@ export function useGetConsumerAgreementAlertProps(agreement: Agreement | undefin
 
   const suspendedBy = (() => {
     if (agreement.state !== 'SUSPENDED') return undefined
-    if (agreement?.suspendedByProducer) return 'byProducer'
-    if (agreement?.suspendedByConsumer) return 'byConsumer'
-    if (agreement?.suspendedByPlatform) return 'byPlatform'
+    if (agreement.suspendedByProducer) return 'byProducer'
+    if (agreement.suspendedByConsumer) return 'byConsumer'
+    if (agreement.suspendedByPlatform) return 'byPlatform'
   })()
 
   if (suspendedBy) {

--- a/src/pages/ConsumerAgreementDetailsPage/hooks/useGetConsumerAgreementAlertProps.ts
+++ b/src/pages/ConsumerAgreementDetailsPage/hooks/useGetConsumerAgreementAlertProps.ts
@@ -1,0 +1,59 @@
+import type { Agreement } from '@/api/api.generatedTypes'
+import { PurposeQueries } from '@/api/purpose'
+import type { Link, RouteKey } from '@/router'
+import type { AlertProps } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+
+export function useGetConsumerAgreementAlertProps(agreement: Agreement | undefined):
+  | {
+      severity: AlertProps['severity']
+      content: string
+      link?: {
+        to: RouteKey
+        params?: React.ComponentProps<typeof Link>['params']
+        options?: React.ComponentProps<typeof Link>['options']
+      }
+    }
+  | undefined {
+  const { t } = useTranslation('agreement')
+
+  const { data: purposes } = PurposeQueries.useGetConsumersList(
+    {
+      limit: 50,
+      offset: 0,
+      producersIds: [agreement?.producer.id as string],
+      eservicesIds: [agreement?.eservice.id as string],
+    },
+    { suspense: false, enabled: !!agreement && agreement.state === 'ACTIVE' }
+  )
+
+  if (!agreement) return undefined
+
+  const suspendedBy = (() => {
+    if (agreement.state !== 'SUSPENDED') return undefined
+    if (agreement?.suspendedByProducer) return 'byProducer'
+    if (agreement?.suspendedByConsumer) return 'byConsumer'
+    if (agreement?.suspendedByPlatform) return 'byPlatform'
+  })()
+
+  if (suspendedBy) {
+    return {
+      severity: 'error',
+      content: t(`consumerRead.suspendedAlert.${suspendedBy}`),
+    }
+  }
+
+  const isWithoutPurposes =
+    purposes?.results.length === 0 ||
+    purposes?.results.every((purpose) => purpose.currentVersion?.state === 'ARCHIVED')
+
+  if (isWithoutPurposes) {
+    return {
+      severity: 'info',
+      content: t('consumerRead.noPurposeAlert'),
+      link: {
+        to: 'SUBSCRIBE_PURPOSE_CREATE',
+      },
+    }
+  }
+}

--- a/src/static/locales/en/agreement.json
+++ b/src/static/locales/en/agreement.json
@@ -119,6 +119,7 @@
       "byConsumer": "This agreement has been suspended by the CONSUMER. Until it is reactivated it will not be possible to access the data.",
       "byPlatform": "This agreement has been suspended by the PLATFORM. Until it is reactivated it will not be possible to access the data."
     },
+    "noPurposeAlert": "To access the data <1>create your first purpose</1>.",
     "noCertifiedAttributesForUpgradeTooltip": "There is an update available but your organization does not have the minimum requirements to perform it.",
     "sections": {
       "generalInformations": {

--- a/src/static/locales/it/agreement.json
+++ b/src/static/locales/it/agreement.json
@@ -119,6 +119,7 @@
       "byConsumer": "Questa richiesta di fruizione è stata sospesa da <strong>fruitore</strong>. Fino alla sua riattivazione non sarà possibile accedere ai dati.",
       "byPlatform": "Questa richiesta di fruizione è stata sospesa da <strong>piattaforma</strong>. Fino alla sua riattivazione non sarà possibile accedere ai dati."
     },
+    "noPurposeAlert": "Per accedere ai dati <1>crea la tua prima finalità</1>.",
     "noCertifiedAttributesForUpgradeTooltip": "C’è un aggiornamento disponibile ma il tuo ente non possiede i requisiti minimi per effettuarlo.",
     "sections": {
       "generalInformations": {


### PR DESCRIPTION
- Updated `Alert` in `ConsumerAgreementDetailsPage`
- Implemented hook `useGetConsumerAgreementAlertProps` that have the business logic to show the correct alert
- Added strings