### PR TITLE
Bugfix: PIN-4746 - showing public pages if user isn't signed in

### DIFF
--- a/src/api/auth/auth.hooks.ts
+++ b/src/api/auth/auth.hooks.ts
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import AuthServices from './auth.services'
 import { STAGE } from '@/config/env'
 import { type UseQueryOptions, useQuery } from '@tanstack/react-query'
-import { parseJwt } from './auth.utils'
+import type { ParsedJwt } from './auth.utils'
 import { useMutation } from '@tanstack/react-query'
 
 export enum AuthQueryKeys {
@@ -10,7 +10,7 @@ export enum AuthQueryKeys {
   GetBlacklist = 'GetBlacklist',
 }
 
-function useJwt(config?: UseQueryOptions<string | null>) {
+function useJwt(config?: UseQueryOptions<ParsedJwt | null>) {
   const { data: sessionToken, isLoading: isLoadingSession } = useQuery({
     queryKey: [AuthQueryKeys.GetSessionToken],
     queryFn: AuthServices.getSessionToken,
@@ -20,7 +20,7 @@ function useJwt(config?: UseQueryOptions<string | null>) {
     ...config,
   })
 
-  return { ...parseJwt(sessionToken), isLoadingSession }
+  return { ...(sessionToken as ParsedJwt), isLoadingSession }
 }
 
 function useGetBlacklist() {

--- a/src/api/auth/auth.hooks.ts
+++ b/src/api/auth/auth.hooks.ts
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import AuthServices from './auth.services'
 import { STAGE } from '@/config/env'
 import { type UseQueryOptions, useQuery } from '@tanstack/react-query'
-import type { ParsedJwt } from './auth.utils'
+import { parseJwt } from './auth.utils'
 import { useMutation } from '@tanstack/react-query'
 
 export enum AuthQueryKeys {
@@ -10,7 +10,7 @@ export enum AuthQueryKeys {
   GetBlacklist = 'GetBlacklist',
 }
 
-function useJwt(config?: UseQueryOptions<ParsedJwt | null>) {
+function useJwt(config?: UseQueryOptions<string | null>) {
   const { data: sessionToken, isLoading: isLoadingSession } = useQuery({
     queryKey: [AuthQueryKeys.GetSessionToken],
     queryFn: AuthServices.getSessionToken,
@@ -20,7 +20,7 @@ function useJwt(config?: UseQueryOptions<ParsedJwt | null>) {
     ...config,
   })
 
-  return { ...(sessionToken as ParsedJwt), isLoadingSession }
+  return { ...parseJwt(sessionToken), isLoadingSession }
 }
 
 function useGetBlacklist() {

--- a/src/api/auth/auth.services.ts
+++ b/src/api/auth/auth.services.ts
@@ -4,6 +4,9 @@ import axios from 'axios'
 import type { SAMLTokenRequest, SessionToken } from '../api.generatedTypes'
 import { MOCK_TOKEN, STORAGE_KEY_SESSION_TOKEN } from '@/config/constants'
 import { TokenExchangeError } from '@/utils/errors.utils'
+import { hasSessionExpired } from '@/utils/common.utils'
+import type { ParsedJwt } from './auth.utils'
+import { parseJwt } from './auth.utils'
 
 async function swapTokens(identity_token: string) {
   const response = await axiosInstance.post<{ session_token: string }>(
@@ -13,10 +16,18 @@ async function swapTokens(identity_token: string) {
   return response.data
 }
 
-async function getSessionToken(): Promise<string | null> {
+async function getSessionToken(): Promise<ParsedJwt | null> {
   const resolveToken = (sessionToken: string) => {
-    window.localStorage.setItem(STORAGE_KEY_SESSION_TOKEN, sessionToken)
-    return sessionToken
+    const parsedToken = parseJwt(sessionToken)
+
+    // Check if session has expired. In that case, we need to remove token from localStorage
+    if (hasSessionExpired(parsedToken.jwt?.exp)) {
+      window.localStorage.removeItem(STORAGE_KEY_SESSION_TOKEN)
+      return null
+    } else {
+      window.localStorage.setItem(STORAGE_KEY_SESSION_TOKEN, sessionToken)
+    }
+    return parsedToken
   }
 
   // 1. Check if there is a mock token: only used for dev purposes

--- a/src/api/auth/auth.utils.ts
+++ b/src/api/auth/auth.utils.ts
@@ -1,5 +1,6 @@
 import { PRODUCER_ALLOWED_ORIGINS } from '@/config/env'
 import type { JwtUser } from '@/types/party.types'
+import { hasSessionExpired } from '@/utils/common.utils'
 import memoize from 'lodash/memoize'
 
 export type ParsedJwt = ReturnType<typeof parseJwt>
@@ -28,3 +29,9 @@ export const parseJwt = memoize((token: string | null | undefined) => {
     isOrganizationAllowedToProduce,
   }
 })
+
+export function isJwtExpired(sessionToken: string) {
+  const parsedJwt = parseJwt(sessionToken)
+
+  return hasSessionExpired(parsedJwt.jwt?.exp)
+}

--- a/src/api/auth/auth.utils.ts
+++ b/src/api/auth/auth.utils.ts
@@ -2,6 +2,8 @@ import { PRODUCER_ALLOWED_ORIGINS } from '@/config/env'
 import type { JwtUser } from '@/types/party.types'
 import memoize from 'lodash/memoize'
 
+export type ParsedJwt = ReturnType<typeof parseJwt>
+
 /**
  * Parse the JWT token and return the user informations stored in it
  */

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -9,7 +9,6 @@ import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import type { SelfcareInstitution } from '@/api/api.generatedTypes'
 import type { JwtUser, UserProductRole } from '@/types/party.types'
-import { UnauthorizedError } from '@/utils/errors.utils'
 import { getCurrentSelfCareProductId } from '@/utils/common.utils'
 
 /**
@@ -92,10 +91,10 @@ export const Header: React.FC<HeaderProps> = ({ jwt, isSupport }) => {
 
   const queriesOptions = {
     suspense: false,
-    useErrorBoundary: (error: unknown) => error instanceof UnauthorizedError,
     retry: false,
     staleTime: Infinity,
     cacheTime: Infinity,
+    enabled: !!jwt,
   }
 
   const { data: parties } = PartyQueries.useGetPartyList(queriesOptions)

--- a/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/components/layout/__tests__/__snapshots__/Header.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`Header > should match snapshot (logged - not support) 1`] = `
               </button>
               <button
                 aria-label="Documentazione"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1450cqm-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-u78awm-MuiButtonBase-root-MuiIconButton-root"
                 tabindex="0"
                 type="button"
               >
@@ -236,7 +236,7 @@ exports[`Header > should match snapshot (logged - support) 1`] = `
               </button>
               <button
                 aria-label="Documentazione"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1450cqm-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-u78awm-MuiButtonBase-root-MuiIconButton-root"
                 tabindex="0"
                 type="button"
               >
@@ -427,7 +427,7 @@ exports[`Header > should match snapshot (not logged) 1`] = `
               </button>
               <button
                 aria-label="Documentazione"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1450cqm-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-u78awm-MuiButtonBase-root-MuiIconButton-root"
                 tabindex="0"
                 type="button"
               >

--- a/src/router/components/RoutesWrapper/__tests__/__snapshots__/RoutesWrapper.test.tsx.snap
+++ b/src/router/components/RoutesWrapper/__tests__/__snapshots__/RoutesWrapper.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`RoutesWrapper > should match the snapshot 1`] = `
             </button>
             <button
               aria-label="Documentazione"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1450cqm-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-u78awm-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               type="button"
             >
@@ -275,7 +275,7 @@ exports[`RoutesWrapper > should match the snapshot 1`] = `
             <a
               aria-label="footer.links.privacy.ariaLabel"
               class="MuiTypography-root MuiTypography-subtitle2 MuiLink-root MuiLink-underlineNone css-2bcyg6-MuiTypography-root-MuiLink-root"
-              href="#!"
+              href="javascript:void(0)"
             >
               footer.links.privacy.label
             </a>
@@ -289,7 +289,7 @@ exports[`RoutesWrapper > should match the snapshot 1`] = `
             <a
               aria-label="footer.links.terms.ariaLabel"
               class="MuiTypography-root MuiTypography-subtitle2 MuiLink-root MuiLink-underlineNone css-2bcyg6-MuiTypography-root-MuiLink-root"
-              href="#!"
+              href="javascript:void(0)"
             >
               footer.links.terms.label
             </a>
@@ -415,7 +415,7 @@ exports[`RoutesWrapper > should show the ErrorPage when an error is thrown 1`] =
               </button>
               <button
                 aria-label="Documentazione"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1450cqm-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-u78awm-MuiButtonBase-root-MuiIconButton-root"
                 tabindex="0"
                 type="button"
               >
@@ -637,7 +637,7 @@ exports[`RoutesWrapper > should show the ErrorPage when an error is thrown 1`] =
               <a
                 aria-label="footer.links.privacy.ariaLabel"
                 class="MuiTypography-root MuiTypography-subtitle2 MuiLink-root MuiLink-underlineNone css-2bcyg6-MuiTypography-root-MuiLink-root"
-                href="#!"
+                href="javascript:void(0)"
               >
                 footer.links.privacy.label
               </a>
@@ -651,7 +651,7 @@ exports[`RoutesWrapper > should show the ErrorPage when an error is thrown 1`] =
               <a
                 aria-label="footer.links.terms.ariaLabel"
                 class="MuiTypography-root MuiTypography-subtitle2 MuiLink-root MuiLink-underlineNone css-2bcyg6-MuiTypography-root-MuiLink-root"
-                href="#!"
+                href="javascript:void(0)"
               >
                 footer.links.terms.label
               </a>
@@ -778,7 +778,7 @@ exports[`RoutesWrapper > should show the TOSAgreement when isPublic is false and
               </button>
               <button
                 aria-label="Documentazione"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1450cqm-MuiButtonBase-root-MuiIconButton-root"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-u78awm-MuiButtonBase-root-MuiIconButton-root"
                 tabindex="0"
                 type="button"
               >
@@ -996,7 +996,7 @@ exports[`RoutesWrapper > should show the TOSAgreement when isPublic is false and
               <a
                 aria-label="footer.links.privacy.ariaLabel"
                 class="MuiTypography-root MuiTypography-subtitle2 MuiLink-root MuiLink-underlineNone css-2bcyg6-MuiTypography-root-MuiLink-root"
-                href="#!"
+                href="javascript:void(0)"
               >
                 footer.links.privacy.label
               </a>
@@ -1010,7 +1010,7 @@ exports[`RoutesWrapper > should show the TOSAgreement when isPublic is false and
               <a
                 aria-label="footer.links.terms.ariaLabel"
                 class="MuiTypography-root MuiTypography-subtitle2 MuiLink-root MuiLink-underlineNone css-2bcyg6-MuiTypography-root-MuiLink-root"
-                href="#!"
+                href="javascript:void(0)"
               >
                 footer.links.terms.label
               </a>


### PR DESCRIPTION
This PR resolve issue about showing public pages. Several components stopped propagation to public pages because without JWT (or with expired jwt) some api calls get 401 so the app redirect user to LOGIN_PAGE though page didn't need token. 

Main changes:

1.  Removed use `useErrorBoundary` from `<Header/>` and added check on jwt
2. check if token is expired in `getSessionToken`