### PR TITLE
Feature: PIN-4726 - Implementing purpose rejection

### DIFF
--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -9,6 +9,11 @@
  * ---------------------------------------------------------------
  */
 
+/** models the reject payload for this purpose version. */
+export interface RejectPurposeVersionPayload {
+  rejectionReason: string
+}
+
 export interface GoogleSAMLPayload {
   /** SAML response */
   SAMLResponse: string
@@ -822,6 +827,7 @@ export type PurposeVersionState =
   | 'ACTIVE'
   | 'DRAFT'
   | 'SUSPENDED'
+  | 'REJECTED'
   | 'WAITING_FOR_APPROVAL'
   | 'ARCHIVED'
 
@@ -3547,6 +3553,28 @@ export namespace Purposes {
       'X-Correlation-Id': string
     }
     export type ResponseBody = File
+  }
+  /**
+   * @description reject the purpose version by id
+   * @tags purposes
+   * @name RejectPurposeVersion
+   * @summary Reject Purpose Version
+   * @request POST:/purposes/{purposeId}/versions/{versionId}/reject
+   * @secure
+   */
+  export namespace RejectPurposeVersion {
+    export type RequestParams = {
+      /** @format uuid */
+      purposeId: string
+      /** @format uuid */
+      versionId: string
+    }
+    export type RequestQuery = {}
+    export type RequestBody = RejectPurposeVersionPayload
+    export type RequestHeaders = {
+      'X-Correlation-Id': string
+    }
+    export type ResponseBody = void
   }
   /**
    * @description archives the purpose version by id

--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -687,6 +687,8 @@ export interface Purpose {
   clients: CompactClient[]
   /** business representation of a purpose version */
   waitingForApprovalVersion?: PurposeVersion
+  /** business representation of a purpose version */
+  rejectedVersion?: PurposeVersion
   suspendedByConsumer?: boolean
   suspendedByProducer?: boolean
   isFreeOfCharge: boolean
@@ -804,6 +806,7 @@ export interface PurposeVersion {
    */
   dailyCalls: number
   riskAnalysisDocument?: PurposeVersionDocument
+  rejectionReason?: string
 }
 
 export interface PurposeVersionDocument {

--- a/src/api/purpose/purpose.hooks.ts
+++ b/src/api/purpose/purpose.hooks.ts
@@ -229,6 +229,17 @@ function useDeleteVersion() {
   })
 }
 
+function useRejectVersion() {
+  const { t } = useTranslation('mutations-feedback', { keyPrefix: 'purpose.rejectVersion' })
+  return useMutation(PurposeServices.rejectVersion, {
+    meta: {
+      successToastLabel: t('outcome.success'),
+      errorToastLabel: t('outcome.error'),
+      loadingLabel: t('loading'),
+    },
+  })
+}
+
 function useClone() {
   const { t } = useTranslation('mutations-feedback', { keyPrefix: 'purpose.clone' })
   return useMutation(PurposeServices.clone, {
@@ -286,6 +297,7 @@ export const PurposeMutations = {
   useActivateVersion,
   useArchiveVersion,
   useDeleteVersion,
+  useRejectVersion,
   useClone,
   useAddClient,
   useRemoveClient,

--- a/src/api/purpose/purpose.services.ts
+++ b/src/api/purpose/purpose.services.ts
@@ -13,6 +13,7 @@ import type {
   PurposeUpdateContent,
   PurposeVersionResource,
   PurposeVersionSeed,
+  RejectPurposeVersionPayload,
   RetrieveRiskAnalysisConfigurationByVersionParams,
   ReversePurposeUpdateContent,
   RiskAnalysisFormConfig,
@@ -173,6 +174,17 @@ function deleteVersion({ purposeId, versionId }: { purposeId: string; versionId:
   )
 }
 
+function rejectVersion({
+  purposeId,
+  versionId,
+  ...payload
+}: { purposeId: string; versionId: string } & RejectPurposeVersionPayload) {
+  return axiosInstance.post(
+    `${BACKEND_FOR_FRONTEND_URL}/purposes/${purposeId}/versions/${versionId}/reject`,
+    payload
+  )
+}
+
 async function clone({ purposeId, ...payload }: { purposeId: string } & PurposeCloneSeed) {
   const response = await axiosInstance.post<PurposeVersionResource>(
     `${BACKEND_FOR_FRONTEND_URL}/purposes/${purposeId}/clone`,
@@ -211,6 +223,7 @@ const PurposeServices = {
   activateVersion,
   archiveVersion,
   deleteVersion,
+  rejectVersion,
   clone,
   addClient,
   removeClient,

--- a/src/components/dialogs/Dialog.tsx
+++ b/src/components/dialogs/Dialog.tsx
@@ -10,6 +10,7 @@ import type {
   DialogClonePurposeProps,
   DialogProps,
   DialogRejectAgreementProps,
+  DialogRejectPurposeVersionProps,
   DialogRemoveOperatorFromClientProps,
   DialogRevokeCertifiedAttributeProps,
   DialogSessionExpiredProps,
@@ -25,6 +26,7 @@ import { DialogRemoveOperatorFromClient } from './DialogRemoveOperatorFromClient
 import { DialogDeleteOperator } from './DialogDeleteOperator'
 import { DialogRevokeCertifiedAttribute } from './DialogRevokeCertifiedAttribute'
 import { DialogClonePurpose } from './DialogClonePurpose/DialogClonePurpose'
+import { DialogRejectPurposeVersion } from './DialogRejectPurposeVersion'
 
 function match<T>(
   onBasic: (props: DialogBasicProps) => T,
@@ -36,7 +38,8 @@ function match<T>(
   onDeleteOperator: (props: DialogDeleteOperatorProps) => T,
   onRemoveOperatorFromClient: (props: DialogRemoveOperatorFromClientProps) => T,
   onRevokeCertifiedAttribute: (props: DialogRevokeCertifiedAttributeProps) => T,
-  onClonePurpose: (props: DialogClonePurposeProps) => T
+  onClonePurpose: (props: DialogClonePurposeProps) => T,
+  onRejectPurposeVersion: (props: DialogRejectPurposeVersionProps) => T
 ) {
   return (props: DialogProps) => {
     switch (props.type) {
@@ -60,6 +63,8 @@ function match<T>(
         return onRevokeCertifiedAttribute(props)
       case 'clonePurpose':
         return onClonePurpose(props)
+      case 'rejectPurposeVersion':
+        return onRejectPurposeVersion(props)
     }
   }
 }
@@ -74,7 +79,8 @@ const _Dialog = match(
   (props) => <DialogDeleteOperator {...props} />,
   (props) => <DialogRemoveOperatorFromClient {...props} />,
   (props) => <DialogRevokeCertifiedAttribute {...props} />,
-  (props) => <DialogClonePurpose {...props} />
+  (props) => <DialogClonePurpose {...props} />,
+  (props) => <DialogRejectPurposeVersion {...props} />
 )
 
 export const Dialog: React.FC = () => {

--- a/src/components/dialogs/DialogRejectPurposeVersion.tsx
+++ b/src/components/dialogs/DialogRejectPurposeVersion.tsx
@@ -1,0 +1,82 @@
+import { PurposeMutations } from '@/api/purpose'
+import { useDialog } from '@/stores'
+import type { DialogRejectPurposeVersionProps } from '@/types/dialog.types'
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material'
+import React from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { RHFTextField } from '../shared/react-hook-form-inputs'
+
+type RejectPurposeVersionFormValues = {
+  reason: string
+}
+
+export const DialogRejectPurposeVersion: React.FC<DialogRejectPurposeVersionProps> = ({
+  purposeId,
+  versionId,
+  isChangePlanRequest,
+}) => {
+  const ariaLabelId = React.useId()
+
+  const { t } = useTranslation('shared-components', {
+    keyPrefix: 'dialogRejectPurposeVersion',
+  })
+  const { closeDialog } = useDialog()
+  const { mutate: rejectVersion } = PurposeMutations.useRejectVersion()
+
+  const formMethods = useForm<RejectPurposeVersionFormValues>({
+    defaultValues: { reason: '' },
+  })
+
+  const onSubmit = ({ reason }: RejectPurposeVersionFormValues) => {
+    rejectVersion({ purposeId, versionId, rejectionReason: reason }, { onSuccess: closeDialog })
+  }
+
+  return (
+    <Dialog aria-labelledby={ariaLabelId} open onClose={closeDialog} fullWidth>
+      <FormProvider {...formMethods}>
+        <Box component="form" noValidate onSubmit={formMethods.handleSubmit(onSubmit)}>
+          <DialogTitle id={ariaLabelId} sx={{ pb: 1 }}>
+            {t(isChangePlanRequest ? 'title.changePlan' : 'title.newPurpose')}
+          </DialogTitle>
+
+          <DialogContent>
+            <Typography variant="body2" sx={{ mb: 3 }}>
+              {t(isChangePlanRequest ? 'subtitle.changePlan' : 'subtitle.newPurpose')}
+            </Typography>
+            <RHFTextField
+              name="reason"
+              label={t('content.reason.label')}
+              infoLabel={t(
+                isChangePlanRequest
+                  ? 'content.reason.infoLabel.changePlan'
+                  : 'content.reason.infoLabel.newPurpose'
+              )}
+              focusOnMount
+              multiline
+              inputProps={{ maxLength: 1000 }}
+              rules={{ required: true, minLength: 20 }}
+            />
+          </DialogContent>
+
+          <DialogActions>
+            <Button type="button" variant="outlined" onClick={closeDialog}>
+              {t('actions.cancelLabel')}
+            </Button>
+            <Button variant="contained" type="submit">
+              {t('actions.confirmLabel')}
+            </Button>
+          </DialogActions>
+        </Box>
+      </FormProvider>
+    </Dialog>
+  )
+}

--- a/src/components/shared/RejectReasonDrawer.tsx
+++ b/src/components/shared/RejectReasonDrawer.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { Drawer } from './Drawer'
+import { Link, Stack, Typography } from '@mui/material'
+import { InformationContainer } from '@pagopa/interop-fe-commons'
+import { formatThousands } from '@/utils/format.utils'
+import { useTranslation } from 'react-i18next'
+
+type RejectReasonDrawerProps = {
+  rejectReason: string
+  rejectedValue?: number
+  isOpen: boolean
+  onClose: VoidFunction
+  guideLink: string
+}
+
+export const RejectReasonDrawer: React.FC<RejectReasonDrawerProps> = ({
+  isOpen,
+  onClose,
+  rejectReason,
+  rejectedValue,
+  guideLink,
+}) => {
+  const { t } = useTranslation('shared-components', { keyPrefix: 'drawerRejectReason' })
+
+  return (
+    <Drawer isOpen={isOpen} onClose={onClose} title={t('title')}>
+      <Stack spacing={3}>
+        <InformationContainer
+          label={t('rejectedReasonLabel')}
+          content={rejectReason}
+          direction="column"
+        />
+        {rejectedValue && (
+          <InformationContainer
+            label={t('rejectedValueLabel')}
+            content={formatThousands(rejectedValue)}
+            direction="column"
+          />
+        )}
+        <Typography variant="body2" component="pre">
+          {t('defaultServiceString')}
+        </Typography>
+        <Link variant="body2" underline="hover" href={guideLink} target="_blank">
+          {t('guideLinkLabel')}
+        </Link>
+      </Stack>
+    </Drawer>
+  )
+}

--- a/src/components/shared/RejectReasonDrawer.tsx
+++ b/src/components/shared/RejectReasonDrawer.tsx
@@ -10,7 +10,7 @@ type RejectReasonDrawerProps = {
   rejectedValue?: number
   isOpen: boolean
   onClose: VoidFunction
-  guideLink: string
+  guideLink?: string
 }
 
 export const RejectReasonDrawer: React.FC<RejectReasonDrawerProps> = ({
@@ -40,9 +40,11 @@ export const RejectReasonDrawer: React.FC<RejectReasonDrawerProps> = ({
         <Typography variant="body2" component="pre">
           {t('defaultServiceString')}
         </Typography>
-        <Link variant="body2" underline="hover" href={guideLink} target="_blank">
-          {t('guideLinkLabel')}
-        </Link>
+        {guideLink && (
+          <Link variant="body2" underline="hover" href={guideLink} target="_blank">
+            {t('guideLinkLabel')}
+          </Link>
+        )}
       </Stack>
     </Drawer>
   )

--- a/src/components/shared/StatusChip.tsx
+++ b/src/components/shared/StatusChip.tsx
@@ -38,6 +38,7 @@ const CHIP_COLORS_PURPOSE: Record<PurposeVersionState, MUIColor> = {
   SUSPENDED: 'error',
   WAITING_FOR_APPROVAL: 'warning',
   ARCHIVED: 'info',
+  REJECTED: 'error',
 }
 
 const chipColors = {
@@ -131,37 +132,25 @@ export const StatusChip: React.FC<StatusChipProps> = (props) => {
 const PurposeStatusChip: React.FC<{ purpose: Purpose }> = ({ purpose }) => {
   const { t } = useTranslation('common')
 
-  const purposeState = purpose.currentVersion?.state ?? 'DRAFT'
+  const currentVersionState = purpose.currentVersion?.state ?? 'DRAFT'
 
-  const isPurposeSuspended =
-    purpose?.currentVersion && purpose?.currentVersion.state === 'SUSPENDED'
+  const waitingForApprovalVersionState =
+    purpose.waitingForApprovalVersion?.state ?? 'WAITING_FOR_APPROVAL'
 
   return (
     <Stack direction="row" spacing={1}>
       {purpose.currentVersion && (
-        <>
-          {isPurposeSuspended ? (
-            <Chip
-              size="small"
-              label={t('status.purpose.SUSPENDED')}
-              color={chipColors['purpose'][purposeState]}
-            />
-          ) : (
-            <Chip
-              size="small"
-              label={t(
-                `status.purpose.${purposeState as Exclude<PurposeVersionState, 'SUSPENDED'>}`
-              )}
-              color={chipColors['purpose'][purposeState]}
-            />
-          )}
-        </>
+        <Chip
+          size="small"
+          label={t(`status.purpose.${currentVersionState}`)}
+          color={chipColors['purpose'][currentVersionState]}
+        />
       )}
       {purpose.waitingForApprovalVersion && !purpose.currentVersion && (
         <Chip
           size="small"
-          label={t('status.purpose.WAITING_FOR_APPROVAL')}
-          color={chipColors['purpose'][purpose.waitingForApprovalVersion.state]}
+          label={t(`status.purpose.${waitingForApprovalVersionState}`)}
+          color={chipColors['purpose'][waitingForApprovalVersionState]}
         />
       )}
     </Stack>

--- a/src/components/shared/StatusChip.tsx
+++ b/src/components/shared/StatusChip.tsx
@@ -137,6 +137,8 @@ const PurposeStatusChip: React.FC<{ purpose: Purpose }> = ({ purpose }) => {
   const waitingForApprovalVersionState =
     purpose.waitingForApprovalVersion?.state ?? 'WAITING_FOR_APPROVAL'
 
+  const rejectedVersionState = purpose.rejectedVersion?.state ?? 'REJECTED'
+
   return (
     <Stack direction="row" spacing={1}>
       {purpose.currentVersion && (
@@ -151,6 +153,13 @@ const PurposeStatusChip: React.FC<{ purpose: Purpose }> = ({ purpose }) => {
           size="small"
           label={t(`status.purpose.${waitingForApprovalVersionState}`)}
           color={chipColors['purpose'][waitingForApprovalVersionState]}
+        />
+      )}
+      {purpose.rejectedVersion && !purpose.currentVersion && (
+        <Chip
+          size="small"
+          label={t(`status.purpose.${rejectedVersionState}`)}
+          color={chipColors['purpose'][rejectedVersionState]}
         />
       )}
     </Stack>

--- a/src/components/shared/__tests__/__snapshots__/StatusChip.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/StatusChip.test.tsx.snap
@@ -394,7 +394,7 @@ exports[`StatusChip > should match the snapshot (purpose - with only waiting for
       class="MuiStack-root css-niqf4j-MuiStack-root"
     >
       <div
-        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-j2ob3e-MuiChip-root"
+        class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorWarning MuiChip-filledWarning css-xiyh2c-MuiChip-root"
       >
         <span
           class="MuiChip-label MuiChip-labelSmall css-wjsjww-MuiChip-label"

--- a/src/hooks/useGetConsumerPurposesActions.ts
+++ b/src/hooks/useGetConsumerPurposesActions.ts
@@ -94,7 +94,11 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
     return { actions: [deleteAction] }
   }
 
-  if (purpose?.currentVersion?.state === 'ARCHIVED' && purpose.eservice.mode === 'DELIVER') {
+  if (
+    purpose.eservice.mode === 'DELIVER' &&
+    ((!purpose.currentVersion && purpose.rejectedVersion) ||
+      purpose?.currentVersion?.state === 'ARCHIVED')
+  ) {
     return { actions: [cloneAction] }
   }
 

--- a/src/hooks/useGetProviderPurposesActions.ts
+++ b/src/hooks/useGetProviderPurposesActions.ts
@@ -5,6 +5,8 @@ import type { Purpose } from '@/api/api.generatedTypes'
 import { AuthHooks } from '@/api/auth'
 import PauseCircleOutlineIcon from '@mui/icons-material/PauseCircleOutline'
 import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline'
+import CloseIcon from '@mui/icons-material/Close'
+import { useDialog } from '@/stores'
 
 function useGetProviderPurposesActions(purpose?: Purpose) {
   const { t } = useTranslation('common', { keyPrefix: 'actions' })
@@ -14,16 +16,25 @@ function useGetProviderPurposesActions(purpose?: Purpose) {
   const { mutate: activateVersion } = PurposeMutations.useActivateVersion()
   const { mutate: suspendVersion } = PurposeMutations.useSuspendVersion()
 
+  const { openDialog } = useDialog()
+
   const currentVersion = purpose?.currentVersion
+  const waitingForApprovalVersion = purpose?.waitingForApprovalVersion
 
   const actions: Array<ActionItemButton> = []
 
-  if (!purpose || purpose?.currentVersion?.state === 'ARCHIVED' || !isAdmin) {
+  if (
+    !purpose ||
+    purpose?.currentVersion?.state === 'ARCHIVED' ||
+    !isAdmin ||
+    !!purpose.rejectedVersion
+  ) {
     return { actions }
   }
 
   const isSuspended = currentVersion && currentVersion.state === 'SUSPENDED'
   const isSuspendedByProvider = purpose.suspendedByProducer
+  const isNewPurpose = !currentVersion && !!waitingForApprovalVersion
 
   if (currentVersion && (!isSuspended || (isSuspended && !isSuspendedByProvider))) {
     actions.push({
@@ -31,7 +42,6 @@ function useGetProviderPurposesActions(purpose?: Purpose) {
       label: t('suspend'),
       color: 'error',
       icon: PauseCircleOutlineIcon,
-      variant: 'naked',
     })
   }
 
@@ -41,8 +51,31 @@ function useGetProviderPurposesActions(purpose?: Purpose) {
       label: t('activate'),
       color: 'primary',
       icon: PlayCircleOutlineIcon,
-      variant: 'naked',
     })
+  }
+
+  if (isNewPurpose) {
+    actions.push(
+      {
+        action: () =>
+          openDialog({
+            type: 'rejectPurposeVersion',
+            purposeId: purpose.id,
+            versionId: waitingForApprovalVersion.id,
+            isChangePlanRequest: false,
+          }),
+        label: t('reject'),
+        color: 'error',
+        icon: CloseIcon,
+      },
+      {
+        action: () =>
+          activateVersion({ purposeId: purpose.id, versionId: waitingForApprovalVersion.id }),
+        label: t('activate'),
+        color: 'primary',
+        icon: PlayCircleOutlineIcon,
+      }
+    )
   }
 
   return { actions }

--- a/src/pages/ConsumerPurposeDetailsPage/ConsumerPurposeDetails.page.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/ConsumerPurposeDetails.page.tsx
@@ -100,7 +100,6 @@ const ConsumerPurposeDetailsPage: React.FC = () => {
           onClose={closeDrawer}
           rejectReason={purpose.rejectedVersion.rejectionReason}
           rejectedValue={purpose.rejectedVersion.dailyCalls}
-          guideLink={'www.google.com'} // TODO link alla guida
         />
       )}
     </PageContainer>

--- a/src/pages/ConsumerPurposeDetailsPage/ConsumerPurposeDetails.page.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/ConsumerPurposeDetails.page.tsx
@@ -4,12 +4,14 @@ import { useActiveTab } from '@/hooks/useActiveTab'
 import useGetConsumerPurposesActions from '@/hooks/useGetConsumerPurposesActions'
 import { Link, useParams } from '@/router'
 import { TabContext, TabList, TabPanel } from '@mui/lab'
-import { Alert, Grid, Tab, Typography } from '@mui/material'
+import { Alert, Grid, Tab, Typography, Link as MUILink } from '@mui/material'
 import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { PurposeClientsTab } from './components/PurposeClientsTab'
 import { PurposeDetailTabSkeleton, PurposeDetailsTab } from './components/PurposeDetailsTab'
 import useGetPurposeStateAlertProps from './hooks/useGetPurposeStateAlertProps'
+import { useDrawerState } from '@/hooks/useDrawerState'
+import { RejectReasonDrawer } from '@/components/shared/RejectReasonDrawer'
 
 const ConsumerPurposeDetailsPage: React.FC = () => {
   const { purposeId } = useParams<'SUBSCRIBE_PURPOSE_DETAILS'>()
@@ -17,6 +19,8 @@ const ConsumerPurposeDetailsPage: React.FC = () => {
 
   const { data: purpose, isLoading } = PurposeQueries.useGetSingle(purposeId, { suspense: false })
   const { activeTab, updateActiveTab } = useActiveTab('details')
+
+  const { isOpen, openDrawer, closeDrawer } = useDrawerState()
 
   const { actions } = useGetConsumerPurposesActions(purpose)
 
@@ -37,19 +41,27 @@ const ConsumerPurposeDetailsPage: React.FC = () => {
       }}
     >
       {alertProps && (
-        <Alert severity={alertProps.severity} sx={{ mb: 3 }}>
+        <Alert severity={alertProps.severity} sx={{ mb: 3 }} variant={alertProps.variant}>
           <Trans
             components={{
               1: alertProps.link ? (
                 <Link
-                  to={alertProps.link!.to}
-                  params={alertProps.link!.params}
-                  options={alertProps.link!.options}
+                  to={alertProps.link.to}
+                  params={alertProps.link.params}
+                  options={alertProps.link.options}
                 />
               ) : (
                 <Typography component="span" variant="inherit" />
               ),
               strong: <Typography component="span" variant="inherit" fontWeight={600} />,
+              2: (
+                <MUILink
+                  onClick={openDrawer}
+                  variant="body2"
+                  fontWeight={700}
+                  sx={{ cursor: 'pointer' }}
+                />
+              ),
             }}
           >
             {alertProps.content}
@@ -70,7 +82,7 @@ const ConsumerPurposeDetailsPage: React.FC = () => {
           <Grid container>
             <Grid item xs={8}>
               {purpose && !isLoading ? (
-                <PurposeDetailsTab purpose={purpose} />
+                <PurposeDetailsTab purpose={purpose} openRejectReasonDrawer={openDrawer} />
               ) : (
                 <PurposeDetailTabSkeleton />
               )}
@@ -82,6 +94,15 @@ const ConsumerPurposeDetailsPage: React.FC = () => {
           <PurposeClientsTab purposeId={purposeId} isPurposeArchived={isPurposeArchived} />
         </TabPanel>
       </TabContext>
+      {purpose && purpose.rejectedVersion?.rejectionReason && (
+        <RejectReasonDrawer
+          isOpen={isOpen}
+          onClose={closeDrawer}
+          rejectReason={purpose.rejectedVersion.rejectionReason}
+          rejectedValue={purpose.rejectedVersion.dailyCalls}
+          guideLink={'www.google.com'} // TODO link alla guida
+        />
+      )}
     </PageContainer>
   )
 }

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsPlanCard.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsPlanCard.tsx
@@ -83,7 +83,7 @@ export const ConsumerPurposeDetailsDailyCallsPlanCard: React.FC<
             <Box flexGrow={1}>
               <Typography variant="h4">{formatThousands(dailyCalls)}</Typography>
             </Box>
-            {!(isSuspended || isArchived || waitingForApprovalVersion || rejectedVersion) && (
+            {!(isSuspended || isArchived || waitingForApprovalVersion || isNewPurposeRejected) && (
               <>
                 <Divider />
                 <IconLink

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsUpdatePlanCard.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsUpdatePlanCard.tsx
@@ -44,15 +44,10 @@ export const ConsumerPurposeDetailsDailyCallsUpdatePlanCard: React.FC<
     >
       <CardHeader
         sx={{ px: 3, pt: 3, pb: 1 }}
-        disableTypography={true}
-        title={
-          <Stack spacing={1}>
-            <Typography variant="sidenav">{t('title')}</Typography>
-            <Typography color="text.secondary" variant="body2">
-              {t('subtitle')}
-            </Typography>
-          </Stack>
-        }
+        titleTypographyProps={{ variant: 'sidenav' }}
+        title={t('title')}
+        subheaderTypographyProps={{ variant: 'body2', color: 'text.secondary' }}
+        subheader={t('subtitle')}
       />
       <CardContent sx={{ px: 3, pt: 1, display: 'flex', flexGrow: 1 }}>
         <Stack direction="column" spacing={2} flexGrow={1}>

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsLoadEstimateSection.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsLoadEstimateSection.tsx
@@ -1,26 +1,47 @@
 import type { Purpose } from '@/api/api.generatedTypes'
 import { SectionContainer } from '@/components/layout/containers'
 import React from 'react'
-import { Stack } from '@mui/material'
-import { useTranslation } from 'react-i18next'
+import { Alert, Link, Stack } from '@mui/material'
+import { Trans, useTranslation } from 'react-i18next'
 import { ConsumerPurposeDetailsDailyCallsThresholdsCard } from './ConsumerPurposeDetailsDailyCallsThresholdsCard'
 import { ConsumerPurposeDetailsDailyCallsPlanCard } from './ConsumerPurposeDetailsDailyCallsPlanCard'
 import { ConsumerPurposeDetailsDailyCallsUpdatePlanCard } from './ConsumerPurposeDetailsDailyCallsUpdatePlanCard'
 
 type ConsumerPurposeDetailsLoadEstimateSectionProps = {
   purpose: Purpose
+  openRejectReasonDrawer: VoidFunction
 }
 
 export const ConsumerPurposeDetailsLoadEstimateSection: React.FC<
   ConsumerPurposeDetailsLoadEstimateSectionProps
-> = ({ purpose }) => {
+> = ({ purpose, openRejectReasonDrawer }) => {
   const { t } = useTranslation('purpose', {
     keyPrefix: 'consumerView.sections.loadEstimate',
   })
 
+  const isUpdatePlanRejected = Boolean(purpose.currentVersion) && Boolean(purpose.rejectedVersion)
+
   return (
     <SectionContainer title={t('title')} description={t('description')}>
       <Stack spacing={3}>
+        {isUpdatePlanRejected && (
+          <Alert severity="error" variant="outlined">
+            <Trans
+              components={{
+                1: (
+                  <Link
+                    onClick={openRejectReasonDrawer}
+                    variant="body2"
+                    fontWeight={700}
+                    sx={{ cursor: 'pointer' }}
+                  />
+                ),
+              }}
+            >
+              {t('rejectedUpdatePlanAlert')}
+            </Trans>
+          </Alert>
+        )}
         <Stack direction="row" spacing={3}>
           <ConsumerPurposeDetailsDailyCallsPlanCard purpose={purpose} />
           <ConsumerPurposeDetailsDailyCallsUpdatePlanCard purpose={purpose} />

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/PurposeDetailsTab.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/PurposeDetailsTab.tsx
@@ -7,13 +7,20 @@ import { Stack } from '@mui/material'
 
 interface PurposeDetailsTabProps {
   purpose: Purpose
+  openRejectReasonDrawer: VoidFunction
 }
 
-export const PurposeDetailsTab: React.FC<PurposeDetailsTabProps> = ({ purpose }) => {
+export const PurposeDetailsTab: React.FC<PurposeDetailsTabProps> = ({
+  purpose,
+  openRejectReasonDrawer,
+}) => {
   return (
     <Stack spacing={3}>
       <ConsumerPurposeDetailsGeneralInfoSection purpose={purpose} />
-      <ConsumerPurposeDetailsLoadEstimateSection purpose={purpose} />
+      <ConsumerPurposeDetailsLoadEstimateSection
+        purpose={purpose}
+        openRejectReasonDrawer={openRejectReasonDrawer}
+      />
     </Stack>
   )
 }

--- a/src/pages/ConsumerPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
+++ b/src/pages/ConsumerPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
@@ -14,6 +14,7 @@ function useGetPurposeStateAlertProps(purpose: Purpose | undefined):
         params?: React.ComponentProps<typeof Link>['params']
         options?: React.ComponentProps<typeof Link>['options']
       }
+      variant: AlertProps['variant']
     }
   | undefined {
   const { t } = useTranslation('purpose', { keyPrefix: 'consumerView' })
@@ -25,11 +26,13 @@ function useGetPurposeStateAlertProps(purpose: Purpose | undefined):
     Boolean(purpose.waitingForApprovalVersion) && Boolean(!purpose.currentVersion)
   const isPurposeActive = purpose.currentVersion?.state === 'ACTIVE'
   const isPurposeArchived = purpose.currentVersion?.state === 'ARCHIVED'
+  const isPurposeRejected = Boolean(purpose.rejectedVersion)
 
   if (isPurposeSuspended) {
     return {
       severity: 'error',
       content: t('suspendedAlert'),
+      variant: 'standard',
     }
   }
 
@@ -37,6 +40,7 @@ function useGetPurposeStateAlertProps(purpose: Purpose | undefined):
     return {
       severity: 'warning',
       content: t('waitingForApprovalAlert'),
+      variant: 'standard',
     }
   }
 
@@ -44,9 +48,35 @@ function useGetPurposeStateAlertProps(purpose: Purpose | undefined):
     return {
       severity: 'info',
       content: t('archivedPurposeAlert'),
+      variant: 'standard',
       link: {
         to: 'SUBSCRIBE_PURPOSE_CREATE',
       },
+    }
+  }
+
+  if (isPurposeRejected && purpose.currentVersion) {
+    return {
+      severity: 'info',
+      content: t('rejectedUpdatePlanInfoAlert'),
+      variant: 'standard',
+      link: {
+        to: 'SUBSCRIBE_PURPOSE_DETAILS',
+        params: { purposeId: purpose.id },
+        options: {
+          urlParams: {
+            tab: 'details',
+          },
+        },
+      },
+    }
+  }
+
+  if (isPurposeRejected && !purpose.currentVersion) {
+    return {
+      severity: 'error',
+      content: t('rejectedPurposeAlert'),
+      variant: 'outlined',
     }
   }
 
@@ -54,6 +84,7 @@ function useGetPurposeStateAlertProps(purpose: Purpose | undefined):
     return {
       severity: 'info',
       content: t('noClientsAlert'),
+      variant: 'standard',
       link: {
         to: 'SUBSCRIBE_PURPOSE_DETAILS',
         params: { purposeId: purpose.id },

--- a/src/pages/ConsumerPurposesListPage/ConsumerPurposesList.page.tsx
+++ b/src/pages/ConsumerPurposesListPage/ConsumerPurposesList.page.tsx
@@ -81,6 +81,7 @@ const ConsumerPurposesListPage: React.FC = () => {
         },
         { label: tPurpose('filters.statusField.optionLabels.SUSPENDED'), value: 'SUSPENDED' },
         { label: tPurpose('filters.statusField.optionLabels.ARCHIVED'), value: 'ARCHIVED' },
+        { label: tPurpose('filters.statusField.optionLabels.REJECTED'), value: 'REJECTED' },
       ],
     },
   ])

--- a/src/pages/ProviderPurposeDetailsPage/ProviderPurposeDetails.page.tsx
+++ b/src/pages/ProviderPurposeDetailsPage/ProviderPurposeDetails.page.tsx
@@ -81,7 +81,6 @@ const ProviderPurposeDetailsPage: React.FC = () => {
           onClose={closeDrawer}
           rejectReason={purpose.rejectedVersion.rejectionReason}
           rejectedValue={purpose.rejectedVersion.dailyCalls}
-          guideLink={'www.google.com'} // TODO link alla guida
         />
       )}
     </PageContainer>

--- a/src/pages/ProviderPurposeDetailsPage/ProviderPurposeDetails.page.tsx
+++ b/src/pages/ProviderPurposeDetailsPage/ProviderPurposeDetails.page.tsx
@@ -3,17 +3,19 @@ import { PageContainer } from '@/components/layout/containers'
 import useGetProviderPurposesActions from '@/hooks/useGetProviderPurposesActions'
 import { useParams } from '@/router'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import {
   ProviderPurposeDetailsGeneralInfoSection,
   ProviderPurposeDetailsGeneralInfoSectionSkeleton,
 } from './components/ProviderPurposeDetailsGeneralInfoSection'
-import { Alert, Grid, Stack } from '@mui/material'
+import { Alert, Grid, Link, Stack, Typography } from '@mui/material'
 import {
   ProviderPurposeDetailsLoadEstimateSection,
   ProviderPurposeDetailsLoadEstimateSectionSkeleton,
 } from './components/ProviderPurposeDetailsLoadEstimateSection'
 import useGetPurposeStateAlertProps from './hooks/useGetPurposeStateAlertProps'
+import { useDrawerState } from '@/hooks/useDrawerState'
+import { RejectReasonDrawer } from '@/components/shared/RejectReasonDrawer'
 
 const ProviderPurposeDetailsPage: React.FC = () => {
   const { t } = useTranslation('purpose')
@@ -22,6 +24,8 @@ const ProviderPurposeDetailsPage: React.FC = () => {
   const { data: purpose, isLoading } = PurposeQueries.useGetSingle(purposeId, { suspense: false })
 
   const { actions } = useGetProviderPurposesActions(purpose)
+
+  const { isOpen, openDrawer, closeDrawer } = useDrawerState()
 
   const alertProps = useGetPurposeStateAlertProps(purpose)
 
@@ -37,8 +41,23 @@ const ProviderPurposeDetailsPage: React.FC = () => {
       }}
     >
       {alertProps && (
-        <Alert severity={alertProps.severity} sx={{ mb: 3 }}>
-          {alertProps.content}
+        <Alert severity={alertProps.severity} sx={{ mb: 3 }} variant={alertProps.variant}>
+          <Typography variant="body2">
+            <Trans
+              components={{
+                1: (
+                  <Link
+                    onClick={openDrawer}
+                    variant="body2"
+                    fontWeight={700}
+                    sx={{ cursor: 'pointer' }}
+                  />
+                ),
+              }}
+            >
+              {alertProps.content}
+            </Trans>
+          </Typography>
         </Alert>
       )}
       <Grid container>
@@ -48,11 +67,23 @@ const ProviderPurposeDetailsPage: React.FC = () => {
           ) : (
             <Stack spacing={3}>
               <ProviderPurposeDetailsGeneralInfoSection purpose={purpose} />
-              <ProviderPurposeDetailsLoadEstimateSection purpose={purpose} />
+              <ProviderPurposeDetailsLoadEstimateSection
+                purpose={purpose}
+                openRejectReasonDrawer={openDrawer}
+              />
             </Stack>
           )}
         </Grid>
       </Grid>
+      {purpose && purpose.rejectedVersion?.rejectionReason && (
+        <RejectReasonDrawer
+          isOpen={isOpen}
+          onClose={closeDrawer}
+          rejectReason={purpose.rejectedVersion.rejectionReason}
+          rejectedValue={purpose.rejectedVersion.dailyCalls}
+          guideLink={'www.google.com'} // TODO link alla guida
+        />
+      )}
     </PageContainer>
   )
 }

--- a/src/pages/ProviderPurposeDetailsPage/components/ProviderPurposeDetailsDailyCallsPlanCard.tsx
+++ b/src/pages/ProviderPurposeDetailsPage/components/ProviderPurposeDetailsDailyCallsPlanCard.tsx
@@ -50,9 +50,17 @@ export const ProviderPurposeDetailsDailyCallsPlanCard: React.FC<
   const waitingForApprovalVersion = purpose.waitingForApprovalVersion
   const isChangePlanRequest = Boolean(waitingForApprovalVersion) && Boolean(purpose.currentVersion)
 
-  const title = waitingForApprovalVersion
-    ? t(`title.waitingForApprovalPlan.${isChangePlanRequest ? 'changePlan' : 'newPurpose'}`)
-    : t('title.activePlan')
+  const rejectedVersion = purpose.rejectedVersion
+  const isNewPurposeRejected = Boolean(rejectedVersion) && !Boolean(purpose.currentVersion)
+
+  const title = React.useMemo(() => {
+    if (waitingForApprovalVersion)
+      return t(`title.waitingForApprovalPlan.${isChangePlanRequest ? 'changePlan' : 'newPurpose'}`)
+
+    if (isNewPurposeRejected) return t('title.rejectedPlan')
+
+    return t('title.activePlan')
+  }, [isChangePlanRequest, isNewPurposeRejected, t, waitingForApprovalVersion])
 
   const handleSetApprovalDate = () => {
     if (!waitingForApprovalVersion || !isAdmin) return null
@@ -121,7 +129,7 @@ export const ProviderPurposeDetailsDailyCallsPlanCard: React.FC<
           sx={{ px: 3, pt: 3, pb: 1 }}
         />
         <CardContent sx={{ px: 3, pt: 1 }}>
-          {waitingForApprovalVersion ? (
+          {waitingForApprovalVersion && (
             <Stack direction="column" spacing={2}>
               <Stack direction="row" alignItems="space-between">
                 <Box flex={1}>
@@ -177,7 +185,13 @@ export const ProviderPurposeDetailsDailyCallsPlanCard: React.FC<
                   : t('setApprovalDateLink.insertLabel')}
               </IconLink>
             </Stack>
-          ) : (
+          )}
+          {isNewPurposeRejected && (
+            <Typography variant="h4">
+              {formatThousands(purpose.rejectedVersion!.dailyCalls)}
+            </Typography>
+          )}
+          {!waitingForApprovalVersion && !isNewPurposeRejected && (
             <Typography variant="h4">
               {formatThousands(purpose.currentVersion!.dailyCalls)}
             </Typography>

--- a/src/pages/ProviderPurposeDetailsPage/components/ProviderPurposeDetailsLoadEstimateSection.tsx
+++ b/src/pages/ProviderPurposeDetailsPage/components/ProviderPurposeDetailsLoadEstimateSection.tsx
@@ -3,23 +3,44 @@ import { SectionContainer, SectionContainerSkeleton } from '@/components/layout/
 import React from 'react'
 import { ProviderPurposeDetailsDailyCallsThresholdsCard } from './ProviderPurposeDetailsDailyCallsThresholdsCard'
 import { ProviderPurposeDetailsDailyCallsPlanCard } from './ProviderPurposeDetailsDailyCallsPlanCard'
-import { Stack } from '@mui/material'
-import { useTranslation } from 'react-i18next'
+import { Alert, Link, Stack } from '@mui/material'
+import { Trans, useTranslation } from 'react-i18next'
 
 type ProviderPurposeDetailsLoadEstimateSectionProps = {
   purpose: Purpose
+  openRejectReasonDrawer: VoidFunction
 }
 
 export const ProviderPurposeDetailsLoadEstimateSection: React.FC<
   ProviderPurposeDetailsLoadEstimateSectionProps
-> = ({ purpose }) => {
+> = ({ purpose, openRejectReasonDrawer }) => {
   const { t } = useTranslation('purpose', {
     keyPrefix: 'providerView.sections.loadEstimate',
   })
 
+  const isUpdatePlanRejected = Boolean(purpose.currentVersion) && Boolean(purpose.rejectedVersion)
+
   return (
     <SectionContainer title={t('title')} description={t('description')}>
       <Stack spacing={3}>
+        {isUpdatePlanRejected && (
+          <Alert severity="error" variant="outlined">
+            <Trans
+              components={{
+                1: (
+                  <Link
+                    onClick={openRejectReasonDrawer}
+                    variant="body2"
+                    fontWeight={700}
+                    sx={{ cursor: 'pointer' }}
+                  />
+                ),
+              }}
+            >
+              {t('rejectedUpdatePlanAlert')}
+            </Trans>
+          </Alert>
+        )}
         <ProviderPurposeDetailsDailyCallsPlanCard purpose={purpose} />
         <ProviderPurposeDetailsDailyCallsThresholdsCard
           dailyCallsPerConsumer={purpose.dailyCallsPerConsumer}

--- a/src/pages/ProviderPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
+++ b/src/pages/ProviderPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
@@ -2,9 +2,13 @@ import type { Purpose } from '@/api/api.generatedTypes'
 import type { AlertProps } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
-function useGetPurposeStateAlertProps(
-  purpose: Purpose | undefined
-): { severity: AlertProps['severity']; content: AlertProps['children'] } | undefined {
+function useGetPurposeStateAlertProps(purpose: Purpose | undefined):
+  | {
+      severity: AlertProps['severity']
+      content: AlertProps['children']
+      variant: AlertProps['variant']
+    }
+  | undefined {
   const { t } = useTranslation('purpose', { keyPrefix: 'providerView' })
 
   if (!purpose) return undefined
@@ -13,11 +17,13 @@ function useGetPurposeStateAlertProps(
   const isUpgradePending =
     Boolean(purpose.waitingForApprovalVersion) && Boolean(purpose.currentVersion)
   const isArchived = purpose.currentVersion?.state === 'ARCHIVED'
+  const isRejected = Boolean(purpose.rejectedVersion)
 
   if (isSuspended) {
     return {
       severity: 'error',
       content: t('suspendedAlert'),
+      variant: 'standard',
     }
   }
 
@@ -25,6 +31,7 @@ function useGetPurposeStateAlertProps(
     return {
       severity: 'warning',
       content: t('waitingForApprovalAlert'),
+      variant: 'standard',
     }
   }
 
@@ -32,6 +39,23 @@ function useGetPurposeStateAlertProps(
     return {
       severity: 'info',
       content: t('archivedPurposeAlert'),
+      variant: 'standard',
+    }
+  }
+
+  if (isRejected && purpose.currentVersion) {
+    return {
+      severity: 'info',
+      content: t('rejectedUpdatePlanInfoAlert'),
+      variant: 'standard',
+    }
+  }
+
+  if (isRejected && !purpose.currentVersion) {
+    return {
+      severity: 'error',
+      content: t('rejectedPurposeAlert'),
+      variant: 'outlined',
     }
   }
 

--- a/src/pages/ProviderPurposesListPage/ProviderPurposesList.page.tsx
+++ b/src/pages/ProviderPurposesListPage/ProviderPurposesList.page.tsx
@@ -76,6 +76,7 @@ const ProviderPurposesListPage: React.FC = () => {
         },
         { label: tPurpose('statusField.optionLabels.SUSPENDED'), value: 'SUSPENDED' },
         { label: tPurpose('statusField.optionLabels.ARCHIVED'), value: 'ARCHIVED' },
+        { label: tPurpose('statusField.optionLabels.REJECTED'), value: 'REJECTED' },
       ],
     },
   ])

--- a/src/static/locales/en/common.json
+++ b/src/static/locales/en/common.json
@@ -85,7 +85,8 @@
       "ACTIVE": "active",
       "SUSPENDED": "suspended",
       "WAITING_FOR_APPROVAL": "waiting for approval",
-      "ARCHIVED": "archived"
+      "ARCHIVED": "archived",
+      "REJECTED": "rejected"
     }
   },
   "userProductRole": {

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -443,6 +443,13 @@
         "description": "By clicking \"confirm\", the update to the number of API calls/day for this purpose will be deleted. This purpose can still be used with the former number of API calls/day declared"
       }
     },
+    "rejectVersion": {
+      "loading": "Rejecting purpose",
+      "outcome": {
+        "success": "The purpose was rejected successfully",
+        "error": "The purpose could not be rejected. Please, try again!"
+      }
+    },
     "downloadRiskAnalysis": {
       "loading": "Downloading risk analysis document",
       "outcome": {

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -141,7 +141,8 @@
           "ACTIVE": "Active",
           "SUSPENDED": "Suspended",
           "WAITING_FOR_APPROVAL": "Waiting for approval",
-          "ARCHIVED": "Archived"
+          "ARCHIVED": "Archived",
+          "REJECTED": "Rejected"
         }
       }
     }
@@ -150,6 +151,8 @@
     "suspendedAlert": "This purpose is suspended. Until it is reactivated, the user will not be able to access the data provided through the API.",
     "waitingForApprovalAlert": "The consumer has requested a load estimate update which requires your approval. Check the “Load Estimate” section.",
     "archivedPurposeAlert": "The user will not be able to obtain a voucher from PDND Interoperabilità for this purpose because it is archived.",
+    "rejectedPurposeAlert": "This purpose has been rejected. <1>Read here the reject reason</1>.",
+    "rejectedUpdatePlanInfoAlert": "A change of plan for this purpose was rejected. Check the “Load Estimate” section.",
     "sections": {
       "generalInformations": {
         "title": "General informations",
@@ -176,10 +179,14 @@
       "loadEstimate": {
         "title": "Load estimate",
         "description": "The number of API calls/day that the user estimates to make to the API of your e-service",
+        "rejectedUpdatePlanAlert": "The plan change was rejected. <1>Read the reject reasons here</1>.",
         "planCard": {
           "title": {
             "activePlan": "Consumer active plan",
-            "waitingForApprovalPlan": "The plan change requested by the user"
+            "waitingForApprovalPlan": {
+              "changePlan": "The plan change requested by the consumer",
+              "newPurpose": "The plan requested by the consumer"
+            }
           },
           "subtitle": "API calls/day",
           "expectApprovalDateInfo": "You estimated to activate this update on the day <strong>{{date}}</strong>",
@@ -187,14 +194,20 @@
             "insertLabel": "Enter estimated activation date",
             "modifyLabel": "Change estimated activation date"
           },
-          "activateUpdateButtonLabel": {
+          "activateVersionButtonLabel": {
             "label": "Activate now"
+          },
+          "rejectVersionButtonLabel": {
+            "label": "Reject"
           },
           "currentPlan": {
             "label": "Current plan"
           },
           "waitingForApprovalPlan": {
-            "label": "New plan required"
+            "label": {
+              "changePlan": "New required plan",
+              "newPurpose": "Required plan"
+            }
           }
         },
         "thresholdsCard": {
@@ -226,6 +239,8 @@
     "waitingForApprovalAlert": "This scope is awaiting approval. <strong>Until its activation</strong> by the provider you will <strong>not be able to access the data</strong> made available through the API and you will <strong>not be able to associate clients</strong>.",
     "archivedPurposeAlert": "This purpose is archived. You cannot access the data made available through the API. You can always <1>create a new one.</1>",
     "archivedPurposeClientsAlert": "This purpose has been archived. All clients were removed and new clients can no longer be associated",
+    "rejectedPurposeAlert": "This purpose has been rejected. <2>Read here the reject reason</2>.",
+    "rejectedUpdatePlanInfoAlert": "A change of plan for this purpose was rejected. Check the “Load Estimate” section in <1>Purpose Details</1>.",
     "noClientsAlert": "This purpose is active but has no associated clients. <1>Pair your first client</1> to use the e-service",
     "addClientToPurposeDisableTooltip": {
       "label": "Only an administrator can manage members of a client"
@@ -261,6 +276,7 @@
       "loadEstimate": {
         "title": "Load estimate",
         "description": "The number of API calls/day that the user estimates to make to the API of your e-service",
+        "rejectedUpdatePlanAlert": "The plan change was rejected. <1>Read the reject reasons here</1>.",
         "planCard": {
           "title": "Consumer active plan",
           "subtitle": "API calls/day",

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -186,7 +186,8 @@
             "waitingForApprovalPlan": {
               "changePlan": "The plan change requested by the consumer",
               "newPurpose": "The plan requested by the consumer"
-            }
+            },
+            "rejectedPlan": "The plan requested by the consumer"
           },
           "subtitle": "API calls/day",
           "expectApprovalDateInfo": "You estimated to activate this update on the day <strong>{{date}}</strong>",
@@ -278,7 +279,11 @@
         "description": "The number of API calls/day that the user estimates to make to the API of your e-service",
         "rejectedUpdatePlanAlert": "The plan change was rejected. <1>Read the reject reasons here</1>.",
         "planCard": {
-          "title": "Consumer active plan",
+          "title": {
+            "activePlan": "Consumer active plan",
+            "waitingForApprovalPlan": "Consumer requeste plan",
+            "rejectedPlan": "Consumer requested plan"
+          },
           "subtitle": "API calls/day",
           "changePlanRequestLink": {
             "label": "Request a change of plan"

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -115,6 +115,13 @@
       "checkbox": "I confirm that I understand the consequences of revocation"
     }
   },
+  "drawerRejectReason": {
+    "title": "Rejected reason",
+    "rejectedReasonLabel": "Description",
+    "rejectedValueLabel": "Rejected value",
+    "defaultServiceString": "---\n\nThank you for your cooperation,\n\nthe Interoperabilità Team.",
+    "guideLinkLabel": "For further doubts and information. Go to the manual."
+  },
   "copyToClipboardButton": {
     "copy": "Copy",
     "copied": "Copied"

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -35,6 +35,29 @@
       "confirmLabel": "Reject"
     }
   },
+  "dialogRejectPurposeVersion": {
+    "title": {
+      "changePlan": "Reject purpose plan change",
+      "newPurpose": "Reject purpose"
+    },
+    "subtitle": {
+      "changePlan": "By refusing this plan change, the user will still be able to continue using the previously available plan.",
+      "newPurpose": "By rejecting this purpose, the user will not be able to access your e-service data."
+    },
+    "content": {
+      "reason": {
+        "label": "Reason",
+        "infoLabel": {
+          "changePlan": "Enter the reason why you reject the plan change. Min 10 characters, max 250 characters",
+          "newPurpose": "Enter the reason why you reject the purpose. Min 10 characters, max 250 characters"
+        }
+      }
+    },
+    "actions": {
+      "cancelLabel": "Cancel",
+      "confirmLabel": "Reject"
+    }
+  },
   "dialogAddClientToPurpose": {
     "title": "Add clients",
     "content": {

--- a/src/static/locales/it/common.json
+++ b/src/static/locales/it/common.json
@@ -85,7 +85,8 @@
       "ACTIVE": "attiva",
       "SUSPENDED": "sospesa",
       "WAITING_FOR_APPROVAL": "in attesa di approvazione",
-      "ARCHIVED": "archiviata"
+      "ARCHIVED": "archiviata",
+      "REJECTED": "rifiutata"
     }
   },
   "userProductRole": {

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -443,6 +443,13 @@
         "description": "Cliccando \"conferma\", questo aggiornamento al numero di chiamate verso l'e-service dell'erogatore sarà cancellato. Potrai continuare a usare questa finalità con il numero di chiamate attuale"
       }
     },
+    "rejectVersion": {
+      "loading": "Stiamo rifiutando la finalità",
+      "outcome": {
+        "success": "La finalità è stata rifiutata correttamente",
+        "error": "Non è stato possibile rifiutare la finalità. Per favore, riprova!"
+      }
+    },
     "downloadRiskAnalysis": {
       "loading": "Stiamo scaricando il documento dell'analisi del rischio",
       "outcome": {

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -186,7 +186,8 @@
             "waitingForApprovalPlan": {
               "changePlan": "Il cambio piano richiesto dal fruitore",
               "newPurpose": "Il piano richiesto dal fruitore"
-            }
+            },
+            "rejectedPlan": "Il piano richiesto dal fruitore"
           },
           "subtitle": "Chiamate API/giorno",
           "expectApprovalDateInfo": "Hai stimato di attivare questo adeguamento il giorno <strong>{{date}}</strong>",
@@ -278,7 +279,11 @@
         "description": "Il numero di chiamate API/giorno che il fruitore stima di fare verso l’API del tuo e-service",
         "rejectedUpdatePlanAlert": "Il cambio piano è stato rifiutato. <1>Leggi qui i motivi del rifiuto</1>.",
         "planCard": {
-          "title": "Il piano attivo del fruitore",
+          "title": {
+            "activePlan": "Il piano attivo del fruitore",
+            "waitingForApprovalPlan": "Il piano richiesto dal fruitore",
+            "rejectedPlan": "Il piano richiesto dal fruitore"
+          },
           "subtitle": "Chiamate API/giorno",
           "changePlanRequestLink": {
             "label": "Richiedi cambio di piano"

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -141,7 +141,8 @@
           "ACTIVE": "Attiva",
           "SUSPENDED": "Sospesa",
           "WAITING_FOR_APPROVAL": "In attesa di approvazione",
-          "ARCHIVED": "Archiviata"
+          "ARCHIVED": "Archiviata",
+          "REJECTED": "Rifiutata"
         }
       }
     }
@@ -150,6 +151,8 @@
     "suspendedAlert": "Questa finalità è sospesa. Fino alla sua riattivazione il fruitore non potrà accedere ai dati erogati attraverso l’API.",
     "waitingForApprovalAlert": "Il fruitore ha richiesto un adeguamento della stima di carico che richiede la tua approvazione. Controlla la sezione “Stima di carico”.",
     "archivedPurposeAlert": "Il fruitore non potrà ottenere un voucher da PDND Interoperabilità per questa finalità perché è archiviata.",
+    "rejectedPurposeAlert": "Questa finalità è stata rifiutata. <1>Leggi qui i motivi del rifiuto</1>.",
+    "rejectedUpdatePlanInfoAlert": "Un cambio piano su questa finalità è stato rifiutato. Controlla la sezione “Stima di carico”.",
     "sections": {
       "generalInformations": {
         "title": "Informazioni generali",
@@ -176,10 +179,14 @@
       "loadEstimate": {
         "title": "Stima di carico",
         "description": "Il numero di chiamate API/giorno che il fruitore stima di fare verso l’API del tuo e-service",
+        "rejectedUpdatePlanAlert": "Il cambio piano è stato rifiutato. <1>Leggi qui i motivi del rifiuto</1>.",
         "planCard": {
           "title": {
             "activePlan": "Il piano attivo del fruitore",
-            "waitingForApprovalPlan": "Il cambio piano richiesto dal fruitore"
+            "waitingForApprovalPlan": {
+              "changePlan": "Il cambio piano richiesto dal fruitore",
+              "newPurpose": "Il piano richiesto dal fruitore"
+            }
           },
           "subtitle": "Chiamate API/giorno",
           "expectApprovalDateInfo": "Hai stimato di attivare questo adeguamento il giorno <strong>{{date}}</strong>",
@@ -187,14 +194,20 @@
             "insertLabel": "Inserisci data stimata di attivazione",
             "modifyLabel": "Modifica data stimata di attivazione"
           },
-          "activateUpdateButtonLabel": {
+          "activateVersionButtonLabel": {
             "label": "Attiva ora"
+          },
+          "rejectVersionButtonLabel": {
+            "label": "Rifiuta"
           },
           "currentPlan": {
             "label": "Piano attuale"
           },
           "waitingForApprovalPlan": {
-            "label": "Nuovo piano richiesto"
+            "label": {
+              "changePlan": "Nuovo piano richiesto",
+              "newPurpose": "Piano richiesto"
+            }
           }
         },
         "thresholdsCard": {
@@ -226,6 +239,8 @@
     "waitingForApprovalAlert": "Questa finalità è in attesa di approvazione. <strong>Fino alla sua attivazione</strong> da parte dell’erogatore <strong>non potrai accedere ai dati</strong> resi disponibili attraverso l’API e <strong>non potrai associare client</strong>.",
     "archivedPurposeAlert": "Questa finalità è archiviata. Non puoi accedere ai dati resi disponibili attraverso l’API. Potrai sempre <1>crearne una nuova.</1>",
     "archivedPurposeClientsAlert": "Questa finalità è stata archiviata. Tutti i client sono stati rimossi all'atto dell'archiviazione e non è più possibile associarne di nuovi",
+    "rejectedPurposeAlert": "Questa finalità è stata rifiutata. <2>Leggi qui i motivi del rifiuto</2>.",
+    "rejectedUpdatePlanInfoAlert": "Un cambio piano su questa finalità è stato rifiutato. Controlla la sezione “Stima di carico” in <1>Dettagli finalità</1>.",
     "noClientsAlert": "Questa finalità è attiva ma non ha client associati. <1>Associa il tuo primo client</1> per fruire dell’e-service",
     "addClientToPurposeDisableTooltip": {
       "label": "Solamente un amministratore può gestire i membri di un client"
@@ -261,6 +276,7 @@
       "loadEstimate": {
         "title": "Stima di carico",
         "description": "Il numero di chiamate API/giorno che il fruitore stima di fare verso l’API del tuo e-service",
+        "rejectedUpdatePlanAlert": "Il cambio piano è stato rifiutato. <1>Leggi qui i motivi del rifiuto</1>.",
         "planCard": {
           "title": "Il piano attivo del fruitore",
           "subtitle": "Chiamate API/giorno",

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -115,6 +115,13 @@
       "checkbox": "Confermo di aver compreso le conseguenze della revoca"
     }
   },
+  "drawerRejectReason": {
+    "title": "Motivo del rifiuto",
+    "rejectedReasonLabel": "Descrizione",
+    "rejectedValueLabel": "Valore rifiutato",
+    "defaultServiceString": "---\n\nGrazie per la collaborazione,\n\nil Team di Interoperabilità.",
+    "guideLinkLabel": "Per ulteriori dubbi e informazioni. Vai al manuale."
+  },
   "copyToClipboardButton": {
     "copy": "Copia",
     "copied": "Copiato"

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -35,6 +35,29 @@
       "confirmLabel": "Rifiuta"
     }
   },
+  "dialogRejectPurposeVersion": {
+    "title": {
+      "changePlan": "Rifiuta cambio piano finalità",
+      "newPurpose": "Rifiuta finalità"
+    },
+    "subtitle": {
+      "changePlan": "Rifiutando questo cambio piano, il fruitore potrà comunque continuare ad usare la quota disponibile precedentemente.",
+      "newPurpose": "Rifiutando questa finalità, il fruitore non potrà accedere ai dati per il tuo e-service."
+    },
+    "content": {
+      "reason": {
+        "label": "Motivazione",
+        "infoLabel": {
+          "changePlan": "Inserisci la motivazione per la quale rifiuti il cambio piano. Min 10 caratteri, max 250 caratteri",
+          "newPurpose": "Inserisci la motivazione per la quale rifiuti la finalità. Min 10 caratteri, max 250 caratteri"
+        }
+      }
+    },
+    "actions": {
+      "cancelLabel": "Annulla",
+      "confirmLabel": "Rifiuta"
+    }
+  },
   "dialogAddClientToPurpose": {
     "title": "Aggiungi client",
     "content": {

--- a/src/types/dialog.types.ts
+++ b/src/types/dialog.types.ts
@@ -25,6 +25,7 @@ export type DialogProps =
   | DialogRemoveOperatorFromClientProps
   | DialogRevokeCertifiedAttributeProps
   | DialogClonePurposeProps
+  | DialogRejectPurposeVersionProps
 
 export type DialogAttributeDetailsProps = {
   type: 'showAttributeDetails'
@@ -82,4 +83,11 @@ export type DialogClonePurposeProps = {
   type: 'clonePurpose'
   purposeId: string
   eservice: CompactPurposeEService
+}
+
+export type DialogRejectPurposeVersionProps = {
+  type: 'rejectPurposeVersion'
+  purposeId: string
+  versionId: string
+  isChangePlanRequest: boolean
 }


### PR DESCRIPTION
- Updated api.generatedTypes
- Modified `waitingForApproval` alert strings and dimensions
- Implemented new design for `ProviderPurposeDetailsDailyCallsPlanCard`
- Implemented rejectVersion service and hook
- Implemented `DialogRejectPurposeVersion`
- Added `rejected` to purpose `statusChip`
- Added `rejected` to `purposeState` filter in purpose list (provider and consumer)
- Added logic to assign actions in rejected purposes (provider and consumer)
- Added new `alertProps` for rejected purpose (provider and consumer)
- Added possibility to reject the change plan request or new purpose
- Implemented `RejectReasonDrawer` and added logic to all components where it is needed
- Added strings
- Updated snapshots
