### PR TITLE
Hotfix: Voucher duration update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interop-dashboard-frontend",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceTechnicalInfoSection/ProviderEServiceThresholdsSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceTechnicalInfoSection/ProviderEServiceThresholdsSection.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import EditIcon from '@mui/icons-material/Edit'
 import { Stack } from '@mui/material'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
-import { secondsToMinutes } from '@/utils/format.utils'
+import { formatThousands, secondsToMinutes } from '@/utils/format.utils'
 import { useDrawerState } from '@/hooks/useDrawerState'
 import { ProviderEServiceUpdateThresholdsDrawer } from './ProviderEServiceUpdateThresholdsDrawer'
 
@@ -54,13 +54,13 @@ export const ProviderEServiceThresholdsSection: React.FC<
           <InformationContainer
             label={t('thresholds.dailyCallsPerConsumer.label')}
             labelDescription={t('thresholds.dailyCallsPerConsumer.labelDescription')}
-            content={`${descriptor.dailyCallsPerConsumer}`}
+            content={`${formatThousands(descriptor.dailyCallsPerConsumer)}`}
           />
 
           <InformationContainer
             label={t('thresholds.dailyCallsTotal.label')}
             labelDescription={t('thresholds.dailyCallsTotal.labelDescription')}
-            content={`${descriptor.dailyCallsTotal}`}
+            content={`${formatThousands(descriptor.dailyCallsTotal)}`}
           />
         </Stack>
       </SectionContainer>

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceTechnicalInfoSection/ProviderEServiceUpdateThresholdsDrawer.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceTechnicalInfoSection/ProviderEServiceUpdateThresholdsDrawer.tsx
@@ -2,6 +2,7 @@ import type { ProducerEServiceDescriptor } from '@/api/api.generatedTypes'
 import { EServiceMutations } from '@/api/eservice'
 import { Drawer } from '@/components/shared/Drawer'
 import { RHFTextField } from '@/components/shared/react-hook-form-inputs'
+import { minutesToSeconds, secondsToMinutes } from '@/utils/format.utils'
 import { Box, Stack } from '@mui/material'
 import React from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -28,7 +29,7 @@ export const ProviderEServiceUpdateThresholdsDrawer: React.FC<
   const { mutate: updateVersion } = EServiceMutations.useUpdateVersion()
 
   const defaultValues = {
-    voucherLifespan: descriptor.voucherLifespan ?? 1,
+    voucherLifespan: descriptor.voucherLifespan ? secondsToMinutes(descriptor.voucherLifespan) : 1,
     dailyCallsPerConsumer: descriptor.dailyCallsPerConsumer ?? 1,
     dailyCallsTotal: descriptor.dailyCallsTotal ?? 1,
   }
@@ -40,7 +41,7 @@ export const ProviderEServiceUpdateThresholdsDrawer: React.FC<
       {
         eserviceId: descriptor.eservice.id,
         descriptorId: descriptor.id,
-        voucherLifespan: values.voucherLifespan,
+        voucherLifespan: minutesToSeconds(values.voucherLifespan),
         dailyCallsPerConsumer: values.dailyCallsPerConsumer,
         dailyCallsTotal: values.dailyCallsTotal,
       },


### PR DESCRIPTION
- Fixed minutes to seconds conversion in drawer that updates the voucher duration
- Improved thousands formatting in threshold section
- Bumped version