### PR TITLE
Feature: PIN-4849 - bug support cannot visualize the OperatorDetailsPage

### DIFF
--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -214,7 +214,7 @@ export const { routes, reactRouterDOMRoutes, hooks, components, utils } = new In
     element: <OperatorDetailsPage />,
     public: false,
     hideSideNav: false,
-    authLevels: ['admin', 'security'],
+    authLevels: ['admin', 'security', 'support'],
   })
   .addRoute({
     key: 'SUBSCRIBE_CLIENT_KEY_EDIT',
@@ -278,7 +278,7 @@ export const { routes, reactRouterDOMRoutes, hooks, components, utils } = new In
     element: <OperatorDetailsPage />,
     public: false,
     hideSideNav: false,
-    authLevels: ['admin', 'security'],
+    authLevels: ['admin', 'security', 'support'],
   })
   .addRoute({
     key: 'SUBSCRIBE_INTEROP_M2M_CLIENT_KEY_EDIT',


### PR DESCRIPTION
- Added `support` in `SUBSCRIBE_CLIENT_OPERATOR_EDIT` and  `SUBSCRIBE_INTEROP_M2M_CLIENT_OPERATOR_EDIT` routes `authLevels`