### PR TITLE
Fix risk analysis form compilation crash

### DIFF
--- a/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryRiskAnalysisAccordion.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryRiskAnalysisAccordion.tsx
@@ -20,7 +20,7 @@ export const ConsumerPurposeSummaryRiskAnalysisAccordion: React.FC<
 
   const { data: riskAnalysisConfig } = useQuery({
     ...PurposeQueries.getRiskAnalysisVersion({
-      riskAnalysisVersion: purpose.riskAnalysisForm!.version,
+      riskAnalysisVersion: purpose.riskAnalysisForm?.version as string,
       eserviceId: purpose.eservice.id,
     }),
     enabled: Boolean(purpose.riskAnalysisForm?.version),


### PR DESCRIPTION
This fixes a client crash once the risk analysis was being submitted.
That was my bad, the non-null assertion operator should be used with more carefulness :)