### PR TITLE
fix-hide-delegation-section-to-noPA-organizations

### DIFF
--- a/src/components/layout/SideNav/hooks/__tests__/useGetSideNavItems.test.ts
+++ b/src/components/layout/SideNav/hooks/__tests__/useGetSideNavItems.test.ts
@@ -305,4 +305,38 @@ describe('useGetSideNavItems', () => {
 
     expect(result.current).not.toContain('TENANT_CERTIFIER')
   })
+
+  it("should not include 'DELEGATIONS' routes if the user is not a PA", () => {
+    mockUseJwt({
+      jwt: {
+        externalId: {
+          origin: 'test',
+          value: 'value',
+        },
+      },
+      currentRoles: ['admin'],
+    })
+
+    const { result } = renderHook(() => useGetSideNavItems())
+
+    expect(result.current.some((routeKey) => routeKey.children?.includes('DELEGATIONS'))).toBe(
+      false
+    )
+  })
+
+  it("should include 'DELEGATIONS' routes if the user is a PA", () => {
+    mockUseJwt({
+      jwt: {
+        externalId: {
+          origin: 'IPA',
+          value: 'value',
+        },
+      },
+      currentRoles: ['admin'],
+    })
+
+    const { result } = renderHook(() => useGetSideNavItems())
+
+    expect(result.current.some((routeKey) => routeKey.children?.includes('DELEGATIONS'))).toBe(true)
+  })
 })

--- a/src/components/layout/SideNav/hooks/useGetSideNavItems.ts
+++ b/src/components/layout/SideNav/hooks/useGetSideNavItems.ts
@@ -43,16 +43,21 @@ export function useGetSideNavItems() {
 
   const isCertifier = isTenantCertifier(tenant)
 
+  const isPA = AuthHooks.useJwt().jwt?.externalId?.origin === 'IPA'
+
   return React.useMemo(() => {
     /**
      * Checks if the user as the authorization level required to access a given route.
      * The no-IPA organizations cannot access the PROVIDE routes.
      * The no-certifier organizations cannot access the TENANT_CERTIFIER routes.
+     * The no-PA organizations cannot access the DELEGATIONS route.
      */
     const isAuthorizedToRoute = (routeKey: RouteKey) => {
       if (!isSupport && !isOrganizationAllowedToProduce && routeKey === 'PROVIDE') return false
 
       if (!isCertifier && routeKey === 'TENANT_CERTIFIER') return false
+
+      if (!isPA && routeKey === 'DELEGATIONS') return false
 
       const authLevels = routes[routeKey].authLevels
       return authLevels.some((authLevel) => currentRoles.includes(authLevel))

--- a/src/components/layout/SideNav/hooks/useGetSideNavItems.ts
+++ b/src/components/layout/SideNav/hooks/useGetSideNavItems.ts
@@ -37,13 +37,13 @@ const views = [
 ] as const
 
 export function useGetSideNavItems() {
-  const { currentRoles, isSupport, isOrganizationAllowedToProduce } = AuthHooks.useJwt()
+  const { currentRoles, isSupport, isOrganizationAllowedToProduce, jwt } = AuthHooks.useJwt()
 
   const { data: tenant } = TenantHooks.useGetActiveUserParty()
 
   const isCertifier = isTenantCertifier(tenant)
 
-  const isPA = AuthHooks.useJwt().jwt?.externalId?.origin === 'IPA'
+  const isPA = jwt?.externalId?.origin === 'IPA'
 
   return React.useMemo(() => {
     /**

--- a/src/router/components/RoutesWrapper/AuthGuard.tsx
+++ b/src/router/components/RoutesWrapper/AuthGuard.tsx
@@ -59,8 +59,25 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({
 
     return isAuthorized && !isInBlacklist && !(isInProvidersRoutes && !canAccessProviderRoutes)
   }
+
+  function isUserAllowedToAccessDelegationsRoutes() {
+    // The IsUserAllowedToAccessDelegationsRoutes method checks if the organization is a PA. Only a PA can access the delegations routes
+    const isPA = jwt?.externalId?.origin === 'IPA'
+    const delegationsRoutes: Array<RouteKey> = [
+      'DELEGATIONS',
+      'DELEGATION_DETAILS',
+      'CREATE_DELEGATION',
+    ]
+    return isPA || !delegationsRoutes.includes(routeKey)
+  }
+
   // JWT will be undefined just in case route is public.
-  if (jwt && (!isUserAllowedToAccessRoute() || !isUserAllowedToAccessCertifierRoutes())) {
+  if (
+    jwt &&
+    (!isUserAllowedToAccessRoute() ||
+      !isUserAllowedToAccessCertifierRoutes() ||
+      !isUserAllowedToAccessDelegationsRoutes())
+  ) {
     throw new ForbiddenError()
   }
 

--- a/src/router/components/RoutesWrapper/__tests__/AuthGuard.test.tsx
+++ b/src/router/components/RoutesWrapper/__tests__/AuthGuard.test.tsx
@@ -128,51 +128,57 @@ describe('AuthGuard', () => {
     expect(getByText('children')).toBeInTheDocument()
   })
 
-  it('Should able to access when user try to access on delegations routes and he is a PA', () => {
-    const props: AuthGuardTestProps = {
-      ...defaultProps,
-      isSupport: false,
+  it.each(['DELEGATIONS', 'DELEGATION_DETAILS', 'CREATE_DELEGATION'] as const)(
+    'Should able to access when user try to access on %s route and he is a PA',
+    (routeKey) => {
+      const props: AuthGuardTestProps = {
+        ...defaultProps,
+        isSupport: false,
+      }
+
+      useAuthGuardSpy.mockReturnValue({
+        isPublic: false,
+        authLevels: [],
+        isUserAuthorized: () => true,
+      })
+      mockUseCurrentRoute({
+        routeKey,
+      })
+      mockUseGetActiveUserParty({
+        data: {
+          externalId: { origin: 'IPA' },
+        },
+      })
+
+      const { getByText } = renderAuthGuard(props)
+      expect(getByText('children')).toBeInTheDocument()
     }
+  )
 
-    useAuthGuardSpy.mockReturnValue({
-      isPublic: false,
-      authLevels: [],
-      isUserAuthorized: () => true,
-    })
-    mockUseCurrentRoute({
-      routeKey: 'DELEGATIONS' || 'DELEGATION_DETAILS' || 'CREATE_DELEGATION',
-    })
-    mockUseGetActiveUserParty({
-      data: {
-        externalId: { origin: 'IPA' },
-      },
-    })
+  it.each(['DELEGATIONS', 'DELEGATION_DETAILS', 'CREATE_DELEGATION'] as const)(
+    'Should render Error component when user try to access on delegations routes and he is not a PA',
+    (routeKey) => {
+      const props: AuthGuardTestProps = {
+        ...defaultProps,
+        isSupport: false,
+      }
 
-    const { getByText } = renderAuthGuard(props)
-    expect(getByText('children')).toBeInTheDocument()
-  })
+      useAuthGuardSpy.mockReturnValue({
+        isPublic: false,
+        authLevels: [],
+        isUserAuthorized: () => false,
+      })
+      mockUseCurrentRoute({
+        routeKey,
+      })
+      mockUseGetActiveUserParty({
+        data: {
+          externalId: { origin: '' },
+        },
+      })
 
-  it('Should render Error component when user try to access on delegations routes and he is not a PA', () => {
-    const props: AuthGuardTestProps = {
-      ...defaultProps,
-      isSupport: false,
+      const { getByText } = renderAuthGuard(props)
+      expect(getByText('error')).toBeInTheDocument()
     }
-
-    useAuthGuardSpy.mockReturnValue({
-      isPublic: false,
-      authLevels: [],
-      isUserAuthorized: () => false,
-    })
-    mockUseCurrentRoute({
-      routeKey: 'DELEGATIONS' || 'DELEGATION_DETAILS' || 'CREATE_DELEGATION',
-    })
-    mockUseGetActiveUserParty({
-      data: {
-        externalId: { origin: '' },
-      },
-    })
-
-    const { getByText } = renderAuthGuard(props)
-    expect(getByText('error')).toBeInTheDocument()
-  })
+  )
 })

--- a/src/router/components/RoutesWrapper/__tests__/AuthGuard.test.tsx
+++ b/src/router/components/RoutesWrapper/__tests__/AuthGuard.test.tsx
@@ -127,4 +127,52 @@ describe('AuthGuard', () => {
     const { getByText } = renderAuthGuard()
     expect(getByText('children')).toBeInTheDocument()
   })
+
+  it('Should able to access when user try to access on delegations routes and he is a PA', () => {
+    const props: AuthGuardTestProps = {
+      ...defaultProps,
+      isSupport: false,
+    }
+
+    useAuthGuardSpy.mockReturnValue({
+      isPublic: false,
+      authLevels: [],
+      isUserAuthorized: () => true,
+    })
+    mockUseCurrentRoute({
+      routeKey: 'DELEGATIONS' || 'DELEGATION_DETAILS' || 'CREATE_DELEGATION',
+    })
+    mockUseGetActiveUserParty({
+      data: {
+        externalId: { origin: 'IPA' },
+      },
+    })
+
+    const { getByText } = renderAuthGuard(props)
+    expect(getByText('children')).toBeInTheDocument()
+  })
+
+  it('Should render Error component when user try to access on delegations routes and he is not a PA', () => {
+    const props: AuthGuardTestProps = {
+      ...defaultProps,
+      isSupport: false,
+    }
+
+    useAuthGuardSpy.mockReturnValue({
+      isPublic: false,
+      authLevels: [],
+      isUserAuthorized: () => false,
+    })
+    mockUseCurrentRoute({
+      routeKey: 'DELEGATIONS' || 'DELEGATION_DETAILS' || 'CREATE_DELEGATION',
+    })
+    mockUseGetActiveUserParty({
+      data: {
+        externalId: { origin: '' },
+      },
+    })
+
+    const { getByText } = renderAuthGuard(props)
+    expect(getByText('error')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
- Added check in useGetSideNavItems to hide delegation section
- Added isUserAllowedToAccessDelegationsRoutes in AuthGuard.tsx