### PR TITLE
Refactor/PIN-6484: remove @ts-ignore and refactor errors handling on RHFTextField

### DIFF
--- a/src/components/shared/react-hook-form-inputs/RHFTextField.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFTextField.tsx
@@ -45,13 +45,20 @@ export const RHFTextField: React.FC<RHFTextFieldProps> = ({
   const { formState } = useFormContext()
   const { t } = useTranslation()
 
-  const error =
-    indexFieldArray !== undefined
-      ? //@ts-ignore
-        (formState.errors[name]?.[indexFieldArray]?.[fieldArrayKeyName]?.message as
-          | string
-          | undefined)
-      : (formState.errors[name]?.message as string | undefined)
+  const error = React.useMemo(() => {
+    const getErrors = (): string | undefined => {
+      if (indexFieldArray !== undefined && fieldArrayKeyName) {
+        // If indexFieldArray and fieldArrayKeyName are provided, means that we're working with fieldArray and we need to handling errors in a different way
+        const err = formState.errors[name] as
+          | Array<Record<string, { message?: string }>>
+          | undefined
+        return err?.[indexFieldArray]?.[fieldArrayKeyName]?.message as string | undefined
+      }
+
+      return formState.errors[name]?.message as string | undefined
+    }
+    return getErrors()
+  }, [formState.errors, name, indexFieldArray, fieldArrayKeyName])
 
   const fieldName =
     indexFieldArray !== undefined ? `${name}.${indexFieldArray}.${fieldArrayKeyName}` : name

--- a/src/components/shared/react-hook-form-inputs/RHFTextField.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFTextField.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { TextField as MUITextField, type TextFieldProps as MUITextFieldProps } from '@mui/material'
 import { InputWrapper } from '../InputWrapper'
+import type { FieldErrors, FieldValues } from 'react-hook-form'
 import { useFormContext, Controller } from 'react-hook-form'
 import type { ControllerProps } from 'react-hook-form/dist/types/controller'
 import { getAriaAccessibilityInputProps, mapValidationErrorMessages } from '@/utils/form.utils'
@@ -45,20 +46,7 @@ export const RHFTextField: React.FC<RHFTextFieldProps> = ({
   const { formState } = useFormContext()
   const { t } = useTranslation()
 
-  const error = React.useMemo(() => {
-    const getErrors = (): string | undefined => {
-      if (indexFieldArray !== undefined && fieldArrayKeyName) {
-        // If indexFieldArray and fieldArrayKeyName are provided, means that we're working with fieldArray and we need to handling errors in a different way
-        const err = formState.errors[name] as
-          | Array<Record<string, { message?: string }>>
-          | undefined
-        return err?.[indexFieldArray]?.[fieldArrayKeyName]?.message as string | undefined
-      }
-
-      return formState.errors[name]?.message as string | undefined
-    }
-    return getErrors()
-  }, [formState.errors, name, indexFieldArray, fieldArrayKeyName])
+  const error = getErrors(indexFieldArray, fieldArrayKeyName, formState.errors, name)
 
   const fieldName =
     indexFieldArray !== undefined ? `${name}.${indexFieldArray}.${fieldArrayKeyName}` : name
@@ -114,4 +102,19 @@ export const RHFTextField: React.FC<RHFTextFieldProps> = ({
       />
     </InputWrapper>
   )
+}
+
+const getErrors = (
+  indexFieldArray: number | undefined,
+  fieldArrayKeyName: string | undefined,
+  errors: FieldErrors<FieldValues>,
+  name: string
+): string | undefined => {
+  if (indexFieldArray !== undefined && fieldArrayKeyName) {
+    // If indexFieldArray and fieldArrayKeyName are provided, means that we're working with fieldArray and we need to handling errors in a different way
+    const err = errors[name] as Array<Record<string, { message?: string }>> | undefined
+    return err?.[indexFieldArray]?.[fieldArrayKeyName]?.message as string | undefined
+  }
+
+  return errors[name]?.message as string | undefined
 }

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFTextField.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFTextField.test.tsx
@@ -3,7 +3,7 @@ import { render, renderHook, screen, waitFor } from '@testing-library/react'
 import { TestInputWrapper } from './test-utils'
 import { RHFTextField } from '@/components/shared/react-hook-form-inputs'
 import userEvent from '@testing-library/user-event'
-import { useFormContext } from 'react-hook-form'
+import { FormProvider, useForm, useFormContext } from 'react-hook-form'
 import { vi } from 'vitest'
 
 const testValues = {
@@ -76,6 +76,65 @@ describe('determine whether the integration between react-hook-form and MUI’s 
     user.type(input, testValues.first)
     await waitFor(() => {
       expect(onValueChange).toHaveBeenCalledWith(testValues.first)
+    })
+  })
+
+  it('should be able to show errors when are present in case of indexFieldArray and fieldArrayKeyName are populated', async () => {
+    const FieldArrayErrorTestWrapper = () => {
+      const formMethods = useForm({
+        defaultValues: {
+          users: [{ name: '' }, { name: '' }],
+        },
+        mode: 'onBlur',
+      })
+
+      return (
+        <FormProvider {...formMethods}>
+          <RHFTextField
+            label="username"
+            name="users"
+            indexFieldArray={0}
+            fieldArrayKeyName="name"
+            rules={{ required: true, minLength: 5 }}
+          />
+        </FormProvider>
+      )
+    }
+
+    const { getByRole } = render(<FieldArrayErrorTestWrapper />)
+    const input = getByRole('textbox')
+    input.focus()
+    input.blur()
+
+    await waitFor(() => {
+      screen.debug()
+      expect(screen.getByText('validation.mixed.required')).toBeInTheDocument()
+    })
+  })
+  it('should be able to show errors when are present without indexFieldArray and fieldArrayKeyName', async () => {
+    const FieldArrayErrorTestWrapper = () => {
+      const formMethods = useForm({
+        defaultValues: {
+          username: '',
+        },
+        mode: 'onBlur',
+      })
+
+      return (
+        <FormProvider {...formMethods}>
+          <RHFTextField label="username" name="users" rules={{ required: true }} />
+        </FormProvider>
+      )
+    }
+
+    const { getByRole } = render(<FieldArrayErrorTestWrapper />)
+    const input = getByRole('textbox')
+    input.focus()
+    input.blur()
+
+    await waitFor(() => {
+      screen.debug()
+      expect(screen.getByText('validation.mixed.required')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
This PR remove a @ts-ignore previous added in order to have `useFieldArray`() hook (react-hook-form) to work with our component.

Based on availability of props `indexFieldArray` and `fieldArrayKeyName` props, RHFTextField understand how to retrieve errors (if it's occur). This is placed inside useMemo to avoid unnecessary rendering. Also it's been introduced two new test in order to verifying this behaviour