### PR TITLE
PIN-6528: Added pagination for ClientPublicKeys

### DIFF
--- a/src/pages/ConsumerClientManagePage/components/ClientPublicKeys/ClientPublicKeys.tsx
+++ b/src/pages/ConsumerClientManagePage/components/ClientPublicKeys/ClientPublicKeys.tsx
@@ -4,11 +4,11 @@ import {
   ClientAddPublicKeyButtonSkeleton,
 } from './ClientAddPublicKeyButton'
 import { ClientPublicKeysTable, ClientPublicKeysTableSkeleton } from './ClientPublicKeysTable'
-import { Filters, useFilters } from '@pagopa/interop-fe-commons'
+import { Filters, useFilters, Pagination, usePagination } from '@pagopa/interop-fe-commons'
 import { ClientQueries } from '@/api/client'
 import type { GetClientKeysParams } from '@/api/api.generatedTypes'
 import { useTranslation } from 'react-i18next'
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 
 interface ClientPublicKeysProps {
   clientId: string
@@ -26,9 +26,8 @@ export const ClientPublicKeys: React.FC<ClientPublicKeysProps> = ({ clientId }) 
       })),
   })
 
-  //TODO: fix this
   const { filtersParams, ...filtersHandlers } = useFilters<
-    Omit<GetClientKeysParams, 'clientId' | 'offset' | 'limit'>
+    Omit<GetClientKeysParams, 'clientId' | 'limit' | 'offset'>
   >([
     {
       name: 'userIds',
@@ -38,10 +37,19 @@ export const ClientPublicKeys: React.FC<ClientPublicKeysProps> = ({ clientId }) 
     },
   ])
 
-  const params = {
+  const { paginationParams, paginationProps, getTotalPageCount } = usePagination({ limit: 10 })
+
+  const queryParams = {
     ...filtersParams,
+    ...paginationParams,
     clientId: clientId,
   }
+
+  const { data: totalPageCount = 0 } = useQuery({
+    ...ClientQueries.getKeyList(queryParams),
+    placeholderData: keepPreviousData,
+    select: ({ pagination }) => getTotalPageCount(pagination?.totalCount),
+  })
 
   return (
     <>
@@ -50,8 +58,16 @@ export const ClientPublicKeys: React.FC<ClientPublicKeysProps> = ({ clientId }) 
       </React.Suspense>
       <Filters {...filtersHandlers} />
       <React.Suspense fallback={<ClientPublicKeysTableSkeleton />}>
-        <ClientPublicKeysTable params={params} />
+        <ClientPublicKeysWrapper params={queryParams} />
+        <Pagination {...paginationProps} totalPages={totalPageCount} />
       </React.Suspense>
     </>
   )
+}
+
+const ClientPublicKeysWrapper: React.FC<{ params: GetClientKeysParams }> = ({ params }) => {
+  const { data, isFetching } = useQuery(ClientQueries.getKeyList(params))
+
+  if (!data && isFetching) return <ClientPublicKeysTableSkeleton />
+  return <ClientPublicKeysTable clientId={params.clientId} keys={data?.keys || []} />
 }

--- a/src/pages/ConsumerClientManagePage/components/ClientPublicKeys/ClientPublicKeysTable.tsx
+++ b/src/pages/ConsumerClientManagePage/components/ClientPublicKeys/ClientPublicKeysTable.tsx
@@ -1,4 +1,3 @@
-import { ClientQueries } from '@/api/client'
 import { Table } from '@pagopa/interop-fe-commons'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
@@ -6,22 +5,15 @@ import {
   ClientPublicKeysTableRow,
   ClientPublicKeysTableRowSkeleton,
 } from './ClientPublicKeysTableRow'
-import type { GetClientKeysParams } from '@/api/api.generatedTypes'
-import { useSuspenseQuery } from '@tanstack/react-query'
+import type { PublicKey } from '@/api/api.generatedTypes'
 
 type ClientPublicKeysTableProps = {
-  //TODO: fix this
-  params: Omit<GetClientKeysParams, 'clientId' | 'offset' | 'limit'>
+  keys: PublicKey[]
+  clientId: string
 }
 
-export const ClientPublicKeysTable: React.FC<ClientPublicKeysTableProps> = ({ params }) => {
+export const ClientPublicKeysTable: React.FC<ClientPublicKeysTableProps> = ({ keys, clientId }) => {
   const { t: tCommon } = useTranslation('common')
-
-  //TODO: fix this
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
-  const { data } = useSuspenseQuery(ClientQueries.getKeyList(params))
-  const publicKeys = data.keys
 
   const headLabels = [
     tCommon('table.headData.keyName'),
@@ -29,19 +21,12 @@ export const ClientPublicKeysTable: React.FC<ClientPublicKeysTableProps> = ({ pa
     tCommon('table.headData.keyUploadDate'),
     '',
   ]
-  const isEmpty = publicKeys.length === 0
+  const isEmpty = keys.length === 0
 
   return (
     <Table headLabels={headLabels} isEmpty={isEmpty}>
-      {publicKeys.map((publicKey) => (
-        <ClientPublicKeysTableRow
-          key={publicKey.keyId}
-          publicKey={publicKey}
-          //TODO: fix this
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          //@ts-ignore
-          clientId={params.clientId}
-        />
+      {keys.map((publicKey) => (
+        <ClientPublicKeysTableRow key={publicKey.keyId} publicKey={publicKey} clientId={clientId} />
       ))}
     </Table>
   )

--- a/src/pages/ConsumerClientManagePage/components/VoucherInstructions/VoucherInstructionsStep1/VoucherInstructionsStep1.tsx
+++ b/src/pages/ConsumerClientManagePage/components/VoucherInstructions/VoucherInstructionsStep1/VoucherInstructionsStep1.tsx
@@ -28,7 +28,6 @@ export const VoucherInstructionsStep1: React.FC = () => {
 
   const { isOpen, openDrawer, closeDrawer } = useDrawerState()
 
-  //TODO: fix this
   const { data: clientKeys } = useSuspenseQuery(
     ClientQueries.getKeyList({ clientId, limit: 1, offset: 0 })
   )


### PR DESCRIPTION
This ticket follow changing of API's behaviour ([PIN-4605](https://pagopa.atlassian.net/browse/PIN-4605)). In FE has been introduced pagination for the listing of public keys.

[PIN-4605]: https://pagopa.atlassian.net/browse/PIN-4605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ