### PR TITLE
DescriptorVersion from string to number

### DIFF
--- a/__mocks__/data/agreement.mocks.ts
+++ b/__mocks__/data/agreement.mocks.ts
@@ -207,12 +207,12 @@ const createMockAgreement = createMockFactory<Agreement>({
     activeDescriptor: {
       id: 'b79fc9ac-2882-49bd-afd1-71f4284f117c',
       state: 'PUBLISHED',
-      version: '1',
+      version: 1,
       audience: [],
     },
     id: '47f82055-77fd-4efd-8ed6-8a7d3021c879',
     name: 'Test_15/02/23',
-    version: '1',
+    version: 1,
   },
   id: 'e8a8153e-9ab2-4aeb-a14c-96aebd4fa049',
   producer: {
@@ -260,7 +260,7 @@ const createMockAgreementListingItem = createMockFactory<AgreementListEntry>({
   descriptor: {
     id: '2881e984-4279-47e8-8fc4-aa236468436e',
     state: 'SUSPENDED',
-    version: '1',
+    version: 1,
     audience: [],
   },
   eservice: {

--- a/__mocks__/data/eservice.mocks.ts
+++ b/__mocks__/data/eservice.mocks.ts
@@ -28,7 +28,7 @@ const createMockEServiceCatalog = createMockFactory<CatalogEService>({
   activeDescriptor: {
     id: 'e9762e42-129a-4b07-9b2e-9614998ef9b8',
     state: 'PUBLISHED',
-    version: '1',
+    version: 1,
     audience: [],
   },
   name: '!! -- CAMMELLO -- Test 18/10 [1]',
@@ -52,7 +52,7 @@ const createMockEServiceDescriptorCatalog = createMockFactory<CatalogEServiceDes
     activeDescriptor: {
       id: 'ec94e366-cbb2-4203-ac07-95acf5289a31',
       state: 'PUBLISHED',
-      version: '1',
+      version: 1,
       audience: [],
     },
     producer: {
@@ -64,7 +64,7 @@ const createMockEServiceDescriptorCatalog = createMockFactory<CatalogEServiceDes
       {
         id: 'ec94e366-cbb2-4203-ac07-95acf5289a31',
         state: 'PUBLISHED',
-        version: '1',
+        version: 1,
         audience: [],
       },
     ],
@@ -86,7 +86,7 @@ const createMockEServiceDescriptorCatalog = createMockFactory<CatalogEServiceDes
     checksum: 'f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2',
   },
   state: 'PUBLISHED',
-  version: '1',
+  version: 1,
   voucherLifespan: 60,
   attributes: {
     certified: [],
@@ -99,7 +99,7 @@ const createMockCatalogDescriptorEService = createMockFactory<CatalogDescriptorE
   activeDescriptor: {
     id: 'ec94e366-cbb2-4203-ac07-95acf5289a31',
     state: 'PUBLISHED',
-    version: '1',
+    version: 1,
     audience: [],
   },
   producer: {
@@ -111,7 +111,7 @@ const createMockCatalogDescriptorEService = createMockFactory<CatalogDescriptorE
     {
       id: 'ec94e366-cbb2-4203-ac07-95acf5289a31',
       state: 'PUBLISHED',
-      version: '1',
+      version: 1,
       audience: [],
     },
   ],
@@ -138,7 +138,7 @@ const createMockEServiceDescriptorProvider = createMockFactory<ProducerEServiceD
       {
         id: '2092c1ef-9127-4dd5-ad81-c9ecf492975a',
         state: 'PUBLISHED',
-        version: '1',
+        version: 1,
         audience: [],
       },
     ],
@@ -161,7 +161,7 @@ const createMockEServiceDescriptorProvider = createMockFactory<ProducerEServiceD
     prettyName: 'Specifica API',
   },
   state: 'PUBLISHED',
-  version: '3',
+  version: 3,
   voucherLifespan: 60,
   attributes: {
     certified: [],

--- a/__mocks__/data/purpose.mocks.ts
+++ b/__mocks__/data/purpose.mocks.ts
@@ -10,7 +10,7 @@ const createMockPurpose = createMockFactory<Purpose>({
     descriptor: {
       id: 'cd80bfe6-54be-493a-aaa1-6bb2b54545f8',
       state: 'PUBLISHED',
-      version: '1',
+      version: 1,
       audience: [],
     },
     id: 'dea4bbf4-df64-4b8a-9ca9-125dd4cd1f5e',

--- a/__mocks__/data/voucher.mocks.ts
+++ b/__mocks__/data/voucher.mocks.ts
@@ -49,7 +49,7 @@ const createMockDebugVoucherResultPassed = createMockFactory<TokenGenerationVali
   eservice: {
     id: 'id test',
     descriptorId: 'descriptor id test',
-    version: 'version test',
+    version: 1,
     name: 'name test',
   },
 })

--- a/scripts/open-api-type-generator.js
+++ b/scripts/open-api-type-generator.js
@@ -2,7 +2,7 @@ import { generateApi } from 'swagger-typescript-api'
 import path from 'path'
 
 const openApiSpecificationFileUrl =
-  'https://raw.githubusercontent.com/pagopa/interop-be-monorepo/145acd61839d96c9373fd58c04a7a07c3e17b5d6/packages/api-clients/open-api/bffApi.yml'
+  'https://raw.githubusercontent.com/pagopa/interop-be-monorepo/refs/heads/develop/packages/api-clients/open-api/bffApi.yml'
 
 const apiFolderPath = path.resolve('./src/api/')
 

--- a/scripts/open-api-type-generator.js
+++ b/scripts/open-api-type-generator.js
@@ -2,7 +2,7 @@ import { generateApi } from 'swagger-typescript-api'
 import path from 'path'
 
 const openApiSpecificationFileUrl =
-'https://raw.githubusercontent.com/pagopa/interop-be-monorepo/refs/heads/develop/packages/api-clients/open-api/bffApi.yml'
+  'https://raw.githubusercontent.com/pagopa/interop-be-monorepo/145acd61839d96c9373fd58c04a7a07c3e17b5d6/packages/api-clients/open-api/bffApi.yml'
 
 const apiFolderPath = path.resolve('./src/api/')
 

--- a/src/api/agreement/agreement.mutations.ts
+++ b/src/api/agreement/agreement.mutations.ts
@@ -12,7 +12,7 @@ function useCreateDraft(hasConfirmationDialog = true) {
       delegationId,
     }: {
       eserviceName: string
-      eserviceVersion: string | undefined
+      eserviceVersion: number | undefined
     } & AgreementPayload) =>
       AgreementServices.createDraft({ eserviceId, descriptorId, delegationId }),
     meta: {

--- a/src/components/shared/EServiceVersionSelectorDrawer.tsx
+++ b/src/components/shared/EServiceVersionSelectorDrawer.tsx
@@ -37,10 +37,7 @@ export const EServiceVersionSelectorDrawer: React.FC<EServiceVersionSelectorDraw
   const marks = React.useMemo<Mark[]>(() => {
     return Array.from({ length: numVersions }).map((_, index) => ({
       value: -(index + 1),
-      label:
-        (index + 1).toString() === descriptor.version
-          ? t('currentVersion', { versionNum: index + 1 })
-          : '',
+      label: index + 1 === descriptor.version ? t('currentVersion', { versionNum: index + 1 }) : '',
     }))
   }, [numVersions, descriptor.version, t])
 
@@ -50,7 +47,7 @@ export const EServiceVersionSelectorDrawer: React.FC<EServiceVersionSelectorDraw
 
   const handleGoToVersion = () => {
     const selectedDescriptor = descriptorsWithoutDraftVersion.find(
-      (d) => d.version === selectedVersion.toString()
+      (d) => d.version === selectedVersion
     )
 
     if (selectedDescriptor) {

--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -64,7 +64,7 @@ function renderUseGetProviderEServiceTableActionsHook(descriptorMock: ProducerES
 describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if the user is admin and e-service is DRAFT with no active descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -74,7 +74,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should not return actions if user is admin and delegator, e-service is DRAFT with no active descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -88,7 +88,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and delegate, e-service is DRAFT with no active descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -102,7 +102,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should not return actions if user is admin and e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -111,7 +111,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and delegator, e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -127,7 +127,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should not return actions if user is admin and delegate, e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -141,7 +141,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should not return actions if user is admin and e-service is ARCHIVED', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -150,7 +150,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should not return actions if user is admin and delegator, e-service is ARCHIVED', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -164,7 +164,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should not return actions if user is admin and delegate, e-service is ARCHIVED', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -178,7 +178,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and e-service is DEPRECATED', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -188,7 +188,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should not return actions if user is admin and delegator, e-service is DEPRECATED', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -202,7 +202,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and delegate, e-service is DEPRECATED', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -217,7 +217,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and e-service is PUBLISHED with no draft descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -229,8 +229,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -243,7 +243,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should not return actions if user is admin and delegator, e-service is PUBLISHED with no draft descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -257,8 +257,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should not return actions if user is admin and delegator, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -273,8 +273,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and delegator, e-service is PUBLISHED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -289,7 +289,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and delegate, e-service is PUBLISHED with no draft descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -305,8 +305,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and delegate, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -323,8 +323,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and delegate, e-service is PUBLISHED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -339,7 +339,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and e-service is SUSPENDED with no draft descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -351,8 +351,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -365,7 +365,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should not return actions if user is admin and delegator, e-service is SUSPENDED with no draft descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -379,8 +379,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should not return actions if user is admin and delegator, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -394,8 +394,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and delegator, e-service is SUSPENDED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -410,7 +410,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and delegate, e-service is SUSPENDED with no draft descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -426,8 +426,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and delegate, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -444,8 +444,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
 
   it('should return the correct actions if user is admin and delegate, e-service is SUSPENDED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -461,7 +461,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and e-service is DRAFT with no active descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -472,7 +472,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegator, e-service is DRAFT with no active descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -487,7 +487,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and delegate, e-service is DRAFT with no active descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'DRAFT', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -502,7 +502,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -512,7 +512,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and delegator, e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -529,7 +529,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegate, e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: '1' },
+      draftDescriptor: { id: 'test-1', state: 'WAITING_FOR_APPROVAL', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -544,7 +544,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and e-service is ARCHIVED', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -554,7 +554,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegator, e-service is ARCHIVED', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -569,7 +569,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegate, e-service is ARCHIVED', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -584,7 +584,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and e-service is DEPRECATED', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -594,7 +594,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegator, e-service is DEPRECATED', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -609,7 +609,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegate, e-service is DEPRECATED', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -624,7 +624,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and e-service is PUBLISHED with no draft descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -636,8 +636,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -650,7 +650,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegator, e-service is PUBLISHED with no draft descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -665,8 +665,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegator, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -682,8 +682,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and delegator, e-service is PUBLISHED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -699,7 +699,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and delegate, e-service is PUBLISHED with no draft descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -715,8 +715,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and delegate, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -733,8 +733,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegate, e-service is PUBLISHED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -749,7 +749,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and e-service is SUSPENDED with no draft descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -761,8 +761,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -775,7 +775,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegator, e-service is SUSPENDED with no draft descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -790,8 +790,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegator, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -806,8 +806,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and delegator, e-service is SUSPENDED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegator: {
           id: 'organizationId',
@@ -823,7 +823,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and delegate, e-service is SUSPENDED with no draft descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -839,8 +839,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should return the correct actions if user is an api operator and delegate, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -857,8 +857,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should not return actions if user is an api operator and delegate, e-service is SUSPENDED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'WAITING_FOR_APPROVAL', version: 2 },
       delegation: createMockDelegationWithCompactTenants({
         delegate: {
           id: 'organizationId',
@@ -873,8 +873,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should navigate to PROVIDE_ESERVICE_EDIT page on clone action success', async () => {
     mockUseJwt({ isAdmin: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
-      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
+      draftDescriptor: { id: 'test-2', state: 'DRAFT', version: 2 },
       delegation: undefined,
     })
     const { result, history } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -901,7 +901,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
   it('should navigate to PROVIDE_ESERVICE_EDIT page on create new draft action success', async () => {
     mockUseJwt({ isAdmin: true })
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: 1 },
       delegation: undefined,
     })
     const { result, history } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
@@ -929,7 +929,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
     mockUseJwt({ isAdmin: false, isOperatorSecurity: true })
 
     const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: 1 },
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)

--- a/src/pages/ConsumerAgreementCreatePage/hooks/__test__/useGetConsumerAgreementCreateAlertProps.test.ts
+++ b/src/pages/ConsumerAgreementCreatePage/hooks/__test__/useGetConsumerAgreementCreateAlertProps.test.ts
@@ -25,9 +25,9 @@ describe('check if useGetConsumerAgreementCreateAlertProps returns the correct a
     const agreement = createMockAgreement({
       state: 'DRAFT',
       eservice: {
-        version: '1',
+        version: 1,
         activeDescriptor: {
-          version: '2',
+          version: 2,
         },
       },
     })

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
@@ -90,7 +90,10 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
             label={t('producer.label')}
             content={descriptor.eservice.producer.name}
           />
-          <InformationContainer label={t('version.label')} content={descriptor.version} />
+          <InformationContainer
+            label={t('version.label')}
+            content={descriptor.version.toString()}
+          />
           <InformationContainer
             label={t('eserviceDescription.label')}
             content={descriptor.eservice.description}

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateContext.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateContext.tsx
@@ -90,7 +90,7 @@ const EServiceCreateContextProvider: React.FC<EServiceCreateContextProviderProps
       // case 1: new e-service
       !descriptor ||
         // case 3: already existing service and version, but version is 1 and still a draft
-        (descriptor && descriptor.version === '1' && descriptor.state === 'DRAFT')
+        (descriptor && descriptor.version === 1 && descriptor.state === 'DRAFT')
     )
 
     return {

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepVersion/EServiceCreateStepVersion.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepVersion/EServiceCreateStepVersion.tsx
@@ -19,7 +19,7 @@ import type { UpdateEServiceDescriptorTemplateInstanceSeed } from '@/api/api.gen
 
 export type EServiceCreateStepVersionFormValues = {
   audience: string
-  version: string
+  version: number
   voucherLifespan: number
   description: string
   dailyCallsPerConsumer: number
@@ -41,7 +41,7 @@ export const EServiceCreateStepVersion: React.FC<ActiveStepProps> = () => {
   })
 
   const defaultValues: EServiceCreateStepVersionFormValues = {
-    version: descriptor?.version ?? '1',
+    version: descriptor?.version ?? 1,
     audience: descriptor?.audience?.[0] ?? '',
     voucherLifespan: descriptor ? secondsToMinutes(descriptor.voucherLifespan) : 1,
     description: descriptor?.description ?? '',

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
@@ -168,7 +168,10 @@ export const ProviderEServiceGeneralInfoSection: React.FC = () => {
         ]}
       >
         <Stack spacing={2}>
-          <InformationContainer label={t('version.label')} content={descriptor.version} />
+          <InformationContainer
+            label={t('version.label')}
+            content={descriptor.version.toString()}
+          />
           {isEserviceFromTemplate ? (
             <>
               <InformationContainer

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableRow.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableRow.tsx
@@ -70,7 +70,7 @@ export const EServiceTableRow: React.FC<EServiceTableRow> = ({ eservice }) => {
         ) : (
           eservice.name
         ),
-        eservice?.activeDescriptor?.version || '1',
+        eservice?.activeDescriptor?.version.toString() || '1',
         <Stack key={eservice?.id} direction="row" spacing={1}>
           {eservice?.activeDescriptor && (
             <StatusChip for="eservice" state={eservice.activeDescriptor.state} />

--- a/src/types/dialog.types.ts
+++ b/src/types/dialog.types.ts
@@ -147,7 +147,7 @@ export type DialogCreateAgreementDraftProps = {
   }
   descriptor: {
     id: string
-    version: string
+    version: number
   }
   onSubmit: ({
     isOwnEService,

--- a/src/utils/__tests__/agreement.utils.test.ts
+++ b/src/utils/__tests__/agreement.utils.test.ts
@@ -22,7 +22,7 @@ describe('canAgreementBeUpgraded', () => {
   it('shoud not be possible to upgrade an ARCHIVED agreement', () => {
     const agreementMock = createMockAgreement({
       state: 'ARCHIVED',
-      eservice: { activeDescriptor: { state: 'PUBLISHED', version: '4' }, version: '3' },
+      eservice: { activeDescriptor: { state: 'PUBLISHED', version: 4 }, version: 3 },
     })
     const result = canAgreementBeUpgraded(agreementMock)
 
@@ -32,7 +32,7 @@ describe('canAgreementBeUpgraded', () => {
   it('shoud not be possible to upgrade an agreement to an e-service with an active version with a state different from SUSPENDED or PUBLISHED', () => {
     const agreementMock = createMockAgreement({
       state: 'ACTIVE',
-      eservice: { activeDescriptor: { state: 'ARCHIVED', version: '4' }, version: '3' },
+      eservice: { activeDescriptor: { state: 'ARCHIVED', version: 4 }, version: 3 },
     })
     const result = canAgreementBeUpgraded(agreementMock)
 
@@ -42,7 +42,7 @@ describe('canAgreementBeUpgraded', () => {
   it('shoud not be possible to upgrade an agreement if the active descriptor version is equal to the actual version the user is subscribed to', () => {
     const agreementMock = createMockAgreement({
       state: 'ACTIVE',
-      eservice: { activeDescriptor: { state: 'PUBLISHED', version: '4' }, version: '4' },
+      eservice: { activeDescriptor: { state: 'PUBLISHED', version: 4 }, version: 4 },
     })
     const result = canAgreementBeUpgraded(agreementMock)
 
@@ -52,7 +52,7 @@ describe('canAgreementBeUpgraded', () => {
   it('shoud be possible to upgrade an agreement if the requirements are met', () => {
     const agreementMock = createMockAgreement({
       state: 'ACTIVE',
-      eservice: { activeDescriptor: { state: 'PUBLISHED', version: '4' }, version: '2' },
+      eservice: { activeDescriptor: { state: 'PUBLISHED', version: 4 }, version: 2 },
     })
     const result = canAgreementBeUpgraded(agreementMock)
 
@@ -62,7 +62,7 @@ describe('canAgreementBeUpgraded', () => {
   it('shoud not be possible to upgrade an agreement if the agreement state is REJECTED', () => {
     const agreementMock = createMockAgreement({
       state: 'REJECTED',
-      eservice: { activeDescriptor: { state: 'PUBLISHED', version: '4' }, version: '2' },
+      eservice: { activeDescriptor: { state: 'PUBLISHED', version: 4 }, version: 2 },
     })
     const result = canAgreementBeUpgraded(agreementMock)
 
@@ -237,7 +237,7 @@ describe('checkIfcanCreateAgreementDraft', () => {
 describe('isNewEServiceVersionAvailable', () => {
   it('should return true if the eservice has an active descriptor and it has a version greater than the actual agreement eservice version', () => {
     const agreement = createMockAgreement({
-      eservice: { activeDescriptor: { version: '4' }, version: '3' },
+      eservice: { activeDescriptor: { version: 4 }, version: 3 },
     })
     const result = isNewEServiceVersionAvailable(agreement)
     expect(result).toBe(true)
@@ -245,7 +245,7 @@ describe('isNewEServiceVersionAvailable', () => {
 
   it('should return false if the eservice has not an active descriptor', () => {
     const agreement = createMockAgreement({
-      eservice: { activeDescriptor: undefined, version: '3' },
+      eservice: { activeDescriptor: undefined, version: 3 },
     })
     const result = isNewEServiceVersionAvailable(agreement)
     expect(result).toBe(false)
@@ -253,7 +253,7 @@ describe('isNewEServiceVersionAvailable', () => {
 
   it('should return false if the eservice has an active descriptor but it has not a version greater than the actual agreement eservice version', () => {
     const agreement = createMockAgreement({
-      eservice: { activeDescriptor: { version: '3' }, version: '3' },
+      eservice: { activeDescriptor: { version: 3 }, version: 3 },
     })
     const result = isNewEServiceVersionAvailable(agreement)
     expect(result).toBe(false)

--- a/src/utils/__tests__/eservice.utils.test.ts
+++ b/src/utils/__tests__/eservice.utils.test.ts
@@ -17,9 +17,9 @@ describe('getDownloadDocumentName utility function testing', () => {
 describe('getLastDescriptor utility function testing', () => {
   it('should correctly get the last descriptor from an array of descriptors', () => {
     const result = getLastDescriptor([
-      { id: 'test-id-1', state: 'PUBLISHED', version: '1', audience: ['test-audience'] },
-      { id: 'test-id-2', state: 'PUBLISHED', version: '2', audience: ['test-audience'] },
-      { id: 'test-id-3', state: 'PUBLISHED', version: '3', audience: ['test-audience'] },
+      { id: 'test-id-1', state: 'PUBLISHED', version: 1, audience: ['test-audience'] },
+      { id: 'test-id-2', state: 'PUBLISHED', version: 2, audience: ['test-audience'] },
+      { id: 'test-id-3', state: 'PUBLISHED', version: 3, audience: ['test-audience'] },
     ])
 
     expect(result?.id).toEqual('test-id-3')

--- a/src/utils/agreement.utils.ts
+++ b/src/utils/agreement.utils.ts
@@ -93,8 +93,7 @@ export const canAgreementBeUpgraded = (agreement?: Agreement) => {
   const isActiveDescriptorPublishedOrSuspended = ['PUBLISHED', 'SUSPENDED'].includes(
     eserviceActiveDescriptor.state
   )
-  const hasNewVersion =
-    parseInt(eserviceActiveDescriptor.version, 10) > parseInt(agreement.eservice.version, 10)
+  const hasNewVersion = eserviceActiveDescriptor.version > agreement.eservice.version
   const isAgreementActiveOrSuspended = ['ACTIVE', 'SUSPENDED'].includes(agreement.state)
 
   return hasNewVersion && isActiveDescriptorPublishedOrSuspended && isAgreementActiveOrSuspended
@@ -107,7 +106,6 @@ export const canAgreementBeUpgraded = (agreement?: Agreement) => {
 export const isNewEServiceVersionAvailable = (agreement: Agreement | undefined) => {
   const eserviceActiveDescriptor = agreement?.eservice.activeDescriptor
   return Boolean(
-    eserviceActiveDescriptor &&
-      parseInt(eserviceActiveDescriptor.version, 10) > parseInt(agreement.eservice.version, 10)
+    eserviceActiveDescriptor && eserviceActiveDescriptor.version > agreement.eservice.version
   )
 }


### PR DESCRIPTION
This PR is based to https://github.com/pagopa/interop-be-monorepo/pull/1688 which updates the descriptor version type from string to number.

The CI fails because the BFF spec change is not in DEV for now.