### PR TITLE
hotfix/PIN-8150:  Use descriptor.state instead of draft on summary E-service page

### DIFF
--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -189,7 +189,7 @@ const ProviderEServiceSummaryPage: React.FC = () => {
       isLoading={isLoading}
       statusChip={{
         for: 'eservice',
-        state: 'DRAFT',
+        state: descriptor?.state || 'DRAFT',
         isDraftToCorrect: requireDelegateCorrections,
       }}
     >


### PR DESCRIPTION
## Issue
[PIN-8150](https://pagopa.atlassian.net/browse/PIN-8150)

## Context / Why
Replaced fixed state "draft" on e-service's summary page. 


[PIN-8150]: https://pagopa.atlassian.net/browse/PIN-8150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ