### PR TITLE
Fix: Added tooltip when edit button is disabled (PIN-8183)

### DIFF
--- a/src/pages/ConsumerPurposeTemplateDetailsPage/components/ConsumerPurposeTemplateLinkedEServiceTab.tsx
+++ b/src/pages/ConsumerPurposeTemplateDetailsPage/components/ConsumerPurposeTemplateLinkedEServiceTab.tsx
@@ -43,6 +43,7 @@ export const ConsumerPurposeTemplateLinkedEServiceTab: React.FC<
             variant: 'contained',
             icon: EditIcon,
             disabled: !isEditable,
+            tooltip: !isEditable ? t('editButtonTooltip') : undefined,
           },
         ]
       : []

--- a/src/static/locales/en/purposeTemplate.json
+++ b/src/static/locales/en/purposeTemplate.json
@@ -217,6 +217,7 @@
     "linkedEservicesTab": {
       "title": "Linked e-services and template e-services",
       "description": "Define a list of e-services for which it is suggested to use the facilitated purpose. The user \n  may also use this template for e-services not included in the list.",
+      "editButtonTooltip": "It is not possible to modify the list of e-services if the template is suspended or archived",
       "filters": {
         "eserviceField": {
           "label": "E-service name"

--- a/src/static/locales/it/purposeTemplate.json
+++ b/src/static/locales/it/purposeTemplate.json
@@ -217,6 +217,7 @@
     "linkedEservicesTab": {
       "title": "E-service e template e-service collegati",
       "description": "Definisci un elenco di e-service per cui è suggerito usare la finalità agevolata. Il fruitore ha facoltà di utilizzare \n questo template anche per e-service che non compaiono nella lista.",
+      "editButtonTooltip": "Non è possibile modificare l'elenco degli e-service se il template è sospeso o archiviato",
       "filters": {
         "eserviceField": {
           "label": "Nome e-service"


### PR DESCRIPTION
## Issue
[PIN-8183](https://pagopa.atlassian.net/browse/PIN-8183)

## Context / Why
Added missing tooltip around edit button when button is disabled. Edit button is disabled when `purpose template` is in `Suspended` o `Archived` status

---

<img width="921" height="238" alt="image" src="https://github.com/user-attachments/assets/7248422d-a087-4290-9821-2dfd90e5f050" />


[PIN-8183]: https://pagopa.atlassian.net/browse/PIN-8183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ