### PR TITLE
Fix/pin 8206 handle error in creator freetext form validation

### DIFF
--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisTextField.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisTextField.tsx
@@ -10,6 +10,7 @@ import RiskAnalysisInputWrapper from './RiskAnalysisInputWrapper'
 import type { RiskAnalysisAnswers } from '@/types/risk-analysis-form.types'
 import { RemoveCircleOutline } from '@mui/icons-material'
 import { usePurposeCreateContext } from '../PurposeCreateContext'
+import { match, P } from 'ts-pattern'
 
 export type RiskAnalysisTextFieldProps = Omit<OutlinedInputProps, 'type'> & {
   questionKey: string
@@ -68,14 +69,14 @@ export const RiskAnalysisTextField: React.FC<RiskAnalysisTextFieldProps> = ({
 
   const isCreatorFreeText = type === 'creator' && questionType === 'text'
 
-  let displayError = error
-  if (isFromPurposeTemplate) {
-    if (type === 'consumer' && suggestedValues.length > 0) {
-      displayError = suggestedValueConsumerError || error
-    } else if (isCreatorFreeText) {
-      displayError = suggestedValuesError || error
-    }
+  const getDisplayError = (error: string | undefined) => {
+    return match([isFromPurposeTemplate, type, questionType, suggestedValues.length > 0])
+      .with([true, 'consumer', P._, true], () => suggestedValueConsumerError || error)
+      .with([true, 'creator', 'text', P._], () => suggestedValuesError || error)
+      .otherwise(() => error)
   }
+
+  const displayError = getDisplayError(error)
 
   const { accessibilityProps, ids } = getAriaAccessibilityInputProps(name, {
     label,


### PR DESCRIPTION
## Issue
[PIN-8206](https://pagopa.atlassian.net/browse/PIN-8206)

## Context / Why
Solved two different errors tied to creator _freeText_ field:
- Added error handling (below image) when there are not _suggested values_ for _freeText_ field when the creator is submitting _risk analysis_.
- Added 250 characters limit for every _suggested values_ added to the form (250 is the BE limit)
---
Error handling
<img width="930" height="364" alt="image" src="https://github.com/user-attachments/assets/4540db30-dc1c-4723-9c04-4d5fa9674082" />


[PIN-8206]: https://pagopa.atlassian.net/browse/PIN-8206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ