### PR TITLE
fix: Update button label from 'publish' to 'publishDraft'

### DIFF
--- a/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
@@ -164,7 +164,7 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
               variant="contained"
               onClick={handlePublishDraft}
             >
-              {tCommon('publish')}
+              {tCommon('publishDraft')}
             </Button>
           </span>
         </Tooltip>


### PR DESCRIPTION
## Issue
[PIN-8218](https://pagopa.atlassian.net/browse/PIN-8218)

## Context / Why
Changed `publish` label to `publish draft` to match _Figma_ requirementes.

[PIN-8218]: https://pagopa.atlassian.net/browse/PIN-8218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ