### PR TITLE
Fix: Update navigation parameters in PurposeCreateForm to use selecte…

### DIFF
--- a/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
@@ -158,11 +158,8 @@ export const PurposeCreateForm: React.FC<PurposeCreateFormProps> = ({ purposeTem
         {
           onSuccess(data) {
             const purposeId = data.id
-            const purposeTemplateIdParam = purposeTemplateId
-              ? purposeTemplateId
-              : purposeTemplateIdSelected
             navigate('SUBSCRIBE_PURPOSE_FROM_TEMPLATE_EDIT', {
-              params: { purposeId, purposeTemplateId: purposeTemplateIdParam },
+              params: { purposeId, purposeTemplateId: purposeTemplateIdSelected },
             })
           },
         }


### PR DESCRIPTION
## Issue
[PIN-8241](https://pagopa.atlassian.net/browse/PIN-8241)

## Context / Why
Changed `purposeTemplateId` used as _path parameter_ by always selecting the autocomplete selected one.

[PIN-8241]: https://pagopa.atlassian.net/browse/PIN-8241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ