### PR TITLE
fix/notification config for clientKeyAddedDeletedToClientUsers param

### DIFF
--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -2207,7 +2207,7 @@ export interface NotificationConfig {
   eserviceNewVersionApprovedRejectedToDelegate: boolean
   delegationSubmittedRevokedToDelegate: boolean
   certifiedVerifiedAttributeAssignedRevokedToAssignee: boolean
-  clientKeyAddedDeletedToClientUsers: boolean
+  clientKeyAndProducerKeychainKeyAddedDeletedToClientUsers: boolean
 }
 
 export interface TenantNotificationConfig {

--- a/src/pages/NotificationUserConfigPage/__test__/NotificationConfigUserTab.test.tsx
+++ b/src/pages/NotificationUserConfigPage/__test__/NotificationConfigUserTab.test.tsx
@@ -25,7 +25,7 @@ const inAppNotificationConfigMock: NotificationConfig = {
   eserviceNewVersionApprovedRejectedToDelegate: true, // 22
   delegationSubmittedRevokedToDelegate: true, // 23
   certifiedVerifiedAttributeAssignedRevokedToAssignee: true, // 24
-  clientKeyAddedDeletedToClientUsers: true, // 25
+  clientKeyAndProducerKeychainKeyAddedDeletedToClientUsers: true, // 25
 }
 
 describe('NotificationConfigUserTab', () => {
@@ -81,12 +81,12 @@ describe('NotificationConfigUserTab', () => {
 
       renderComponent('inApp', true, {
         certifiedVerifiedAttributeAssignedRevokedToAssignee: false,
-        clientKeyAddedDeletedToClientUsers: false,
+        clientKeyAndProducerKeychainKeyAddedDeletedToClientUsers: false,
       })
-      // To test this will be tested keyAndAttributes section with key: [certifiedVerifiedAttributeAssignedRevokedToAssignee,clientKeyAddedDeletedToClientUsers]
+      // To test this will be tested keyAndAttributes section with key: [certifiedVerifiedAttributeAssignedRevokedToAssignee,clientKeyAndProducerKeychainKeyAddedDeletedToClientUsers]
 
       const firstKey = screen.getByTestId('certifiedVerifiedAttributeAssignedRevokedToAssignee')
-      const secondKey = screen.getByTestId('clientKeyAddedDeletedToClientUsers')
+      const secondKey = screen.getByTestId('clientKeyAndProducerKeychainKeyAddedDeletedToClientUsers')
       const enableAllSectionButton = screen.getByTestId(
         'enableSectionAllNotifications-keyAndAttributes'
       )

--- a/src/pages/NotificationUserConfigPage/hooks/useNotificationConfigHook.ts
+++ b/src/pages/NotificationUserConfigPage/hooks/useNotificationConfigHook.ts
@@ -220,7 +220,7 @@ export function useNotificationConfigHook(type: NotificationConfigType) {
           title: t('keyAndAttributes.keys.title'),
           components: [
             {
-              key: 'clientKeyAddedDeletedToClientUsers',
+              key: 'clientKeyAndProducerKeychainKeyAddedDeletedToClientUsers',
               title: t('keyAndAttributes.keys.components.clientKeysAssociationUpdated.label'), // 25
               description: t(
                 'keyAndAttributes.keys.components.clientKeysAssociationUpdated.description'


### PR DESCRIPTION
Small fix on the clientKeyAddedDeletedToClientUsers param for notification config endpoint body