### PR TITLE
Fix/pin 8338 add missing tooltip

### DIFF
--- a/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepRiskAnalysis/RiskAnalysisForm/RiskAnalysisAnswerComponent.tsx
+++ b/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepRiskAnalysis/RiskAnalysisForm/RiskAnalysisAnswerComponent.tsx
@@ -5,7 +5,7 @@ import { ButtonNaked } from '@pagopa/mui-italia'
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import UploadFileIcon from '@mui/icons-material/UploadFile'
-import { Box, Stack, Typography, Button } from '@mui/material'
+import { Box, Stack, Typography, Button, Tooltip } from '@mui/material'
 import { DocumentContainer } from '@/components/layout/containers/DocumentContainer'
 import { useDrawerState } from '@/hooks/useDrawerState'
 import { AddAnnotationDrawer } from '@/components/shared/AddAnnotationDrawer'
@@ -358,16 +358,28 @@ export const RiskAnalysisAnswerComponent: React.FC<{
         />
       )}
       {!annotation?.text && (
-        <ButtonNaked
-          color="primary"
-          type="button"
-          disabled={!isAddAnnotationButtonEnabled}
-          sx={{ fontWeight: 700 }}
-          startIcon={<AddIcon fontSize="small" />}
-          onClick={handleClick}
+        <Tooltip
+          title={
+            !isAddAnnotationButtonEnabled
+              ? t('notifications.addAnnotationButtonDisabledTooltip')
+              : ''
+          }
+          arrow
+          placement="top"
         >
-          {t('addAnnotationBtn')}
-        </ButtonNaked>
+          <span>
+            <ButtonNaked
+              color="primary"
+              type="button"
+              disabled={!isAddAnnotationButtonEnabled}
+              sx={{ fontWeight: 700 }}
+              startIcon={<AddIcon fontSize="small" />}
+              onClick={handleClick}
+            >
+              {t('addAnnotationBtn')}
+            </ButtonNaked>
+          </span>
+        </Tooltip>
       )}
 
       {annotation?.text && (

--- a/src/static/locales/en/purposeTemplate.json
+++ b/src/static/locales/en/purposeTemplate.json
@@ -103,6 +103,7 @@
       "addDocumentBtn": "Attach documentation",
       "uploadBtn": "Upload",
       "notifications": {
+        "addAnnotationButtonDisabledTooltip": "Select an answer or assign the completion to provide annotations",
         "annotationAddedSuccess": "Annotation added successfully.",
         "annotationAddError": "It was not possible to add the annotation. Make sure you have entered the correct information and try again.",
         "annotationDeletedSuccess": "Annotation deleted successfully.",

--- a/src/static/locales/it/purposeTemplate.json
+++ b/src/static/locales/it/purposeTemplate.json
@@ -103,6 +103,7 @@
       "addDocumentBtn": "Allega documentazione",
       "uploadBtn": "Carica",
       "notifications": {
+        "addAnnotationButtonDisabledTooltip": "Seleziona una risposta o assegna la compilazione per fornire annotazioni",
         "annotationAddedSuccess": "Annotazione aggiunta con successo.",
         "annotationAddError": "Non è stato possibile aggiungere l'annotazione. Assicurati di aver inserito le informazioni corrette e riprova.",
         "annotationDeletedSuccess": "Annotazione eliminata con successo.",


### PR DESCRIPTION
## Issue
[PIN-8338](https://pagopa.atlassian.net/browse/PIN-8338)

## Context / Why
A risk analysis question must have an answer to enable user adding annotations. Every time this is not true, the _add annotation_ button is disabled. This PR adds a tooltip message to inform the user why the _add annotation_ button is disabled.

---
<img width="942" height="640" alt="image" src="https://github.com/user-attachments/assets/25336df9-0baa-4675-b80c-13370926f661" />


[PIN-8338]: https://pagopa.atlassian.net/browse/PIN-8338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ