### PR TITLE
hotfix/PIN-8601-missing-template-creator-name-in-alert-eservice-step-general

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/ProviderEServiceCreate.page.tsx
+++ b/src/pages/ProviderEServiceCreatePage/ProviderEServiceCreate.page.tsx
@@ -32,6 +32,7 @@ import {
 import type { EServiceMode } from '@/api/api.generatedTypes'
 import { useQuery } from '@tanstack/react-query'
 import { EServiceCreateFromTemplateStepPurpose } from './components/EServiceCreateStepPurpose/EServiceCreateFromTemplateStepPurpose'
+import { EServiceTemplateQueries } from '@/api/eserviceTemplate'
 
 const ProviderEServiceCreatePage: React.FC = () => {
   const { t } = useTranslation('eservice')
@@ -52,6 +53,11 @@ const ProviderEServiceCreatePage: React.FC = () => {
 
   const eservice = descriptor?.eservice
   const isEserviceFromTemplate = Boolean(descriptor?.templateRef)
+  const eserviceTemplateId = descriptor?.templateRef?.templateId
+  const { data: eserviceTemplate } = useQuery({
+    ...EServiceTemplateQueries.getSingleByEServiceTemplateId(eserviceTemplateId as string),
+    enabled: isEserviceFromTemplate,
+  })
 
   const eserviceMode =
     selectedEServiceMode || // The mode selected by the user
@@ -145,6 +151,7 @@ const ProviderEServiceCreatePage: React.FC = () => {
           descriptor={descriptor}
           eserviceMode={eserviceMode}
           onEserviceModeChange={setSelectedEServiceMode}
+          eserviceTemplate={eserviceTemplate}
           {...stepProps}
         >
           <Step />

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/EServiceCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/EServiceCreateStepGeneral.tsx
@@ -262,7 +262,7 @@ export const EServiceCreateStepGeneral: React.FC = () => {
                 isOptionValueAsBoolean
               />
               {isEserviceFromTemplate && eserviceTemplate?.personalData === undefined && (
-                <Alert severity="error">
+                <Alert severity="error" variant="outlined">
                   {t('create.step1.eservicePersonalDataField.alertMissingPersonalData', {
                     tenantName: eserviceTemplate?.creator.name,
                   })}


### PR DESCRIPTION
## Issue

[PIN-8601](https://pagopa.atlassian.net/browse/PIN-8601)

## Description / Context / Why
When creating an eService from a template, the template wasn't passed to the context, causing the creator's name to be undefined in the alert. This fix ensures the template is correctly passed and adds the variant outlined for the alert (like it was in Figma).
<img width="943" height="749" alt="Screenshot 2025-11-21 alle 12 20 01" src="https://github.com/user-attachments/assets/9b50b385-28f7-4ad8-889c-9894f961f2b2" />



[PIN-8601]: https://pagopa.atlassian.net/browse/PIN-8601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ