### PR TITLE
hotfix/PIN-8671-add-purpose-template-reference-in-purpose-details-page

### DIFF
--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsGeneralInfoSection.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsGeneralInfoSection.tsx
@@ -44,6 +44,8 @@ export const ConsumerPurposeDetailsGeneralInfoSection: React.FC<
     onClick: handleDownloadDocument,
   }
 
+  const isFromPurposeTemplate = Boolean(purpose.purposeTemplate?.id)
+
   return (
     <SectionContainer
       title={t('title')}
@@ -87,6 +89,21 @@ export const ConsumerPurposeDetailsGeneralInfoSection: React.FC<
           <InformationContainer
             label={t('delegatedConsumerField.label')}
             content={purpose.delegation.delegate.name}
+          />
+        )}
+        {isFromPurposeTemplate && (
+          <InformationContainer
+            label={t('purposeTemplateField.label')}
+            content={
+              <Link
+                to="SUBSCRIBE_PURPOSE_TEMPLATE_CATALOG_DETAILS"
+                params={{
+                  purposeTemplateId: purpose.purposeTemplate?.id as string,
+                }}
+              >
+                {purpose.purposeTemplate?.purposeTitle as string}
+              </Link>
+            }
           />
         )}
         <InformationContainer

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -358,6 +358,9 @@
         "delegatedConsumerField": {
           "label": "Delegated Consumer"
         },
+        "purposeTemplateField": {
+          "label": "Linked purpose template"
+        },
         "descriptionField": {
           "label": "Purpose description"
         },

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -358,6 +358,9 @@
         "delegatedConsumerField": {
           "label": "Delegato alla fruizione"
         },
+        "purposeTemplateField": {
+          "label": "Template collegato"
+        },
         "descriptionField": {
           "label": "Descrizione della finalità"
         },


### PR DESCRIPTION
## Issue

[PIN-8671](https://pagopa.atlassian.net/browse/PIN-8671)

## Description / Context / Why
Added purpose template reference to consumer purpose details page 

<img width="1695" height="652" alt="Screenshot 2025-11-28 alle 16 20 05" src="https://github.com/user-attachments/assets/c33bdfbc-543a-4990-b404-88976812a99f" />


[PIN-8671]: https://pagopa.atlassian.net/browse/PIN-8671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ