### PR TITLE
fix: Removed eservice template references in purpose template (PIN-8…

### DIFF
--- a/src/static/locales/en/purposeTemplate.json
+++ b/src/static/locales/en/purposeTemplate.json
@@ -220,7 +220,7 @@
       }
     },
     "linkedEservicesTab": {
-      "title": "Linked e-services and template e-services",
+      "title": "Linked e-services",
       "description": "Define a list of e-services for which it is suggested to use the facilitated purpose. The user \n  may also use this template for e-services not included in the list.",
       "editButtonTooltip": "It is not possible to modify the list of e-services if the template is suspended or archived",
       "filters": {

--- a/src/static/locales/it/purposeTemplate.json
+++ b/src/static/locales/it/purposeTemplate.json
@@ -220,7 +220,7 @@
       }
     },
     "linkedEservicesTab": {
-      "title": "E-service e template e-service collegati",
+      "title": "E-service collegati",
       "description": "Definisci un elenco di e-service per cui è suggerito usare la finalità agevolata. Il fruitore ha facoltà di utilizzare \n questo template anche per e-service che non compaiono nella lista.",
       "editButtonTooltip": "Non è possibile modificare l'elenco degli e-service se il template è sospeso o archiviato",
       "filters": {


### PR DESCRIPTION
## Issue
[PIN-8665](https://pagopa.atlassian.net/browse/PIN-8665)

## Context / Why
Since the eservice template section exists no more in purpose template UI, this PR removed the e-service template references.

---
<img width="876" height="386" alt="image" src="https://github.com/user-attachments/assets/cec54f9f-6798-40b9-86a0-3aebbd0c9a5f" />


[PIN-8665]: https://pagopa.atlassian.net/browse/PIN-8665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ