### PR TITLE
[bugfix] in app notification preference saved

### DIFF
--- a/src/pages/NotificationUserConfigPage/NotificationUserConfig.page.tsx
+++ b/src/pages/NotificationUserConfigPage/NotificationUserConfig.page.tsx
@@ -100,10 +100,15 @@ const NotificationUserConfigTabs: React.FC<{
                 emailDigestPreference: data.emailDigestPreference,
                 emailNotificationPreference: data.emailNotificationPreference,
               }}
-              handleUpdateNotificationConfigs={(notification, type, preferenceChoice) =>
+              handleUpdateNotificationConfigs={(
+                notification,
+                inAppNotificationPreference,
+                _emailNotificationPreference,
+                _emailDigestPreference
+              ) =>
                 handleUpdateNotificationConfigInApp(
                   notification,
-                  preferenceChoice as UserNotificationConfig['inAppNotificationPreference']
+                  inAppNotificationPreference as UserNotificationConfig['inAppNotificationPreference']
                 )
               }
             />


### PR DESCRIPTION
The POST payload was built with the email preference flag because the in-app tab’s handler forwarded its second argument (meant for the email flow) instead of the first. By deconstructing the params correctly, now it saves the correct value in the API payload