### PR TITLE
feature/PIN-9056-align-documents-purpose-template-details

### DIFF
--- a/src/components/shared/PurposeTemplate/PurposeTemplateDetailsTab/PurposeTemplateDocumentationSection.tsx
+++ b/src/components/shared/PurposeTemplate/PurposeTemplateDetailsTab/PurposeTemplateDocumentationSection.tsx
@@ -74,7 +74,7 @@ export const PurposeTemplateDocumentationSection: React.FC<
           label={t('documentsLabel')}
           content={
             documentation && documentation.length > 0 ? (
-              <Stack spacing={2} direction="column">
+              <Stack spacing={2} direction="column" alignItems="flex-start">
                 {documentation.map((doc) => (
                   <IconLink
                     key={doc.id}


### PR DESCRIPTION
## Issue

[PIN-9056](https://pagopa.atlassian.net/browse/PIN-9056)

## Description / Context / Why
This PR fixes the documentation links on the PurposeTemplateDetails page. The links are now aligned to the start of the column.

<img width="868" height="275" alt="Screenshot 2026-01-28 alle 17 36 06" src="https://github.com/user-attachments/assets/1cb8058d-da4e-4302-8816-a60d97faa8ab" />




[PIN-9056]: https://pagopa.atlassian.net/browse/PIN-9056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ