### PR TITLE
PIN-9284: removed Alert API v2

### DIFF
--- a/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
+++ b/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
@@ -65,14 +65,6 @@ const ConsumerClientManagePage: React.FC = () => {
         to: clientKind === 'API' ? 'SUBSCRIBE_INTEROP_M2M' : 'SUBSCRIBE_CLIENT_LIST',
       }}
     >
-      <Alert severity="info">
-        <Stack direction="row" spacing={3}>
-          <Typography>{t('alertApiV2.description')}</Typography>
-          <Link variant="button" underline="none" href={apiV2GuideLink} target="_blank">
-            {t('alertApiV2.linkLabel')}
-          </Link>
-        </Stack>
-      </Alert>
       {clientKind === 'API' && (
         <Grid container>
           <Grid item xs={8}>

--- a/src/static/locales/en/client.json
+++ b/src/static/locales/en/client.json
@@ -50,10 +50,6 @@
     }
   },
   "edit": {
-    "alertApiV2": {
-      "description": "PDND will soon update its API model to version 2. In the future, it will no longer be possible to interact with the previous version.",
-      "linkLabel": "Learn more"
-    },
     "adminSection": {
       "title": "Admin API",
       "description": "The Client Admin API is a user belonging to the party who is authorized to perform write operations through the machine-to-machine channel.",

--- a/src/static/locales/it/client.json
+++ b/src/static/locales/it/client.json
@@ -50,10 +50,6 @@
     }
   },
   "edit": {
-    "alertApiV2": {
-      "description": "PDND aggiornerà presto il proprio modello API alla versione 2. In futuro non sarà più possibile interagire con la versione precedente.",
-      "linkLabel": "Scopri di più"
-    },
     "adminSection": {
       "title": "Admin API",
       "description": "Il Client Admin API è un utente appartenente all’ente che ha facoltà di effettuare operazioni di scrittura attraverso il canale machine to machine.",


### PR DESCRIPTION
## 🔗 Issue

[PIN-9284](https://pagopa.atlassian.net/browse/PIN-9284)
## 📝 Description / Context

This PR remove Alert about introduction of API v2.

## 🧪 How to test

Go on "**Gestione client**" -> "**API e-service**" and choose a client. Within it you're not see "Alert" about API v2 anymore.

[PIN-9284]: https://pagopa.atlassian.net/browse/PIN-9284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ