### PR TITLE
feat: add instanceLabel field to template instantiation flow (PIN-9154)

### DIFF
--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -131,6 +131,7 @@ export interface UpdateEServiceTemplateInstanceSeed {
   isSignalHubEnabled?: boolean
   isConsumerDelegable?: boolean
   isClientAccessDelegable?: boolean
+  instanceLabel?: string
 }
 
 export interface EServiceSeed {
@@ -497,6 +498,7 @@ export interface ProducerDescriptorEService {
   isConsumerDelegable?: boolean
   isClientAccessDelegable?: boolean
   personalData?: boolean
+  instanceLabel?: string
 }
 
 export interface ProducerDescriptorEServiceProducer {
@@ -2122,6 +2124,7 @@ export interface InstanceEServiceSeed {
   isSignalHubEnabled?: boolean
   isConsumerDelegable?: boolean
   isClientAccessDelegable?: boolean
+  instanceLabel?: string
 }
 
 export interface VersionSeedForEServiceTemplateCreation {

--- a/src/api/eserviceTemplate/eserviceTemplate.mutations.ts
+++ b/src/api/eserviceTemplate/eserviceTemplate.mutations.ts
@@ -1,11 +1,14 @@
 import { useMutation } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
+import { AxiosError } from 'axios'
 import { EServiceTemplateServices } from './eserviceTemplate.services'
 import type {
   EServiceTemplateRiskAnalysisSeed,
   UpdateEServiceTemplateVersionSeed,
 } from '../api.generatedTypes'
 import type { AttributeKey } from '@/types/attribute.types'
+
+export const DUPLICATE_INSTANCE_LABEL_ERROR_CODE = 'eServiceNameDuplicateForProducer'
 
 function useUpdateEServiceTemplateName() {
   const { t } = useTranslation('mutations-feedback', {
@@ -332,7 +335,14 @@ function useCreateInstanceFromEServiceTemplate() {
   return useMutation({
     mutationFn: EServiceTemplateServices.createInstanceFromEServiceTemplate,
     meta: {
-      errorToastLabel: t('outcome.error'),
+      errorToastLabel: (error: unknown) => {
+        if (
+          error instanceof AxiosError &&
+          error.response?.data?.errors?.[0]?.code === DUPLICATE_INSTANCE_LABEL_ERROR_CODE
+        )
+          return ''
+        return t('outcome.error')
+      },
       loadingLabel: t('loading'),
     },
   })
@@ -343,7 +353,14 @@ function useUpdateInstanceFromEServiceTemplate() {
   return useMutation({
     mutationFn: EServiceTemplateServices.updateInstanceFromEServiceTemplate,
     meta: {
-      errorToastLabel: t('outcome.error'),
+      errorToastLabel: (error: unknown) => {
+        if (
+          error instanceof AxiosError &&
+          error.response?.data?.errors?.[0]?.code === DUPLICATE_INSTANCE_LABEL_ERROR_CODE
+        )
+          return ''
+        return t('outcome.error')
+      },
       loadingLabel: t('loading'),
     },
   })

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/EServiceCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/EServiceCreateStepGeneral.tsx
@@ -21,6 +21,7 @@ import type {
   ProducerEServiceDescriptor,
 } from '@/api/api.generatedTypes'
 import { compareObjects } from '@/utils/common.utils'
+import { AxiosError } from 'axios'
 import SaveIcon from '@mui/icons-material/Save'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { IconLink } from '@/components/shared/IconLink'
@@ -33,11 +34,15 @@ import {
 } from '@/config/constants'
 import { trackEvent } from '@/config/tracking'
 import { AuthHooks } from '@/api/auth'
-import { EServiceTemplateMutations } from '@/api/eserviceTemplate'
+import {
+  EServiceTemplateMutations,
+  DUPLICATE_INSTANCE_LABEL_ERROR_CODE,
+} from '@/api/eserviceTemplate'
 import {
   FEATURE_FLAG_ESERVICE_PERSONAL_DATA,
   SIGNALHUB_PERSONAL_DATA_PROCESS_URL,
 } from '@/config/env'
+import { InstanceLabelSection } from './InstanceLabelSection'
 
 export type EServiceCreateStepGeneralFormValues = {
   name: string
@@ -48,6 +53,7 @@ export type EServiceCreateStepGeneralFormValues = {
   isSignalHubEnabled: boolean
   isConsumerDelegable: boolean
   isClientAccessDelegable: boolean
+  instanceLabel: string | undefined
 }
 
 type SignalHubSectionProps = {
@@ -85,6 +91,34 @@ export const EServiceCreateStepGeneral: React.FC = () => {
   const defaultValues = evaluateFormDefaultValues(eserviceTemplate, descriptor, eserviceMode)
   const formMethods = useForm({ defaultValues })
 
+  /**
+   * Resolves the instanceLabel form value to the API payload value:
+   * - non-empty string → string (BE validates the label)
+   * - empty string or undefined → undefined (axios omits the key from JSON, BE validates the undefined value for the label)
+   */
+  const resolveInstanceLabel = (formValue: string | undefined): string | undefined => {
+    return !formValue ? undefined : formValue
+  }
+
+  /**
+   * TODO(BE-API-SPEC): Verificare con le specifiche API del BE pubblicate:
+   * - Confermare il codice errore (DUPLICATE_INSTANCE_LABEL_ERROR_CODE) e la struttura
+   *   della risposta (error.response.data.errors[0].code)
+   * - Verificare errori che richiedono messaggi diversi (es. label troppo lunga, caratteri non ammessi)
+   */
+  const handleInstanceLabelError = (error: unknown) => {
+    if (!(error instanceof AxiosError)) return
+    const errorCode = error.response?.data?.errors?.[0]?.code
+    if (errorCode === DUPLICATE_INSTANCE_LABEL_ERROR_CODE) {
+      const instanceLabelValue = formMethods.getValues('instanceLabel')
+      formMethods.setError('instanceLabel', {
+        message: instanceLabelValue
+          ? t('create.step1.instanceLabelField.validation.duplicate')
+          : t('create.step1.instanceLabelField.validation.emptyNotAvailable'),
+      })
+    }
+  }
+
   const onSubmit = (formValues: EServiceCreateStepGeneralFormValues & InstanceEServiceSeed) => {
     // If we are editing an existing e-service, we update the draft
     if (descriptor) {
@@ -99,8 +133,9 @@ export const EServiceCreateStepGeneral: React.FC = () => {
                 isClientAccessDelegable: formValues.isClientAccessDelegable,
                 isConsumerDelegable: formValues.isConsumerDelegable,
                 isSignalHubEnabled: formValues.isSignalHubEnabled,
+                instanceLabel: resolveInstanceLabel(formValues.instanceLabel),
               },
-              { onSuccess: forward }
+              { onSuccess: forward, onError: handleInstanceLabelError }
             )
           : updateDraft(
               { eserviceId: descriptor.eservice.id, ...formValues },
@@ -135,6 +170,7 @@ export const EServiceCreateStepGeneral: React.FC = () => {
         isClientAccessDelegable: formValues.isClientAccessDelegable,
         isConsumerDelegable: formValues.isConsumerDelegable,
         isSignalHubEnabled: formValues.isSignalHubEnabled,
+        instanceLabel: resolveInstanceLabel(formValues.instanceLabel),
       }
 
       createDraftFromTemplate(body, {
@@ -146,6 +182,7 @@ export const EServiceCreateStepGeneral: React.FC = () => {
           })
           forward()
         },
+        onError: handleInstanceLabelError,
       })
     }
   }
@@ -271,6 +308,13 @@ export const EServiceCreateStepGeneral: React.FC = () => {
             </>
           )}
         </SectionContainer>
+
+        {isEserviceFromTemplate && (
+          <InstanceLabelSection
+            templateName={eserviceTemplate?.name ?? descriptor?.templateRef?.templateName ?? ''}
+            instanceLabel={formMethods.watch('instanceLabel') ?? ''}
+          />
+        )}
 
         {/* Signalhub switch can be editable also if coming from a eservice eserviceTemplate */}
         <SignalHubSection isSignalHubActivationEditable={areEServiceGeneralInfoEditable} />
@@ -423,6 +467,7 @@ function evaluateFormDefaultValues(
       isSignalHubEnabled: descriptor?.eservice.isSignalHubEnabled ?? false,
       isConsumerDelegable: descriptor?.eservice.isConsumerDelegable ?? true,
       isClientAccessDelegable: descriptor?.eservice.isClientAccessDelegable ?? true,
+      instanceLabel: descriptor?.eservice.instanceLabel ?? '',
     }
 
   return {
@@ -434,5 +479,6 @@ function evaluateFormDefaultValues(
     isSignalHubEnabled: eserviceTemplate?.isSignalHubEnabled ?? false,
     isConsumerDelegable: true,
     isClientAccessDelegable: true,
+    instanceLabel: '',
   }
 }

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/InstanceLabelSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/InstanceLabelSection.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { SectionContainer } from '@/components/layout/containers'
+import { Box, Typography } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import { RHFTextField } from '@/components/shared/react-hook-form-inputs'
+
+type InstanceLabelSectionProps = {
+  templateName: string
+  instanceLabel: string
+}
+
+export const InstanceLabelSection: React.FC<InstanceLabelSectionProps> = ({
+  templateName,
+  instanceLabel,
+}) => {
+  const { t } = useTranslation('eservice')
+
+  return (
+    <SectionContainer
+      title={t('create.step1.instanceLabelField.title')}
+      description={t('create.step1.instanceLabelField.description')}
+      component="div"
+    >
+      <RHFTextField
+        label={t('create.step1.instanceLabelField.label')}
+        infoLabel={t('create.step1.instanceLabelField.infoLabel')}
+        name="instanceLabel"
+        rules={{ maxLength: 12 }}
+        inputProps={{ maxLength: 12 }}
+        size="small"
+        sx={{ my: 0, mt: 1 }}
+      />
+      {instanceLabel && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 2 }}>
+          <Typography variant="body2" color="text.secondary">
+            {t('create.step1.instanceLabelField.catalogPreviewLabel')}
+          </Typography>
+          <Typography variant="body2" fontWeight={700}>
+            {templateName} - {instanceLabel}
+          </Typography>
+        </Box>
+      )}
+    </SectionContainer>
+  )
+}

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/__tests__/EServiceCreateStepGeneral.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/__tests__/EServiceCreateStepGeneral.test.tsx
@@ -1,0 +1,283 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import { EServiceCreateStepGeneral } from '../EServiceCreateStepGeneral'
+import { renderWithApplicationContext, mockUseJwt } from '@/utils/testing.utils'
+import * as ContextModule from '../../EServiceCreateContext'
+import * as EServiceModule from '@/api/eservice'
+import * as EServiceTemplateModule from '@/api/eserviceTemplate'
+import type { EServiceTemplateDetails, ProducerEServiceDescriptor } from '@/api/api.generatedTypes'
+
+const mockForward = vi.fn()
+const mockCreateDraftFromTemplate = vi.fn()
+const mockUpdateDraftFromTemplate = vi.fn()
+
+function mockContext(
+  overrides: Partial<ReturnType<typeof ContextModule.useEServiceCreateContext>> = {}
+) {
+  vi.spyOn(ContextModule, 'useEServiceCreateContext').mockReturnValue({
+    descriptor: undefined,
+    eserviceMode: 'DELIVER',
+    onEserviceModeChange: vi.fn(),
+    back: vi.fn(),
+    forward: mockForward,
+    areEServiceGeneralInfoEditable: true,
+    riskAnalysisFormState: { isOpen: false, riskAnalysisId: undefined },
+    openRiskAnalysisForm: vi.fn(),
+    closeRiskAnalysisForm: vi.fn(),
+    eserviceTemplate: undefined,
+    ...overrides,
+  })
+}
+
+const mockEServiceTemplate: EServiceTemplateDetails = {
+  id: 'template-id',
+  name: 'Credenziale IT-Wallet',
+  description: 'Template description',
+  technology: 'REST',
+  mode: 'DELIVER',
+  versions: [{ id: 'v1', state: 'PUBLISHED', createdAt: '2024-01-01T00:00:00Z' }],
+  creator: { id: 'creator-id', name: 'Creator' },
+  isSignalHubEnabled: false,
+  personalData: true,
+  riskAnalysis: [],
+} as unknown as EServiceTemplateDetails
+
+const mockDescriptorFromTemplate: ProducerEServiceDescriptor = {
+  id: 'desc-id',
+  version: '1',
+  state: 'DRAFT',
+  audience: [],
+  voucherLifespan: 100,
+  dailyCallsPerConsumer: 1000,
+  dailyCallsTotal: 10000,
+  agreementApprovalPolicy: 'AUTOMATIC',
+  attributes: { certified: [], declared: [], verified: [] },
+  eservice: {
+    id: 'eservice-id',
+    name: 'Credenziale IT-Wallet - Patente',
+    description: 'Eservice description',
+    producer: { id: 'producer-id' },
+    technology: 'REST',
+    mode: 'DELIVER',
+    riskAnalysis: [],
+    descriptors: [],
+    isSignalHubEnabled: false,
+    isConsumerDelegable: true,
+    isClientAccessDelegable: true,
+    personalData: true,
+    instanceLabel: 'Patente',
+  },
+  templateRef: {
+    templateId: 'template-id',
+    templateName: 'Credenziale IT-Wallet',
+  },
+} as unknown as ProducerEServiceDescriptor
+
+vi.mock('@/router', () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ eServiceTemplateId: 'template-id' }),
+}))
+
+vi.mock('@/config/tracking', () => ({
+  trackEvent: vi.fn(),
+}))
+
+beforeEach(() => {
+  mockUseJwt()
+
+  vi.spyOn(EServiceModule.EServiceMutations, 'useUpdateDraft').mockReturnValue({
+    mutate: vi.fn(),
+  } as never)
+  vi.spyOn(EServiceModule.EServiceMutations, 'useCreateDraft').mockReturnValue({
+    mutate: vi.fn(),
+  } as never)
+  vi.spyOn(
+    EServiceTemplateModule.EServiceTemplateMutations,
+    'useCreateInstanceFromEServiceTemplate'
+  ).mockReturnValue({ mutate: mockCreateDraftFromTemplate } as never)
+  vi.spyOn(
+    EServiceTemplateModule.EServiceTemplateMutations,
+    'useUpdateInstanceFromEServiceTemplate'
+  ).mockReturnValue({ mutate: mockUpdateDraftFromTemplate } as never)
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('EServiceCreateStepGeneral - instanceLabel', () => {
+  it('does NOT show the instanceLabel section when creating a regular e-service (not from template)', () => {
+    mockContext({ eserviceTemplate: undefined, descriptor: undefined })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    expect(screen.queryByText('create.step1.instanceLabelField.title')).not.toBeInTheDocument()
+  })
+
+  it('shows the instanceLabel section when creating from a template', () => {
+    mockContext({ eserviceTemplate: mockEServiceTemplate })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    expect(screen.getByText('create.step1.instanceLabelField.title')).toBeInTheDocument()
+    expect(screen.getByText('create.step1.instanceLabelField.description')).toBeInTheDocument()
+  })
+
+  it('shows the instanceLabel section when editing an existing e-service from template', () => {
+    mockContext({ descriptor: mockDescriptorFromTemplate })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    expect(screen.getByText('create.step1.instanceLabelField.title')).toBeInTheDocument()
+  })
+
+  it('pre-fills instanceLabel when editing an existing draft from template', () => {
+    mockContext({ descriptor: mockDescriptorFromTemplate })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    const instanceLabelInput = screen.getByRole('textbox', {
+      name: 'create.step1.instanceLabelField.label',
+    })
+    expect(instanceLabelInput).toHaveValue('Patente')
+  })
+
+  it('shows the catalog preview when user types in the instanceLabel field', async () => {
+    const user = userEvent.setup()
+    mockContext({ eserviceTemplate: mockEServiceTemplate })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    const instanceLabelInput = screen.getByRole('textbox', {
+      name: 'create.step1.instanceLabelField.label',
+    })
+    await user.type(instanceLabelInput, 'Patente')
+
+    await waitFor(() => {
+      expect(screen.getByText('Credenziale IT-Wallet - Patente')).toBeInTheDocument()
+    })
+  })
+
+  it('does not show the catalog preview when instanceLabel is empty', () => {
+    mockContext({ eserviceTemplate: mockEServiceTemplate })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    expect(
+      screen.queryByText('create.step1.instanceLabelField.catalogPreviewLabel')
+    ).not.toBeInTheDocument()
+  })
+
+  it('enforces maxLength of 12 characters on the instanceLabel input', () => {
+    mockContext({ eserviceTemplate: mockEServiceTemplate })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    const instanceLabelInput = screen.getByRole('textbox', {
+      name: 'create.step1.instanceLabelField.label',
+    })
+    expect(instanceLabelInput).toHaveAttribute('maxlength', '12')
+  })
+
+  it('sends instanceLabel as undefined in the create payload when field is empty (BE assigns default)', async () => {
+    const user = userEvent.setup()
+    mockContext({ eserviceTemplate: mockEServiceTemplate })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    const submitButton = screen.getByRole('button', { name: 'create.forwardWithSaveBtn' })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockCreateDraftFromTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({ instanceLabel: undefined }),
+        expect.anything()
+      )
+    })
+  })
+
+  it('sends instanceLabel as string in the create payload when user types a value', async () => {
+    const user = userEvent.setup()
+    mockContext({ eserviceTemplate: mockEServiceTemplate })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    const instanceLabelInput = screen.getByRole('textbox', {
+      name: 'create.step1.instanceLabelField.label',
+    })
+    await user.type(instanceLabelInput, 'Patente')
+
+    const submitButton = screen.getByRole('button', { name: 'create.forwardWithSaveBtn' })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockCreateDraftFromTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({ instanceLabel: 'Patente' }),
+        expect.anything()
+      )
+    })
+  })
+
+  it('sends instanceLabel as string in the update payload when user types a value', async () => {
+    const user = userEvent.setup()
+    mockContext({ descriptor: mockDescriptorFromTemplate })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    const instanceLabelInput = screen.getByRole('textbox', {
+      name: 'create.step1.instanceLabelField.label',
+    })
+    await user.clear(instanceLabelInput)
+    await user.type(instanceLabelInput, 'CIE')
+
+    const submitButton = screen.getByRole('button', { name: 'create.forwardWithSaveBtn' })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockUpdateDraftFromTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          instanceLabel: 'CIE',
+          eServiceId: 'eservice-id',
+        }),
+        expect.anything()
+      )
+    })
+  })
+
+  it('sends instanceLabel as undefined in the update payload when field is cleared', async () => {
+    const user = userEvent.setup()
+    mockContext({ descriptor: mockDescriptorFromTemplate })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    const instanceLabelInput = screen.getByRole('textbox', {
+      name: 'create.step1.instanceLabelField.label',
+    })
+    await user.clear(instanceLabelInput)
+
+    const submitButton = screen.getByRole('button', { name: 'create.forwardWithSaveBtn' })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockUpdateDraftFromTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          instanceLabel: undefined,
+          eServiceId: 'eservice-id',
+        }),
+        expect.anything()
+      )
+    })
+  })
+})

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/index.ts
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/index.ts
@@ -1,1 +1,2 @@
 export * from './EServiceCreateStepGeneral'
+export * from './InstanceLabelSection'

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -25,6 +25,17 @@
         "label": "E-service name",
         "infoLabel": "Min 5 characters, max 60 characters"
       },
+      "instanceLabelField": {
+        "title": "E-service identifying word",
+        "description": "Add a word that helps identify your e-service from others created from the same template: it is useful to have a unique name and avoid duplicates.",
+        "label": "E-service identifying word",
+        "infoLabel": "Max 12 characters",
+        "catalogPreviewLabel": "How it will appear in the catalog",
+        "validation": {
+          "duplicate": "You already created an e-service with this name, use another one.",
+          "emptyNotAvailable": "Add a word to differentiate your e-service."
+        }
+      },
       "eserviceDescriptionField": {
         "label": "E-service description",
         "infoLabel": "Include input and output data in the description. Min 10 characters, max 250 characters"

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -25,6 +25,17 @@
         "label": "Nome dell'e-service",
         "infoLabel": "Min 5 caratteri, max 60 caratteri"
       },
+      "instanceLabelField": {
+        "title": "Parola che identifica l'e-service",
+        "description": "Aggiungi una parola che aiuta a identificare il tuo e-service dagli altri creati dallo stesso template: è utile per avere un nome unico ed evitare duplicati.",
+        "label": "Parola identificativa dell'e-service",
+        "infoLabel": "Max 12 caratteri",
+        "catalogPreviewLabel": "Come comparirà nel catalogo",
+        "validation": {
+          "duplicate": "Hai già creato un e-service con questo nome, usane un altro.",
+          "emptyNotAvailable": "Aggiungi una parola per differenziare il tuo e-service."
+        }
+      },
       "eserviceDescriptionField": {
         "label": "Descrizione dell'e-service",
         "infoLabel": "Includere nel testo i dati di input e output. Min 10 caratteri, max 250 caratteri"


### PR DESCRIPTION
## Summary
- Add optional `instanceLabel` suffix field (max 12 chars) to step 1 of e-service creation/editing from template
- Field is shown in its own section with a live catalog preview (`{templateName} - {suffix}`)
- `instanceLabel` is sent as `string` when filled, or omitted (`undefined`) when empty, in both create and update payloads
- Handles duplicate name errors (`eServiceNameDuplicateForProducer`) inline on the field, suppressing the generic toast
- `InstanceLabelSection` extracted as a reusable component

## Test plan
- [ ] instanceLabel field NOT visible for regular e-service creation (not from template)
- [ ] instanceLabel field visible when creating from a template
- [ ] instanceLabel field visible when editing an existing e-service from template
- [ ] Pre-fills instanceLabel when editing an existing draft from template
- [ ] Live catalog preview shown when user types a value
- [ ] No preview when field is empty
- [ ] maxLength 12 enforced
- [ ] Create payload sends `instanceLabel` as string when filled, omits when empty
- [ ] Update payload sends `instanceLabel` as string when filled, omits when empty
- [ ] Duplicate label error shown inline on the field (no toast)