### PR TITLE
chore: update DescriptorAttribute handling to include dailyCallsPerCo…

### DIFF
--- a/__mocks__/data/attribute.mocks.ts
+++ b/__mocks__/data/attribute.mocks.ts
@@ -46,7 +46,12 @@ const createMockCompactAttribute = createMockFactory<CompactAttribute>({
   name: 'Attribute Name',
 })
 
-const createMockDescriptorAttribute = createMockFactory<DescriptorAttribute>({
+// TODO: Remove DescriptorAttributeWithThreshold when backend adds dailyCallsPerConsumer to DescriptorAttribute
+type DescriptorAttributeWithThreshold = DescriptorAttribute & {
+  dailyCallsPerConsumer?: number
+}
+
+const createMockDescriptorAttribute = createMockFactory<DescriptorAttributeWithThreshold>({
   id: 'id-party-attribute',
   name: 'Attribute Name',
   description: 'Attribute description',

--- a/src/components/shared/CustomizeThresholdDrawer.tsx
+++ b/src/components/shared/CustomizeThresholdDrawer.tsx
@@ -9,6 +9,11 @@ import { WarningAmber } from '@mui/icons-material'
 import { create } from 'zustand'
 import isEmpty from 'lodash/isEmpty'
 
+// TODO: Remove when backend adds dailyCallsPerConsumer to DescriptorAttribute
+type DescriptorAttributeWithThreshold = DescriptorAttribute & {
+  dailyCallsPerConsumer?: number
+}
+
 export type CustomizeThresholdDrawerProps = {
   dailyCallsPerConsumer?: number
   dailyCallsTotal?: number
@@ -17,9 +22,9 @@ export type CustomizeThresholdDrawerProps = {
 
 type CustomizeThresholdDrawerStore = {
   isOpen: boolean
-  open: (attribute: DescriptorAttribute, attributeGroupIndex: number) => void
+  open: (attribute: DescriptorAttributeWithThreshold, attributeGroupIndex: number) => void
   close: VoidFunction
-  attribute?: DescriptorAttribute
+  attribute?: DescriptorAttributeWithThreshold
   attributeGroupIndex?: number
 }
 


### PR DESCRIPTION
## 🔗 Issue
[PIN-9320](https://pagopa.atlassian.net/browse/PIN-9320)

## 📝 Description / Context

  The `CustomizeThresholdDrawer` component accesses `dailyCallsPerConsumer` on `DescriptorAttribute`, but this property does not yet exist in the backend-generated types. This causes TypeScript compilation errors that
  block the CI build across all PRs.

  As a temporary workaround, a local extended type `DescriptorAttributeWithThreshold` has been introduced to unblock development. This will be removed once the backend API is updated to include `dailyCallsPerConsumer`
   in the `DescriptorAttribute` schema and the frontend types are regenerated accordingly.

##  🛠 List of changes

  - Created `DescriptorAttributeWithThreshold` type extending `DescriptorAttribute` with `dailyCallsPerConsumer?`: number in `CustomizeThresholdDrawer.tsx`
  - Applied the same extended type in the mock factory (attribute.mocks.ts) to fix the test compilation error
  - Added TODO comments to both files as a reminder to remove the workaround when the backend is aligned

##  🧪 How to test

  1. Run `npm run build` — verify no TypeScript errors related to `dailyCallsPerConsumer` on `DescriptorAttribute`
  2. Run the `CustomizeThresholdDrawer` tests — verify all pass
  3. Open the customize threshold drawer in the UI and verify it behaves as expected


[PIN-9320]: https://pagopa.atlassian.net/browse/PIN-9320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ