### PR TITLE
fix: show inline error for duplicate eservice name in delegation creation (PIN-9249)

### DIFF
--- a/src/api/delegation/__tests__/delegation.mutations.test.ts
+++ b/src/api/delegation/__tests__/delegation.mutations.test.ts
@@ -16,9 +16,19 @@ vi.mock('@tanstack/react-query', async () => {
   }
 })
 
+const {
+  mockCreateProducerDelegationAndEservice,
+  mockCreateProducerDelegationAndEserviceFromTemplate,
+} = vi.hoisted(() => ({
+  mockCreateProducerDelegationAndEservice: vi.fn(),
+  mockCreateProducerDelegationAndEserviceFromTemplate: vi.fn(),
+}))
+
 vi.mock('../delegation.services', () => ({
   DelegationServices: {
-    createProducerDelegationAndEserviceFromTemplate: vi.fn(),
+    createProducerDelegationAndEservice: mockCreateProducerDelegationAndEservice,
+    createProducerDelegationAndEserviceFromTemplate:
+      mockCreateProducerDelegationAndEserviceFromTemplate,
   },
 }))
 
@@ -30,6 +40,22 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+function getErrorToastLabel(mutationFn: unknown) {
+  const options = capturedMutationOptions.find((opt) => opt.mutationFn === mutationFn)
+  expect(options).toBeDefined()
+  return (options!.meta as Record<string, unknown>).errorToastLabel as (error: unknown) => string
+}
+
+function makeDuplicateError() {
+  return new AxiosError('test', undefined, undefined, undefined, {
+    status: 400,
+    statusText: 'Bad Request',
+    data: { errors: [{ code: DUPLICATE_INSTANCE_LABEL_ERROR_CODE }] },
+    headers: {},
+    config: {} as never,
+  })
+}
+
 describe('useCreateProducerDelegationAndEserviceFromTemplate', () => {
   it('suppresses error toast for duplicate instance label error', () => {
     renderHookWithApplicationContext(
@@ -37,25 +63,9 @@ describe('useCreateProducerDelegationAndEserviceFromTemplate', () => {
       { withReactQueryContext: true }
     )
 
-    const options = capturedMutationOptions.find(
-      (opt) => typeof (opt.meta as Record<string, unknown>)?.errorToastLabel === 'function'
-    )
+    const errorToastLabel = getErrorToastLabel(mockCreateProducerDelegationAndEserviceFromTemplate)
 
-    expect(options).toBeDefined()
-
-    const errorToastLabel = (options!.meta as Record<string, unknown>).errorToastLabel as (
-      error: unknown
-    ) => string
-
-    const duplicateError = new AxiosError('test', undefined, undefined, undefined, {
-      status: 400,
-      statusText: 'Bad Request',
-      data: { errors: [{ code: DUPLICATE_INSTANCE_LABEL_ERROR_CODE }] },
-      headers: {},
-      config: {} as never,
-    })
-
-    expect(errorToastLabel(duplicateError)).toBe('')
+    expect(errorToastLabel(makeDuplicateError())).toBe('')
   })
 
   it('returns default error label for non-duplicate errors', () => {
@@ -64,13 +74,31 @@ describe('useCreateProducerDelegationAndEserviceFromTemplate', () => {
       { withReactQueryContext: true }
     )
 
-    const options = capturedMutationOptions.find(
-      (opt) => typeof (opt.meta as Record<string, unknown>)?.errorToastLabel === 'function'
+    const errorToastLabel = getErrorToastLabel(mockCreateProducerDelegationAndEserviceFromTemplate)
+
+    expect(errorToastLabel(new Error('generic error'))).toBe('outcome.error')
+  })
+})
+
+describe('useCreateProducerDelegationAndEservice', () => {
+  it('suppresses error toast for duplicate eservice name error', () => {
+    renderHookWithApplicationContext(
+      () => DelegationMutations.useCreateProducerDelegationAndEservice(),
+      { withReactQueryContext: true }
     )
 
-    const errorToastLabel = (options!.meta as Record<string, unknown>).errorToastLabel as (
-      error: unknown
-    ) => string
+    const errorToastLabel = getErrorToastLabel(mockCreateProducerDelegationAndEservice)
+
+    expect(errorToastLabel(makeDuplicateError())).toBe('')
+  })
+
+  it('returns default error label for non-duplicate errors', () => {
+    renderHookWithApplicationContext(
+      () => DelegationMutations.useCreateProducerDelegationAndEservice(),
+      { withReactQueryContext: true }
+    )
+
+    const errorToastLabel = getErrorToastLabel(mockCreateProducerDelegationAndEservice)
 
     expect(errorToastLabel(new Error('generic error'))).toBe('outcome.error')
   })

--- a/src/api/delegation/delegation.mutations.ts
+++ b/src/api/delegation/delegation.mutations.ts
@@ -102,7 +102,14 @@ function useCreateProducerDelegationAndEservice() {
     mutationFn: DelegationServices.createProducerDelegationAndEservice,
     meta: {
       successToastLabel: t('outcome.success'),
-      errorToastLabel: t('outcome.error'),
+      errorToastLabel: (error: unknown) => {
+        if (
+          error instanceof AxiosError &&
+          error.response?.data?.errors?.[0]?.code === DUPLICATE_INSTANCE_LABEL_ERROR_CODE
+        )
+          return ''
+        return t('outcome.error')
+      },
       loadingLabel: t('loading'),
     },
   })

--- a/src/pages/DelegationCreatePage/components/DelegationCreateForm.tsx
+++ b/src/pages/DelegationCreatePage/components/DelegationCreateForm.tsx
@@ -3,7 +3,9 @@ import React, { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { useQuery } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
 import type { DelegationKind } from '@/api/api.generatedTypes'
+import { DUPLICATE_INSTANCE_LABEL_ERROR_CODE } from '@/api/eserviceTemplate/eserviceTemplate.mutations'
 import { SectionContainer } from '@/components/layout/containers'
 import { useDialog } from '@/stores'
 import { DelegationMutations, DelegationQueries } from '@/api/delegation'
@@ -125,6 +127,16 @@ export const DelegationCreateForm: React.FC<DelegationCreateFormProps> = ({
         {
           onSuccess: () => {
             navigate('DELEGATIONS')
+          },
+          onError: (error) => {
+            if (
+              error instanceof AxiosError &&
+              error.response?.data?.errors?.[0]?.code === DUPLICATE_INSTANCE_LABEL_ERROR_CODE
+            ) {
+              formMethods.setError('eserviceName', {
+                message: t('delegations.create.eserviceField.validation.duplicateName'),
+              })
+            }
           },
         }
       )

--- a/src/pages/DelegationCreatePage/components/__tests__/DelegationCreateForm.duplicateEserviceName.test.tsx
+++ b/src/pages/DelegationCreatePage/components/__tests__/DelegationCreateForm.duplicateEserviceName.test.tsx
@@ -1,0 +1,164 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import { AxiosError } from 'axios'
+import { renderWithApplicationContext, mockUseJwt } from '@/utils/testing.utils'
+import { DelegationCreateForm } from '../DelegationCreateForm'
+import * as DelegationModule from '@/api/delegation'
+
+vi.mock('../DelegationCreateEServiceFromTemplateAutocomplete', () => ({
+  DelegationCreateEServiceFromTemplateAutocomplete: () => (
+    <div data-testid="mock-template-autocomplete" />
+  ),
+}))
+
+vi.mock('../DelegationCreateEServiceAutocomplete', () => ({
+  DelegationCreateEServiceAutocomplete: () => <div data-testid="mock-eservice-autocomplete" />,
+}))
+
+vi.mock('../DelegationCreateTenantAutocomplete', () => ({
+  DelegationCreateTenantAutocomplete: () => <div data-testid="mock-tenant-autocomplete" />,
+}))
+
+vi.mock('@/api/eserviceTemplate/eserviceTemplate.mutations', () => ({
+  DUPLICATE_INSTANCE_LABEL_ERROR_CODE: '001-007',
+}))
+
+let mockCreateAndEservice: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  mockUseJwt()
+  mockCreateAndEservice = vi.fn()
+
+  vi.spyOn(DelegationModule.DelegationMutations, 'useCreateProducerDelegation').mockReturnValue({
+    mutate: vi.fn(),
+  } as never)
+
+  vi.spyOn(DelegationModule.DelegationMutations, 'useCreateConsumerDelegation').mockReturnValue({
+    mutate: vi.fn(),
+  } as never)
+
+  vi.spyOn(
+    DelegationModule.DelegationMutations,
+    'useCreateProducerDelegationAndEservice'
+  ).mockReturnValue({ mutate: mockCreateAndEservice } as never)
+
+  vi.spyOn(
+    DelegationModule.DelegationMutations,
+    'useCreateProducerDelegationAndEserviceFromTemplate'
+  ).mockReturnValue({ mutate: vi.fn() } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('DelegationCreateForm - duplicate eservice name', () => {
+  it('shows inline error on eserviceName field when mutation fails with 001-007', async () => {
+    mockCreateAndEservice.mockImplementation(
+      (_params: unknown, { onError }: { onError: (error: unknown) => void }) => {
+        onError(
+          new AxiosError('test', undefined, undefined, undefined, {
+            status: 409,
+            statusText: 'Conflict',
+            data: { errors: [{ code: '001-007' }] },
+            headers: {},
+            config: {} as never,
+          })
+        )
+      }
+    )
+
+    const user = userEvent.setup()
+
+    renderWithApplicationContext(
+      <DelegationCreateForm delegationKind="DELEGATED_PRODUCER" setActiveStep={vi.fn()} />,
+      { withRouterContext: true, withReactQueryContext: true }
+    )
+
+    // Toggle "create eservice" switch
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: /delegateField.provider.switch$/i,
+      })
+    )
+
+    // Fill eservice name (min 5 chars)
+    const nameInput = screen.getByRole('textbox', { name: /eserviceField.label/i })
+    await user.type(nameInput, 'Test Eservice Name')
+
+    // Fill description (min 10 chars)
+    const descriptionInput = screen.getByRole('textbox', {
+      name: /eserviceField.descriptionLabel/i,
+    })
+    await user.type(descriptionInput, 'A description for the eservice')
+
+    // Submit form
+    await user.click(screen.getByRole('button', { name: /submitBtn/i }))
+
+    // Confirm dialog
+    const checkbox = screen.getByRole('checkbox', { name: /checkboxLabel/i })
+    await user.click(checkbox)
+    await user.click(screen.getByRole('button', { name: /proceedLabel/i }))
+
+    await waitFor(() => {
+      expect(mockCreateAndEservice).toHaveBeenCalled()
+    })
+
+    // The inline error message should be shown
+    await waitFor(() => {
+      expect(
+        screen.getByText('delegations.create.eserviceField.validation.duplicateName')
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('does not show inline error for non-duplicate errors', async () => {
+    mockCreateAndEservice.mockImplementation(
+      (_params: unknown, { onError }: { onError: (error: unknown) => void }) => {
+        onError(new Error('generic error'))
+      }
+    )
+
+    const user = userEvent.setup()
+
+    renderWithApplicationContext(
+      <DelegationCreateForm delegationKind="DELEGATED_PRODUCER" setActiveStep={vi.fn()} />,
+      { withRouterContext: true, withReactQueryContext: true }
+    )
+
+    // Toggle "create eservice" switch
+    await user.click(
+      screen.getByRole('checkbox', {
+        name: /delegateField.provider.switch$/i,
+      })
+    )
+
+    // Fill eservice name
+    const nameInput = screen.getByRole('textbox', { name: /eserviceField.label/i })
+    await user.type(nameInput, 'Test Eservice Name')
+
+    // Fill description
+    const descriptionInput = screen.getByRole('textbox', {
+      name: /eserviceField.descriptionLabel/i,
+    })
+    await user.type(descriptionInput, 'A description for the eservice')
+
+    // Submit form
+    await user.click(screen.getByRole('button', { name: /submitBtn/i }))
+
+    // Confirm dialog
+    const checkbox = screen.getByRole('checkbox', { name: /checkboxLabel/i })
+    await user.click(checkbox)
+    await user.click(screen.getByRole('button', { name: /proceedLabel/i }))
+
+    await waitFor(() => {
+      expect(mockCreateAndEservice).toHaveBeenCalled()
+    })
+
+    // The inline error message should NOT be shown
+    expect(
+      screen.queryByText('delegations.create.eserviceField.validation.duplicateName')
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/static/locales/en/party.json
+++ b/src/static/locales/en/party.json
@@ -157,7 +157,10 @@
         },
         "descriptionLabel": "E-service description",
         "descriptionInfoLabel": "Include input and output data in the text. Min 10 characters, max 250 characters",
-        "eserviceNameLabel": "Produced by"
+        "eserviceNameLabel": "Produced by",
+        "validation": {
+          "duplicateName": "Your organization already created an e-service with this name. Choose a different one."
+        }
       },
       "delegateField": {
         "consumer": {

--- a/src/static/locales/it/party.json
+++ b/src/static/locales/it/party.json
@@ -157,7 +157,10 @@
         },
         "descriptionLabel": "Descrizione dell'e-service",
         "descriptionInfoLabel": "Includere nel testo i dati di input e output. Min 10 caratteri, max 250 caratteri",
-        "eserviceNameLabel": "Erogato da"
+        "eserviceNameLabel": "Erogato da",
+        "validation": {
+          "duplicateName": "Il tuo ente ha già creato un e-service con questo nome. Scegline uno diverso."
+        }
       },
       "delegateField": {
         "consumer": {


### PR DESCRIPTION
## Summary
- Show inline error instead of toast when creating an e-service from delegation with a duplicate name
- Add test coverage for the duplicate name error flow
