### PR TITLE
feat: add voucher update functionality to EServiceTemplateTechnicalIn…

### DIFF
--- a/src/components/shared/EserviceTemplate/EServiceTemplateTechnicalInfoSection.tsx
+++ b/src/components/shared/EserviceTemplate/EServiceTemplateTechnicalInfoSection.tsx
@@ -6,10 +6,14 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { EServiceTemplateQueries } from '@/api/eserviceTemplate'
+import { EServiceTemplateMutations } from '@/api/eserviceTemplate'
 import { EServiceTemplateThresholdsSection } from './EServiceTemplateThresholdsSection'
 import { EServiceTemplateDocumentationSection } from './EServiceTemplateDocumentationSection'
 import { EServiceTemplateUsefulLinksSection } from './EServiceTemplateUsefulLinksSection'
+import { UpdateVoucherDrawer } from '@/components/shared/UpdateVoucherDrawer'
 import { secondsToMinutes } from '@/utils/format.utils'
+import { useDrawerState } from '@/hooks/useDrawerState'
+import EditIcon from '@mui/icons-material/Edit'
 
 type EServiceTemplateTechnicalInfoSectionProps = {
   readonly: boolean
@@ -23,6 +27,9 @@ export const EServiceTemplateTechnicalInfoSection: React.FC<
     keyPrefix: 'read.sections.technicalInformations',
   })
   const { t: tCommon } = useTranslation('common')
+  const { t: tDrawer } = useTranslation('eserviceTemplate', {
+    keyPrefix: 'read.drawers.updateVoucherDrawer',
+  })
 
   const { eServiceTemplateId, eServiceTemplateVersionId } = useParams<typeof routeKey>()
   const { data: eserviceTemplate } = useSuspenseQuery(
@@ -30,6 +37,23 @@ export const EServiceTemplateTechnicalInfoSection: React.FC<
   )
 
   const voucherLifespan = secondsToMinutes(eserviceTemplate.voucherLifespan)
+
+  const { isOpen, openDrawer, closeDrawer } = useDrawerState()
+
+  const { mutate: updateEserviceTemplateQuotas } = EServiceTemplateMutations.useUpdateQuotas()
+
+  const handleVoucherUpdate = (id: string, newVoucherLifespan: number, versionId?: string) => {
+    updateEserviceTemplateQuotas(
+      {
+        eServiceTemplateId: id,
+        eServiceTemplateVersionId: versionId!,
+        voucherLifespan: newVoucherLifespan,
+        dailyCallsPerConsumer: eserviceTemplate.dailyCallsPerConsumer,
+        dailyCallsTotal: eserviceTemplate.dailyCallsTotal,
+      },
+      { onSuccess: closeDrawer }
+    )
+  }
 
   return (
     <SectionContainer title={t('title')} description={t('description')}>
@@ -46,15 +70,29 @@ export const EServiceTemplateTechnicalInfoSection: React.FC<
               labelDescription={t('mode.labelDescription')}
               content={t(`mode.value.${eserviceTemplate.eserviceTemplate.mode}`)}
             />
-
-            <InformationContainer
-              label={t('thresholds.voucherLifespan.label')}
-              labelDescription={t('thresholds.voucherLifespan.labelDescription')}
-              content={`${voucherLifespan} ${tCommon('time.minute', {
-                count: voucherLifespan,
-              })}`}
-            />
           </Stack>
+        </SectionContainer>
+        <Divider />
+        <SectionContainer
+          innerSection
+          title={t('voucher.title')}
+          topSideActions={
+            readonly
+              ? undefined
+              : [
+                  {
+                    action: openDrawer,
+                    label: tCommon('actions.edit'),
+                    icon: EditIcon,
+                  },
+                ]
+          }
+        >
+          <InformationContainer
+            label={t('thresholds.voucherLifespan.label')}
+            labelDescription={t('thresholds.voucherLifespan.labelDescription')}
+            content={`${voucherLifespan}`}
+          />
         </SectionContainer>
         {!hideThresholds && (
           <>
@@ -73,6 +111,15 @@ export const EServiceTemplateTechnicalInfoSection: React.FC<
         <Divider />
         <EServiceTemplateUsefulLinksSection />
       </Stack>
+      <UpdateVoucherDrawer
+        isOpen={isOpen}
+        onClose={closeDrawer}
+        id={eserviceTemplate.eserviceTemplate.id}
+        voucherLifespan={eserviceTemplate.voucherLifespan}
+        versionId={eServiceTemplateVersionId}
+        subtitle={tDrawer('subtitle')}
+        onSubmit={handleVoucherUpdate}
+      />
     </SectionContainer>
   )
 }

--- a/src/components/shared/EserviceTemplate/__tests__/EServiceTemplateTechnicalInfoSection.test.tsx
+++ b/src/components/shared/EserviceTemplate/__tests__/EServiceTemplateTechnicalInfoSection.test.tsx
@@ -127,6 +127,44 @@ describe('EServiceTemplateTechnicalInfoSection', () => {
     expect(screen.queryByTestId('thresholds-section')).not.toBeInTheDocument()
   })
 
+  it('renders voucher section with title and edit button when not readonly', () => {
+    const mockData = createMockEServiceTemplateVersionDetails()
+    useSuspenseQueryMock.mockReturnValue({ data: mockData })
+
+    renderWithApplicationContext(
+      <EServiceTemplateTechnicalInfoSection
+        readonly={false}
+        routeKey="PROVIDE_ESERVICE_TEMPLATE_DETAILS"
+      />,
+      {
+        withReactQueryContext: true,
+        withRouterContext: true,
+      }
+    )
+
+    expect(screen.getByText('voucher.title')).toBeInTheDocument()
+    expect(screen.getByText('actions.edit')).toBeInTheDocument()
+  })
+
+  it('does not render edit button for voucher section when readonly', () => {
+    const mockData = createMockEServiceTemplateVersionDetails()
+    useSuspenseQueryMock.mockReturnValue({ data: mockData })
+
+    renderWithApplicationContext(
+      <EServiceTemplateTechnicalInfoSection
+        readonly={true}
+        routeKey="PROVIDE_ESERVICE_TEMPLATE_DETAILS"
+      />,
+      {
+        withReactQueryContext: true,
+        withRouterContext: true,
+      }
+    )
+
+    expect(screen.getByText('voucher.title')).toBeInTheDocument()
+    expect(screen.queryByText('actions.edit')).not.toBeInTheDocument()
+  })
+
   it('renders documentation and useful links sections', () => {
     const mockData = createMockEServiceTemplateVersionDetails()
     useSuspenseQueryMock.mockReturnValue({ data: mockData })

--- a/src/static/locales/en/eserviceTemplate.json
+++ b/src/static/locales/en/eserviceTemplate.json
@@ -63,6 +63,9 @@
             "RECEIVE": "Receive"
           }
         },
+        "voucher": {
+          "title": "Voucher"
+        },
         "thresholds": {
           "title": "Thresholds",
           "voucherLifespan": {
@@ -141,6 +144,9 @@
         "subtitle": "From this panel, you can update the quotas of the template e-service. The changes made will take effect immediately",
         "dailyCallsPerConsumerLabel": "Per consumer suggested threshold",
         "dailyCallsTotalLabel": "Total suggested threshold"
+      },
+      "updateVoucherDrawer": {
+        "subtitle": "From this panel, you can update the voucher lifespan of the template e-service. The changes made will take effect immediately."
       },
       "updateDocumentationDrawer": {
         "title": "Edit documentation",

--- a/src/static/locales/it/eserviceTemplate.json
+++ b/src/static/locales/it/eserviceTemplate.json
@@ -63,6 +63,9 @@
             "RECEIVE": "Riceve"
           }
         },
+        "voucher": {
+          "title": "Voucher"
+        },
         "thresholds": {
           "title": "Soglie",
           "voucherLifespan": {
@@ -141,6 +144,9 @@
         "subtitle": "Da questo pannello puoi aggiornare i parametri della tua versione del template di e-service. Le modifiche apportate avranno effetto da subito.",
         "dailyCallsPerConsumerLabel": "Soglia suggerita per fruitore",
         "dailyCallsTotalLabel": "Soglia suggerita totale"
+      },
+      "updateVoucherDrawer": {
+        "subtitle": "Da questo pannello puoi aggiornare la durata del voucher del template di e-service. Le modifiche apportate avranno effetto da subito."
       },
       "updateDocumentationDrawer": {
         "title": "Modifica documentazione",


### PR DESCRIPTION
## 🔗 Issue
[PIN-9375](https://pagopa.atlassian.net/browse/PIN-9375)

## 📝 Description / Context
 Extract the voucher lifespan from the generic technical info block into its own "Voucher" subsection within the "Specifiche tecniche e-service" section, with a dedicated Edit button and drawer, matching the updated Figma design.

## 🛠 List of changes
- Extract voucher `InformationContainer` from the technology/mode block into a dedicated `SectionContainer` with title "Voucher" and Edit action
- Wire up `UpdateVoucherDrawer` for inline voucher lifespan editing (preserving existing daily calls values)
- Display voucher value as number-only (sublabel already indicates "in minuti")
- Add EN/IT translations for voucher.title and `updateVoucherDrawer.subtitle` in `eserviceTemplate.json`
- Add tests for voucher section title visibility and Edit button readonly behavior

## 🧪 How to test

<img width="864" height="537" alt="Screenshot 2026-03-03 alle 12 07 32" src="https://github.com/user-attachments/assets/c52b44f9-8f7d-45ed-9ed7-6a9fafb20abf" />


[PIN-9375]: https://pagopa.atlassian.net/browse/PIN-9375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ