### PR TITLE
feature/PIN-9382_remove-notification-banner

### DIFF
--- a/src/pages/NotificationUserConfigPage/components/NotificationUserConfigTab.tsx
+++ b/src/pages/NotificationUserConfigPage/components/NotificationUserConfigTab.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FormProvider } from 'react-hook-form'
 import { SectionContainer } from '@/components/layout/containers'
-import { Box, Stack, Typography, Alert, Link } from '@mui/material'
+import { Box, Stack, Typography, Link } from '@mui/material'
 import { RHFSwitch, SwitchLabelDescription } from '@/components/shared/react-hook-form-inputs'
 import { useTranslation } from 'react-i18next'
 import { useGetNotificationConfigSchema } from '../hooks/useGetNotificationConfigSchema'
@@ -29,9 +29,6 @@ export const NotificationConfigUserTab: React.FC<NotificationConfigUserTabProps>
   handleUpdateNotificationConfigs,
   type,
 }) => {
-  const { t: tConfiguration } = useTranslation('notification', {
-    keyPrefix: 'notifications.configurationPage',
-  })
   const { t } = useTranslation('notification', {
     keyPrefix: `notifications.configurationPage.${type}`,
   })
@@ -69,13 +66,6 @@ export const NotificationConfigUserTab: React.FC<NotificationConfigUserTabProps>
     <FormProvider {...formMethods}>
       <SectionContainer sx={{ px: 4, pt: 4 }} title={t('title')} description={t('description')}>
         {type === 'email' ? <EmailConfigHeader userEmail={userEmail} /> : <InAppConfigHeader />}
-        {/* {inAppNotificationPreference !== 'DIGEST' && ( */}
-        {isEnabledShowPreferencesSwitch && (
-          <Alert sx={{ mt: 2 }} severity="info">
-            {tConfiguration('infoAlert')}
-          </Alert>
-        )}
-        {/* )} */}
         <Box sx={{ ml: 2, mt: 2 }}>
           {isEnabledShowPreferencesSwitch &&
             Object.keys(notificationSchema).map((sectionName) => {

--- a/src/static/locales/en/notification.json
+++ b/src/static/locales/en/notification.json
@@ -65,7 +65,6 @@
       "description": "Manage your notification settings in app and via personal email. Not sure how to set up notifications? <1>See the manual</1>",
       "inAppTabTitle": "In-App Notifications",
       "emailTabTitle": "Email",
-      "infoAlert": "Selected notifications may not arrive immediately, as we are planning a gradual rollout. No further action will be required after setting your preferences.",
       "inApp": {
         "title": "Platform Notification Preferences Configuration",
         "manualLinkLabel": "Doubts? See the manual",

--- a/src/static/locales/it/notification.json
+++ b/src/static/locales/it/notification.json
@@ -66,7 +66,6 @@
       "description": "Gestisci le tue impostazioni di notifica in app e via email personale. Hai dubbi su come configurare le notifiche? <1>Consulta il manuale</1>",
       "inAppTabTitle": "Notifiche in-app",
       "emailTabTitle": "Email",
-      "infoAlert": "Le notifiche selezionate potrebbero non arrivare subito, in quanto programmiamo un rilascio graduale. Dopo la tua configurazione delle preferenze non ti sarà richiesta alcuna azione.",
       "inApp": {
         "title": "Configurazione delle preferenze di notifica in piattaforma",
         "manualLinkLabel": "Dubbi? Vai sul manuale",


### PR DESCRIPTION
## 🔗 Issue

[PIN-9382](https://pagopa.atlassian.net/browse/PIN-9382)

## 📝 Description / Context

This pull request removes the info alert about the gradual rollout of notifications from the notification user configuration tab, along with its associated translation strings in both English and Italian. 



[PIN-9382]: https://pagopa.atlassian.net/browse/PIN-9382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ