### PR TITLE
Bugfix/pin 9394 fix navigation template eservice consumer side

### DIFF
--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
@@ -253,7 +253,7 @@ export const ProviderEServiceGeneralInfoSection: React.FC = () => {
                 label={t('eserviceTemplateName.label')}
                 content={
                   <Link
-                    to="PROVIDE_ESERVICE_TEMPLATE_DETAILS"
+                    to="SUBSCRIBE_ESERVICE_TEMPLATE_DETAILS"
                     params={{
                       eServiceTemplateId: descriptor.templateRef?.templateId as string,
                       eServiceTemplateVersionId: descriptor.templateRef


### PR DESCRIPTION
## 🔗 Issue

[PIN-9394](https://pagopa.atlassian.net/browse/PIN-9394)

## 📝 Description / Context

 Fixed the route in `ProviderEServiceGeneralInfoSection.tsx` by changing the `to` prop from `"PROVIDE_ESERVICE_TEMPLATE_DETAILS"` to `"SUBSCRIBE_ESERVICE_TEMPLATE_DETAILS"`.



[PIN-9394]: https://pagopa.atlassian.net/browse/PIN-9394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ