### PR TITLE
fix/PIN-9411: replace instanceLabel with catalog name in summary

### DIFF
--- a/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceGeneralInfoSummary.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceGeneralInfoSummary.tsx
@@ -25,10 +25,7 @@ export const ProviderEServiceGeneralInfoSummary: React.FC = () => {
         content={descriptor.eservice.description}
       />
       {descriptor.templateRef && (
-        <InformationContainer
-          label={t('instanceLabel.label')}
-          content={descriptor.eservice?.instanceLabel || '-'}
-        />
+        <InformationContainer label={t('catalogName.label')} content={descriptor.eservice.name} />
       )}
       <InformationContainer
         label={t('apiTechnology.label')}

--- a/src/pages/ProviderEServiceSummaryPage/components/__tests__/ProviderEServiceGeneralInfoSummary.instanceLabel.test.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/components/__tests__/ProviderEServiceGeneralInfoSummary.instanceLabel.test.tsx
@@ -30,8 +30,8 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-describe('ProviderEServiceGeneralInfoSummary - instanceLabel', () => {
-  it('shows the instanceLabel when the e-service is from a template', () => {
+describe('ProviderEServiceGeneralInfoSummary - catalogName', () => {
+  it('shows the catalog name when the e-service is from a template', () => {
     mockDescriptorData = createMockEServiceDescriptorProvider({
       eservice: {
         name: 'Credenziale IT-Wallet - Patente',
@@ -48,11 +48,11 @@ describe('ProviderEServiceGeneralInfoSummary - instanceLabel', () => {
       withReactQueryContext: true,
     })
 
-    expect(screen.getByText('instanceLabel.label')).toBeInTheDocument()
-    expect(screen.getByText('Patente')).toBeInTheDocument()
+    expect(screen.getByText('catalogName.label')).toBeInTheDocument()
+    expect(screen.getByText('Credenziale IT-Wallet - Patente')).toBeInTheDocument()
   })
 
-  it('shows "-" when instanceLabel is undefined but e-service is from a template', () => {
+  it('shows the catalog name even when instanceLabel is undefined', () => {
     mockDescriptorData = createMockEServiceDescriptorProvider({
       eservice: {
         name: 'Credenziale IT-Wallet',
@@ -69,11 +69,11 @@ describe('ProviderEServiceGeneralInfoSummary - instanceLabel', () => {
       withReactQueryContext: true,
     })
 
-    expect(screen.getByText('instanceLabel.label')).toBeInTheDocument()
-    expect(screen.getByText('-')).toBeInTheDocument()
+    expect(screen.getByText('catalogName.label')).toBeInTheDocument()
+    expect(screen.getByText('Credenziale IT-Wallet')).toBeInTheDocument()
   })
 
-  it('does NOT show instanceLabel for non-template e-services', () => {
+  it('does NOT show catalog name for non-template e-services', () => {
     mockDescriptorData = createMockEServiceDescriptorProvider({
       eservice: {
         name: 'Regular E-Service',
@@ -84,6 +84,6 @@ describe('ProviderEServiceGeneralInfoSummary - instanceLabel', () => {
       withReactQueryContext: true,
     })
 
-    expect(screen.queryByText('instanceLabel.label')).not.toBeInTheDocument()
+    expect(screen.queryByText('catalogName.label')).not.toBeInTheDocument()
   })
 })

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -256,8 +256,8 @@
           "undefined": "Not specified"
         }
       },
-      "instanceLabel": {
-        "label": "E-service distinctive name"
+      "catalogName": {
+        "label": "How it will appear in the catalog"
       },
       "apiTechnology": {
         "label": "API Technology"

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -256,8 +256,8 @@
           "undefined": "Non indicato"
         }
       },
-      "instanceLabel": {
-        "label": "Parola che identifica l'e-service"
+      "catalogName": {
+        "label": "Come comparirà nel catalogo"
       },
       "apiTechnology": {
         "label": "Tecnologia API"


### PR DESCRIPTION
## Summary
- Nel summary di pubblicazione bozza da template, sostituito il campo "Parola che identifica l'e-service" (instanceLabel) con "Come comparirà nel catalogo" (nome completo dell'e-service)