### PR TITLE
fix: swap delegation and signal hub sections order

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/EServiceCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/EServiceCreateStepGeneral.tsx
@@ -323,9 +323,6 @@ export const EServiceCreateStepGeneral: React.FC = () => {
           />
         )}
 
-        {/* Signalhub switch can be editable also if coming from a eservice eserviceTemplate */}
-        <SignalHubSection isSignalHubActivationEditable={areEServiceGeneralInfoEditable} />
-
         {isOrganizationAllowedToProduce && (
           <SectionContainer
             title={t('create.step1.delegationSection.title')}
@@ -381,6 +378,9 @@ export const EServiceCreateStepGeneral: React.FC = () => {
             )}
           </SectionContainer>
         )}
+
+        {/* Signalhub switch can be editable also if coming from a eservice eserviceTemplate */}
+        <SignalHubSection isSignalHubActivationEditable={areEServiceGeneralInfoEditable} />
 
         <StepActions
           forward={

--- a/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceGeneralInfoSummary.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceGeneralInfoSummary.tsx
@@ -37,10 +37,6 @@ export const ProviderEServiceGeneralInfoSummary: React.FC = () => {
           content={t(`personalDataField.value.${descriptor.eservice.personalData}`)}
         />
       )}
-      <InformationContainer
-        label={t('isSignalHubEnabled.label')}
-        content={t(`isSignalHubEnabled.value.${descriptor.eservice.isSignalHubEnabled}`)}
-      />
       {isOrganizationAllowedToProduce && (
         <>
           <InformationContainer
@@ -55,6 +51,10 @@ export const ProviderEServiceGeneralInfoSummary: React.FC = () => {
           />
         </>
       )}
+      <InformationContainer
+        label={t('isSignalHubEnabled.label')}
+        content={t(`isSignalHubEnabled.value.${descriptor.eservice.isSignalHubEnabled}`)}
+      />
     </Stack>
   )
 }


### PR DESCRIPTION
## Summary
- Swapped the order of "Deleghe" and "Signal Hub" sections in the e-service creation form and summary page
- "Deleghe" now correctly precedes "Signal Hub" in both views