### PR TITLE
feat: renamed updated daily calls to remaining (PIN-9419)

### DIFF
--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -606,6 +606,18 @@ export interface EServiceTemplateRef {
   templateInterface?: EServiceDoc;
   interfaceMetadata?: TemplateInstanceInterfaceMetadata;
   isNewTemplateVersionAvailable?: boolean;
+  /**
+   * @format int32
+   * @min 1
+   * @max 1000000000
+   */
+  templateDailyCallsPerConsumer?: number;
+  /**
+   * @format int32
+   * @min 1
+   * @max 1000000000
+   */
+  templateDailyCallsTotal?: number;
 }
 
 export interface EServiceDoc {
@@ -1390,17 +1402,17 @@ export interface Purposes {
   pagination: Pagination;
 }
 
-export interface UpdatedDailyCallsResponse {
+export interface RemainingDailyCallsResponse {
   /**
    * @format int32
    * @min 0
    */
-  updatedDailyCallsPerConsumer: number;
+  remainingDailyCallsPerConsumer: number;
   /**
    * @format int32
    * @min 0
    */
-  updatedDailyCallsTotal: number;
+  remainingDailyCallsTotal: number;
 }
 
 export interface DelegationWithCompactTenants {
@@ -4267,7 +4279,7 @@ export interface RetrieveRiskAnalysisConfigurationByVersionParams {
   riskAnalysisVersion: string;
 }
 
-export interface GetUpdatedDailyCallsParams {
+export interface GetRemainingDailyCallsParams {
   /**
    * the purpose id
    * @format uuid
@@ -8689,13 +8701,13 @@ export namespace Purposes {
   }
 
   /**
-   * @description Retrieve updated available daily calls for a purpose
+   * @description Retrieve remaining daily calls for a purpose
    * @tags purposes
-   * @name GetUpdatedDailyCalls
-   * @request GET:/purposes/{purposeId}/updatedDailyCalls
+   * @name GetRemainingDailyCalls
+   * @request GET:/purposes/{purposeId}/remainingDailyCalls
    * @secure
    */
-  export namespace GetUpdatedDailyCalls {
+  export namespace GetRemainingDailyCalls {
     export type RequestParams = {
       /**
        * the purpose id
@@ -8706,7 +8718,7 @@ export namespace Purposes {
     export type RequestQuery = {};
     export type RequestBody = never;
     export type RequestHeaders = {};
-    export type ResponseBody = UpdatedDailyCallsResponse;
+    export type ResponseBody = RemainingDailyCallsResponse;
   }
 }
 

--- a/src/api/purpose/purpose.queries.ts
+++ b/src/api/purpose/purpose.queries.ts
@@ -4,7 +4,7 @@ import { PurposeServices } from './purpose.services'
 import type {
   GetConsumerPurposesParams,
   GetProducerPurposesParams,
-  GetUpdatedDailyCallsParams,
+  GetRemainingDailyCallsParams,
   RetrieveLatestRiskAnalysisConfigurationParams,
   RetrieveRiskAnalysisConfigurationByVersionParams,
 } from '../api.generatedTypes'
@@ -51,10 +51,10 @@ function getRiskAnalyisLatestOrSpecificVersion(params: RiskAnlysisVersionConfig)
   })
 }
 
-function getUpdatedDailyCalls(params: GetUpdatedDailyCallsParams) {
+function getRemainingDailyCalls(params: GetRemainingDailyCallsParams) {
   return queryOptions({
-    queryKey: ['GetUpdatedDailyCalls', params],
-    queryFn: () => PurposeServices.getUpdatedDailyCalls(params),
+    queryKey: ['getRemainingDailyCalls', params],
+    queryFn: () => PurposeServices.getRemainingDailyCalls(params),
   })
 }
 
@@ -65,5 +65,5 @@ export const PurposeQueries = {
   getRiskAnalysisLatest,
   getRiskAnalysisVersion,
   getRiskAnalyisLatestOrSpecificVersion,
-  getUpdatedDailyCalls,
+  getRemainingDailyCalls,
 }

--- a/src/api/purpose/purpose.services.ts
+++ b/src/api/purpose/purpose.services.ts
@@ -5,6 +5,7 @@ import type {
   DelegationRef,
   GetConsumerPurposesParams,
   GetProducerPurposesParams,
+  GetRemainingDailyCallsParams,
   PatchPurposeUpdateFromTemplateContent,
   Purpose,
   PurposeAdditionDetailsSeed,
@@ -17,12 +18,11 @@ import type {
   PurposeVersionResource,
   PurposeVersionSeed,
   RejectPurposeVersionPayload,
+  RemainingDailyCallsResponse,
   RetrieveLatestRiskAnalysisConfigurationParams,
   RetrieveRiskAnalysisConfigurationByVersionParams,
   ReversePurposeUpdateContent,
   RiskAnalysisFormConfig,
-  GetUpdatedDailyCallsParams,
-  UpdatedDailyCallsResponse,
 } from '../api.generatedTypes'
 
 /**
@@ -282,13 +282,13 @@ async function createDraftFromPurposeTemplate({
   return response.data
 }
 
-async function getUpdatedDailyCalls({ purposeId }: GetUpdatedDailyCallsParams) {
-  /* @TODO - remove this mock */
-  /* const response = await axiosInstance.get<UpdatedDailyCallsResponse>(
-    `${BACKEND_FOR_FRONTEND_URL}/purposes/${purposeId}/updatedDailyCalls`
+async function getRemainingDailyCalls({ purposeId }: GetRemainingDailyCallsParams) {
+  /* @TODO - remove this mock when the endpoint will be available on dev */
+  /* const response = await axiosInstance.get<RemainingDailyCallsResponse>(
+    `${BACKEND_FOR_FRONTEND_URL}/purposes/${purposeId}/remainingDailyCalls`
   )
   return response.data */
-  return { updatedDailyCallsPerConsumer: 100, updatedDailyCallsTotal: 500 }
+  return { remainingDailyCallsPerConsumer: 100, remainingDailyCallsTotal: 500 }
 }
 
 export const PurposeServices = {
@@ -316,5 +316,5 @@ export const PurposeServices = {
   removeClient,
   createDraftFromPurposeTemplate,
   downloadRiskAnalysis,
-  getUpdatedDailyCalls,
+  getRemainingDailyCalls,
 }

--- a/src/hooks/__tests__/useGetPurposeInfoAlert.test.tsx
+++ b/src/hooks/__tests__/useGetPurposeInfoAlert.test.tsx
@@ -6,8 +6,8 @@ const defaultMockData = {
   dailyCalls: 5,
   dailyCallsPerConsumer: 10,
   dailyCallsTotal: 15,
-  updatedDailyCallsPerConsumer: 10,
-  updatedDailyCallsTotal: 15,
+  remainingDailyCallsPerConsumer: 10,
+  remainingDailyCallsTotal: 15,
   keyPrefix: 'test' as KeyPrefix<'purpose'>,
   showFallback: false,
 }
@@ -17,8 +17,8 @@ describe('useGetPurposeInfoAlert', () => {
     const { result } = renderHook(() => {
       const mockData = {
         ...defaultMockData,
-        updatedDailyCallsPerConsumer: 0,
-        updatedDailyCallsTotal: 0,
+        remainingDailyCallsPerConsumer: 0,
+        remainingDailyCallsTotal: 0,
       }
       return useGetPurposeInfoAlert(mockData)
     })
@@ -28,13 +28,13 @@ describe('useGetPurposeInfoAlert', () => {
     })
   })
 
-  it('should return infoDailyCallsTotalResidualExceed if dailyCalls > updatedDailyCallsTotal', () => {
+  it('should return infoDailyCallsTotalResidualExceed if dailyCalls > remainingDailyCallsTotal', () => {
     const { result } = renderHook(() => {
       const mockData = {
         ...defaultMockData,
         dailyCalls: 2,
-        updatedDailyCallsPerConsumer: 100,
-        updatedDailyCallsTotal: 1,
+        remainingDailyCallsPerConsumer: 100,
+        remainingDailyCallsTotal: 1,
       }
       return useGetPurposeInfoAlert(mockData)
     })
@@ -44,13 +44,13 @@ describe('useGetPurposeInfoAlert', () => {
     })
   })
 
-  it('should return infoDailyCallsPerConsumerResidualExceed if dailyCalls > updatedDailyCallsPerConsumer', () => {
+  it('should return infoDailyCallsPerConsumerResidualExceed if dailyCalls > remainingDailyCallsPerConsumer', () => {
     const { result } = renderHook(() => {
       const mockData = {
         ...defaultMockData,
         dailyCalls: 2,
-        updatedDailyCallsPerConsumer: 1,
-        updatedDailyCallsTotal: 100,
+        remainingDailyCallsPerConsumer: 1,
+        remainingDailyCallsTotal: 100,
       }
       return useGetPurposeInfoAlert(mockData)
     })
@@ -66,8 +66,8 @@ describe('useGetPurposeInfoAlert', () => {
         ...defaultMockData,
         dailyCalls: 20,
         dailyCallsTotal: 15,
-        updatedDailyCallsPerConsumer: undefined,
-        updatedDailyCallsTotal: undefined,
+        remainingDailyCallsPerConsumer: undefined,
+        remainingDailyCallsTotal: undefined,
       }
       return useGetPurposeInfoAlert(mockData)
     })
@@ -84,8 +84,8 @@ describe('useGetPurposeInfoAlert', () => {
         dailyCalls: 12,
         dailyCallsPerConsumer: 10,
         dailyCallsTotal: 100,
-        updatedDailyCallsPerConsumer: undefined,
-        updatedDailyCallsTotal: undefined,
+        remainingDailyCallsPerConsumer: undefined,
+        remainingDailyCallsTotal: undefined,
       }
       return useGetPurposeInfoAlert(mockData)
     })
@@ -100,8 +100,8 @@ describe('useGetPurposeInfoAlert', () => {
       const mockData = {
         ...defaultMockData,
         showFallback: true,
-        updatedDailyCallsPerConsumer: undefined,
-        updatedDailyCallsTotal: undefined,
+        remainingDailyCallsPerConsumer: undefined,
+        remainingDailyCallsTotal: undefined,
         dailyCalls: 5,
         dailyCallsPerConsumer: 10,
         dailyCallsTotal: 100,

--- a/src/hooks/useGetPurposeInfoAlert.ts
+++ b/src/hooks/useGetPurposeInfoAlert.ts
@@ -7,16 +7,16 @@ export function useGetPurposeInfoAlert({
   dailyCalls,
   dailyCallsPerConsumer,
   dailyCallsTotal,
-  updatedDailyCallsPerConsumer,
-  updatedDailyCallsTotal,
+  remainingDailyCallsPerConsumer,
+  remainingDailyCallsTotal,
   keyPrefix,
   showFallback,
 }: {
   dailyCalls: number | undefined
   dailyCallsPerConsumer: number
   dailyCallsTotal: number
-  updatedDailyCallsPerConsumer: number | undefined
-  updatedDailyCallsTotal: number | undefined
+  remainingDailyCallsPerConsumer: number | undefined
+  remainingDailyCallsTotal: number | undefined
   keyPrefix: KeyPrefix<'purpose'>
   showFallback?: boolean
 }): AlertProps | undefined {
@@ -31,13 +31,13 @@ export function useGetPurposeInfoAlert({
   }
 
   const isDailyCallsMaximumReached =
-    updatedDailyCallsPerConsumer === 0 || updatedDailyCallsTotal === 0
+    remainingDailyCallsPerConsumer === 0 || remainingDailyCallsTotal === 0
 
   const isDailyCallsTotalResidualExceed =
-    updatedDailyCallsTotal !== undefined && dailyCalls > updatedDailyCallsTotal
+    remainingDailyCallsTotal !== undefined && dailyCalls > remainingDailyCallsTotal
 
   const isDailyCallsPerConsumerResidualExceed =
-    updatedDailyCallsPerConsumer !== undefined && dailyCalls > updatedDailyCallsPerConsumer
+    remainingDailyCallsPerConsumer !== undefined && dailyCalls > remainingDailyCallsPerConsumer
 
   const isDailyCallsTotalExceed = dailyCalls > dailyCallsTotal
   const isDailyCallsPerConsumerExceed = dailyCalls > dailyCallsPerConsumer

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsUpdateDrawer.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsUpdateDrawer.tsx
@@ -45,8 +45,8 @@ export const ConsumerPurposeDetailsDailyCallsUpdateDrawer: React.FC<
     formMethods.reset(defaultValues)
   }
 
-  const { data: updatedDailyCalls } = useQuery(
-    PurposeQueries.getUpdatedDailyCalls({ purposeId: purpose.id })
+  const { data: remainingDailyCalls } = useQuery(
+    PurposeQueries.getRemainingDailyCalls({ purposeId: purpose.id })
   )
 
   const dailyCalls = formMethods.watch('dailyCalls')
@@ -55,8 +55,8 @@ export const ConsumerPurposeDetailsDailyCallsUpdateDrawer: React.FC<
     dailyCalls,
     dailyCallsPerConsumer: purpose.dailyCallsPerConsumer,
     dailyCallsTotal: purpose.dailyCallsTotal,
-    updatedDailyCallsPerConsumer: updatedDailyCalls?.updatedDailyCallsPerConsumer,
-    updatedDailyCallsTotal: updatedDailyCalls?.updatedDailyCallsTotal,
+    remainingDailyCallsPerConsumer: remainingDailyCalls?.remainingDailyCallsPerConsumer,
+    remainingDailyCallsTotal: remainingDailyCalls?.remainingDailyCallsTotal,
     keyPrefix: 'consumerView.sections.loadEstimate.drawer.alerts',
     showFallback: false,
   })
@@ -120,7 +120,7 @@ export const ConsumerPurposeDetailsDailyCallsUpdateDrawer: React.FC<
                 </Typography>
                 <Typography variant="caption" fontWeight={600}>
                   {t('providerThresholdsInfo.dailyCallsPerConsumer.value', {
-                    min: updatedDailyCalls?.updatedDailyCallsPerConsumer ?? t('na'),
+                    min: remainingDailyCalls?.remainingDailyCallsPerConsumer ?? t('na'),
                     max: purpose.dailyCallsPerConsumer,
                   })}
                 </Typography>
@@ -131,7 +131,7 @@ export const ConsumerPurposeDetailsDailyCallsUpdateDrawer: React.FC<
                 </Typography>
                 <Typography variant="caption" fontWeight={600}>
                   {t('providerThresholdsInfo.dailyCallsTotal.value', {
-                    min: updatedDailyCalls?.updatedDailyCallsTotal ?? t('na'),
+                    min: remainingDailyCalls?.remainingDailyCallsTotal ?? t('na'),
                     max: purpose.dailyCallsTotal,
                   })}
                 </Typography>

--- a/src/pages/ConsumerPurposeDetailsPage/components/__tests__/ConsumerPurposeDetailsDailyCallsUpdateDrawer.test.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/__tests__/ConsumerPurposeDetailsDailyCallsUpdateDrawer.test.tsx
@@ -15,11 +15,11 @@ vi.mock('@/api/purpose', () => ({
     }),
   },
   PurposeQueries: {
-    getUpdatedDailyCalls: vi.fn(() => ({
+    getRemainingDailyCalls: vi.fn(() => ({
       queryKey: ['purposeId', purpose.id],
       queryFn: vi.fn().mockResolvedValue({
-        updatedDailyCallsPerConsumer: 5,
-        updatedDailyCallsTotal: 100,
+        remainingDailyCallsPerConsumer: 5,
+        remainingDailyCallsTotal: 100,
       }),
     })),
   },

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
@@ -84,16 +84,16 @@ const PurposeEditStepGeneralForm: React.FC<PurposeEditStepGeneralFormProps> = ({
 
   const dailyCallsTotal = purpose.dailyCallsTotal
 
-  const { data: updatedDailyCalls } = useQuery(
-    PurposeQueries.getUpdatedDailyCalls({ purposeId: purpose.id })
+  const { data: remainingDailyCalls } = useQuery(
+    PurposeQueries.getRemainingDailyCalls({ purposeId: purpose.id })
   )
 
   const alertProps = useGetPurposeInfoAlert({
     dailyCalls: dailyCallsFormValue,
     dailyCallsPerConsumer,
     dailyCallsTotal,
-    updatedDailyCallsPerConsumer: updatedDailyCalls?.updatedDailyCallsPerConsumer,
-    updatedDailyCallsTotal: updatedDailyCalls?.updatedDailyCallsTotal,
+    remainingDailyCallsPerConsumer: remainingDailyCalls?.remainingDailyCallsPerConsumer,
+    remainingDailyCallsTotal: remainingDailyCalls?.remainingDailyCallsTotal,
     keyPrefix: 'edit.loadEstimationSection.alerts',
     showFallback: false,
   })
@@ -171,7 +171,7 @@ const PurposeEditStepGeneralForm: React.FC<PurposeEditStepGeneralFormProps> = ({
                     'edit.loadEstimationSection.providerThresholdsInfo.dailyCallsPerConsumer.value',
                     {
                       min:
-                        updatedDailyCalls?.updatedDailyCallsPerConsumer ??
+                        remainingDailyCalls?.remainingDailyCallsPerConsumer ??
                         t('edit.loadEstimationSection.providerThresholdsInfo.na'),
                       max: dailyCallsPerConsumer,
                     }
@@ -185,7 +185,7 @@ const PurposeEditStepGeneralForm: React.FC<PurposeEditStepGeneralFormProps> = ({
                 <Typography fontWeight={600}>
                   {t('edit.loadEstimationSection.providerThresholdsInfo.dailyCallsTotal.value', {
                     min:
-                      updatedDailyCalls?.updatedDailyCallsTotal ??
+                      remainingDailyCalls?.remainingDailyCallsTotal ??
                       t('edit.loadEstimationSection.providerThresholdsInfo.na'),
                     max: dailyCallsTotal,
                   })}

--- a/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryGeneralInformationAccordion.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryGeneralInformationAccordion.tsx
@@ -17,7 +17,9 @@ export const ConsumerPurposeSummaryGeneralInformationAccordion: React.FC<
 > = ({ purposeId }) => {
   const { data: purpose } = useSuspenseQuery(PurposeQueries.getSingle(purposeId))
 
-  const { data: updatedDailyCalls } = useQuery(PurposeQueries.getUpdatedDailyCalls({ purposeId }))
+  const { data: remainingDailyCalls } = useQuery(
+    PurposeQueries.getRemainingDailyCalls({ purposeId })
+  )
 
   const { t } = useTranslation('purpose', { keyPrefix: 'summary.generalInformationSection' })
 
@@ -25,8 +27,8 @@ export const ConsumerPurposeSummaryGeneralInformationAccordion: React.FC<
     dailyCalls: purpose.currentVersion?.dailyCalls,
     dailyCallsPerConsumer: purpose.dailyCallsPerConsumer,
     dailyCallsTotal: purpose.dailyCallsTotal,
-    updatedDailyCallsPerConsumer: updatedDailyCalls?.updatedDailyCallsPerConsumer,
-    updatedDailyCallsTotal: updatedDailyCalls?.updatedDailyCallsTotal,
+    remainingDailyCallsPerConsumer: remainingDailyCalls?.remainingDailyCallsPerConsumer,
+    remainingDailyCallsTotal: remainingDailyCalls?.remainingDailyCallsTotal,
     keyPrefix: 'summary.alerts',
     showFallback: true,
   })


### PR DESCRIPTION
## Issue
- [PIN-9419](https://pagopa.atlassian.net/browse/PIN-9419)
## Description / Context / Why
- Generated models
- Renamed updatedDailyCalls with remainingDailyCalls
- Renamed updatedDailyCallsPerConsumer with remainingDailyCallsPerConsumer
- Renamed updatedDailyCallsTotal with remainingDailyCallsTotal
- Changed GET:/purposes/{purposeId}/updatedDailyCalls endpoint with GET:/purposes/{purposeId}/remainingDailyCalls
- Updated tests

[PIN-9419]: https://pagopa.atlassian.net/browse/PIN-9419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ