### PR TITLE
fix: remove dash from catalog preview when instanceLabel is whitespace-only (PIN-9474)

### DIFF
--- a/src/components/shared/UpdateInstanceLabelDrawer.tsx
+++ b/src/components/shared/UpdateInstanceLabelDrawer.tsx
@@ -98,7 +98,7 @@ export const UpdateInstanceLabelDrawer = React.forwardRef<
             </Typography>
             <Typography variant="body2" fontWeight={700}>
               {templateName}
-              {watchedInstanceLabel ? ` - ${watchedInstanceLabel.trim()}` : ''}
+              {watchedInstanceLabel.trim() ? ` - ${watchedInstanceLabel.trim()}` : ''}
             </Typography>
           </Box>
         </Box>

--- a/src/components/shared/__tests__/UpdateInstanceLabelDrawer.test.tsx
+++ b/src/components/shared/__tests__/UpdateInstanceLabelDrawer.test.tsx
@@ -81,6 +81,22 @@ describe('UpdateInstanceLabelDrawer', () => {
     })
   })
 
+  it('does not show the dash separator in catalog preview when instanceLabel is only whitespace', async () => {
+    const user = userEvent.setup()
+    renderWithApplicationContext(
+      <UpdateInstanceLabelDrawer {...defaultProps} currentInstanceLabel="" />,
+      { withReactQueryContext: true }
+    )
+
+    const input = screen.getByRole('textbox', { name: 'instanceLabelField.label' })
+    await user.type(input, '   ')
+
+    await waitFor(() => {
+      const previewValue = screen.getByText('Credenziale IT-Wallet')
+      expect(previewValue.textContent).toBe('Credenziale IT-Wallet')
+    })
+  })
+
   it('calls onSubmit with eServiceId and new instanceLabel value', async () => {
     const user = userEvent.setup()
     renderWithApplicationContext(<UpdateInstanceLabelDrawer {...defaultProps} />, {

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/InstanceLabelSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/InstanceLabelSection.tsx
@@ -39,7 +39,7 @@ export const InstanceLabelSection: React.FC<InstanceLabelSectionProps> = ({
           {t('create.step1.instanceLabelField.catalogPreviewLabel')}
         </Typography>
         <Typography variant="body2" fontWeight={700} marginLeft={6}>
-          {templateName} {instanceLabel ? `- ${instanceLabel.trim()}` : ''}
+          {templateName} {instanceLabel.trim() ? `- ${instanceLabel.trim()}` : ''}
         </Typography>
       </Box>
     </SectionContainer>

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/__tests__/EServiceCreateStepGeneral.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/__tests__/EServiceCreateStepGeneral.test.tsx
@@ -152,6 +152,24 @@ describe('EServiceCreateStepGeneral - instanceLabel', () => {
     })
   })
 
+  it('does not show the dash separator in catalog preview when instanceLabel is only whitespace', async () => {
+    const user = userEvent.setup()
+    mockContext({ eserviceTemplate: mockEServiceTemplate })
+    renderWithApplicationContext(<EServiceCreateStepGeneral />, {
+      withReactQueryContext: true,
+    })
+
+    const instanceLabelInput = screen.getByRole('textbox', {
+      name: 'create.step1.instanceLabelField.label',
+    })
+    await user.type(instanceLabelInput, '   ')
+
+    await waitFor(() => {
+      const previewText = screen.getByText('Credenziale IT-Wallet')
+      expect(previewText.textContent).toBe('Credenziale IT-Wallet ')
+    })
+  })
+
   it('shows the catalog preview with only e-service name when instanceLabel is empty', () => {
     mockContext({ eserviceTemplate: mockEServiceTemplate })
     renderWithApplicationContext(<EServiceCreateStepGeneral />, {


### PR DESCRIPTION
## Summary
- In `InstanceLabelSection` and `UpdateInstanceLabelDrawer`, check `instanceLabel.trim()` instead of `instanceLabel` before rendering the ` - ` separator, so whitespace-only input doesn't show a dangling dash in the catalog preview.