### PR TITLE
fix: hide CTA for delegate on template eservice in WAITING_FOR_APPROVAL

### DIFF
--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -389,40 +389,41 @@ const ProviderEServiceSummaryPage: React.FC = () => {
               </Alert>
             )}
         </Stack>
-        {!isDelegator && (
-          <>
-            {!canBePublished() && (
-              <Alert severity="warning" sx={{ mt: 3 }}>
-                {t('summary.publishWarningLabel')}
-              </Alert>
-            )}
-            <Stack spacing={1} sx={{ mt: 3 }} direction="row" justifyContent="end">
-              <Button
-                startIcon={<DeleteOutlineIcon />}
-                variant="text"
-                color="error"
-                onClick={handleDeleteDraft}
-                disabled={isSupport}
-              >
-                {tCommon('deleteDraft')}
-              </Button>
-              <Button
-                startIcon={<CreateIcon />}
-                variant="text"
-                onClick={handleEditDraft}
-                disabled={isSupport}
-              >
-                {tCommon('editDraft')}
-              </Button>
-              <PublishButton
-                onClick={handlePublishDraft}
-                disabled={!canBePublished() || isSupport}
-                arePersonalDataSet={arePersonalDataSet}
-                isRulesetExpired={isRulesetExpired}
-              />
-            </Stack>
-          </>
-        )}
+        {!isDelegator &&
+          !(isEServiceFromTemplate && descriptor?.state === 'WAITING_FOR_APPROVAL') && (
+            <>
+              {!canBePublished() && (
+                <Alert severity="warning" sx={{ mt: 3 }}>
+                  {t('summary.publishWarningLabel')}
+                </Alert>
+              )}
+              <Stack spacing={1} sx={{ mt: 3 }} direction="row" justifyContent="end">
+                <Button
+                  startIcon={<DeleteOutlineIcon />}
+                  variant="text"
+                  color="error"
+                  onClick={handleDeleteDraft}
+                  disabled={isSupport}
+                >
+                  {tCommon('deleteDraft')}
+                </Button>
+                <Button
+                  startIcon={<CreateIcon />}
+                  variant="text"
+                  onClick={handleEditDraft}
+                  disabled={isSupport}
+                >
+                  {tCommon('editDraft')}
+                </Button>
+                <PublishButton
+                  onClick={handlePublishDraft}
+                  disabled={!canBePublished() || isSupport}
+                  arePersonalDataSet={arePersonalDataSet}
+                  isRulesetExpired={isRulesetExpired}
+                />
+              </Stack>
+            </>
+          )}
         {isDelegator && descriptor?.state === 'WAITING_FOR_APPROVAL' && (
           <Stack spacing={1} sx={{ mt: 4 }} direction="row" justifyContent="end">
             <Button

--- a/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
@@ -6,6 +6,7 @@ import * as router from '@/router'
 import {
   createMockEServiceDescriptorReceive,
   createMockEServiceDescriptorProvider,
+  createMockEServiceDescriptorProviderWithTemplateRef,
 } from '@/../__mocks__/data/eservice.mocks'
 
 mockUseParams({
@@ -77,12 +78,14 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
   }
 })
 
+const mockDelegationRole = vi.fn().mockReturnValue({
+  isDelegator: false,
+  isDelegate: false,
+  producerDelegations: [],
+})
+
 vi.mock('@/hooks/useGetProducerDelegationUserRole', () => ({
-  useGetProducerDelegationUserRole: () => ({
-    isDelegator: false,
-    isDelegate: false,
-    producerDelegations: [],
-  }),
+  useGetProducerDelegationUserRole: (...args: unknown[]) => mockDelegationRole(...args),
 }))
 
 describe('ProviderEServiceSummaryPage', () => {
@@ -210,5 +213,29 @@ describe('ProviderEServiceSummaryPage', () => {
     })
 
     expect(screen.queryByTestId('DeleteOutlineIcon')).toBeInTheDocument()
+  })
+
+  it('should not render CTA buttons for delegate viewing a template eservice in WAITING_FOR_APPROVAL state', () => {
+    mockDelegationRole.mockReturnValue({
+      isDelegator: false,
+      isDelegate: true,
+      producerDelegations: [],
+    })
+
+    useQueryMock.mockReturnValue({
+      data: createMockEServiceDescriptorProviderWithTemplateRef({
+        state: 'WAITING_FOR_APPROVAL',
+      }),
+      isLoading: false,
+    })
+
+    renderWithApplicationContext(<ProviderEServiceSummaryPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.queryByRole('button', { name: 'publish' })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('DeleteOutlineIcon')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('CreateIcon')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Hide delete/edit/publish CTA buttons on the summary page when a delegate views a template-based eservice with descriptor in WAITING_FOR_APPROVAL state
- Add test covering the new behavior