### PR TITLE
fix: add safe optional chaining in useResolveError (PIN-9458)

### DIFF
--- a/src/hooks/__tests__/useResolveError.test.tsx
+++ b/src/hooks/__tests__/useResolveError.test.tsx
@@ -91,6 +91,41 @@ describe('', () => {
     expect(screen.getByRole('button', { name: 'actions.retry' })).toBeInTheDocument()
   })
 
+  it('should not crash when AxiosError response has no errors array (e.g. 503)', () => {
+    const error = new AxiosError('Service Unavailable', '503', undefined, undefined, {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: {},
+      config: {} as never,
+      data: { correlationId: 'test-id' },
+    })
+
+    const screen = render(<ThrowErrorComponent error={error} />, {
+      wrapper: ErrorBoundaryTest,
+    })
+
+    expect(screen.getByText('axiosError.title')).toBeInTheDocument()
+    expect(screen.getByText('axiosError.description')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'actions.retry' })).toBeInTheDocument()
+  })
+
+  it('should not crash when AxiosError response data is undefined', () => {
+    const error = new AxiosError('Server Error', '500', undefined, undefined, {
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: {},
+      config: {} as never,
+      data: undefined,
+    })
+
+    const screen = render(<ThrowErrorComponent error={error} />, {
+      wrapper: ErrorBoundaryTest,
+    })
+
+    expect(screen.getByText('axiosError.title')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'actions.retry' })).toBeInTheDocument()
+  })
+
   it('should correctly resolve the TokenExchangeError throw', () => {
     const screen = render(<ThrowErrorComponent error={new TokenExchangeError()} />, {
       wrapper: ErrorBoundaryTest,

--- a/src/hooks/useResolveError.tsx
+++ b/src/hooks/useResolveError.tsx
@@ -35,8 +35,8 @@ function useResolveError(fallbackProps: FallbackProps): UseResolveErrorReturnTyp
 
   let title, description: string | undefined
   let content: JSX.Element | null = null
-  const correlationId = error.response?.data.correlationId
-  const errorCode = error.response?.data.errors[0].code
+  const correlationId = error.response?.data?.correlationId
+  const errorCode = error.response?.data?.errors?.[0]?.code
 
   const { setErrorData } = useErrorData()
 


### PR DESCRIPTION
## 🔗 Issue
[PIN-9458](https://pagopa.atlassian.net/browse/PIN-9458)

## 📝 Description / Context
When the BFF responds with a 503 (or any error with a non-standard body), `useResolveError` crashes trying to access `error.response.data.errors[0].code`, causing an "Unexpected Application Error" instead of the proper error page.

## 🛠 List of changes
- Added safe optional chaining (`?.`) in `useResolveError` for `correlationId` and `errorCode` extraction, matching the safe pattern already used in `query-client.ts`
- Added tests for AxiosError with missing `errors` array (503) and undefined `data`

## 🧪 How to test
- Start the app locally and simulate a 503 response from the BFF (e.g., by stopping the BFF service)
- Verify the error page renders correctly with the retry button instead of the raw React error screen

[PIN-9458]: https://pagopa.atlassian.net/browse/PIN-9458