### PR TITLE
feature: add edit button to eservice summary accordion (PIN-9528)

### DIFF
--- a/src/components/shared/SummaryAccordion.tsx
+++ b/src/components/shared/SummaryAccordion.tsx
@@ -10,8 +10,11 @@ import {
   Skeleton,
   Divider,
   Stack,
+  Button,
 } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import EditIcon from '@mui/icons-material/Edit'
+import { useTranslation } from 'react-i18next'
 
 type SummaryAccordionProps = {
   headline: string
@@ -20,6 +23,7 @@ type SummaryAccordionProps = {
   defaultExpanded?: boolean
   showWarning?: boolean
   warningLabel?: string
+  onEditStep?: VoidFunction
 }
 export const SummaryAccordion: React.FC<SummaryAccordionProps> = ({
   headline,
@@ -28,8 +32,10 @@ export const SummaryAccordion: React.FC<SummaryAccordionProps> = ({
   defaultExpanded,
   showWarning,
   warningLabel,
+  onEditStep,
 }) => {
   const id = React.useId()
+  const { t } = useTranslation('common', { keyPrefix: 'actions' })
 
   return (
     <Paper elevation={8} sx={{ borderRadius: 4, overflow: 'hidden' }}>
@@ -74,6 +80,18 @@ export const SummaryAccordion: React.FC<SummaryAccordionProps> = ({
         <AccordionDetails sx={{ px: 4, pb: 3 }}>
           <Divider sx={{ mb: 3, mt: -1 }} />
           {children}
+          {onEditStep && (
+            <Button
+              sx={{
+                pl: 0,
+                mt: 1,
+              }}
+              startIcon={<EditIcon />}
+              onClick={onEditStep}
+            >
+              {t('edit')}
+            </Button>
+          )}
         </AccordionDetails>
       </MUIAccordion>
     </Paper>

--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -91,14 +91,14 @@ const ProviderEServiceSummaryPage: React.FC = () => {
     )
   }
 
-  const handleEditDraft = () => {
+  const handleEditDraft = (step?: number) => {
     if (!descriptor) return
     navigate('PROVIDE_ESERVICE_EDIT', {
       params: {
         eserviceId: descriptor.eservice.id,
         descriptorId: descriptor.id,
       },
-      state: { stepIndexDestination: 1 },
+      state: { stepIndexDestination: step ?? 1 },
     })
   }
 
@@ -351,12 +351,17 @@ const ProviderEServiceSummaryPage: React.FC = () => {
               defaultExpanded={true}
               showWarning={!isGeneralInfoSectionValid}
               warningLabel={t('summary.missingInformationsLabel')}
+              onEditStep={() => handleEditDraft(0)}
             >
               <ProviderEServiceGeneralInfoSummarySection />
             </SummaryAccordion>
           </React.Suspense>
           <React.Suspense fallback={<SummaryAccordionSkeleton />}>
-            <SummaryAccordion headline="2" title={t('summary.attributeVersionSummary.title')}>
+            <SummaryAccordion
+              headline="2"
+              title={t('summary.attributeVersionSummary.title')}
+              onEditStep={() => handleEditDraft(1)}
+            >
               <ProviderEServiceAttributeVersionSummarySection />
             </SummaryAccordion>
           </React.Suspense>
@@ -373,6 +378,7 @@ const ProviderEServiceSummaryPage: React.FC = () => {
               title={t('summary.documentationSummary.title')}
               showWarning={!isDocumentationSectionValid}
               warningLabel={t('summary.missingInformationsLabel')}
+              onEditStep={() => handleEditDraft(2)}
             >
               <ProviderEServiceDocumentationSummarySection />
             </SummaryAccordion>
@@ -383,6 +389,7 @@ const ProviderEServiceSummaryPage: React.FC = () => {
               title={t('summary.versionInfoSummary.title')}
               showWarning={!isVersionInfoSectionValid}
               warningLabel={t('summary.missingInformationsLabel')}
+              onEditStep={() => handleEditDraft(3)}
             >
               <ProviderEServiceVersionInfoSummarySection />
             </SummaryAccordion>
@@ -440,7 +447,7 @@ const ProviderEServiceSummaryPage: React.FC = () => {
                 <Button
                   startIcon={<CreateIcon />}
                   variant="text"
-                  onClick={handleEditDraft}
+                  onClick={() => handleEditDraft()}
                   disabled={isSupport}
                 >
                   {tCommon('editDraft')}


### PR DESCRIPTION
## Jira Issue
[PIN-9528](https://pagopa.atlassian.net/browse/PIN-9528)

## Context/Why
**Provider e-service summary**
- Allow user to go back to edit a certain step

## Key Changes
 - Modify `SummaryAccordion` to have optional edit button
 - Modify `ProviderEServiceSummary` page to allow navigation to a certain step

[PIN-9528]: https://pagopa.atlassian.net/browse/PIN-9528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ