### PR TITLE
feature/pin 22655 int 86 reflow drawer 400% zoom

### DIFF
--- a/src/components/shared/Drawer.tsx
+++ b/src/components/shared/Drawer.tsx
@@ -70,9 +70,24 @@ export const Drawer: React.FC<DrawerProps> = ({
       onClose={onClose}
       sx={{ zIndex: 100 }}
       ModalProps={{ onTransitionExited: onTransitionExited }}
+      PaperProps={{
+        sx: {
+          width: { xs: '100%', sm: 375 },
+          maxWidth: '100%',
+          overflowX: 'hidden',
+        },
+      }}
     >
       <HeaderDrawer onDrawerClose={onClose} />
-      <Stack width={375} px={3} pt={2} flexGrow={1}>
+      <Stack
+        px={3}
+        pt={2}
+        flexGrow={1}
+        sx={{
+          overflowY: 'auto',
+          overflowX: 'hidden',
+        }}
+      >
         <Stack spacing={1} pb={5}>
           <Typography variant="h6" fontWeight={600}>
             {title}
@@ -80,10 +95,15 @@ export const Drawer: React.FC<DrawerProps> = ({
           {subtitle && <Typography variant="body2">{subtitle}</Typography>}
         </Stack>
 
-        <Box sx={{ flexGrow: 1, mt: 2 }}>{children}</Box>
+        <Box sx={{ flexGrow: 1, mt: 2, maxWidth: '100%' }}>{children}</Box>
 
         {buttonAction && (
-          <Box sx={{ pb: 4, mt: 0.5 }} width={327} display="flex" alignItems="flex-end">
+          <Box
+            sx={{ pb: 4, mt: 0.5, maxWidth: '100%' }}
+            width={327}
+            display="flex"
+            alignItems="flex-end"
+          >
             <Tooltip arrow title={buttonAction.disabled ? buttonAction.disabledTooltip : undefined}>
               <span tabIndex={buttonAction.disabled ? 0 : undefined} style={{ width: '100%' }}>
                 <Button

--- a/src/components/shared/Drawer.tsx
+++ b/src/components/shared/Drawer.tsx
@@ -38,10 +38,10 @@ const HeaderDrawer: React.FC<HeaderDrawerProps> = ({ onDrawerClose }) => {
   return (
     <Box
       display="flex"
-      justifyContent="end"
-      alignItems="end"
+      justifyContent="flex-end"
+      alignItems="flex-end"
       height={64}
-      width={375}
+      width="100%"
       pr={1}
       pb={1}
       flexShrink={0}
@@ -74,7 +74,6 @@ export const Drawer: React.FC<DrawerProps> = ({
         sx: {
           width: { xs: '100%', sm: 375 },
           maxWidth: '100%',
-          overflowX: 'hidden',
         },
       }}
     >
@@ -85,7 +84,6 @@ export const Drawer: React.FC<DrawerProps> = ({
         flexGrow={1}
         sx={{
           overflowY: 'auto',
-          overflowX: 'hidden',
         }}
       >
         <Stack spacing={1} pb={5}>
@@ -100,7 +98,7 @@ export const Drawer: React.FC<DrawerProps> = ({
         {buttonAction && (
           <Box
             sx={{ pb: 4, mt: 0.5, maxWidth: '100%' }}
-            width={327}
+            width="100%"
             display="flex"
             alignItems="flex-end"
           >


### PR DESCRIPTION
## 🔗 Issue

[PIN-A2-2655](https://pagopa.atlassian.net/browse/A2-2655)

## 📝 Description / Context
This pull request updates the `Drawer` and `HeaderDrawer` components to improve their layout responsiveness and ensure better styling consistency, especially on different screen sizes. The changes primarily focus on making widths and alignments flexible and ensuring the drawer content is scrollable when needed.

First screenshot 500% zoom, second screenshot mobile 320px width 100% zoom
<img width="1694" height="976" alt="Screenshot 2026-04-02 alle 15 14 06" src="https://github.com/user-attachments/assets/85c7a2e8-6bdf-4641-a9b3-d4b7d600cbdc" />
<img width="654" height="985" alt="Screenshot 2026-04-02 alle 15 14 21" src="https://github.com/user-attachments/assets/bd4eab71-e868-4651-a858-e9d6421aa369" />

