### PR TITLE
feature/PIN-2645_INT-76-focus-order-create-delegation-form

### DIFF
--- a/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
@@ -15,6 +15,7 @@ export type RHFSwitchProps = Omit<MUISwitchProps, 'checked' | 'onChange'> & {
   infoLabel?: string
   name: string
   rules?: ControllerProps['rules']
+  inputRef?: React.Ref<HTMLInputElement>
 }
 
 export const RHFSwitch: React.FC<RHFSwitchProps> = ({
@@ -24,6 +25,7 @@ export const RHFSwitch: React.FC<RHFSwitchProps> = ({
   sx,
   rules,
   disabled,
+  inputRef,
   ...props
 }) => {
   const { formState } = useFormContext()
@@ -51,7 +53,7 @@ export const RHFSwitch: React.FC<RHFSwitchProps> = ({
                 disabled={disabled}
                 inputProps={{ ...props.inputProps, ...accessibilityProps }}
                 checked={value}
-                inputRef={ref}
+                inputRef={inputRef || ref}
                 sx={{ marginRight: 1 }}
               />
             }

--- a/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
@@ -15,7 +15,6 @@ export type RHFSwitchProps = Omit<MUISwitchProps, 'checked' | 'onChange'> & {
   infoLabel?: string
   name: string
   rules?: ControllerProps['rules']
-  inputRef?: React.Ref<HTMLInputElement>
 }
 
 export const RHFSwitch: React.FC<RHFSwitchProps> = ({
@@ -25,7 +24,6 @@ export const RHFSwitch: React.FC<RHFSwitchProps> = ({
   sx,
   rules,
   disabled,
-  inputRef,
   ...props
 }) => {
   const { formState } = useFormContext()
@@ -53,7 +51,7 @@ export const RHFSwitch: React.FC<RHFSwitchProps> = ({
                 disabled={disabled}
                 inputProps={{ ...props.inputProps, ...accessibilityProps }}
                 checked={value}
-                inputRef={mergeRefs(ref, inputRef)}
+                inputRef={ref}
                 sx={{ marginRight: 1 }}
               />
             }
@@ -63,17 +61,4 @@ export const RHFSwitch: React.FC<RHFSwitchProps> = ({
       />
     </InputWrapper>
   )
-}
-
-export function mergeRefs<T>(...refs: Array<React.Ref<T> | undefined>) {
-  //Merging the refs so that both the RHF ref and the consumer's inputRef receive the underlying DOM node when it mounts.
-  return (value: T | null) => {
-    refs.forEach((ref) => {
-      if (typeof ref === 'function') {
-        ref(value)
-      } else if (ref != null) {
-        ;(ref as React.MutableRefObject<T | null>).current = value
-      }
-    })
-  }
 }

--- a/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
@@ -53,7 +53,7 @@ export const RHFSwitch: React.FC<RHFSwitchProps> = ({
                 disabled={disabled}
                 inputProps={{ ...props.inputProps, ...accessibilityProps }}
                 checked={value}
-                inputRef={inputRef || ref}
+                inputRef={mergeRefs(ref, inputRef)}
                 sx={{ marginRight: 1 }}
               />
             }
@@ -63,4 +63,17 @@ export const RHFSwitch: React.FC<RHFSwitchProps> = ({
       />
     </InputWrapper>
   )
+}
+
+export function mergeRefs<T>(...refs: Array<React.Ref<T> | undefined>) {
+  //Merging the refs so that both the RHF ref and the consumer's inputRef receive the underlying DOM node when it mounts.
+  return (value: T | null) => {
+    refs.forEach((ref) => {
+      if (typeof ref === 'function') {
+        ref(value)
+      } else if (ref != null) {
+        ;(ref as React.MutableRefObject<T | null>).current = value
+      }
+    })
+  }
 }

--- a/src/pages/DelegationCreatePage/components/DelegationCreateForm.tsx
+++ b/src/pages/DelegationCreatePage/components/DelegationCreateForm.tsx
@@ -220,16 +220,22 @@ export const DelegationCreateForm: React.FC<DelegationCreateFormProps> = ({
               <RHFSwitch
                 name="isEserviceToBeCreated"
                 label={t('delegations.create.delegateField.provider.switch')}
+                inputProps={{
+                  'aria-expanded': isEserviceToBeCreated,
+                  'aria-controls': 'eservice-creation-section',
+                }}
               />
             )}
-            {!isEserviceToBeCreated || delegationKind === 'DELEGATED_CONSUMER' ? (
-              <DelegationCreateEServiceAutocomplete delegationKind={delegationKind} />
-            ) : (
-              <DelegationCreateFormCreateEservice
-                delegationKind={delegationKind}
-                handleTemplateNameAutocompleteChange={handleTemplateNameAutocompleteChange}
-              />
-            )}
+            <Box id="eservice-creation-section" aria-live="polite">
+              {!isEserviceToBeCreated || delegationKind === 'DELEGATED_CONSUMER' ? (
+                <DelegationCreateEServiceAutocomplete delegationKind={delegationKind} />
+              ) : (
+                <DelegationCreateFormCreateEservice
+                  delegationKind={delegationKind}
+                  handleTemplateNameAutocompleteChange={handleTemplateNameAutocompleteChange}
+                />
+              )}
+            </Box>
             <DelegationCreateTenantAutocomplete delegationKind={delegationKind} />
             {delegationKind === 'DELEGATED_CONSUMER' && (hasAgreement || isDelegated) && (
               <Alert severity="warning">

--- a/src/pages/DelegationCreatePage/components/DelegationCreateFormCreateEservice.tsx
+++ b/src/pages/DelegationCreatePage/components/DelegationCreateFormCreateEservice.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { Alert } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { RHFTextField, RHFSwitch } from '@/components/shared/react-hook-form-inputs'
 import { useFormContext, useWatch } from 'react-hook-form'
 import type { DelegationKind } from '@/api/api.generatedTypes'
 import { DelegationCreateEServiceFromTemplateAutocomplete } from './DelegationCreateEServiceFromTemplateAutocomplete'
+import { Stack } from '@mui/system'
 
 type DelegationCreateFormCreateEserviceProps = {
   delegationKind: DelegationKind
@@ -25,20 +26,36 @@ export const DelegationCreateFormCreateEservice: React.FC<
     defaultValue: false,
   })
 
+  const childSwitchRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    // Focus the switch when the component mounts to improve accessibility
+    const timeoutId = setTimeout(() => {
+      if (childSwitchRef.current) {
+        childSwitchRef.current.focus()
+      }
+    }, 0)
+
+    return () => clearTimeout(timeoutId)
+  }, [])
+
   return (
     <>
       <RHFSwitch
         name="isEserviceFromTemplate"
         label={t('delegateField.provider.switchEserviceFromTemplate')}
+        inputRef={childSwitchRef}
       />
 
       {isEserviceFromTemplate ? (
         <>
-          <Alert severity="info">{t('delegateField.provider.alertEserviceFromTemplate')}</Alert>
-          <DelegationCreateEServiceFromTemplateAutocomplete
-            delegationKind={delegationKind}
-            handleTemplateNameAutocompleteChange={handleTemplateNameAutocompleteChange}
-          />
+          <Stack spacing={3}>
+            <Alert severity="info">{t('delegateField.provider.alertEserviceFromTemplate')}</Alert>
+            <DelegationCreateEServiceFromTemplateAutocomplete
+              delegationKind={delegationKind}
+              handleTemplateNameAutocompleteChange={handleTemplateNameAutocompleteChange}
+            />
+          </Stack>
         </>
       ) : (
         <>

--- a/src/pages/DelegationCreatePage/components/DelegationCreateFormCreateEservice.tsx
+++ b/src/pages/DelegationCreatePage/components/DelegationCreateFormCreateEservice.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect, useRef } from 'react'
-import { Alert } from '@mui/material'
+import React from 'react'
+import { Alert, Stack } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { RHFTextField, RHFSwitch } from '@/components/shared/react-hook-form-inputs'
 import { useFormContext, useWatch } from 'react-hook-form'
 import type { DelegationKind } from '@/api/api.generatedTypes'
 import { DelegationCreateEServiceFromTemplateAutocomplete } from './DelegationCreateEServiceFromTemplateAutocomplete'
-import { Stack } from '@mui/system'
 
 type DelegationCreateFormCreateEserviceProps = {
   delegationKind: DelegationKind
@@ -26,41 +25,25 @@ export const DelegationCreateFormCreateEservice: React.FC<
     defaultValue: false,
   })
 
-  const childSwitchRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    // Focus the switch when the component mounts to improve accessibility
-    const timeoutId = setTimeout(() => {
-      if (childSwitchRef.current) {
-        childSwitchRef.current.focus()
-      }
-    }, 0)
-
-    return () => clearTimeout(timeoutId)
-  }, [])
-
   return (
     <>
       <RHFSwitch
         name="isEserviceFromTemplate"
         label={t('delegateField.provider.switchEserviceFromTemplate')}
-        inputRef={childSwitchRef}
+        autoFocus
       />
 
       {isEserviceFromTemplate ? (
-        <>
-          <Stack spacing={3}>
-            <Alert severity="info">{t('delegateField.provider.alertEserviceFromTemplate')}</Alert>
-            <DelegationCreateEServiceFromTemplateAutocomplete
-              delegationKind={delegationKind}
-              handleTemplateNameAutocompleteChange={handleTemplateNameAutocompleteChange}
-            />
-          </Stack>
-        </>
+        <Stack spacing={3} sx={{ mt: 2 }}>
+          <Alert severity="info">{t('delegateField.provider.alertEserviceFromTemplate')}</Alert>
+          <DelegationCreateEServiceFromTemplateAutocomplete
+            delegationKind={delegationKind}
+            handleTemplateNameAutocompleteChange={handleTemplateNameAutocompleteChange}
+          />
+        </Stack>
       ) : (
         <>
           <RHFTextField
-            focusOnMount={true}
             name="eserviceName"
             label={t('eserviceField.label')}
             infoLabel={t('eserviceField.infoLabel')}


### PR DESCRIPTION
## 🔗 Issue

[A2-2645](https://pagopa.atlassian.net/browse/A2-2645)
## 📝 Description / Context
This pull request enhances accessibility and usability in the delegation creation forms by improving focus management and ARIA attributes, and by making the `RHFSwitch` component more flexible. The most important changes are grouped below:

**Accessibility Improvements:**

* Added ARIA attributes (`aria-expanded`, `aria-controls`) to the `RHFSwitch` for the "isEserviceToBeCreated" field and wrapped the related section in a `Box` with `aria-live="polite"` to improve screen reader support. 
* In the "Create Eservice" form, the switch for "isEserviceFromTemplate" is now automatically focused on mount to aid keyboard and screen reader users. 


**UI Structure:**

* Grouped the alert and autocomplete components in the "Create Eservice" form inside a `Stack` for improved spacing and layout consistency. 

Now the second switch can be reached with tab
<img width="995" height="757" alt="Screenshot 2026-04-03 alle 14 26 10" src="https://github.com/user-attachments/assets/4e536e02-95a8-48df-8dd5-80bd33dedfc9" />



[A2-2645]: https://pagopa.atlassian.net/browse/A2-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ