### PR TITLE
fix: prevent error boundary crash on getRemainingDailyCalls 403 (PIN-9655)

### DIFF
--- a/src/api/purpose/purpose.queries.ts
+++ b/src/api/purpose/purpose.queries.ts
@@ -55,6 +55,7 @@ function getRemainingDailyCalls(params: GetRemainingDailyCallsParams) {
   return queryOptions({
     queryKey: ['getRemainingDailyCalls', params],
     queryFn: () => PurposeServices.getRemainingDailyCalls(params),
+    throwOnError: false,
   })
 }
 


### PR DESCRIPTION
## 🔗 Issue
[PIN-9655](https://pagopa.atlassian.net/browse/PIN-9655)

## 📝 Description / Context
When a purpose is active and the associated agreement gets suspended (e.g. after an attribute revocation by the provider), the `ConsumerPurposeDetailsDailyCallsUpdateDrawer` component is still mounted on the purpose details page. At mount, it fires a `GET /purposes/{purposeId}/remainingDailyCalls` query. With a suspended agreement, the backend returns a `403 Forbidden` (see [here](https://github.com/pagopa/interop-be-monorepo/pull/3230)).

Since react-query's default config has `throwOnError: true` for queries, the 403 propagates to the error boundary, crashing the entire page — even though the user never interacts with the drawer (the button to open it is hidden when the agreement is suspended).

## 🛠 List of changes
- Added `throwOnError: false` to the `getRemainingDailyCalls` query options in `purpose.queries.ts`

When the 403 occurs, `data` stays `undefined` and the consuming components already handle this with "N/A" fallbacks. The result is a silent no-op instead of a page crash.

## 🧪 How to test
- Run `pnpm tsc --noEmit` — should pass
- Run `pnpm test -- --run` — all tests should pass
- On UAT: navigate to a purpose details page where the associated agreement is suspended (e.g. after attribute revocation). The page should load without errors.

[PIN-9655]: https://pagopa.atlassian.net/browse/PIN-9655