### PR TITLE
fix: update IconLink components to use button (PIN-2603 - A11Y)

### DIFF
--- a/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsGeneralInfoSection/ConsumerAgreementDetailsGeneralInfoSection.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsGeneralInfoSection/ConsumerAgreementDetailsGeneralInfoSection.tsx
@@ -134,7 +134,6 @@ export const ConsumerAgreementDetailsGeneralInfoSection: React.FC = () => {
                   component="button"
                   sx={{ alignSelf: 'start' }}
                   onClick={handleOpenCertifiedAttributesDrawer}
-                  style={{ alignSelf: 'start' }}
                 >
                   {t('certifiedAttributeLink.label')}
                 </IconLink>
@@ -145,7 +144,7 @@ export const ConsumerAgreementDetailsGeneralInfoSection: React.FC = () => {
                 onClick={handleOpenContactDrawer}
                 startIcon={<ContactMailIcon />}
                 component="button"
-                style={{ alignSelf: 'start' }}
+                sx={{ alignSelf: 'start' }}
               >
                 {t('providerDetailsLink.label')}
               </IconLink>

--- a/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsGeneralInfoSection/ConsumerAgreementDetailsGeneralInfoSection.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsGeneralInfoSection/ConsumerAgreementDetailsGeneralInfoSection.tsx
@@ -131,6 +131,7 @@ export const ConsumerAgreementDetailsGeneralInfoSection: React.FC = () => {
               <>
                 <IconLink
                   startIcon={<RuleIcon />}
+                  component="button"
                   sx={{ alignSelf: 'start' }}
                   onClick={handleOpenCertifiedAttributesDrawer}
                   style={{ alignSelf: 'start' }}
@@ -143,6 +144,7 @@ export const ConsumerAgreementDetailsGeneralInfoSection: React.FC = () => {
               <IconLink
                 onClick={handleOpenContactDrawer}
                 startIcon={<ContactMailIcon />}
+                component="button"
                 style={{ alignSelf: 'start' }}
               >
                 {t('providerDetailsLink.label')}


### PR DESCRIPTION
## 🔗 Issue

[PIN-A2-2603](https://pagopa.atlassian.net/browse/A2-2603)

## 📝 Description / Context

This pull request makes a small update to the `ConsumerAgreementDetailsGeneralInfoSection` component to improve accessibility and semantic correctness. The `IconLink` components are now explicitly rendered as `<button>` elements instead of their previous default.

BEFORE:

https://github.com/user-attachments/assets/89dcc4fb-8857-4c5e-a6a1-388897b03c4f

NOW:

https://github.com/user-attachments/assets/da273cfd-5c33-4ef0-b404-d66e4a792762




