### PR TITLE
fix/PIN-9648: use correct mutation for template instance in thresholds step

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepThresholds/EServiceCreateStepThresholds.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepThresholds/EServiceCreateStepThresholds.tsx
@@ -4,12 +4,12 @@ import { useEServiceCreateContext } from '../EServiceCreateContext'
 import { EServiceMutations } from '@/api/eservice'
 import { type SubmitHandler, useForm, FormProvider, useWatch } from 'react-hook-form'
 import React from 'react'
+import { match } from 'ts-pattern'
 import { type AttributeKey } from '@/types/attribute.types'
 import {
   type ProducerEServiceDescriptor,
   type DescriptorAttribute,
   type DescriptorAttributes,
-  type UpdateEServiceDescriptorSeed,
 } from '@/api/api.generatedTypes'
 import { useAttributesCountersAlert } from './useAttributesCountersAlert'
 import { Alert, Box } from '@mui/material'
@@ -38,6 +38,10 @@ export const EServiceCreateStepThresholds: React.FC<ActiveStepProps> = () => {
   const { descriptor, forward, back } = useEServiceCreateContext()
 
   const { mutate: updateVersionDraft } = EServiceMutations.useUpdateVersionDraft({
+    suppressSuccessToast: true,
+  })
+
+  const { mutate: updateInstanceVersionDraft } = EServiceMutations.useUpdateInstanceVersionDraft({
     suppressSuccessToast: true,
   })
 
@@ -139,22 +143,37 @@ export const EServiceCreateStepThresholds: React.FC<ActiveStepProps> = () => {
       return
     }
 
-    const payload: UpdateEServiceDescriptorSeed & {
-      eserviceId: string
-      descriptorId: string
-    } = {
-      audience: descriptor.audience,
-      voucherLifespan: descriptor.voucherLifespan,
-      dailyCallsPerConsumer: values.dailyCallsPerConsumer,
-      dailyCallsTotal: values.dailyCallsTotal,
-      agreementApprovalPolicy: descriptor.agreementApprovalPolicy,
-      description: descriptor.description,
-      attributes: remapDescriptorAttributesToDescriptorAttributesSeed(attributes),
-      eserviceId: descriptor.eservice.id,
-      descriptorId: descriptor.id,
-    }
-
-    updateVersionDraft(payload, { onSuccess: forward })
+    match(isEServiceCreatedFromTemplate)
+      .with(true, () =>
+        updateInstanceVersionDraft(
+          {
+            eserviceId: descriptor.eservice.id,
+            descriptorId: descriptor.id,
+            audience: descriptor.audience,
+            dailyCallsPerConsumer: values.dailyCallsPerConsumer,
+            dailyCallsTotal: values.dailyCallsTotal,
+            agreementApprovalPolicy: descriptor.agreementApprovalPolicy,
+          },
+          { onSuccess: forward }
+        )
+      )
+      .with(false, () =>
+        updateVersionDraft(
+          {
+            eserviceId: descriptor.eservice.id,
+            descriptorId: descriptor.id,
+            audience: descriptor.audience,
+            voucherLifespan: descriptor.voucherLifespan,
+            dailyCallsPerConsumer: values.dailyCallsPerConsumer,
+            dailyCallsTotal: values.dailyCallsTotal,
+            agreementApprovalPolicy: descriptor.agreementApprovalPolicy,
+            description: descriptor.description,
+            attributes: remapDescriptorAttributesToDescriptorAttributesSeed(attributes),
+          },
+          { onSuccess: forward }
+        )
+      )
+      .exhaustive()
   }
 
   return (

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepThresholds/__tests__/EServiceCreateStepThresholds.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepThresholds/__tests__/EServiceCreateStepThresholds.test.tsx
@@ -27,10 +27,12 @@ vi.mock('../../sections/EServiceAttributesSection', () => ({
 }))
 
 const updateVersionDraft = vi.fn()
+const updateInstanceVersionDraft = vi.fn()
 
 vi.mock('@/api/eservice', () => ({
   EServiceMutations: {
     useUpdateVersionDraft: () => ({ mutate: updateVersionDraft }),
+    useUpdateInstanceVersionDraft: () => ({ mutate: updateInstanceVersionDraft }),
   },
 }))
 


### PR DESCRIPTION
## 🔗 Issue
[PIN-9648](https://pagopa.atlassian.net/browse/PIN-9648)

## 📝 Description / Context
When creating an e-service instance from a template, the "Thresholds and attributes" step was calling the wrong API endpoint (`updateVersionDraft` instead of `updateInstanceVersionDraft`), causing a 400 Bad Request error from the backend (`"TemplateId must be undefined"`).

## 🛠 List of changes
- Use `updateInstanceVersionDraft` mutation for template instances in `EServiceCreateStepThresholds`, matching the pattern already used in the other creation steps (Info Version and Tech Spec)
- Use `ts-pattern` match on `isEServiceCreatedFromTemplate` to select the correct mutation with exhaustive check

## 🧪 How to test
- Create a published e-service template
- Search for it in "Template e-service" and click "Usa template"
- Proceed to the "Soglie e attributi" step
- Set `dailyCallsTotal` greater than `dailyCallsPerConsumer` and submit
- Verify no 400 error occurs and the step proceeds correctly

---

## Before


https://github.com/user-attachments/assets/62235756-1da5-45ad-b3f3-1fd7b578d272

## After


https://github.com/user-attachments/assets/8be15c58-9893-4389-9932-e5e6354146f3



[PIN-9648]: https://pagopa.atlassian.net/browse/PIN-9648