### PR TITLE
feature: inserted role in type delegation card in create delegation (PIN-2643_INT-74)

### DIFF
--- a/src/pages/DelegationCreatePage/DelegationCreate.page.tsx
+++ b/src/pages/DelegationCreatePage/DelegationCreate.page.tsx
@@ -33,12 +33,10 @@ export const DelegationCreatePage: React.FC = () => {
       <Stack spacing={2}>
         {activeStep === 'KIND' && (
           <SectionContainer title={t('delegations.create.kindSectionTitle')}>
-            <Stack spacing={2} direction="row" sx={{ width: '100%' }}>
-              <DelegationCreateCards
-                selectedDelegationKind={delegationKind}
-                changeDelegationKind={changeDelegationKind}
-              />
-            </Stack>
+            <DelegationCreateCards
+              selectedDelegationKind={delegationKind}
+              changeDelegationKind={changeDelegationKind}
+            />
           </SectionContainer>
         )}
         {activeStep === 'FORM' && delegationKind != null && (

--- a/src/pages/DelegationCreatePage/components/DelegationCreateCards.tsx
+++ b/src/pages/DelegationCreatePage/components/DelegationCreateCards.tsx
@@ -33,7 +33,7 @@ export const DelegationCreateCards: React.FC<DelegationCreateCardsProps> = ({
 }
 
 const svgCardIcon = (
-  <svg width="60" height="81" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <svg width="60" height="81" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
     <path
       d="M26.83 60.73h-8.02c-.596 0-1.082.481-1.082 1.07 0 .59.486 1.071 1.082 1.071h8.02c.596 0 1.082-.48 1.082-1.07 0-.59-.486-1.07-1.083-1.07ZM26.83 64.459h-8.02c-.596 0-1.082.48-1.082 1.07 0 .59.486 1.07 1.082 1.07h8.02c.596 0 1.082-.48 1.082-1.07 0-.59-.486-1.07-1.083-1.07Z"
       fill="#0073E6"
@@ -91,7 +91,7 @@ const DelegationKindButton: React.FC<{
   const { t } = useTranslation('party')
 
   return (
-    <Button onClick={onClick} sx={sx} variant="outlined" disableRipple>
+    <Button onClick={onClick} sx={sx} variant="outlined" disableRipple aria-pressed={selected}>
       {svgCardIcon}
       <div>
         <Typography variant="body1">{t('delegations.create.cards.common')}</Typography>

--- a/src/pages/DelegationCreatePage/components/DelegationCreateCards.tsx
+++ b/src/pages/DelegationCreatePage/components/DelegationCreateCards.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { DelegationKind } from '@/api/api.generatedTypes'
 import type { SxProps } from '@mui/material'
-import { Button, Typography } from '@mui/material'
+import { Button, Stack, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
 type DelegationCreateCardsProps = {
@@ -16,7 +16,13 @@ export const DelegationCreateCards: React.FC<DelegationCreateCardsProps> = ({
   const { t } = useTranslation('party')
 
   return (
-    <>
+    <Stack
+      direction="row"
+      spacing={2}
+      sx={{ width: '100%' }}
+      role="radiogroup"
+      aria-label={t('delegations.create.kindSectionAriaLabel')}
+    >
       <DelegationKindButton
         selected={selectedDelegationKind === 'DELEGATED_CONSUMER'}
         onClick={() => changeDelegationKind('DELEGATED_CONSUMER')}
@@ -28,7 +34,7 @@ export const DelegationCreateCards: React.FC<DelegationCreateCardsProps> = ({
         onClick={() => changeDelegationKind('DELEGATED_PRODUCER')}
         label={t('delegations.create.cards.provider')}
       />
-    </>
+    </Stack>
   )
 }
 
@@ -91,7 +97,14 @@ const DelegationKindButton: React.FC<{
   const { t } = useTranslation('party')
 
   return (
-    <Button onClick={onClick} sx={sx} variant="outlined" disableRipple aria-pressed={selected}>
+    <Button
+      onClick={onClick}
+      sx={sx}
+      variant="outlined"
+      disableRipple
+      role="radio"
+      aria-checked={selected}
+    >
       {svgCardIcon}
       <div>
         <Typography variant="body1">{t('delegations.create.cards.common')}</Typography>

--- a/src/static/locales/en/party.json
+++ b/src/static/locales/en/party.json
@@ -132,6 +132,7 @@
     "create": {
       "title": "Create delegation",
       "kindSectionTitle": "Delegation types",
+      "kindSectionAriaLabel": "Select the delegation type you want to create",
       "consumerDelegationTitle": "Delegation for consuming",
       "providerDelegationTitle": "Delegation for producing",
       "cancelBtn": "Cancel",

--- a/src/static/locales/it/party.json
+++ b/src/static/locales/it/party.json
@@ -132,6 +132,7 @@
     "create": {
       "title": "Crea delega",
       "kindSectionTitle": "Tipologie di delega",
+      "kindSectionAriaLabel": "Seleziona il tipo di delega che vuoi creare",
       "consumerDelegationTitle": "Delega alla fruizione",
       "providerDelegationTitle": "Delega all'erogazione",
       "cancelBtn": "Annulla",


### PR DESCRIPTION
## 🔗 Issue

[PIN-2643_INT-74](https://pagopa.atlassian.net/jira/software/c/projects/A2/boards/3337?assignee=620a1141a713ab0068110f9e&selectedIssue=A2-2643)

## 📝 Description / Context

The role of the buttons to select the type of the delegation the user want to create `DelegationsCreateCards` was not specified so the screen reader can not be able to read which one was selected. This PR add a `radio` role to the buttons and implement a `radiogroup` container for them to solve this problem.

## 🛠 List of changes

- Add `role='radio'` and `aria-checked={selected}` to the `DelegationKindButton`
- Implement a `Stack` to contain them with `role='radiogroup'` and a aria-label for the screen reader
