### PR TITLE
feature/PIN-2607_INT-32-label-name-consumer-agreements-list-actions

### DIFF
--- a/src/pages/ConsumerAgreementsListPage/components/ConsumerAgreementsTableRow.tsx
+++ b/src/pages/ConsumerAgreementsListPage/components/ConsumerAgreementsTableRow.tsx
@@ -55,6 +55,9 @@ export const ConsumerAgreementsTableRow: React.FC<{ agreement: AgreementListEntr
     </Stack>
   )
 
+  const computedAriaLabel = canBeUpgraded //compute the aria-label based on the action and if the agreement is upgradable for screen readers, if the agreement is upgradable we want to add the tooltip text to the aria-label to make sure that screen reader users are aware of the upgrade possibility
+    ? `${tCommon(isAgreementEditable ? 'edit' : 'inspect')}. ${t('upgradableAgreementTooltip')}`
+    : tCommon(isAgreementEditable ? 'edit' : 'inspect')
   return (
     <TableRow
       cellData={[
@@ -73,6 +76,7 @@ export const ConsumerAgreementsTableRow: React.FC<{ agreement: AgreementListEntr
           to={isAgreementEditable ? 'SUBSCRIBE_AGREEMENT_EDIT' : 'SUBSCRIBE_AGREEMENT_READ'}
           params={{ agreementId: agreement.id }}
           endIcon={canBeUpgraded ? <UpdateIcon /> : undefined}
+          aria-label={computedAriaLabel}
         >
           {tCommon(isAgreementEditable ? 'edit' : 'inspect')}
         </Link>

--- a/src/pages/ConsumerAgreementsListPage/components/ConsumerAgreementsTableRow.tsx
+++ b/src/pages/ConsumerAgreementsListPage/components/ConsumerAgreementsTableRow.tsx
@@ -55,7 +55,9 @@ export const ConsumerAgreementsTableRow: React.FC<{ agreement: AgreementListEntr
     </Stack>
   )
 
-  const computedAriaLabel = canBeUpgraded //compute the aria-label based on the action and if the agreement is upgradable for screen readers, if the agreement is upgradable we want to add the tooltip text to the aria-label to make sure that screen reader users are aware of the upgrade possibility
+  // Include the tooltip text in the aria-label when the agreement can be
+  // upgraded so screen reader users are informed about that option.
+  const computedAriaLabel = canBeUpgraded
     ? `${tCommon(isAgreementEditable ? 'edit' : 'inspect')}. ${t('upgradableAgreementTooltip')}`
     : tCommon(isAgreementEditable ? 'edit' : 'inspect')
   return (

--- a/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
@@ -56,8 +56,8 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
     </>
   )
 
-  // Include the tooltip text in the aria-label when the agreement can be
-  // upgraded so screen reader users are informed about that option.
+  // Include the tooltip text in the aria-label when the purpose has a
+  //  waiting for approval version so screen reader users are informed about that option.
   const computedAriaLabel = hasWaitingForApprovalVersion
     ? `${tCommon(`actions.${isPurposeEditable ? 'edit' : 'inspect'}`)}. ${t(
         'list.waitingForApprovalVersionTooltip'

--- a/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
@@ -56,6 +56,8 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
     </>
   )
 
+  // Include the tooltip text in the aria-label when the agreement can be
+  // upgraded so screen reader users are informed about that option.
   const computedAriaLabel = hasWaitingForApprovalVersion
     ? `${tCommon(`actions.${isPurposeEditable ? 'edit' : 'inspect'}`)}. ${t(
         'list.waitingForApprovalVersionTooltip'

--- a/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
@@ -56,6 +56,12 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
     </>
   )
 
+  const computedAriaLabel = hasWaitingForApprovalVersion
+    ? `${tCommon(`actions.${isPurposeEditable ? 'edit' : 'inspect'}`)}. ${t(
+        'list.waitingForApprovalVersionTooltip'
+      )}`
+    : tCommon(`actions.${isPurposeEditable ? 'edit' : 'inspect'}`)
+
   return (
     <TableRow
       cellData={[
@@ -69,20 +75,19 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
         open={hasWaitingForApprovalVersion ? undefined : false}
         title={t('list.waitingForApprovalVersionTooltip')}
       >
-        <span tabIndex={hasWaitingForApprovalVersion ? 0 : undefined}>
-          <Link
-            as="button"
-            onPointerEnter={handlePrefetch}
-            onFocusVisible={handlePrefetch}
-            variant="outlined"
-            size="small"
-            to={isPurposeEditable ? 'SUBSCRIBE_PURPOSE_SUMMARY' : 'SUBSCRIBE_PURPOSE_DETAILS'}
-            endIcon={hasWaitingForApprovalVersion ? <PendingActionsIcon /> : undefined}
-            params={{ purposeId: purpose.id }}
-          >
-            {tCommon(`actions.${isPurposeEditable ? 'edit' : 'inspect'}`)}
-          </Link>
-        </span>
+        <Link
+          as="button"
+          onPointerEnter={handlePrefetch}
+          onFocusVisible={handlePrefetch}
+          variant="outlined"
+          size="small"
+          to={isPurposeEditable ? 'SUBSCRIBE_PURPOSE_SUMMARY' : 'SUBSCRIBE_PURPOSE_DETAILS'}
+          endIcon={hasWaitingForApprovalVersion ? <PendingActionsIcon /> : undefined}
+          params={{ purposeId: purpose.id }}
+          aria-label={computedAriaLabel}
+        >
+          {tCommon(`actions.${isPurposeEditable ? 'edit' : 'inspect'}`)}
+        </Link>
       </Tooltip>
 
       <Box component="span" sx={{ ml: 2, display: 'inline-block' }}>

--- a/src/pages/ProviderPurposesListPage/components/ProviderPurposesTableRow.tsx
+++ b/src/pages/ProviderPurposesListPage/components/ProviderPurposesTableRow.tsx
@@ -38,8 +38,8 @@ export const ProviderPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
     </Stack>
   )
 
-  // Include the tooltip text in the aria-label when the agreement can be
-  // upgraded so screen reader users are informed about that option.
+  // Include the tooltip text in the aria-label when the purpose has
+  // a waiting for approval version so screen reader users are informed about that option.
   const computedAriaLabel = hasWaitingForApprovalVersion
     ? `${tCommon(`actions.inspect`)}. ${t('newVersionAvailableTooltip')}`
     : tCommon(`actions.inspect`)

--- a/src/pages/ProviderPurposesListPage/components/ProviderPurposesTableRow.tsx
+++ b/src/pages/ProviderPurposesListPage/components/ProviderPurposesTableRow.tsx
@@ -38,6 +38,8 @@ export const ProviderPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
     </Stack>
   )
 
+  // Include the tooltip text in the aria-label when the agreement can be
+  // upgraded so screen reader users are informed about that option.
   const computedAriaLabel = hasWaitingForApprovalVersion
     ? `${tCommon(`actions.inspect`)}. ${t('newVersionAvailableTooltip')}`
     : tCommon(`actions.inspect`)

--- a/src/pages/ProviderPurposesListPage/components/ProviderPurposesTableRow.tsx
+++ b/src/pages/ProviderPurposesListPage/components/ProviderPurposesTableRow.tsx
@@ -38,6 +38,10 @@ export const ProviderPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
     </Stack>
   )
 
+  const computedAriaLabel = hasWaitingForApprovalVersion
+    ? `${tCommon(`actions.inspect`)}. ${t('newVersionAvailableTooltip')}`
+    : tCommon(`actions.inspect`)
+
   return (
     <TableRow
       cellData={[
@@ -59,6 +63,7 @@ export const ProviderPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
           to="PROVIDE_PURPOSE_DETAILS"
           params={{ purposeId: purpose.id }}
           endIcon={hasWaitingForApprovalVersion ? <ErrorIcon /> : undefined}
+          aria-label={computedAriaLabel}
         >
           {tCommon('actions.inspect')}
         </Link>


### PR DESCRIPTION


## 🔗 Issue

[PIN-A2-2607](https://pagopa.atlassian.net/browse/A2-2607)

## 📝 Description / Context
This pull request improves accessibility for screen reader users by enhancing the `aria-label` attributes of action links in various table row components. The changes ensure that users are informed about additional context, such as upgrade possibilities or pending approvals, directly through the screen reader.