### PR TITLE
feature: fix accessibility into sidebar collapsable components (PIN-2641_INT-72)

### DIFF
--- a/src/components/sidebar/components/SidebarItemGroup.tsx
+++ b/src/components/sidebar/components/SidebarItemGroup.tsx
@@ -47,6 +47,7 @@ export const SidebarItemGroup: React.FC<SidebarItemGroupProps> = ({
           data-testid="sidebar-item-group-button"
           selected={isSelected}
           onClick={handleExpandParent}
+          aria-expanded={isExpanded}
           sx={
             !open && isSelected
               ? {


### PR DESCRIPTION
## 🔗 Issue

[PIN-2641_INT-72](https://pagopa.atlassian.net/jira/software/c/projects/A2/boards/3337?assignee=620a1141a713ab0068110f9e&selectedIssue=A2-2641)

## 📝 Description / Context

There is no method for the screen reader to coomunicate if the sidebar collapsable element in expanded or not. This PR introduce the `aria-expanded` prop to `SidebarItemGroup` component so the screen reader can know if the element is expanded or not.

## 🛠 List of changes

- added `aria-expanded` prop to `SidebarItemGroup` component
