### PR TITLE
fix: update button label from 'saveEdits' to 'upgrade' in delegation …

### DIFF
--- a/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceUpdateDelegationFlagsDrawer.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceUpdateDelegationFlagsDrawer.test.tsx
@@ -107,7 +107,7 @@ describe('ProviderEServiceUpdateDelegationFlagsDrawer', () => {
       })
       await user.click(clientAccessCheckbox)
 
-      const saveButton = screen.getByRole('button', { name: 'common.actions.saveEdits' })
+      const saveButton = screen.getByRole('button', { name: 'common.actions.upgrade' })
       await user.click(saveButton)
 
       await waitFor(() => {
@@ -143,7 +143,7 @@ describe('ProviderEServiceUpdateDelegationFlagsDrawer', () => {
         { withReactQueryContext: true }
       )
 
-      const saveButton = screen.getByRole('button', { name: 'common.actions.saveEdits' })
+      const saveButton = screen.getByRole('button', { name: 'common.actions.upgrade' })
       await user.click(saveButton)
 
       await waitFor(() => {

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceUpdateDelegationFlagsDrawer.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceUpdateDelegationFlagsDrawer.tsx
@@ -90,7 +90,7 @@ export const ProviderEServiceUpdateDelegationFlagsDrawer: React.FC<
           </Trans>
         }
         buttonAction={{
-          label: tCommon('actions.saveEdits'),
+          label: tCommon('actions.upgrade'),
           action: formMethods.handleSubmit(onSubmit),
         }}
         onTransitionExited={handleTransitionExited}


### PR DESCRIPTION
## 🔗 Issue

[PIN-9687](https://pagopa.atlassian.net/browse/PIN-9687)

## 📝 Description / Context

Updated button label in ProviderEServiceUpdateDelegationFlagsDrawer.tsx



[PIN-9687]: https://pagopa.atlassian.net/browse/PIN-9687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ