### PR TITLE
feature: add error message to forward button in create delegation if no delegation kind is selected (PIN-2644_INT-75)

### DIFF
--- a/src/pages/DelegationCreatePage/DelegationCreate.page.tsx
+++ b/src/pages/DelegationCreatePage/DelegationCreate.page.tsx
@@ -1,6 +1,6 @@
 import { PageContainer, SectionContainer } from '@/components/layout/containers'
 import { useNavigate } from '@/router'
-import { Stack } from '@mui/material'
+import { FormHelperText, Stack } from '@mui/material'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DelegationCreateCards } from './components/DelegationCreateCards'
@@ -17,10 +17,16 @@ export const DelegationCreatePage: React.FC = () => {
   const navigate = useNavigate()
   const [delegationKind, setDelegationKind] = useState<DelegationKind>()
   const [activeStep, setActiveStep] = useState<'KIND' | 'FORM'>('KIND')
+  const [showErrorMessage, setShowErrorMessage] = useState<boolean>(false)
 
   const changeDelegationKind = (delegationKind: DelegationKind) => {
+    setShowErrorMessage(false)
     setDelegationKind(delegationKind)
   }
+
+  const errorTextSx = { fontWeight: 400, color: 'text.secondary', display: 'block' }
+
+  const errorMessageId = 'delegationKindErrorId'
 
   return (
     <PageContainer
@@ -32,11 +38,23 @@ export const DelegationCreatePage: React.FC = () => {
     >
       <Stack spacing={2}>
         {activeStep === 'KIND' && (
-          <SectionContainer title={t('delegations.create.kindSectionTitle')}>
+          <SectionContainer title={t('delegations.create.kindSectionTitle')} aria-live="assertive">
             <DelegationCreateCards
               selectedDelegationKind={delegationKind}
               changeDelegationKind={changeDelegationKind}
+              showErrorMessage={showErrorMessage}
+              errorMessageId={errorMessageId}
             />
+            {showErrorMessage && (
+              <FormHelperText
+                id={errorMessageId}
+                error={true}
+                sx={{ ...errorTextSx }}
+                aria-atomic={true}
+              >
+                {t('delegations.create.kindSectionErrorMessage')}
+              </FormHelperText>
+            )}
           </SectionContainer>
         )}
         {activeStep === 'FORM' && delegationKind !== undefined && (
@@ -55,9 +73,12 @@ export const DelegationCreatePage: React.FC = () => {
             type: 'button',
             endIcon: <ArrowForwardIcon />,
             onClick: () => {
-              setActiveStep('FORM')
+              if (delegationKind === undefined) {
+                setShowErrorMessage(true)
+              } else {
+                setActiveStep('FORM')
+              }
             },
-            disabled: delegationKind === undefined,
           }}
         />
       )}

--- a/src/pages/DelegationCreatePage/DelegationCreate.page.tsx
+++ b/src/pages/DelegationCreatePage/DelegationCreate.page.tsx
@@ -39,7 +39,7 @@ export const DelegationCreatePage: React.FC = () => {
             />
           </SectionContainer>
         )}
-        {activeStep === 'FORM' && delegationKind != null && (
+        {activeStep === 'FORM' && delegationKind !== undefined && (
           <DelegationCreateForm delegationKind={delegationKind} setActiveStep={setActiveStep} />
         )}
       </Stack>
@@ -55,8 +55,9 @@ export const DelegationCreatePage: React.FC = () => {
             type: 'button',
             endIcon: <ArrowForwardIcon />,
             onClick: () => {
-              delegationKind != null && setActiveStep('FORM')
+              setActiveStep('FORM')
             },
+            disabled: delegationKind === undefined,
           }}
         />
       )}

--- a/src/pages/DelegationCreatePage/components/DelegationCreateCards.tsx
+++ b/src/pages/DelegationCreatePage/components/DelegationCreateCards.tsx
@@ -7,11 +7,15 @@ import { useTranslation } from 'react-i18next'
 type DelegationCreateCardsProps = {
   selectedDelegationKind: DelegationKind | undefined
   changeDelegationKind: (delegationKind: DelegationKind) => void
+  showErrorMessage: boolean
+  errorMessageId: string
 }
 
 export const DelegationCreateCards: React.FC<DelegationCreateCardsProps> = ({
   selectedDelegationKind,
   changeDelegationKind,
+  showErrorMessage,
+  errorMessageId,
 }) => {
   const { t } = useTranslation('party')
 
@@ -22,6 +26,9 @@ export const DelegationCreateCards: React.FC<DelegationCreateCardsProps> = ({
       sx={{ width: '100%' }}
       role="radiogroup"
       aria-label={t('delegations.create.kindSectionAriaLabel')}
+      aria-invalid={showErrorMessage}
+      aria-errormessage={errorMessageId}
+      aria-required={true}
     >
       <DelegationKindButton
         selected={selectedDelegationKind === 'DELEGATED_CONSUMER'}

--- a/src/static/locales/en/party.json
+++ b/src/static/locales/en/party.json
@@ -133,6 +133,7 @@
       "title": "Create delegation",
       "kindSectionTitle": "Delegation types",
       "kindSectionAriaLabel": "Select the delegation type you want to create",
+      "kindSectionErrorMessage": "To continue, select whether you want to create a delegation for consuming or producing.",
       "consumerDelegationTitle": "Delegation for consuming",
       "providerDelegationTitle": "Delegation for producing",
       "cancelBtn": "Cancel",

--- a/src/static/locales/it/party.json
+++ b/src/static/locales/it/party.json
@@ -133,6 +133,7 @@
       "title": "Crea delega",
       "kindSectionTitle": "Tipologie di delega",
       "kindSectionAriaLabel": "Seleziona il tipo di delega che vuoi creare",
+      "kindSectionErrorMessage": "Per proseguire, seleziona se vuoi creare una delega alla fruizione o all'erogazione.",
       "consumerDelegationTitle": "Delega alla fruizione",
       "providerDelegationTitle": "Delega all'erogazione",
       "cancelBtn": "Annulla",


### PR DESCRIPTION
## 🔗 Issue

[PIN-2644_INT-75](https://pagopa.atlassian.net/jira/software/c/projects/A2/boards/3337?issueParent=496863&selectedIssue=A2-2644)

## 📝 Description / Context

The forward button in create delegation process, does nothing if the delegation kind is not selected. This PR add an error message when we click the button without selecting any delegation kind

## 🛠 List of changes

- Add an accessible error message to the button forward if delegation kind is not selected
