### PR TITLE
feat: initial devtools client assertion debug form commit (PIN-9658)

### DIFF
--- a/src/api/voucher/voucher.mutations.ts
+++ b/src/api/voucher/voucher.mutations.ts
@@ -6,6 +6,19 @@ function useValidateTokenGeneration() {
   const { t } = useTranslation('mutations-feedback', { keyPrefix: 'voucher.tokenVerification' })
   return useMutation({
     mutationFn: VoucherServices.validateTokenGeneration,
+    retry: false,
+    meta: {
+      errorToastLabel: t('outcome.error'),
+      loadingLabel: t('loading'),
+    },
+  })
+}
+
+function useValidateDPoPProof() {
+  const { t } = useTranslation('mutations-feedback', { keyPrefix: 'voucher.dPoPProofVerification' })
+  return useMutation({
+    mutationFn: VoucherServices.validateDPoPProof,
+    retry: false,
     meta: {
       errorToastLabel: t('outcome.error'),
       loadingLabel: t('loading'),
@@ -15,4 +28,5 @@ function useValidateTokenGeneration() {
 
 export const VoucherMutations = {
   useValidateTokenGeneration,
+  useValidateDPoPProof,
 }

--- a/src/api/voucher/voucher.services.ts
+++ b/src/api/voucher/voucher.services.ts
@@ -16,6 +16,21 @@ async function validateTokenGeneration(payload: AccessTokenRequest) {
   return response.data
 }
 
+async function validateDPoPProof(payload: AccessTokenRequest) {
+  const response = await axiosInstance.post<TokenGenerationValidationResult>(
+    `${BACKEND_FOR_FRONTEND_URL}/tools/validateDPoPProof`,
+    payload,
+    {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    }
+  )
+
+  return response.data
+}
+
 export const VoucherServices = {
   validateTokenGeneration,
+  validateDPoPProof,
 }

--- a/src/pages/ConsumerDebugVoucherPage/ConsumerDebugVoucher.page.tsx
+++ b/src/pages/ConsumerDebugVoucherPage/ConsumerDebugVoucher.page.tsx
@@ -5,7 +5,8 @@ import { DebugVoucherForm } from './components/DebugVoucherForm'
 import { DebugVoucherResults } from './components/DebugVoucherResults'
 import { DebugVoucherContextProvider } from './DebugVoucherContext'
 import type { AccessTokenRequest, TokenGenerationValidationResult } from '@/api/api.generatedTypes'
-import { Grid } from '@mui/material'
+import { Box, Grid } from '@mui/material'
+import { RequiredTextLabel } from '@/components/shared/RequiredTextLabel'
 
 const ConsumerDebugVoucherPage: React.FC = () => {
   const { t } = useTranslation('pages', { keyPrefix: 'consumerDebugVoucher' })
@@ -21,6 +22,9 @@ const ConsumerDebugVoucherPage: React.FC = () => {
 
   return (
     <PageContainer title={t('title')} description={t('description')}>
+      <Box sx={{ mt: 2, mb: 1 }}>
+        <RequiredTextLabel />
+      </Box>
       <Grid container>
         <Grid item xs={8}>
           {!debugVoucherValues ? (

--- a/src/pages/ConsumerDebugVoucherPage/__test__/ConsumerDebugVoucher.page.test.tsx
+++ b/src/pages/ConsumerDebugVoucherPage/__test__/ConsumerDebugVoucher.page.test.tsx
@@ -45,7 +45,9 @@ describe('ConsumerDebugVoucherPage testing', () => {
       withRouterContext: true,
     })
 
-    const clientAssertionInput = screen.getByLabelText('clientAssertionLabel')
+    const clientAssertionInput = screen.getByRole('textbox', {
+      name: 'clientAssertionLabel',
+    })
     const clientIdInput = screen.getByLabelText('clientIdLabel')
     const submitButton = screen.getByRole('button', { name: 'submitBtn' })
 
@@ -64,7 +66,9 @@ describe('ConsumerDebugVoucherPage testing', () => {
       withRouterContext: true,
     })
 
-    const clientAssertionInput = screen.getByLabelText('clientAssertionLabel')
+    const clientAssertionInput = screen.getByRole('textbox', {
+      name: 'clientAssertionLabel',
+    })
     const clientIdInput = screen.getByLabelText('clientIdLabel')
     const submitButton = screen.getByRole('button', { name: 'submitBtn' })
 

--- a/src/pages/ConsumerDebugVoucherPage/components/DebugVoucherForm.tsx
+++ b/src/pages/ConsumerDebugVoucherPage/components/DebugVoucherForm.tsx
@@ -1,16 +1,21 @@
 import { SectionContainer } from '@/components/layout/containers'
-import { RHFTextField } from '@/components/shared/react-hook-form-inputs'
-import { Box, Button, Typography } from '@mui/material'
+import { RHFRadioGroup, RHFTextField } from '@/components/shared/react-hook-form-inputs'
+import { Alert, Box, Button, Stack, Typography } from '@mui/material'
 import React from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { Trans, useTranslation } from 'react-i18next'
 import { VoucherMutations } from '@/api/voucher'
 import type { AccessTokenRequest, TokenGenerationValidationResult } from '@/api/api.generatedTypes'
 import { AUTHORIZATION_SERVER_TOKEN_CREATION_URL } from '@/config/env'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import InfoOutlined from '@mui/icons-material/InfoOutlined'
+import { useNavigate } from '@/router'
 
 export type DebugVoucherFormValues = {
   clientAssertion: string
+  dPopProof: string
   clientId: string
+  interactionType: string // mocked form field
 }
 
 export type DebugVoucherFormProps = {
@@ -23,17 +28,29 @@ export type DebugVoucherFormProps = {
 
 export const DebugVoucherForm: React.FC<DebugVoucherFormProps> = ({ setDebugVoucherValues }) => {
   const { t } = useTranslation('voucher', { keyPrefix: 'consumerDebugVoucher.edit' })
-  const { mutate: validateVoucher } = VoucherMutations.useValidateTokenGeneration()
+  const navigate = useNavigate()
+
+  const { mutateAsync: validateVoucherAsync } = VoucherMutations.useValidateTokenGeneration()
+  const { mutateAsync: validateDPoPProofAsync } = VoucherMutations.useValidateDPoPProof() // mocked mutation
+
   const defaultValues: DebugVoucherFormValues = {
     clientAssertion: '',
+    dPopProof: '',
     clientId: '',
+    interactionType: 'sync', // mocked interaction type default value
   }
+
+  // mocked interaction type options
+  const interactionTypeOptions: Array<{ label: string; value: string }> = [
+    { label: t('interactionModelSync'), value: 'sync' },
+    { label: t('interactionModelAsync'), value: 'async' },
+  ]
 
   const formMethods = useForm({
     defaultValues,
   })
 
-  const onSubmit = (formValues: DebugVoucherFormValues) => {
+  const onSubmit = async (formValues: DebugVoucherFormValues) => {
     const payloadValidateVoucher: AccessTokenRequest = {
       client_id: formValues.clientId || undefined,
       client_assertion: formValues.clientAssertion,
@@ -41,9 +58,29 @@ export const DebugVoucherForm: React.FC<DebugVoucherFormProps> = ({ setDebugVouc
       grant_type: 'client_credentials',
     }
 
-    validateVoucher(payloadValidateVoucher, {
-      onSuccess(data) {
-        setDebugVoucherValues({ request: payloadValidateVoucher, response: data })
+    if (!formValues.dPopProof) {
+      const response = await validateVoucherAsync(payloadValidateVoucher)
+
+      setDebugVoucherValues({
+        request: payloadValidateVoucher,
+        response,
+      })
+
+      return
+    }
+
+    const [tokenResponse, dpopResponse] = await Promise.all([
+      validateVoucherAsync(payloadValidateVoucher),
+      validateDPoPProofAsync(payloadValidateVoucher), // mocked DPoP proof validation payload
+    ])
+
+    setDebugVoucherValues({
+      request: payloadValidateVoucher,
+      response: {
+        steps: {
+          ...tokenResponse.steps,
+          ...dpopResponse.steps,
+        },
       },
     })
   }
@@ -51,28 +88,66 @@ export const DebugVoucherForm: React.FC<DebugVoucherFormProps> = ({ setDebugVouc
   return (
     <FormProvider {...formMethods}>
       <Box component="form" noValidate onSubmit={formMethods.handleSubmit(onSubmit)}>
-        <SectionContainer title={t('title')}>
-          <RHFTextField
-            name="clientAssertion"
-            focusOnMount
-            multiline
-            label={t('clientAssertionLabel')}
-            rules={{ required: true }}
-          />
+        <SectionContainer title={t('title')} description={t('description')}>
+          <Stack spacing={3}>
+            <RHFTextField
+              name="clientAssertion"
+              focusOnMount
+              multiline
+              required
+              label={t('clientAssertionLabel')}
+              rules={{ required: true }}
+              size="medium"
+              infoLabel={t('clientAssertionInfoLabel')}
+            />
 
-          <RHFTextField name="clientId" label={t('clientIdLabel')} />
-          <Typography variant="body2">
-            <Trans
-              components={{
-                strong: <Typography component="span" variant="inherit" fontWeight={700} />,
-              }}
-            >
-              {t('description', { authServer: AUTHORIZATION_SERVER_TOKEN_CREATION_URL })}
-            </Trans>
-          </Typography>
+            <RHFTextField
+              name="dPopProof"
+              multiline
+              size="medium"
+              label={t('dPopProofLabel')}
+              infoLabel={t('dPopProofInfoLabel')}
+            />
+
+            <RHFTextField
+              sx={{ mt: 1 }}
+              name="clientId"
+              label={t('clientIdLabel')}
+              infoLabel={t('clientIdInfoLabel')}
+            />
+
+            {/* --- Probably not needed, waiting for an update on the Figma */}
+            <RHFRadioGroup
+              disabled
+              name="interactionType"
+              label={t('interactionModelLabel')}
+              rules={{ required: true }}
+              required
+              options={interactionTypeOptions}
+            />
+            {/* --- */}
+
+            <Alert color="info" icon={<InfoOutlined />}>
+              <Trans
+                components={{
+                  strong: <Typography component="span" variant="inherit" fontWeight={700} />,
+                }}
+              >
+                {t('alert', { authServer: AUTHORIZATION_SERVER_TOKEN_CREATION_URL })}
+              </Trans>
+            </Alert>
+          </Stack>
         </SectionContainer>
 
-        <Box sx={{ display: 'flex', justifyContent: 'end', pt: 4 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', pt: 3 }}>
+          <Button
+            onClick={() => navigate('DEVELOPER_TOOLS')}
+            type="button"
+            variant="outlined"
+            startIcon={<ArrowBackIcon />}
+          >
+            {t('goBackBtn')}
+          </Button>
           <Button type="submit" variant="contained">
             {t('submitBtn')}
           </Button>

--- a/src/pages/ConsumerDebugVoucherPage/components/DebugVoucherForm.tsx
+++ b/src/pages/ConsumerDebugVoucherPage/components/DebugVoucherForm.tsx
@@ -58,7 +58,7 @@ export const DebugVoucherForm: React.FC<DebugVoucherFormProps> = ({ setDebugVouc
       grant_type: 'client_credentials',
     }
 
-    if (!formValues.dPopProof) {
+    if (!formValues.dPopProof || formValues.dPopProof === '') {
       const response = await validateVoucherAsync(payloadValidateVoucher)
 
       setDebugVoucherValues({
@@ -116,7 +116,7 @@ export const DebugVoucherForm: React.FC<DebugVoucherFormProps> = ({ setDebugVouc
               infoLabel={t('clientIdInfoLabel')}
             />
 
-            {/* --- Probably not needed, waiting for an update on the Figma */}
+            {/* The input will be disabled for this release: https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW?node-id=4078-14921#1712917799 */}
             <RHFRadioGroup
               disabled
               name="interactionType"

--- a/src/pages/ConsumerDebugVoucherPage/components/__test__/DebugVoucherForm.test.tsx
+++ b/src/pages/ConsumerDebugVoucherPage/components/__test__/DebugVoucherForm.test.tsx
@@ -11,6 +11,7 @@ import {
   createMockDebugVoucherResultPassed,
 } from '@/../__mocks__/data/voucher.mocks'
 import type { TokenGenerationValidationResult } from '@/api/api.generatedTypes'
+import { VoucherMutations } from '@/api/voucher'
 
 const response = createMockDebugVoucherResultPassed()
 
@@ -31,10 +32,13 @@ describe('DebugVoucherForm testing', () => {
       <DebugVoucherForm setDebugVoucherValues={setDebugVoucherValuesMockFn} />,
       {
         withReactQueryContext: true,
+        withRouterContext: true,
       }
     )
 
-    const clientAssertionInput = screen.getByLabelText('clientAssertionLabel')
+    const clientAssertionInput = screen.getByRole('textbox', {
+      name: 'clientAssertionLabel',
+    })
     const clientIdInput = screen.getByLabelText('clientIdLabel')
     const submitButton = screen.getByRole('button', { name: 'submitBtn' })
 
@@ -61,10 +65,13 @@ describe('DebugVoucherForm testing', () => {
       <DebugVoucherForm setDebugVoucherValues={setDebugVoucherValuesMockFn} />,
       {
         withReactQueryContext: true,
+        withRouterContext: true,
       }
     )
 
-    const clientAssertionInput = screen.getByLabelText('clientAssertionLabel')
+    const clientAssertionInput = screen.getByRole('textbox', {
+      name: 'clientAssertionLabel',
+    })
     const submitButton = screen.getByRole('button', { name: 'submitBtn' })
 
     fireEvent.change(clientAssertionInput, { target: { value: 'test client assertion' } })
@@ -81,5 +88,69 @@ describe('DebugVoucherForm testing', () => {
         response: response,
       })
     )
+  })
+
+  it('should call both APIs and merge responses when dPopProof is provided', async () => {
+    const setDebugVoucherValuesMockFn = vi.fn()
+
+    const tokenResponse = createMockDebugVoucherResultPassed()
+
+    const dpopResponse = createMockDebugVoucherResultPassed()
+
+    const validateVoucherMock = vi.fn().mockResolvedValue(tokenResponse)
+    const validateDPoPMock = vi.fn().mockResolvedValue(dpopResponse)
+
+    vi.spyOn(VoucherMutations, 'useValidateTokenGeneration').mockReturnValue({
+      mutateAsync: validateVoucherMock,
+    } as never)
+
+    vi.spyOn(VoucherMutations, 'useValidateDPoPProof').mockReturnValue({
+      mutateAsync: validateDPoPMock,
+    } as never)
+
+    const screen = renderWithApplicationContext(
+      <DebugVoucherForm setDebugVoucherValues={setDebugVoucherValuesMockFn} />,
+      {
+        withReactQueryContext: true,
+        withRouterContext: true,
+      }
+    )
+
+    const clientAssertionInput = await screen.findByRole('textbox', {
+      name: 'clientAssertionLabel',
+    })
+
+    const dpopInput = await screen.findByRole('textbox', {
+      name: 'dPopProofLabel',
+    })
+
+    const submitButton = screen.getByRole('button', { name: 'submitBtn' })
+
+    fireEvent.change(clientAssertionInput, {
+      target: { value: 'test client assertion' },
+    })
+
+    fireEvent.change(dpopInput, {
+      target: { value: 'test dpop proof' },
+    })
+
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(validateVoucherMock).toHaveBeenCalledTimes(1)
+      expect(validateDPoPMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(setDebugVoucherValuesMockFn).toHaveBeenCalledWith({
+      request: expect.objectContaining({
+        client_assertion: 'test client assertion',
+      }),
+      response: {
+        steps: {
+          ...tokenResponse.steps,
+          ...dpopResponse.steps,
+        },
+      },
+    })
   })
 })

--- a/src/pages/ConsumerDebugVoucherPage/components/__test__/DebugVoucherForm.test.tsx
+++ b/src/pages/ConsumerDebugVoucherPage/components/__test__/DebugVoucherForm.test.tsx
@@ -116,11 +116,11 @@ describe('DebugVoucherForm testing', () => {
       }
     )
 
-    const clientAssertionInput = await screen.findByRole('textbox', {
+    const clientAssertionInput = screen.getByRole('textbox', {
       name: 'clientAssertionLabel',
     })
 
-    const dpopInput = await screen.findByRole('textbox', {
+    const dpopInput = screen.getByRole('textbox', {
       name: 'dPopProofLabel',
     })
 

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -722,6 +722,12 @@
       "outcome": {
         "error": "There was an error processing your request. Please try again later!"
       }
+    },
+    "dPoPProofVerification": {
+      "loading": "Verification is being performed. Please wait",
+      "outcome": {
+        "error": "There was an error processing your request. Please try again later!"
+      }
     }
   },
   "keychain": {

--- a/src/static/locales/en/pages.json
+++ b/src/static/locales/en/pages.json
@@ -33,7 +33,7 @@
   },
   "consumerDebugVoucher": {
     "title": "Client Assertion Debug",
-    "description": "The debug tool allows you to highlight any anomalies contained in your client assertion necessary for obtaining an access token."
+    "description": "If you can't get a voucher and don't know why, you can debug it with this simulator and understand possible errors."
   },
   "consumerSimulateGetVoucher": {
     "title": "Simulate getting a voucher",

--- a/src/static/locales/en/voucher.json
+++ b/src/static/locales/en/voucher.json
@@ -207,10 +207,19 @@
   "consumerDebugVoucher": {
     "edit": {
       "title": "Request data to the server",
-      "clientAssertionLabel": "Enter your client assertion (required)",
-      "clientIdLabel": "Enter the client ID",
-      "description": "The request will be sent to the authorization server endpoint: <strong>{{ authServer }}</strong>",
-      "submitBtn": "Send request"
+      "description": "Copy the information you sent to the PDND authorization server that generated the error into these fields.",
+      "clientAssertionLabel": "Client assertion",
+      "clientAssertionInfoLabel": "The client assertion is a JWT token consisting of a string starting with \"ey.\" Copy it without adding spaces.",
+      "dPopProofLabel": "DPoP Proof",
+      "dPopProofInfoLabel": "If you generated a DPoP token, you will also need to enter the DPoP Proof in this field.",
+      "clientIdLabel": "client_id or producer_id",
+      "clientIdInfoLabel": "Please enter the same client_id or producer_id used to make the request to PDND.",
+      "interactionModelLabel": "Interaction model",
+      "interactionModelSync": "Synchronous (standard)",
+      "interactionModelAsync": "Asynchronous (deferred)",
+      "alert": "The request will be sent to the authorization server endpoint: <strong>{{ authServer }}</strong>",
+      "submitBtn": "Send request",
+      "goBackBtn": "Back"
     },
     "result": {
       "newRequestBtn": "Perform new check",

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -722,6 +722,12 @@
       "outcome": {
         "error": "C’è stato un errore nell’elaborazione della richiesta. Per favore, riprova in seguito!"
       }
+    },
+    "dPoPProofVerification": {
+      "loading": "Stiamo effettuando la verifica. Attendere, prego",
+      "outcome": {
+        "error": "C’è stato un errrore nell’elaborazione della richiesta. Per favore, riprova in seguito!"
+      }
     }
   },
   "keychain": {

--- a/src/static/locales/it/pages.json
+++ b/src/static/locales/it/pages.json
@@ -32,8 +32,8 @@
     "description": "Gli enti che intendono fruire dei tuoi e-service dovranno indicare come tratteranno i dati che eroghi. Le finalità che ricevi sono raccolte in questa area."
   },
   "consumerDebugVoucher": {
-    "title": "Debug client assertion",
-    "description": "Lo strumento di debug ti consente di evidenziare eventuali anomalie contenute nella tua client assertion necessaria per l’ottenimento dell’access token."
+    "title": "Debug della client assertion",
+    "description": "Se non riesci ad ottenere un voucher e non sai perché, puoi effettuare il debugging con questo simulatore e capire i possibili errori."
   },
   "consumerSimulateGetVoucher": {
     "title": "Simula l’ottenimento di un voucher",

--- a/src/static/locales/it/voucher.json
+++ b/src/static/locales/it/voucher.json
@@ -207,10 +207,19 @@
   "consumerDebugVoucher": {
     "edit": {
       "title": "Dati della richiesta al server",
-      "clientAssertionLabel": "Inserisci la tua client assertion (richiesto)",
-      "clientIdLabel": "Inserisci il client id",
-      "description": "La richiesta sarà inoltrata all’endpoint del server autorizzativo: <strong>{{ authServer }}</strong>",
-      "submitBtn": "Inoltra richiesta"
+      "description": "Copia in questi campi le informazioni che hai inviato al server autorizzativo di PDND e che hanno generato l’errore.",
+      "clientAssertionLabel": "Client assertion",
+      "clientAssertionInfoLabel": "La client assertion è un token JWT composto da una stringa che inizia per \"ey\". Copiala senza aggiungere spazi.",
+      "dPopProofLabel": "DPoP Proof",
+      "dPopProofInfoLabel": "Se hai generato un token DPoP, dovrai inserire anche la DPoP Proof in questo campo.",
+      "clientIdLabel": "client_id o producer_id",
+      "clientIdInfoLabel": "Inserisci lo stesso client_id o producer_id usati per formulare la richiesta verso PDND.",
+      "interactionModelLabel": "Modello di interazione",
+      "interactionModelSync": "Sincrono (standard)",
+      "interactionModelAsync": "Asincrono (differito)",
+      "alert": "La richiesta sarà inoltrata all’endpoint del server autorizzativo: <strong>{{ authServer }}</strong>",
+      "submitBtn": "Inoltra richiesta",
+      "goBackBtn": "Indietro"
     },
     "result": {
       "newRequestBtn": "Effettua nuova verifica",


### PR DESCRIPTION
## Issue
- [PIN-9673](https://pagopa.atlassian.net/browse/PIN-9673)
## Description / Context / Why
- Changed copy in the form page
- Added legend and required attribute for required fields (“Client assertion” and “Interation Type”)
- Added “DPoP Proof” TextArea
- Added “Interation Type” RadioGroup
- Changed auth server url to an Alert
- Added “Back” button
- Set up double call logic if user enters “DPoP Proof”
- Added _**/tools/validateDPoPProof**_ endpoint

[PIN-9658]: https://pagopa.atlassian.net/browse/PIN-9658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PIN-9673]: https://pagopa.atlassian.net/browse/PIN-9673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ