### PR TITLE
feature/PIN-2589_reflow-card-content-400% (PIN-A2-2589 - INT-11)

### DIFF
--- a/src/components/shared/CatalogCard.tsx
+++ b/src/components/shared/CatalogCard.tsx
@@ -73,7 +73,18 @@ export function CatalogCard<TRouteKey extends CatalogRoutesKeys>({
           <AccountBalanceIcon sx={{ color: '#bdbdbd' }} fontSize="small" />
         </Avatar>
         <Typography variant="caption" color="text.secondary">
-          {producerName}
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ligula sapien, congue eu odio
+          vel, condimentum efficitur neque. Suspendisse interdum metus eget ligula mattis, eu
+          finibus urna viverra. Nulla rutrum sem sem, ac egestas nisi rutrum eu. Mauris ultricies at
+          erat vel efficitur. Ut venenatis tellus eget sapien rhoncus bibendum non luctus urna.
+          Curabitur fermentum suscipit dolor sagittis vulputate. Maecenas ante metus, finibus ut
+          ipsum cursus, consectetur euismod velit. Nulla vel eleifend nibh. In vel justo quis leo
+          consequat mattis. Cras ac iaculis lorem, sed malesuada odio. Vivamus sem massa, rutrum
+          eget ullamcorper a, ullamcorper eu sapien. Duis iaculis magna non neque tincidunt gravida.
+          Mauris in ligula nulla. Vivamus ac dapibus massa. Donec id felis nec nunc semper congue.
+          Mauris eu dolor quis neque imperdiet sollicitudin et congue ante. Integer cursus porta
+          sem. Nullam iaculis rhoncus erat sit amet semper. Morbi vulputate venenatis ipsum, luctus
+          finibus orci ultricies vitae.
         </Typography>
       </Box>
 
@@ -109,7 +120,7 @@ export function CatalogCard<TRouteKey extends CatalogRoutesKeys>({
           sx={{ maxWidth: '100%', width: { xs: '100%', sm: 'auto' } }}
         >
           <Tooltip open={disabled ? undefined : false} title={t('list.disabledTooltip')} arrow>
-            <span style={{ display: 'block', width: '100%' }}>
+            <span style={{ display: 'block' }}>
               <Link
                 as="button"
                 size="small"

--- a/src/components/shared/CatalogCard.tsx
+++ b/src/components/shared/CatalogCard.tsx
@@ -3,10 +3,10 @@ import type { RouteKey, useParams } from '@/router'
 import { Link } from '@/router'
 import {
   Avatar,
+  Box,
   Card,
   CardActions,
   CardContent,
-  CardHeader,
   Skeleton,
   Stack,
   Tooltip,
@@ -52,25 +52,32 @@ export function CatalogCard<TRouteKey extends CatalogRoutesKeys>({
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        minHeight: 410,
+        minHeight: { xs: 'auto', sm: 410 },
         opacity: disabled ? 0.5 : 1,
       }}
     >
-      <CardHeader
-        sx={{ p: 3, pb: 0 }}
-        disableTypography={true}
-        title={
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Avatar src={avatarURL} alt={producerName} sx={{ bgcolor: 'background.default' }}>
-              <AccountBalanceIcon sx={{ color: '#bdbdbd' }} fontSize="small" />
-            </Avatar>
-            <Typography variant="caption" color="text.secondary">
-              {producerName}
-            </Typography>
-          </Stack>
-        }
-      />
-      <CardContent sx={{ alignItems: 'start' }}>
+      <Box
+        sx={{
+          p: { xs: 1, sm: 3 },
+          pb: { xs: 1, sm: 0 },
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
+        <Avatar
+          src={avatarURL}
+          alt={producerName}
+          sx={{ bgcolor: 'background.default', flexShrink: 0 }}
+        >
+          <AccountBalanceIcon sx={{ color: '#bdbdbd' }} fontSize="small" />
+        </Avatar>
+        <Typography variant="caption" color="text.secondary" sx={{ wordBreak: 'break-word' }}>
+          {producerName}
+        </Typography>
+      </Box>
+
+      <CardContent sx={{ alignItems: 'start', flexGrow: 1, p: { xs: 2, sm: 3 } }}>
         <Typography variant="h6" color="text.primary" sx={{ marginBottom: 1 }}>
           {title}
         </Typography>
@@ -88,10 +95,21 @@ export function CatalogCard<TRouteKey extends CatalogRoutesKeys>({
         </Typography>
       </CardContent>
 
-      <CardActions sx={{ justifyContent: 'end', alignItems: 'end', flex: 1 }}>
-        <Stack direction="row" spacing={2}>
+      <CardActions
+        sx={{
+          justifyContent: { xs: 'flex-start', sm: 'flex-end' },
+          alignItems: 'center',
+          p: { xs: 2, sm: 3 },
+          pt: 0,
+        }}
+      >
+        <Stack
+          direction="row"
+          spacing={2}
+          sx={{ maxWidth: '100%', width: { xs: '100%', sm: 'auto' } }}
+        >
           <Tooltip open={disabled ? undefined : false} title={t('list.disabledTooltip')} arrow>
-            <span>
+            <span style={{ display: 'block', width: '100%' }}>
               <Link
                 as="button"
                 size="small"
@@ -101,6 +119,13 @@ export function CatalogCard<TRouteKey extends CatalogRoutesKeys>({
                 onFocusVisible={prefetchFn}
                 color="primary"
                 disabled={disabled}
+                sx={{
+                  width: '100%',
+                  whiteSpace: 'normal',
+                  wordBreak: 'break-word',
+                  textAlign: 'center',
+                  padding: { xs: 0.5, sm: 2.5 },
+                }}
               >
                 {tCommon('actions.inspect')}
               </Link>
@@ -113,5 +138,14 @@ export function CatalogCard<TRouteKey extends CatalogRoutesKeys>({
 }
 
 export const CatalogCardSkeleton = () => {
-  return <Skeleton sx={{ borderRadius: 2 }} variant="rectangular" height={410} />
+  return (
+    <Skeleton
+      sx={{
+        borderRadius: 2,
+        height: '100%',
+        minHeight: { xs: 200, sm: 410 },
+      }}
+      variant="rectangular"
+    />
+  )
 }

--- a/src/components/shared/CatalogCard.tsx
+++ b/src/components/shared/CatalogCard.tsx
@@ -73,18 +73,7 @@ export function CatalogCard<TRouteKey extends CatalogRoutesKeys>({
           <AccountBalanceIcon sx={{ color: '#bdbdbd' }} fontSize="small" />
         </Avatar>
         <Typography variant="caption" color="text.secondary">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ligula sapien, congue eu odio
-          vel, condimentum efficitur neque. Suspendisse interdum metus eget ligula mattis, eu
-          finibus urna viverra. Nulla rutrum sem sem, ac egestas nisi rutrum eu. Mauris ultricies at
-          erat vel efficitur. Ut venenatis tellus eget sapien rhoncus bibendum non luctus urna.
-          Curabitur fermentum suscipit dolor sagittis vulputate. Maecenas ante metus, finibus ut
-          ipsum cursus, consectetur euismod velit. Nulla vel eleifend nibh. In vel justo quis leo
-          consequat mattis. Cras ac iaculis lorem, sed malesuada odio. Vivamus sem massa, rutrum
-          eget ullamcorper a, ullamcorper eu sapien. Duis iaculis magna non neque tincidunt gravida.
-          Mauris in ligula nulla. Vivamus ac dapibus massa. Donec id felis nec nunc semper congue.
-          Mauris eu dolor quis neque imperdiet sollicitudin et congue ante. Integer cursus porta
-          sem. Nullam iaculis rhoncus erat sit amet semper. Morbi vulputate venenatis ipsum, luctus
-          finibus orci ultricies vitae.
+          {producerName}
         </Typography>
       </Box>
 

--- a/src/components/shared/CatalogCard.tsx
+++ b/src/components/shared/CatalogCard.tsx
@@ -77,7 +77,7 @@ export function CatalogCard<TRouteKey extends CatalogRoutesKeys>({
         </Typography>
       </Box>
 
-      <CardContent sx={{ alignItems: 'start', flexGrow: 1, p: { xs: 2, sm: 3 } }}>
+      <CardContent sx={{ flexGrow: 1, p: { xs: 2, sm: 3 } }}>
         <Typography variant="h6" color="text.primary" sx={{ marginBottom: 1 }}>
           {title}
         </Typography>

--- a/src/components/shared/CatalogCard.tsx
+++ b/src/components/shared/CatalogCard.tsx
@@ -72,7 +72,7 @@ export function CatalogCard<TRouteKey extends CatalogRoutesKeys>({
         >
           <AccountBalanceIcon sx={{ color: '#bdbdbd' }} fontSize="small" />
         </Avatar>
-        <Typography variant="caption" color="text.secondary" sx={{ wordBreak: 'break-word' }}>
+        <Typography variant="caption" color="text.secondary">
           {producerName}
         </Typography>
       </Box>
@@ -121,10 +121,6 @@ export function CatalogCard<TRouteKey extends CatalogRoutesKeys>({
                 disabled={disabled}
                 sx={{
                   width: '100%',
-                  whiteSpace: 'normal',
-                  wordBreak: 'break-word',
-                  textAlign: 'center',
-                  padding: { xs: 0.5, sm: 2.5 },
                 }}
               >
                 {tCommon('actions.inspect')}

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogGrid.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogGrid.tsx
@@ -20,7 +20,7 @@ export const EServiceCatalogGrid: React.FC<EServiceCatalogGridProps> = ({ eservi
   return (
     <Grid container spacing={3}>
       {eservices?.map((eservice) => (
-        <Grid item key={eservice.id} xs={4}>
+        <Grid item key={eservice.id} xs={12} sm={4}>
           <EServiceCatalogCard
             key={eservice.activeDescriptor?.id}
             eservice={eservice}
@@ -67,7 +67,7 @@ export const EServiceCatalogGridSkeleton: React.FC = () => {
   return (
     <Grid container spacing={3}>
       {new Array(9).fill('').map((_, i) => (
-        <Grid key={i} xs={4} item>
+        <Grid key={i} xs={12} sm={4} item>
           <CatalogCardSkeleton />
         </Grid>
       ))}

--- a/src/pages/ConsumerPurposeTemplateCatalogPage/components/CatalogCardForPurposeTemplate.tsx
+++ b/src/pages/ConsumerPurposeTemplateCatalogPage/components/CatalogCardForPurposeTemplate.tsx
@@ -85,7 +85,7 @@ export function CatalogCardForPurposeTemplate<TRouteKey extends CatalogRoutesKey
           display: 'flex',
           justifyContent: 'space-between',
           flex: 1,
-          alignItems: { xs: 'start', sm: 'flex-end' },
+          alignItems: { xs: 'flex-start', sm: 'flex-end' },
           flexDirection: { xs: 'column', sm: 'row' },
           gap: { xs: 2, sm: 0 },
         }}

--- a/src/pages/ConsumerPurposeTemplateCatalogPage/components/CatalogCardForPurposeTemplate.tsx
+++ b/src/pages/ConsumerPurposeTemplateCatalogPage/components/CatalogCardForPurposeTemplate.tsx
@@ -54,7 +54,6 @@ export function CatalogCardForPurposeTemplate<TRouteKey extends CatalogRoutesKey
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        maxHeight: 294,
         maxWidth: 620,
       }}
     >
@@ -82,7 +81,14 @@ export function CatalogCardForPurposeTemplate<TRouteKey extends CatalogRoutesKey
       </CardContent>
 
       <CardActions
-        sx={{ display: 'flex', justifyContent: 'space-between', flex: 1, alignItems: 'end' }}
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          flex: 1,
+          alignItems: { xs: 'start', sm: 'flex-end' },
+          flexDirection: { xs: 'column', sm: 'row' },
+          gap: { xs: 2, sm: 0 },
+        }}
       >
         <Stack direction="row" spacing={1} alignItems="center" sx={{ flexGrow: 1 }}>
           <Avatar src={avatarURL} alt={creatorName} sx={{ bgcolor: 'background.default' }}>

--- a/src/pages/ConsumerPurposeTemplateCatalogPage/components/CatalogCardForPurposeTemplate.tsx
+++ b/src/pages/ConsumerPurposeTemplateCatalogPage/components/CatalogCardForPurposeTemplate.tsx
@@ -117,5 +117,5 @@ export function CatalogCardForPurposeTemplate<TRouteKey extends CatalogRoutesKey
 }
 
 export const CatalogCardForPurposeTemplateSkeleton = () => {
-  return <Skeleton sx={{ borderRadius: 2 }} variant="rectangular" height={294} />
+  return <Skeleton sx={{ borderRadius: 2, height: '100%', minHeight: 294 }} variant="rectangular" />
 }

--- a/src/pages/ConsumerPurposeTemplateCatalogPage/components/PurposeTemplateCatalogGrid.tsx
+++ b/src/pages/ConsumerPurposeTemplateCatalogPage/components/PurposeTemplateCatalogGrid.tsx
@@ -25,7 +25,7 @@ export const PurposeTemplateCatalogGrid: React.FC<PurposeTemplateGridProps> = ({
     <Box sx={{ mt: 3, px: 1.5 }}>
       <Grid container spacing={3}>
         {purposeTemplates?.map((purposeTemplate) => (
-          <Grid item key={purposeTemplate.id} xs={6} md={6}>
+          <Grid item key={purposeTemplate.id} xs={12} md={6}>
             <PurposeTemplateCatalogCard
               key={purposeTemplate.id}
               purposeTemplate={purposeTemplate}

--- a/src/pages/ConsumerPurposeTemplateCatalogPage/components/PurposeTemplateCatalogGrid.tsx
+++ b/src/pages/ConsumerPurposeTemplateCatalogPage/components/PurposeTemplateCatalogGrid.tsx
@@ -72,7 +72,7 @@ export const PurposeTemplateCatalogGridSkeleton: React.FC = () => {
     <Box sx={{ mt: 3, px: 1.5 }}>
       <Grid container spacing={3}>
         {new Array(9).fill('').map((_, i) => (
-          <Grid key={i} xs={6} md={6} item>
+          <Grid key={i} xs={12} md={6} item>
             <CatalogCardForPurposeTemplateSkeleton />
           </Grid>
         ))}

--- a/src/pages/ProviderEServiceTemplatesCatalogPage/components/EServiceTemplateCatalogGrid.tsx
+++ b/src/pages/ProviderEServiceTemplatesCatalogPage/components/EServiceTemplateCatalogGrid.tsx
@@ -23,7 +23,7 @@ export const EServiceTemplateCatalogGrid: React.FC<EServiceTemplateCatalogGridPr
   return (
     <Grid container spacing={3}>
       {eservicesTemplateList?.map((eserviceTemplate) => (
-        <Grid item key={eserviceTemplate.id} xs={4}>
+        <Grid item key={eserviceTemplate.id} xs={12} sm={4}>
           <EServiceTemplateCatalogCard eserviceTemplate={eserviceTemplate} />
         </Grid>
       ))}
@@ -69,7 +69,7 @@ export const EServiceTemplateCatalogGridSkeletron: React.FC = () => {
   return (
     <Grid container spacing={3}>
       {new Array(9).fill('').map((_, i) => (
-        <Grid key={i} xs={4} item>
+        <Grid key={i} xs={12} sm={4} item>
           <CatalogCardSkeleton />
         </Grid>
       ))}

--- a/src/pages/ProviderEServiceTemplatesCatalogPage/components/EServiceTemplateCatalogGrid.tsx
+++ b/src/pages/ProviderEServiceTemplatesCatalogPage/components/EServiceTemplateCatalogGrid.tsx
@@ -2,7 +2,7 @@ import { Grid, Alert } from '@mui/material'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import type { CatalogEServiceTemplate } from '@/api/api.generatedTypes'
-import { CatalogCard, CatalogCardSkeleton } from '@/components/shared/CatalogCard'
+import { CatalogCard } from '@/components/shared/CatalogCard'
 import { useQueryClient } from '@tanstack/react-query'
 import { EServiceTemplateQueries } from '@/api/eserviceTemplate'
 import { AVATAR_BASEPATH } from '@/config/env'
@@ -62,17 +62,5 @@ export const EServiceTemplateCatalogCard: React.FC<{
         eServiceTemplateId: eserviceTemplate.id,
       }}
     />
-  )
-}
-
-export const EServiceTemplateCatalogGridSkeleton: React.FC = () => {
-  return (
-    <Grid container spacing={3}>
-      {new Array(9).fill('').map((_, i) => (
-        <Grid key={i} xs={12} sm={4} item>
-          <CatalogCardSkeleton />
-        </Grid>
-      ))}
-    </Grid>
   )
 }

--- a/src/pages/ProviderEServiceTemplatesCatalogPage/components/EServiceTemplateCatalogGrid.tsx
+++ b/src/pages/ProviderEServiceTemplatesCatalogPage/components/EServiceTemplateCatalogGrid.tsx
@@ -65,7 +65,7 @@ export const EServiceTemplateCatalogCard: React.FC<{
   )
 }
 
-export const EServiceTemplateCatalogGridSkeletron: React.FC = () => {
+export const EServiceTemplateCatalogGridSkeleton: React.FC = () => {
   return (
     <Grid container spacing={3}>
       {new Array(9).fill('').map((_, i) => (


### PR DESCRIPTION
## 🔗 Issue

[PIN-A2-2589](https://pagopa.atlassian.net/browse/A2-2589)

## 📝 Description / Context
This pull request improves the responsiveness and accessibility of catalog cards and their grids across the application. The main changes include updating the layout to better support smaller screens, refactoring card headers for greater flexibility, and enhancing the skeleton loading states.

**Responsive layout improvements:**
* Updated all catalog grid components to use `xs={12}` for full-width cards on extra-small screens and `sm={4}` or `md={6}` for multi-column layouts on larger screens, improving mobile usability. 
**Catalog card UI refactoring:**
* Replaced the `CardHeader` component with a custom `Box` layout for the card header.
* Made card content and actions paddings responsive and improved button and tooltip accessibility, ensuring buttons and tooltips scale and align properly on all screen sizes. 


