### PR TITLE
hotfix/PIN-9695_fix-delegation-authorization-logic-prevent-call-errors

### DIFF
--- a/src/api/hooks/useIsOrganizationAllowedToDelegations.ts
+++ b/src/api/hooks/useIsOrganizationAllowedToDelegations.ts
@@ -8,10 +8,7 @@ export const useIsOrganizationAllowedToDelegations = (
 ) => {
   const { data, isLoading, isError } = useQuery({
     ...TenantQueries.getIsTenantAllowedToDelegation(tenantId),
-    enabled:
-      !FEATURE_FLAG_DELEGATION_CONSTRAINT_SKIP &&
-      shouldCheckDelegationsPermission !== false &&
-      !!tenantId,
+    enabled: !FEATURE_FLAG_DELEGATION_CONSTRAINT_SKIP && shouldCheckDelegationsPermission !== false,
     retry: false,
     throwOnError: false,
   })

--- a/src/api/hooks/useIsOrganizationAllowedToDelegations.ts
+++ b/src/api/hooks/useIsOrganizationAllowedToDelegations.ts
@@ -6,16 +6,23 @@ export const useIsOrganizationAllowedToDelegations = (
   tenantId: string,
   shouldCheckDelegationsPermission?: boolean
 ) => {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     ...TenantQueries.getIsTenantAllowedToDelegation(tenantId),
-    enabled: !FEATURE_FLAG_DELEGATION_CONSTRAINT_SKIP && shouldCheckDelegationsPermission !== false,
+    enabled:
+      !FEATURE_FLAG_DELEGATION_CONSTRAINT_SKIP &&
+      shouldCheckDelegationsPermission !== false &&
+      !!tenantId,
+    retry: false,
+    throwOnError: false,
   })
 
   if (FEATURE_FLAG_DELEGATION_CONSTRAINT_SKIP) {
     return { isAllowed: true, isLoading: false }
   }
 
-  const isAllowed = data?.isAllowed ?? false
+  if (isError) {
+    return { isAllowed: false, isLoading: false }
+  }
 
-  return { isAllowed, isLoading }
+  return { isAllowed: data?.isAllowed ?? false, isLoading }
 }

--- a/src/components/sidebar/useGetSidebarItems.tsx
+++ b/src/components/sidebar/useGetSidebarItems.tsx
@@ -18,10 +18,11 @@ export function useGetSidebarItems(): SidebarRoutes {
   const { currentRoles, isSupport, isOrganizationAllowedToProduce } = AuthHooks.useJwt()
 
   const { data: tenant } = TenantHooks.useGetActiveUserParty()
+  const shouldCheckDelegationsPermission = isSupport || currentRoles.includes('admin')
   const {
     isAllowed: isOrganizationAllowedToDelegations,
     isLoading: isOrganizationAllowedToDelegationsLoading,
-  } = useIsOrganizationAllowedToDelegations(tenant.id)
+  } = useIsOrganizationAllowedToDelegations(tenant.id, shouldCheckDelegationsPermission)
 
   return React.useMemo(() => {
     const interopRoutes: SidebarRoutes = [


### PR DESCRIPTION
## 🔗 Issue

[PIN-9695](https://pagopa.atlassian.net/browse/PIN-9695)

## 📝 Description / Context

This pull request improves permission checking and error handling for organization delegation features. The main changes ensure that delegation checks are only performed when appropriate, handle errors more gracefully, and prevent unnecessary API calls when the `tenantId` is missing.

**Delegation permission checks and error handling:**

* Updated `useIsOrganizationAllowedToDelegations` to include error handling: returns `{ isAllowed: false, isLoading: false }` if the query fails, and disables retries and error throwing for a smoother user experience. Also, the query is only enabled if `tenantId` is present, preventing unnecessary API calls.
* In `useGetSidebarItems`, now passes a `shouldCheckDelegationsPermission` flag (based on user role) to `useIsOrganizationAllowedToDelegations`, ensuring that permission checks are only performed for support users or admins.
