### PR TITLE
feat: hide thresholds on update attributes drawer (PIN-9699)

### DIFF
--- a/src/components/layout/containers/AttributeContainer.tsx
+++ b/src/components/layout/containers/AttributeContainer.tsx
@@ -35,6 +35,7 @@ type AttributeContainerProps<
   checked?: boolean
   onRemove?: (id: string, name: string) => void
   onCustomizeThreshold?: VoidFunction
+  hideThreshold?: boolean
 }
 
 export const AttributeContainer = <
@@ -46,6 +47,7 @@ export const AttributeContainer = <
   checked,
   onRemove,
   onCustomizeThreshold,
+  hideThreshold,
 }: AttributeContainerProps<TAttribute>) => {
   const { t } = useTranslation('shared-components', { keyPrefix: 'attributeContainer' })
   const panelContentId = React.useId()
@@ -93,7 +95,7 @@ export const AttributeContainer = <
               <Typography fontWeight={600}>{attribute.name}</Typography>
               {(attribute.dailyCallsPerConsumer !== undefined || onCustomizeThreshold) && (
                 <Stack direction={'row'} spacing={2} alignItems={'center'}>
-                  {attribute.dailyCallsPerConsumer !== undefined && (
+                  {attribute.dailyCallsPerConsumer !== undefined && !hideThreshold && (
                     <Stack direction={'row'} spacing={1}>
                       <Typography sx={{ fontSize: 16 }}>{t('thresholdLabel')}</Typography>
                       <Typography sx={{ fontSize: 16, fontWeight: 700 }}>

--- a/src/components/shared/UpdateAttributesDrawer.tsx
+++ b/src/components/shared/UpdateAttributesDrawer.tsx
@@ -150,6 +150,7 @@ export const UpdateAttributesDrawer: React.FC<UpdateAttributesDrawerProps> = ({
                   <Box component="li">
                     <AttributeContainer
                       attribute={attribute}
+                      hideThreshold
                       onRemove={
                         canAttributeBeRemoved(groupIdx, attribute)
                           ? (attribute) => handleRemoveAttributeFromGroup(groupIdx, attribute)


### PR DESCRIPTION
## Jira Issue
[PIN-9699](https://pagopa.atlassian.net/browse/PIN-9699)

## Context/Why
**Eservice Details/ Update Attributes Drawer**

## Key Changes
 - Modify `AttributeContainer` to hide customized threshold

[PIN-9699]: https://pagopa.atlassian.net/browse/PIN-9699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ