### PR TITLE
feature/PIN-2666_INT-97-tab-navigation-tooltip-in-update-documetation-drawer

### DIFF
--- a/src/components/shared/EserviceTemplate/EServiceTemplateUpdateDocumentationDrawer.tsx
+++ b/src/components/shared/EserviceTemplate/EServiceTemplateUpdateDocumentationDrawer.tsx
@@ -171,7 +171,7 @@ export const EServiceTemplateUpdateDocumentationDrawer: React.FC<
           if (!doc) return null
           if (index === 0 && paginationParams.offset === 0)
             return (
-              <Stack spacing={1}>
+              <Stack spacing={1} key={doc.id}>
                 <InterfaceDocumentContainer doc={doc} onDownload={handleDownloadDocument} />
                 <Divider />
               </Stack>
@@ -260,7 +260,14 @@ const InterfaceDocumentContainer: React.FC<InterfaceDocumentContainerProps> = ({
       <Stack direction="row" alignItems="center" spacing={1}>
         <Typography variant="body2">{doc.prettyName}</Typography>
         <Tooltip title={t('interfaceInfoTooltip')}>
-          <InfoIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+          <InfoIcon
+            fontSize="small"
+            sx={{ color: 'text.secondary' }}
+            tabIndex={0}
+            role="button"
+            aria-disabled={true} //we just want to make it focusable for accessibility reasons, so we set aria-disabled to true to communicate that it's not interactive
+            aria-label={t('interfaceInfoTooltip')}
+          />
         </Tooltip>
       </Stack>
       {onDownload && (

--- a/src/components/shared/EserviceTemplate/EServiceTemplateUpdateDocumentationDrawer.tsx
+++ b/src/components/shared/EserviceTemplate/EServiceTemplateUpdateDocumentationDrawer.tsx
@@ -260,14 +260,14 @@ const InterfaceDocumentContainer: React.FC<InterfaceDocumentContainerProps> = ({
       <Stack direction="row" alignItems="center" spacing={1}>
         <Typography variant="body2">{doc.prettyName}</Typography>
         <Tooltip title={t('interfaceInfoTooltip')}>
-          <InfoIcon
-            fontSize="small"
-            sx={{ color: 'text.secondary' }}
+          <Stack
+            component="span"
             tabIndex={0}
-            role="button"
-            aria-disabled={true} //we just want to make it focusable for accessibility reasons, so we set aria-disabled to true to communicate that it's not interactive
             aria-label={t('interfaceInfoTooltip')}
-          />
+            sx={{ display: 'inline-flex', alignItems: 'center' }}
+          >
+            <InfoIcon fontSize="small" sx={{ color: 'text.secondary' }} aria-hidden={true} />
+          </Stack>
         </Tooltip>
       </Stack>
       {onDownload && (

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceUpdateDocumentationDrawer.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceUpdateDocumentationDrawer.tsx
@@ -254,14 +254,14 @@ const InterfaceDocumentContainer: React.FC<InterfaceDocumentContainerProps> = ({
       <Stack direction="row" alignItems="center" spacing={1}>
         <Typography variant="body2">{doc.prettyName}</Typography>
         <Tooltip title={t('interfaceInfoTooltip')}>
-          <InfoIcon
-            fontSize="small"
-            sx={{ color: 'text.secondary' }}
+          <Stack
+            component="span"
             tabIndex={0}
-            role="button"
-            aria-disabled={true} //we just want to make it focusable for accessibility reasons, so we set aria-disabled to true to communicate that it's not interactive
             aria-label={t('interfaceInfoTooltip')}
-          />
+            sx={{ display: 'inline-flex', alignItems: 'center' }}
+          >
+            <InfoIcon fontSize="small" sx={{ color: 'text.secondary' }} aria-hidden={true} />
+          </Stack>
         </Tooltip>
       </Stack>
       {onDownload && (

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceUpdateDocumentationDrawer.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceUpdateDocumentationDrawer.tsx
@@ -165,7 +165,7 @@ export const ProviderEServiceUpdateDocumentationDrawer: React.FC<
           if (!doc) return null
           if (index === 0 && paginationParams.offset === 0)
             return (
-              <Stack spacing={1}>
+              <Stack spacing={1} key={doc.id}>
                 <InterfaceDocumentContainer doc={doc} onDownload={handleDownloadDocument} />
                 <Divider />
               </Stack>
@@ -254,7 +254,14 @@ const InterfaceDocumentContainer: React.FC<InterfaceDocumentContainerProps> = ({
       <Stack direction="row" alignItems="center" spacing={1}>
         <Typography variant="body2">{doc.prettyName}</Typography>
         <Tooltip title={t('interfaceInfoTooltip')}>
-          <InfoIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+          <InfoIcon
+            fontSize="small"
+            sx={{ color: 'text.secondary' }}
+            tabIndex={0}
+            role="button"
+            aria-disabled={true} //we just want to make it focusable for accessibility reasons, so we set aria-disabled to true to communicate that it's not interactive
+            aria-label={t('interfaceInfoTooltip')}
+          />
         </Tooltip>
       </Stack>
       {onDownload && (


### PR DESCRIPTION
## 🔗 Issue

[PIN-A2-2666](https://pagopa.atlassian.net/browse/A2-2666)

## 📝 Description / Context

**Accessibility improvements:**
* Updated the `InfoIcon` in `InterfaceDocumentContainer` to be focusable, with `tabIndex={0}`, `role="button"`, `aria-disabled={true}`, and an appropriate `aria-label` for screen readers. This makes the icon accessible while communicating that it is not interactive. 
<img width="470" height="475" alt="Screenshot 2026-04-21 alle 15 26 05" src="https://github.com/user-attachments/assets/067be24e-cb0c-4e44-8e23-8643165ccc08" />


