### PR TITLE
feature/PIN-2671_INT-102-tab-navigation-add-operators-to-client-alert

### DIFF
--- a/src/components/shared/AddOperatorsToClientDrawer.tsx
+++ b/src/components/shared/AddOperatorsToClientDrawer.tsx
@@ -88,7 +88,7 @@ export const AddOperatorsToClientDrawer: React.FC<AddOperatorsDrawerProps> = ({
             loading={isLoadingAllPartyOperators}
           />
 
-          <Alert severity="info" role="alert" aria-live="polite">
+          <Alert severity="info" aria-live="polite">
             {t('adminAlert')}
           </Alert>
         </Stack>

--- a/src/components/shared/AddOperatorsToClientDrawer.tsx
+++ b/src/components/shared/AddOperatorsToClientDrawer.tsx
@@ -88,7 +88,9 @@ export const AddOperatorsToClientDrawer: React.FC<AddOperatorsDrawerProps> = ({
             loading={isLoadingAllPartyOperators}
           />
 
-          <Alert severity="info">{t('adminAlert')}</Alert>
+          <Alert severity="info" role="alert" aria-live="polite">
+            {t('adminAlert')}
+          </Alert>
         </Stack>
       </Drawer>
     </FormProvider>

--- a/src/components/shared/AddUsersToKeychainDrawer.tsx
+++ b/src/components/shared/AddUsersToKeychainDrawer.tsx
@@ -87,7 +87,9 @@ export const AddUsersToKeychainDrawer: React.FC<AddUsersToKeychainDrawerProps> =
             options={options}
             loading={isLoadingAllPartyUsers}
           />
-          <Alert severity="info">{t('adminAlert')}</Alert>
+          <Alert severity="info" role="alert" aria-live="polite">
+            {t('adminAlert')}
+          </Alert>
         </Stack>
       </Drawer>
     </FormProvider>

--- a/src/components/shared/AddUsersToKeychainDrawer.tsx
+++ b/src/components/shared/AddUsersToKeychainDrawer.tsx
@@ -87,7 +87,7 @@ export const AddUsersToKeychainDrawer: React.FC<AddUsersToKeychainDrawerProps> =
             options={options}
             loading={isLoadingAllPartyUsers}
           />
-          <Alert severity="info" role="alert" aria-live="polite">
+          <Alert severity="info" aria-live="polite">
             {t('adminAlert')}
           </Alert>
         </Stack>


### PR DESCRIPTION
## 🔗 Issue

[PIN-A2-2671](https://pagopa.atlassian.net/browse/A2-2671)

## 📝 Description / Context

Added aria-live attribute to the admin alert in AddOperatorsToClientDrawer and in AddUsersToKeychainDrawer for accessibility reasons.

Now the screen reader announces the alert content to the user:
<img width="1700" height="980" alt="Screenshot 2026-04-22 alle 14 58 04" src="https://github.com/user-attachments/assets/1c99bade-d6bc-40e8-beee-84e8ce794f79" />

