### PR TITLE
fix: disable SignalHub toggle on published template edit (PIN-9784)

### DIFF
--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
@@ -134,7 +134,11 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
           />
 
           <SectionContainer title={t('create.step1.signalHubTitle')} component="div">
-            <RHFSwitch name="isSignalHubEnabled" label={signalHubLabel} />
+            <RHFSwitch
+              name="isSignalHubEnabled"
+              label={signalHubLabel}
+              disabled={!areEServiceTemplateGeneralInfoEditable}
+            />
           </SectionContainer>
 
           <StepActions


### PR DESCRIPTION
## 🔗 Issue
[PIN-9784](https://pagopa.atlassian.net/browse/PIN-9784)

## 📝 Description / Context
When editing a draft of a new version (v2+) of an e-service template that already has a published version, the wizard "Modifica Template E-Service" exposed the SignalHub toggle as editable. Toggling it made the submit call `POST /eservices/templates/{id}` (template-level update), which the backend rejects with `400 011-0010 "EService Template not in draft state"`, blocking the user from saving the draft at step 1.

After aligning with the feature owner on Slack:
- `isSignalHubEnabled` is a **template-level** field (shared across all versions), not version-specific. Changing it would impact the already-published v1.
- Template creator fields are only **suggestions** for who instantiates the template afterwards — they are intentionally not propagated to existing instances.
- Consequently, the correct UX for step 1 when the template has a published version is to keep the toggle non-editable, consistent with the rest of the "Informazioni generali" section, which is already declared *"Queste informazioni non sono modificabili"*.

## 🛠 List of changes
- `EServiceTemplateCreateStepGeneral.tsx`: add `disabled={!areEServiceTemplateGeneralInfoEditable}` to the SignalHub `RHFSwitch` rendered in the read-only branch of step 1. No other code paths are touched.

## 🧪 How to test
- Open a template with a **published v1** and a **v2 in draft** → click "Modifica Template E-Service" → step 1 *"Informazioni generali"*:
  - The SignalHub toggle must be **disabled** (greyed out), consistent with the other fields of the section.
  - Clicking "Salva bozza e prosegui" moves to step 2 with no error.
- Open a template with **only a v1 in draft** (no published version yet) → the SignalHub toggle must remain **enabled**, no regression on the creation/initial edit flow.
- Create a brand new template from scratch → the SignalHub toggle must be **enabled**, no regression on the create flow.

<img width="940" height="214" alt="Screenshot 2026-04-23 alle 12 52 14" src="https://github.com/user-attachments/assets/9b2c27c1-23b2-4490-b3b1-5477329c3f34" />


[PIN-9784]: https://pagopa.atlassian.net/browse/PIN-9784