### PR TITLE
feature/PIN-2683_INT-47-missing-attribute

### DIFF
--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisInputWrapper.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisInputWrapper.tsx
@@ -65,12 +65,9 @@ const RiskAnalysisInputWrapper: React.FC<RiskAnalysisInputWrapperProps> = ({
           <Stack spacing={1} sx={{ mb: 4 }}>
             <Box display="flex" justifyContent="space-between" alignItems="flex-start" gap={2}>
               <Box sx={{ flex: 1, minWidth: 0 }}>
-                <FormLabel
-                  htmlFor={name}
-                  component={isInputGroup ? 'legend' : 'label'}
-                  id={labelId}
-                  sx={{ fontWeight: 600 }}
-                >
+                <FormLabel htmlFor={name} component="legend" id={labelId} sx={{ fontWeight: 600 }}>
+                  {' '}
+                  {/* Use legend due to accessibility reasons, otherwise label tag is rendered without for attribute */}
                   {label}
                 </FormLabel>
               </Box>

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisInputWrapper.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisInputWrapper.tsx
@@ -65,9 +65,13 @@ const RiskAnalysisInputWrapper: React.FC<RiskAnalysisInputWrapperProps> = ({
           <Stack spacing={1} sx={{ mb: 4 }}>
             <Box display="flex" justifyContent="space-between" alignItems="flex-start" gap={2}>
               <Box sx={{ flex: 1, minWidth: 0 }}>
-                <FormLabel htmlFor={name} component="legend" id={labelId} sx={{ fontWeight: 600 }}>
-                  {' '}
-                  {/* Use legend due to accessibility reasons, otherwise label tag is rendered without for attribute */}
+                <FormLabel
+                  htmlFor={name}
+                  component={isInputGroup ? 'legend' : name ? 'label' : 'div'}
+                  id={labelId}
+                  sx={{ fontWeight: 600 }}
+                >
+                  {/* we render a div if name is not provided to avoid accessibility issues */}
                   {label}
                 </FormLabel>
               </Box>

--- a/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
@@ -50,7 +50,7 @@ export const RHFRadioGroup: React.FC<RHFRadioGroupProps> = ({
   const error = formState.errors[name]?.message as string | undefined
 
   return (
-    <InputWrapper error={error} sx={sx} infoLabel={infoLabel}>
+    <InputWrapper error={error} sx={sx} infoLabel={infoLabel} component="fieldset">
       {label && (
         <FormLabel
           sx={{
@@ -62,7 +62,7 @@ export const RHFRadioGroup: React.FC<RHFRadioGroupProps> = ({
           }}
           id={labelId}
           required={required}
-          component="div" /* Use div due to accessibility reasons, otherwise label tag is rendered without for attribute */
+          component="legend"
         >
           {label}
         </FormLabel>
@@ -72,7 +72,7 @@ export const RHFRadioGroup: React.FC<RHFRadioGroupProps> = ({
         rules={mapValidationErrorMessages(rules, t)}
         render={({ field: { onChange, ...fieldProps } }) => (
           <MUIRadioGroup
-            aria-labelledby={labelId}
+            aria-labelledby={label ? labelId : undefined}
             {...props}
             {...fieldProps}
             onChange={(_, val) => {

--- a/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
@@ -62,6 +62,7 @@ export const RHFRadioGroup: React.FC<RHFRadioGroupProps> = ({
           }}
           id={labelId}
           required={required}
+          component="div" /* Use div due to accessibility reasons, otherwise label tag is rendered without for attribute */
         >
           {label}
         </FormLabel>

--- a/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
@@ -67,6 +67,7 @@ export const RHFRadioGroup: React.FC<RHFRadioGroupProps> = ({
           }}
           id={labelId}
           required={required}
+          component="div" /* Use div due to accessibility reasons, otherwise label tag is rendered without for attribute */
         >
           {label}
         </FormLabel>

--- a/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
@@ -55,7 +55,7 @@ export const RHFRadioGroup: React.FC<RHFRadioGroupProps> = ({
   })
 
   return (
-    <InputWrapper error={error} sx={sx} infoLabel={infoLabel} {...ids}>
+    <InputWrapper error={error} sx={sx} infoLabel={infoLabel} {...ids} component="fieldset">
       {label && (
         <FormLabel
           sx={{
@@ -67,7 +67,7 @@ export const RHFRadioGroup: React.FC<RHFRadioGroupProps> = ({
           }}
           id={labelId}
           required={required}
-          component="div" /* Use div due to accessibility reasons, otherwise label tag is rendered without for attribute */
+          component="legend"
         >
           {label}
         </FormLabel>
@@ -77,7 +77,7 @@ export const RHFRadioGroup: React.FC<RHFRadioGroupProps> = ({
         rules={mapValidationErrorMessages(rules, t)}
         render={({ field: { onChange, ...fieldProps } }) => (
           <MUIRadioGroup
-            aria-labelledby={labelId}
+            aria-labelledby={label ? labelId : undefined}
             {...props}
             {...fieldProps}
             {...accessibilityProps}


### PR DESCRIPTION
## 🔗 Issue

[PIN-A2-2683](https://pagopa.atlassian.net/browse/A2-2683)

## 📝 Description / Context
This pull request introduces accessibility improvements to form label components by adjusting their rendered HTML elements to ensure proper semantics and attributes. 

* In `RiskAnalysisInputWrapper.tsx`, the `FormLabel` now always uses the `legend` component for better accessibility.
* In `RHFRadioGroup.tsx`, the `FormLabel` is set to render as a `div` to avoid rendering a `label` without a `for` attribute.

