### PR TITLE
feature/PIN-2682_INT-39-missing-target-id

### DIFF
--- a/src/components/shared/react-hook-form-inputs/RHFCheckbox.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFCheckbox.tsx
@@ -42,7 +42,10 @@ export const RHFCheckbox: React.FC<RHFCheckboxProps> = ({
         rules={mapValidationErrorMessages(rules, t)}
         render={({ field: { value, ref, ...fieldProps } }) => (
           <FormControlLabel
-            label={label}
+            label={
+              <span id={ids.labelId}>{label}</span>
+            } /* This span is needed to properly associate the label with the checkbox for accessibility purposes;
+             ** there was a conflict between the getAriaAccessibilityInputProps function and the default behavior of the MUI FormControlLabel component */
             disabled={disabled}
             control={
               <MUICheckbox

--- a/src/components/shared/react-hook-form-inputs/RHFCheckbox.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFCheckbox.tsx
@@ -42,10 +42,8 @@ export const RHFCheckbox: React.FC<RHFCheckboxProps> = ({
         rules={mapValidationErrorMessages(rules, t)}
         render={({ field: { value, ref, ...fieldProps } }) => (
           <FormControlLabel
-            label={
-              <span id={ids.labelId}>{label}</span>
-            } /* This span is needed to properly associate the label with the checkbox for accessibility purposes;
-             ** there was a conflict between the getAriaAccessibilityInputProps function and the default behavior of the MUI FormControlLabel component */
+            label={label}
+            componentsProps={{ typography: { id: ids.labelId } }}
             disabled={disabled}
             control={
               <MUICheckbox

--- a/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
@@ -36,6 +36,7 @@ export const RHFSwitch: React.FC<RHFSwitchProps> = ({
     infoLabel,
     error,
   })
+  console.log('accessibilityProps', accessibilityProps, 'ids', ids)
 
   return (
     <InputWrapper error={error} sx={sx} infoLabel={infoLabel} {...ids}>
@@ -55,7 +56,10 @@ export const RHFSwitch: React.FC<RHFSwitchProps> = ({
                 sx={{ marginRight: 1 }}
               />
             }
-            label={label}
+            label={
+              <span id={ids.labelId}>{label}</span>
+            } /* This span is needed to properly associate the label with the switch for accessibility purposes;
+             ** there was a conflict between the getAriaAccessibilityInputProps function and the default behavior of the MUI FormControlLabel component */
           />
         )}
       />

--- a/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
@@ -55,10 +55,8 @@ export const RHFSwitch: React.FC<RHFSwitchProps> = ({
                 sx={{ marginRight: 1 }}
               />
             }
-            label={
-              <span id={ids.labelId}>{label}</span>
-            } /* This span is needed to properly associate the label with the switch for accessibility purposes;
-             ** there was a conflict between the getAriaAccessibilityInputProps function and the default behavior of the MUI FormControlLabel component */
+            label={label}
+            componentsProps={{ typography: { id: ids.labelId } }}
           />
         )}
       />

--- a/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFSwitch.tsx
@@ -36,7 +36,6 @@ export const RHFSwitch: React.FC<RHFSwitchProps> = ({
     infoLabel,
     error,
   })
-  console.log('accessibilityProps', accessibilityProps, 'ids', ids)
 
   return (
     <InputWrapper error={error} sx={sx} infoLabel={infoLabel} {...ids}>

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFCheckbox.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFCheckbox.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { TestInputWrapper } from '@/components/shared/react-hook-form-inputs/__tests__/test-utils'
 import { RHFCheckbox } from '@/components/shared/react-hook-form-inputs'
+import { ReactHookFormWrapper } from '@/utils/testing.utils'
 
 const checkbox = {
   standard: {
@@ -29,5 +30,29 @@ describe('determine whether the integration between react-hook-form and MUI’s 
 
     await user.click(checkboxInput)
     expect(checkboxInput).not.toBeChecked()
+  })
+})
+
+describe('RHFCheckbox Accessibility', () => {
+  it('should link the input aria-labelledby to the label element ID to prevent orphaned labels', () => {
+    const testLabel = 'Accessibility Test Label'
+
+    render(
+      <ReactHookFormWrapper>
+        <RHFCheckbox name="testAccessibilityCheckbox" label={testLabel} />
+      </ReactHookFormWrapper>
+    )
+
+    const checkboxInput = screen.getByRole('checkbox')
+
+    const ariaLabelledBy = checkboxInput.getAttribute('aria-labelledby')
+
+    expect(ariaLabelledBy).toBeTruthy()
+
+    const labelElementById = document.getElementById(ariaLabelledBy as string)
+
+    expect(labelElementById).toBeInTheDocument()
+
+    expect(labelElementById).toHaveTextContent(testLabel)
   })
 })

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFCheckbox.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFCheckbox.test.tsx
@@ -38,7 +38,7 @@ describe('RHFCheckbox Accessibility', () => {
 
     render(
       <TestInputWrapper>
-        <RHFCheckbox name="testAccessibilityCheckbox" label={testLabel} />
+        <RHFCheckbox name={checkbox.standard.name} label={testLabel} />
       </TestInputWrapper>
     )
 

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFCheckbox.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFCheckbox.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event'
 
 import { TestInputWrapper } from '@/components/shared/react-hook-form-inputs/__tests__/test-utils'
 import { RHFCheckbox } from '@/components/shared/react-hook-form-inputs'
-import { ReactHookFormWrapper } from '@/utils/testing.utils'
 
 const checkbox = {
   standard: {
@@ -38,9 +37,9 @@ describe('RHFCheckbox Accessibility', () => {
     const testLabel = 'Accessibility Test Label'
 
     render(
-      <ReactHookFormWrapper>
+      <TestInputWrapper>
         <RHFCheckbox name="testAccessibilityCheckbox" label={testLabel} />
-      </ReactHookFormWrapper>
+      </TestInputWrapper>
     )
 
     const checkboxInput = screen.getByRole('checkbox')

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFSwitch.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFSwitch.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event'
 
 import { TestInputWrapper } from '@/components/shared/react-hook-form-inputs/__tests__/test-utils'
 import { RHFSwitch } from '@/components/shared/react-hook-form-inputs'
-import { ReactHookFormWrapper } from '@/utils/testing.utils'
 
 const switchProps = {
   standard: {
@@ -38,9 +37,9 @@ describe('RHFSwitch Accessibility', () => {
     const testLabel = 'Accessibility Test Label'
 
     render(
-      <ReactHookFormWrapper>
+      <TestInputWrapper>
         <RHFSwitch name="testAccessibilitySwitch" label={testLabel} />
-      </ReactHookFormWrapper>
+      </TestInputWrapper>
     )
 
     // MUI Switch renders an <input type="checkbox" role="checkbox" /> under the hood

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFSwitch.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFSwitch.test.tsx
@@ -38,7 +38,7 @@ describe('RHFSwitch Accessibility', () => {
 
     render(
       <TestInputWrapper>
-        <RHFSwitch name="testAccessibilitySwitch" label={testLabel} />
+        <RHFSwitch name={switchProps.standard.name} label={testLabel} />
       </TestInputWrapper>
     )
 

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFSwitch.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFSwitch.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { TestInputWrapper } from '@/components/shared/react-hook-form-inputs/__tests__/test-utils'
 import { RHFSwitch } from '@/components/shared/react-hook-form-inputs'
+import { ReactHookFormWrapper } from '@/utils/testing.utils'
 
 const switchProps = {
   standard: {
@@ -29,5 +30,30 @@ describe('determine whether the integration between react-hook-form and MUI’s 
 
     await user.click(switchInput)
     expect(switchInput).not.toBeChecked()
+  })
+})
+
+describe('RHFSwitch Accessibility', () => {
+  it('should link the input aria-labelledby to the label element ID to prevent orphaned labels', () => {
+    const testLabel = 'Accessibility Test Label'
+
+    render(
+      <ReactHookFormWrapper>
+        <RHFSwitch name="testAccessibilitySwitch" label={testLabel} />
+      </ReactHookFormWrapper>
+    )
+
+    // MUI Switch renders an <input type="checkbox" role="checkbox" /> under the hood
+    const switchInput = screen.getByRole('checkbox')
+
+    const ariaLabelledBy = switchInput.getAttribute('aria-labelledby')
+
+    expect(ariaLabelledBy).toBeTruthy()
+
+    const labelElementById = document.getElementById(ariaLabelledBy as string)
+
+    expect(labelElementById).toBeInTheDocument()
+
+    expect(labelElementById).toHaveTextContent(testLabel)
   })
 })


### PR DESCRIPTION
## 🔗 Issue

[PIN-A2-2682](https://pagopa.atlassian.net/browse/A2-2682)

## 📝 Description / Context

* Updated `RHFCheckbox` and `RHFSwitch` to set the label's element ID via `componentsProps`, ensuring the input's `aria-labelledby` correctly references the label for better accessibility. 

* Added unit tests

