### PR TITLE
feat: update publish e-service new version dialog copy (PIN-9938)

### DIFF
--- a/src/api/eservice/eservice.mutations.ts
+++ b/src/api/eservice/eservice.mutations.ts
@@ -146,7 +146,10 @@ function usePublishVersionDraft({ isByDelegation }: { isByDelegation?: boolean }
                 eserviceName: variables.eserviceName,
               })
             }
-          : () => t('confirmDialog.description'),
+          : (variables: unknown) =>
+              (variables as { isFirstVersion?: boolean }).isFirstVersion
+                ? t('confirmDialog.description')
+                : t('confirmDialog.descriptionNewVersion'),
         proceedLabel: isByDelegation
           ? t('confirmDialog.actions.proceed')
           : t('confirmDialog.proceedLabel'),

--- a/src/components/dialogs/DialogBasic.tsx
+++ b/src/components/dialogs/DialogBasic.tsx
@@ -62,6 +62,13 @@ export const DialogBasic: React.FC<DialogBasicProps> = ({
           <Trans
             components={{
               strong: <Typography component="span" variant="inherit" fontWeight={600} />,
+              p: (
+                <Typography
+                  component="p"
+                  variant="inherit"
+                  sx={{ '&:not(:last-of-type)': { mb: 2 } }}
+                />
+              ),
             }}
           >
             {description}

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -90,8 +90,9 @@
       },
       "confirmDialog": {
         "title": "Publish e-service",
-        "titleNewVersion": "Publish new e-service version",
+        "titleNewVersion": "Publish new version",
         "description": "Once published, this version will be available in the e-service catalog and can no longer be deleted. You can still suspend it or mark it as deprecated when you publish a new version.",
+        "descriptionNewVersion": "<p>When a new version of the e-service is published, it is immediately available in the catalog and can no longer be deleted.</p><p>The previous version becomes deprecated or, if it has no active consumers, will be archived automatically.</p><p>You will be able to suspend the new version or mark it as deprecated when you publish a subsequent version.</p>",
         "proceedLabel": "Publish"
       }
     },

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -90,8 +90,9 @@
       },
       "confirmDialog": {
         "title": "Pubblica e-service",
-        "titleNewVersion": "Pubblica nuova versione e-service",
+        "titleNewVersion": "Pubblica nuova versione",
         "description": "Una volta pubblicata, questa versione sarà disponibile nel catalogo degli e-service e non potrà più essere cancellata. Potrai comunque sospenderla o renderla obsoleta quando pubblicherai una nuova versione.",
+        "descriptionNewVersion": "<p>Quando una nuova versione dell'e-service viene pubblicata, è subito disponibile nel catalogo e non può più essere cancellata.</p><p>La versione precedente diventa obsoleta oppure, se non ha fruitori attivi, sarà archiviata automaticamente.</p><p>Potrai sospendere la nuova versione o renderla obsoleta quando pubblicherai una versione successiva.</p>",
         "proceedLabel": "Pubblica"
       }
     },


### PR DESCRIPTION
## 🔗 Issue
[PIN-9938]

## 📝 Description / Context
Updates the copy of the "Publish new e-service version" confirmation dialog according to the new [Figma design](https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW/Interop-%E2%80%94-Delivery-FE---QA?node-id=5281-10800&t=Do8MHSQQUebJViEc-4). Only the new-version flow is impacted; first-version publish and delegated publish flows are intentionally left unchanged.

## 🛠 List of changes
- Updated Italian and English copy for the publish-new-version confirmation dialog in `mutations-feedback.json`:
  - `titleNewVersion`: simplified to "Pubblica nuova versione" / "Publish new version".
  - Added `descriptionNewVersion`: 3-paragraph copy describing the new lifecycle behavior (catalog availability, deprecation/auto-archival of the previous version, future suspend/deprecation).
- `usePublishVersionDraft` now selects `descriptionNewVersion` when the variant is not the first version (and not delegated); the first-version description is unchanged.
- `DialogBasic` adds a `p` mapping to its `<Trans>` components so multi-paragraph descriptions render with proper inter-paragraph spacing.

## 🧪 How to test
- As a provider, open an e-service that already has at least one published version and a draft of a subsequent version (e.g. version 2).
- Navigate to the draft summary page (Erogazione → I miei e-service → bozza versione 2).
- Click "Pubblica" in the summary footer.
- Verify the dialog title is "Pubblica nuova versione" and the description renders three separate paragraphs matching the Figma copy.
- Switch language to English and verify the EN copy.
- Sanity check that publishing the very first version of a different e-service still shows the unchanged "Pubblica e-service" title and original single-paragraph description.

<img width="740" height="447" alt="Screenshot 2026-04-27 alle 17 09 12" src="https://github.com/user-attachments/assets/fef6b723-ca6a-4840-9e3f-1e9004fa3b22" />


[PIN-9938]: https://pagopa.atlassian.net/browse/PIN-9938