### PR TITLE
hotfix: restore consumer e-service details signal hub sectiona (PIN-9954)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interop-dashboard-frontend",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "scripts": {

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceDetailsTab.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceDetailsTab.tsx
@@ -1,4 +1,3 @@
-import { AuthHooks } from '@/api/auth'
 import { EServiceQueries } from '@/api/eservice'
 import { useTrackPageViewEvent } from '@/config/tracking'
 import { Grid } from '@mui/material'
@@ -18,6 +17,10 @@ import {
   ConsumerLinkedPurposeTemplatesSection,
   ConsumerLinkedPurposeTemplatesSectionSkeleton,
 } from './ConsumerEServicePurposeTemplateSection'
+import {
+  ConsumerEServiceSignalHubSection,
+  ConsumerEServiceSignalHubSectionSkeleton,
+} from './ConsumerEServiceSignalHubSection'
 
 const ConsumerEServiceDetailsTab: React.FC = () => {
   const { eserviceId, descriptorId } = useParams<'SUBSCRIBE_CATALOG_VIEW'>()
@@ -42,7 +45,10 @@ const ConsumerEServiceDetailsTab: React.FC = () => {
           <React.Suspense fallback={<ConsumerLinkedPurposeTemplatesSectionSkeleton />}>
             <ConsumerLinkedPurposeTemplatesSection />
           </React.Suspense>
-<React.Suspense fallback={<ConsumerEServiceDescriptorAttributesSkeleton />}>
+          <React.Suspense fallback={<ConsumerEServiceSignalHubSectionSkeleton />}>
+            <ConsumerEServiceSignalHubSection />
+          </React.Suspense>
+          <React.Suspense fallback={<ConsumerEServiceDescriptorAttributesSkeleton />}>
             <ConsumerEServiceDescriptorAttributes />
           </React.Suspense>
         </Grid>


### PR DESCRIPTION
## Jira Issue
[PIN-9954](https://pagopa.atlassian.net/browse/PIN-9954)

## Context/Why
**Consumer Eservice Details**
- Signal Hub section wrongly removed

## Key Changes
- Restore Signal Hub Section in `ConsumerEServiceDetailsTab.tsx`

[PIN-9954]: https://pagopa.atlassian.net/browse/PIN-9954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ