### PR TITLE
feat: replace e-service version selector slider with dropdown (PIN-9941)

### DIFF
--- a/src/components/shared/EServiceVersionSelectorDrawer.tsx
+++ b/src/components/shared/EServiceVersionSelectorDrawer.tsx
@@ -4,8 +4,7 @@ import type {
   ProducerEServiceDescriptor,
 } from '@/api/api.generatedTypes'
 import { Drawer } from '@/components/shared/Drawer'
-import { Slider, Typography } from '@mui/material'
-import type { Mark } from '@mui/base'
+import { MenuItem, TextField } from '@mui/material'
 import { type RouteKey, useCurrentRoute, useNavigate } from '@/router'
 import { useTranslation } from 'react-i18next'
 
@@ -26,23 +25,13 @@ export const EServiceVersionSelectorDrawer: React.FC<EServiceVersionSelectorDraw
   const [selectedVersion, setSelectedVersion] = React.useState(() => Number(descriptor.version))
   const navigate = useNavigate()
 
-  const sliderId = React.useId()
-
   const descriptorsWithoutDraftVersion = descriptor.eservice.descriptors.filter(
     (d) => d.state !== 'DRAFT'
   )
 
   const numVersions = descriptorsWithoutDraftVersion.length
 
-  const marks = React.useMemo<Mark[]>(() => {
-    return Array.from({ length: numVersions }).map((_, index) => ({
-      value: -(index + 1),
-      label:
-        (index + 1).toString() === descriptor.version
-          ? t('currentVersion', { versionNum: index + 1 })
-          : '',
-    }))
-  }, [numVersions, descriptor.version, t])
+  const versionOptions = Array.from({ length: numVersions }, (_, index) => index + 1)
 
   const handleReset = () => {
     setSelectedVersion(Number(descriptor.version))
@@ -78,30 +67,19 @@ export const EServiceVersionSelectorDrawer: React.FC<EServiceVersionSelectorDraw
         action: handleGoToVersion,
       }}
     >
-      <Typography
-        sx={{ mb: 4, display: 'block' }}
-        variant="label"
-        component="label"
-        htmlFor={sliderId}
+      <TextField
+        select
+        fullWidth
+        label={t('label')}
+        value={selectedVersion}
+        onChange={(event) => setSelectedVersion(Number(event.target.value))}
       >
-        {t('label')}
-      </Typography>
-
-      <Slider
-        id={sliderId}
-        sx={{ maxHeight: 250, ml: 3 }}
-        onChange={(_, value) => setSelectedVersion(-value as number)}
-        orientation="vertical"
-        size="small"
-        value={-selectedVersion}
-        max={-1}
-        min={-numVersions}
-        step={null}
-        marks={marks}
-        scale={(x) => -x}
-        valueLabelDisplay="on"
-        track={false}
-      />
+        {versionOptions.map((version) => (
+          <MenuItem key={version} value={version}>
+            {version}
+          </MenuItem>
+        ))}
+      </TextField>
     </Drawer>
   )
 }

--- a/src/components/shared/EserviceTemplate/EServiceTemplateVersionSelectorDrawer.tsx
+++ b/src/components/shared/EserviceTemplate/EServiceTemplateVersionSelectorDrawer.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import type { CompactEServiceTemplateVersion } from '@/api/api.generatedTypes'
 import { Drawer } from '@/components/shared/Drawer'
-import { Slider, Typography } from '@mui/material'
-import type { Mark } from '@mui/base'
+import { MenuItem, TextField } from '@mui/material'
 import { type RouteKey, useCurrentRoute, useNavigate } from '@/router'
 import { useTranslation } from 'react-i18next'
 
@@ -25,21 +24,11 @@ export const EServiceTemplateVersionSelectorDrawer: React.FC<
   const [selectedVersion, setSelectedVersion] = React.useState(() => Number(actualVersion))
   const navigate = useNavigate()
 
-  const sliderId = React.useId()
-
   const templatesVersionsNotInDraft = versions.filter((d) => d.state !== 'DRAFT')
 
   const numVersions = templatesVersionsNotInDraft.length
 
-  const marks = React.useMemo<Mark[]>(() => {
-    return Array.from({ length: numVersions }).map((_, index) => ({
-      value: -(index + 1),
-      label:
-        (index + 1).toString() === actualVersion
-          ? t('currentVersion', { versionNum: index + 1 })
-          : '',
-    }))
-  }, [numVersions, actualVersion, t])
+  const versionOptions = Array.from({ length: numVersions }, (_, index) => index + 1)
 
   const handleReset = () => {
     setSelectedVersion(Number(actualVersion))
@@ -81,30 +70,19 @@ export const EServiceTemplateVersionSelectorDrawer: React.FC<
         action: handleGoToVersion,
       }}
     >
-      <Typography
-        sx={{ mb: 4, display: 'block' }}
-        variant="label"
-        component="label"
-        htmlFor={sliderId}
+      <TextField
+        select
+        fullWidth
+        label={t('label')}
+        value={selectedVersion}
+        onChange={(event) => setSelectedVersion(Number(event.target.value))}
       >
-        {t('label')}
-      </Typography>
-
-      <Slider
-        id={sliderId}
-        sx={{ maxHeight: 250, ml: 3 }}
-        onChange={(_, value) => setSelectedVersion(-value as number)}
-        orientation="vertical"
-        size="small"
-        value={-selectedVersion}
-        max={-1}
-        min={-numVersions}
-        step={null}
-        marks={marks}
-        scale={(x) => -x}
-        valueLabelDisplay="on"
-        track={false}
-      />
+        {versionOptions.map((version) => (
+          <MenuItem key={version} value={version}>
+            {version}
+          </MenuItem>
+        ))}
+      </TextField>
     </Drawer>
   )
 }

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -886,9 +886,8 @@
         "notes": "Notes"
       },
       "versionSelectorDrawer": {
-        "title": "Navigate to another e-service version",
+        "title": "View another e-service version",
         "label": "Select version",
-        "currentVersion": "{{ versionNum }} - current version",
         "goToSelectedVersion": "Go to the selected version"
       },
       "updateDocumentationDrawer": {

--- a/src/static/locales/en/eserviceTemplate.json
+++ b/src/static/locales/en/eserviceTemplate.json
@@ -161,9 +161,8 @@
         "downloadDocumentTooltip": "Download document"
       },
       "versionSelectorDrawer": {
-        "title": "Navigate to another e-service template version",
+        "title": "View another e-service template version",
         "label": "Select version",
-        "currentVersion": "{{ versionNum }} - current version",
         "goToSelectedVersion": "Go to the selected version"
       }
     }

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -886,9 +886,8 @@
         "notes": "Note"
       },
       "versionSelectorDrawer": {
-        "title": "Naviga ad un’altra versione dell’e-service",
+        "title": "Vedi un’altra versione dell’e-service",
         "label": "Seleziona versione",
-        "currentVersion": "{{ versionNum }} - versione visualizzata",
         "goToSelectedVersion": "Vai alla versione selezionata"
       },
       "updateDocumentationDrawer": {

--- a/src/static/locales/it/eserviceTemplate.json
+++ b/src/static/locales/it/eserviceTemplate.json
@@ -161,9 +161,8 @@
         "downloadDocumentTooltip": "Scarica documento"
       },
       "versionSelectorDrawer": {
-        "title": "Naviga ad un’altra versione di questo template e-service",
+        "title": "Vedi un’altra versione di questo template e-service",
         "label": "Seleziona versione",
-        "currentVersion": "{{ versionNum }} - versione visualizzata",
         "goToSelectedVersion": "Vai alla versione selezionata"
       }
     }


### PR DESCRIPTION
## 🔗 Issue
[PIN-9941](https://pagopa.atlassian.net/browse/PIN-9941)

## 📝 Description / Context
Updates the version selector drawer used to navigate between different versions of an e-service (and of an e-service template) so that the inner control is a dropdown (`Select`) instead of the current vertical `Slider`, in line with the new design.

The change is split into two separate commits within this PR:
1. E-service version selector drawer
2. E-service template version selector drawer (kept aligned for UX consistency)

The change of the activation point (today the "Naviga a un'altra versione dell'e-service" link in the General Information section) is **out of scope** for this ticket and will be addressed separately. The current opening trigger keeps working as before.

## 🛠 List of changes
- `EServiceVersionSelectorDrawer`: replaced the vertical `Slider` with a `TextField select` (single dropdown) and dropped the `Mark` / `currentVersion` label logic.
- `EServiceTemplateVersionSelectorDrawer`: same refactor for the e-service template variant.
- Updated drawer titles in `it`/`en` locales: from "Naviga ad un'altra versione…" to "Vedi un'altra versione…" (and the equivalent for the template).
- Removed the now unused `currentVersion` translation key from both `eservice.json` and `eserviceTemplate.json` (it / en).

Preserved behaviour: the same `state !== 'DRAFT'` filter, the same version order, the same `numVersions <= 1` early-return, the same reset-on-close behaviour, and the same navigation logic (provider vs consumer routes).

## 🧪 How to test
- Open an e-service detail page that has at least 2 non-draft versions.
- Click "Naviga a un'altra versione dell'e-service" in the General Information section.
- The drawer should now show a single dropdown labelled "Seleziona versione" with the available version numbers.
- Select a different version and confirm with "Vai alla versione selezionata": the page should navigate to the selected version (provider or consumer route, depending on the section in use).
- Repeat the same flow on an e-service template detail page with at least 2 non-draft versions.
- Verify Italian and English copy on both drawers.

https://github.com/user-attachments/assets/2ae3d646-c53b-4d67-9d81-97ab1cbdb1ae


[PIN-9941]: https://pagopa.atlassian.net/browse/PIN-9941