### PR TITLE
Feature/pin 9937 page container redesign

### DIFF
--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -60,7 +60,7 @@ type IntroProps = {
   infoSection?: HeaderInfoSectionProps
 } & ActionsSectionProps
 
-type PageContainerProps = {
+export type PageContainerProps = {
   isLoading?: boolean
   sx?: SxProps
   children: React.ReactNode

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -219,7 +219,7 @@ const ActionsSection: React.FC<ActionsSectionProps> = ({
       <Stack direction="row" spacing={2}>
         {secondaryAction && renderActionButton(secondaryAction)}
         {primaryAction && renderActionButton(primaryAction)}
-        {menuActions.length !== 0 && <ActionMenu actions={menuActions} />}
+        {menuActions.length !== 0 && <ActionMenu actions={menuActions} hasIconBorder={true} />}
       </Stack>
     </Stack>
   )

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -1,0 +1,273 @@
+import React from 'react'
+import type { SxProps } from '@mui/material'
+import { Box, Button, Skeleton, Stack, Tooltip, Typography } from '@mui/material'
+import type { ActionItemButton } from '@/types/common.types'
+import { Breadcrumbs } from '../Breadcrumbs'
+import { StatusChip } from '@/components/shared/StatusChip'
+import { Link, type RouteKey } from '@/router'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
+
+export type PageBackToAction = {
+  label: string
+  to: RouteKey
+  params?: Record<string, string>
+  urlParams?: Record<string, string>
+}
+
+type PageContainerActionsProps = {
+  topSideActions?: Array<ActionItemButton>
+}
+
+type PageContainerBreadcrumbsProps = {
+  backToAction?: PageBackToAction
+}
+
+type PageContainerSecondaryIntroProps = {
+  label: string
+  link: {
+    label: string
+    onClink: () => void
+  }
+  actions: Array<ActionItemButton>
+  statusChip?: React.ComponentProps<typeof StatusChip>
+}
+
+type PageContainerIntroProps = {
+  title?: string
+  description?: string | React.ReactNode
+  secondaryIntro?: PageContainerSecondaryIntroProps
+} & PageContainerActionsProps
+
+type PageContainerProps = {
+  isLoading?: boolean
+  sx?: SxProps
+  children: React.ReactNode
+} & PageContainerBreadcrumbsProps &
+  PageContainerIntroProps
+
+type PageContainerSkeletonProps = {
+  children?: React.ReactNode
+  backToAction?: PageBackToAction
+}
+
+export const NewPageContainer: React.FC<PageContainerProps> = ({
+  children,
+  isLoading,
+  ...props
+}) => {
+  return (
+    <Stack direction={'column'} spacing={3}>
+      <PageContainerBreadcrumbs {...props} />
+      {isLoading ? <PageContainerIntroSkeleton /> : <PageContainerIntro {...props} />}
+      {/* {!isLoading && <PageContainerActions {...props} />} */}
+      <Box>{children}</Box>
+    </Stack>
+  )
+}
+
+export const PageContainerSkeleton: React.FC<PageContainerSkeletonProps> = ({
+  children,
+  backToAction,
+}) => {
+  return (
+    <Box>
+      <PageContainerBreadcrumbs backToAction={backToAction} />
+      <PageContainerIntroSkeleton />
+      <Box sx={{ mt: 1 }}>{children}</Box>
+    </Box>
+  )
+}
+
+const PageContainerIntro: React.FC<PageContainerIntroProps> = ({
+  title,
+  description,
+  topSideActions,
+  secondaryIntro,
+}) => {
+  return (
+    <Box sx={{ flex: 1 }}>
+      <Stack direction="row" spacing={2}>
+        {title && (
+          <Typography component="h1" variant="h4">
+            {title}
+          </Typography>
+        )}
+        {<PageContainerActions topSideActions={topSideActions} />}
+      </Stack>
+      {description && <PageContainerSubtitle description={description} />}
+      {secondaryIntro && <PageContainerSecondaryIntro {...secondaryIntro} />}
+    </Box>
+  )
+}
+
+type PageContainerSubtitle = {
+  description: string | React.ReactNode
+}
+
+const PageContainerSubtitle: React.FC<PageContainerSubtitle> = ({ description }) => {
+  return typeof description === 'string' ? (
+    <Typography component="p" variant="body1" sx={{ mt: 1, mb: 0 }}>
+      {description}
+    </Typography>
+  ) : (
+    description
+  )
+}
+const PageContainerBreadcrumbs: React.FC<PageContainerBreadcrumbsProps> = ({ backToAction }) => {
+  return (
+    <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 1 }}>
+      {backToAction && (
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        <Link
+          to={backToAction.to}
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          params={backToAction.params}
+          options={backToAction.urlParams ? { urlParams: backToAction.urlParams } : undefined}
+          as="button"
+          startIcon={<ArrowBackIcon />}
+          size="small"
+          variant="naked"
+        >
+          {backToAction.label}
+        </Link>
+      )}
+      <Breadcrumbs />
+    </Stack>
+  )
+}
+
+const PageContainerActions: React.FC<PageContainerActionsProps> = ({ topSideActions }) => {
+  if (!topSideActions) return null
+
+  const primaryActions = topSideActions?.filter(
+    (action) => action.hierarchy && action.hierarchy === 'primary'
+  )
+  const secondaryActions = topSideActions?.filter(
+    (action) => action.hierarchy && action.hierarchy === 'secondary'
+  )
+  const menuActions = topSideActions?.filter((action) => action.hierarchy === undefined)
+
+  const getButtonWrapper = (tooltip?: string, disabled?: boolean) => {
+    return tooltip
+      ? ({ children }: { children: React.ReactElement }) => (
+          <Tooltip arrow title={tooltip}>
+            <span tabIndex={disabled ? 0 : undefined}>{children}</span>
+          </Tooltip>
+        )
+      : React.Fragment
+  }
+
+  return (
+    <Stack
+      sx={{ minHeight: 40 }}
+      direction="row"
+      alignItems="center"
+      justifyContent="flex-end"
+      flex={1}
+    >
+      <Stack direction="row" spacing={2}>
+        {secondaryActions &&
+          secondaryActions.map(({ action, label, color, icon: Icon, tooltip, ...props }, index) => {
+            const Wrapper = getButtonWrapper(tooltip, props.disabled)
+            return (
+              <Wrapper key={index}>
+                <Button
+                  onClick={action}
+                  variant="outlined"
+                  size="small"
+                  color={color}
+                  startIcon={Icon && <Icon />}
+                  {...props}
+                >
+                  {label}
+                </Button>
+              </Wrapper>
+            )
+          })}
+        {primaryActions &&
+          primaryActions.map(({ action, label, color, icon: Icon, tooltip, ...props }, index) => {
+            const Wrapper = getButtonWrapper(tooltip, props.disabled)
+            return (
+              <Wrapper key={index}>
+                <Button
+                  onClick={action}
+                  variant="contained"
+                  size="small"
+                  color={color}
+                  startIcon={Icon && <Icon />}
+                  {...props}
+                >
+                  {label}
+                </Button>
+              </Wrapper>
+            )
+          })}
+        {menuActions ? <ActionMenu actions={menuActions} /> : <ActionMenuSkeleton />}
+      </Stack>
+    </Stack>
+  )
+}
+
+export const PageContainerSecondaryIntro: React.FC<PageContainerSecondaryIntroProps> = ({
+  label,
+  link,
+  statusChip,
+  actions,
+}) => {
+  return (
+    <Box bgcolor="ThreeDFace" py={2} px={2} borderRadius={1} mt={3}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Stack direction="row" spacing={4} alignItems="center">
+          <Typography component="h2" variant="body2" textTransform="uppercase">
+            {label}
+          </Typography>
+          <Button
+            component="a"
+            type="button"
+            variant="naked"
+            sx={{ textDecoration: 'underline' }}
+            onClick={link.onClink}
+          >
+            {link.label}
+          </Button>
+          {statusChip && <StatusChip {...statusChip} />}
+        </Stack>
+        <Stack direction="row" spacing={3}>
+          {actions.map(({ action, label, color, icon: Icon, ...props }, index) => {
+            return (
+              <Button
+                key={index}
+                onClick={action}
+                variant="text"
+                size="small"
+                color={color}
+                startIcon={Icon && <Icon />}
+                {...props}
+              >
+                {label}
+              </Button>
+            )
+          })}
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}
+
+export const PageContainerIntroSkeleton: React.FC = () => {
+  return (
+    <Stack direction="row" alignItems="end" spacing={2}>
+      <Box sx={{ flex: 1 }}>
+        <Typography component="h1" variant="h4">
+          <Skeleton />
+        </Typography>
+        <Typography component="p" variant="body1" sx={{ mt: 1, mb: 0 }}>
+          <Skeleton />
+        </Typography>
+      </Box>
+    </Stack>
+  )
+}

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -25,12 +25,25 @@ type BreadcrumbsSectionProps = {
   backToAction?: PageBackToAction
 }
 
+type ShortCutProps =
+  | {
+      [K in RouteKey]: {
+        type: 'link'
+        label: string
+        to: K // the specified route
+        params?: RouteParams<K> // params corresponding to that route
+        urlParams?: Record<string, string>
+      }
+    }[RouteKey]
+  | {
+      type: 'button'
+      label: string
+      onClick: () => void
+    }
+
 type HeaderInfoSectionProps = {
   label: string
-  link: {
-    label: string
-    onClick: () => void
-  }
+  shortcut: ShortCutProps
   actions?: Array<ActionItemButton>
   statusChip?: React.ComponentProps<typeof StatusChip>
 }
@@ -213,7 +226,7 @@ const ActionsSection: React.FC<ActionsSectionProps> = ({
 
 export const HeaderInfoSection: React.FC<HeaderInfoSectionProps> = ({
   label,
-  link,
+  shortcut,
   statusChip,
   actions = [],
 }) => {
@@ -224,15 +237,28 @@ export const HeaderInfoSection: React.FC<HeaderInfoSectionProps> = ({
           <Typography component="h2" variant="body2" textTransform="uppercase">
             {label}
           </Typography>
-          <Button
-            component="a"
-            type="button"
-            variant="naked"
-            sx={{ textDecoration: 'underline' }}
-            onClick={link.onClick}
-          >
-            {link.label}
-          </Button>
+          {shortcut.type === 'button' && (
+            <Button
+              type="button"
+              variant="naked"
+              sx={{ textDecoration: 'underline' }}
+              onClick={shortcut.onClick}
+            >
+              {shortcut.label}
+            </Button>
+          )}
+          {shortcut.type === 'link' && (
+            <Link
+              to={shortcut.to}
+              params={shortcut.params}
+              options={shortcut.urlParams ? { urlParams: shortcut.urlParams } : undefined}
+              as="button"
+              variant="naked"
+              sx={{ textDecoration: 'underline' }}
+            >
+              {shortcut.label}
+            </Link>
+          )}
           {statusChip && <StatusChip {...statusChip} />}
         </Stack>
         <Stack direction="row" spacing={3}>

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -29,7 +29,7 @@ type PageContainerSecondaryIntroProps = {
     label: string
     onClick: () => void
   }
-  actions: Array<ActionItemButton>
+  actions?: Array<ActionItemButton>
   statusChip?: React.ComponentProps<typeof StatusChip>
 }
 
@@ -57,10 +57,9 @@ export const NewPageContainer: React.FC<PageContainerProps> = ({
   ...props
 }) => {
   return (
-    <Stack direction={'column'} spacing={3}>
+    <Stack direction="column" spacing={3}>
       <PageContainerBreadcrumbs {...props} />
       {isLoading ? <PageContainerIntroSkeleton /> : <PageContainerIntro {...props} />}
-      {/* {!isLoading && <PageContainerActions {...props} />} */}
       <Box>{children}</Box>
     </Stack>
   )
@@ -142,12 +141,8 @@ const PageContainerBreadcrumbs: React.FC<PageContainerBreadcrumbsProps> = ({ bac
 const PageContainerActions: React.FC<PageContainerActionsProps> = ({ topSideActions }) => {
   if (!topSideActions) return null
 
-  const primaryActions = topSideActions?.filter(
-    (action) => action.hierarchy && action.hierarchy === 'primary'
-  )
-  const secondaryActions = topSideActions?.filter(
-    (action) => action.hierarchy && action.hierarchy === 'secondary'
-  )
+  const primaryActions = topSideActions?.filter((action) => action.hierarchy === 'primary')
+  const secondaryActions = topSideActions?.filter((action) => action.hierarchy === 'secondary')
   const menuActions = topSideActions?.filter((action) => action.hierarchy === undefined)
 
   const getButtonWrapper = (tooltip?: string, disabled?: boolean) => {
@@ -215,7 +210,7 @@ export const PageContainerSecondaryIntro: React.FC<PageContainerSecondaryIntroPr
   label,
   link,
   statusChip,
-  actions,
+  actions = [],
 }) => {
   return (
     <Box bgcolor="ThreeDFace" py={2} px={2} borderRadius={1} mt={3}>
@@ -229,7 +224,7 @@ export const PageContainerSecondaryIntro: React.FC<PageContainerSecondaryIntroPr
             type="button"
             variant="naked"
             sx={{ textDecoration: 'underline' }}
-            onClick={link.onClink}
+            onClick={link.onClick}
           >
             {link.label}
           </Button>

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -172,7 +172,7 @@ const ActionsSection: React.FC<ActionsSectionProps> = ({
   secondaryAction,
   menuActions = [],
 }) => {
-  if (menuActions.length === 0 && !primaryAction) return null
+  if (menuActions.length === 0 && !primaryAction && !secondaryAction) return null
 
   const renderActionButton = ({
     action,

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -95,7 +95,7 @@ const Intro: React.FC<IntroProps> = ({
     <Box sx={{ flex: 1 }}>
       <Stack direction="row" alignItems="center" spacing={2}>
         {title && (
-          <Typography component="h1" variant="h4">
+          <Typography component="h1" variant="h4" maxWidth="50%">
             {title}
           </Typography>
         )}

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -15,15 +15,15 @@ export type PageBackToAction = {
   urlParams?: Record<string, string>
 }
 
-type PageContainerActionsProps = {
+type ActionsSectionProps = {
   topSideActions?: Array<ActionItemButton>
 }
 
-type PageContainerBreadcrumbsProps = {
+type BreadcrumbsSectionProps = {
   backToAction?: PageBackToAction
 }
 
-type PageContainerSecondaryIntroProps = {
+type HeaderInfoSectionProps = {
   label: string
   link: {
     label: string
@@ -33,22 +33,26 @@ type PageContainerSecondaryIntroProps = {
   statusChip?: React.ComponentProps<typeof StatusChip>
 }
 
-type PageContainerIntroProps = {
+type IntroProps = {
   title?: string
   description?: string | React.ReactNode
-  secondaryIntro?: PageContainerSecondaryIntroProps
-} & PageContainerActionsProps
+  infoSection?: HeaderInfoSectionProps
+} & ActionsSectionProps
 
 type PageContainerProps = {
   isLoading?: boolean
   sx?: SxProps
   children: React.ReactNode
-} & PageContainerBreadcrumbsProps &
-  PageContainerIntroProps
+} & BreadcrumbsSectionProps &
+  IntroProps
 
 type PageContainerSkeletonProps = {
   children?: React.ReactNode
   backToAction?: PageBackToAction
+}
+
+type SubtitleProps = {
+  description: string | React.ReactNode
 }
 
 export const NewPageContainer: React.FC<PageContainerProps> = ({
@@ -58,8 +62,8 @@ export const NewPageContainer: React.FC<PageContainerProps> = ({
 }) => {
   return (
     <Stack direction="column" spacing={3}>
-      <PageContainerBreadcrumbs {...props} />
-      {isLoading ? <PageContainerIntroSkeleton /> : <PageContainerIntro {...props} />}
+      <BreadcrumbsSection {...props} />
+      {isLoading ? <IntroSkeleton /> : <Intro {...props} />}
       <Box>{children}</Box>
     </Stack>
   )
@@ -71,18 +75,18 @@ export const PageContainerSkeleton: React.FC<PageContainerSkeletonProps> = ({
 }) => {
   return (
     <Box>
-      <PageContainerBreadcrumbs backToAction={backToAction} />
-      <PageContainerIntroSkeleton />
+      <BreadcrumbsSection backToAction={backToAction} />
+      <IntroSkeleton />
       <Box sx={{ mt: 1 }}>{children}</Box>
     </Box>
   )
 }
 
-const PageContainerIntro: React.FC<PageContainerIntroProps> = ({
+const Intro: React.FC<IntroProps> = ({
   title,
   description,
   topSideActions,
-  secondaryIntro,
+  infoSection,
 }) => {
   return (
     <Box sx={{ flex: 1 }}>
@@ -94,17 +98,13 @@ const PageContainerIntro: React.FC<PageContainerIntroProps> = ({
         )}
         {<PageContainerActions topSideActions={topSideActions} />}
       </Stack>
-      {description && <PageContainerSubtitle description={description} />}
-      {secondaryIntro && <PageContainerSecondaryIntro {...secondaryIntro} />}
+      {description && <Subtitle description={description} />}
+      {infoSection && <HeaderInfoSection {...infoSection} />}
     </Box>
   )
 }
 
-type PageContainerSubtitle = {
-  description: string | React.ReactNode
-}
-
-const PageContainerSubtitle: React.FC<PageContainerSubtitle> = ({ description }) => {
+const Subtitle: React.FC<SubtitleProps> = ({ description }) => {
   return typeof description === 'string' ? (
     <Typography component="p" variant="body1" sx={{ mt: 1, mb: 0 }}>
       {description}
@@ -113,7 +113,7 @@ const PageContainerSubtitle: React.FC<PageContainerSubtitle> = ({ description })
     description
   )
 }
-const PageContainerBreadcrumbs: React.FC<PageContainerBreadcrumbsProps> = ({ backToAction }) => {
+const BreadcrumbsSection: React.FC<BreadcrumbsSectionProps> = ({ backToAction }) => {
   return (
     <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 1 }}>
       {backToAction && (
@@ -138,7 +138,7 @@ const PageContainerBreadcrumbs: React.FC<PageContainerBreadcrumbsProps> = ({ bac
   )
 }
 
-const PageContainerActions: React.FC<PageContainerActionsProps> = ({ topSideActions }) => {
+const ActionsSection: React.FC<ActionsSectionProps> = ({ topSideActions }) => {
   if (!topSideActions) return null
 
   const primaryActions = topSideActions?.filter((action) => action.hierarchy === 'primary')
@@ -206,7 +206,7 @@ const PageContainerActions: React.FC<PageContainerActionsProps> = ({ topSideActi
   )
 }
 
-export const PageContainerSecondaryIntro: React.FC<PageContainerSecondaryIntroProps> = ({
+export const HeaderInfoSection: React.FC<HeaderInfoSectionProps> = ({
   label,
   link,
   statusChip,
@@ -252,7 +252,7 @@ export const PageContainerSecondaryIntro: React.FC<PageContainerSecondaryIntroPr
   )
 }
 
-export const PageContainerIntroSkeleton: React.FC = () => {
+export const IntroSkeleton: React.FC = () => {
   return (
     <Stack direction="row" alignItems="end" spacing={2}>
       <Box sx={{ flex: 1 }}>

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -220,7 +220,7 @@ export const HeaderInfoSection: React.FC<HeaderInfoSectionProps> = ({
   actions = [],
 }) => {
   return (
-    <Box bgcolor="ThreeDFace" py={2} px={2} borderRadius={1} mt={3}>
+    <Box bgcolor="grey.100" py={2} px={2} borderRadius={1} mt={3}>
       <Stack direction="row" alignItems="center" justifyContent="space-between">
         <Stack direction="row" spacing={4} alignItems="center">
           <Typography component="h2" variant="body2" textTransform="uppercase">

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -27,7 +27,7 @@ type PageContainerSecondaryIntroProps = {
   label: string
   link: {
     label: string
-    onClink: () => void
+    onClick: () => void
   }
   actions: Array<ActionItemButton>
   statusChip?: React.ComponentProps<typeof StatusChip>

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -36,6 +36,7 @@ type HeaderInfoSectionProps = {
 type IntroProps = {
   title?: string
   description?: string | React.ReactNode
+  statusChip?: React.ComponentProps<typeof StatusChip>
   infoSection?: HeaderInfoSectionProps
 } & ActionsSectionProps
 
@@ -85,18 +86,24 @@ export const PageContainerSkeleton: React.FC<PageContainerSkeletonProps> = ({
 const Intro: React.FC<IntroProps> = ({
   title,
   description,
+  statusChip,
   topSideActions,
   infoSection,
 }) => {
   return (
     <Box sx={{ flex: 1 }}>
-      <Stack direction="row" spacing={2}>
+      <Stack direction="row" alignItems="center" spacing={2}>
         {title && (
           <Typography component="h1" variant="h4">
             {title}
           </Typography>
         )}
-        {<PageContainerActions topSideActions={topSideActions} />}
+        {statusChip && (
+          <Box>
+            <StatusChip {...statusChip} />
+          </Box>
+        )}
+        <ActionsSection topSideActions={topSideActions} />
       </Stack>
       {description && <Subtitle description={description} />}
       {infoSection && <HeaderInfoSection {...infoSection} />}

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -7,7 +7,6 @@ import { StatusChip } from '@/components/shared/StatusChip'
 import { Link, type RouteKey } from '@/router'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
-import { match } from 'ts-pattern'
 
 export type PageBackToAction = {
   label: string
@@ -17,7 +16,9 @@ export type PageBackToAction = {
 }
 
 type ActionsSectionProps = {
-  topSideActions?: Array<ActionItemButton>
+  primaryAction?: ActionItemButton
+  secondaryAction?: ActionItemButton
+  menuActions?: Array<ActionItemButton>
 }
 
 type BreadcrumbsSectionProps = {
@@ -88,7 +89,9 @@ const Intro: React.FC<IntroProps> = ({
   title,
   description,
   statusChip,
-  topSideActions,
+  primaryAction,
+  secondaryAction,
+  menuActions,
   infoSection,
 }) => {
   return (
@@ -104,7 +107,11 @@ const Intro: React.FC<IntroProps> = ({
             <StatusChip {...statusChip} />
           </Box>
         )}
-        <ActionsSection topSideActions={topSideActions} />
+        <ActionsSection
+          primaryAction={primaryAction}
+          secondaryAction={secondaryAction}
+          menuActions={menuActions}
+        />
       </Stack>
       {description && <Subtitle description={description} />}
       {infoSection && <HeaderInfoSection {...infoSection} />}
@@ -146,26 +153,23 @@ const BreadcrumbsSection: React.FC<BreadcrumbsSectionProps> = ({ backToAction })
   )
 }
 
-const ActionsSection: React.FC<ActionsSectionProps> = ({ topSideActions }) => {
-  if (!topSideActions) return null
+const ActionsSection: React.FC<ActionsSectionProps> = ({
+  primaryAction,
+  secondaryAction,
+  menuActions,
+}) => {
+  if (!menuActions && !primaryAction) return null
 
-  const primaryActions: Array<ActionItemButton> = []
-  const secondaryActions: Array<ActionItemButton> = []
-  const menuActions: Array<ActionItemButton> = []
-
-  topSideActions.forEach((action) => {
-    match(action.variant)
-      .with('contained', () => {
-        primaryActions.push(action)
-      })
-      .with('outlined', () => secondaryActions.push(action))
-      .otherwise(() => menuActions.push(action))
-  })
-
-  const renderActionButton = (
-    { action, label, color, icon: Icon, tooltip, disabled, variant, ...props }: ActionItemButton,
-    index: number
-  ) => {
+  const renderActionButton = ({
+    action,
+    label,
+    color,
+    icon: Icon,
+    tooltip,
+    disabled,
+    variant,
+    ...props
+  }: ActionItemButton) => {
     const Wrapper = tooltip
       ? ({ children }: { children: React.ReactElement }) => (
           <Tooltip arrow title={tooltip}>
@@ -175,7 +179,7 @@ const ActionsSection: React.FC<ActionsSectionProps> = ({ topSideActions }) => {
       : React.Fragment
 
     return (
-      <Wrapper key={index}>
+      <Wrapper key={label}>
         <Button
           onClick={action}
           variant={variant}
@@ -199,8 +203,8 @@ const ActionsSection: React.FC<ActionsSectionProps> = ({ topSideActions }) => {
       flex={1}
     >
       <Stack direction="row" spacing={2}>
-        {secondaryActions.map(renderActionButton)}
-        {primaryActions.map(renderActionButton)}
+        {secondaryAction && renderActionButton(secondaryAction)}
+        {primaryAction && renderActionButton(primaryAction)}
         {menuActions ? <ActionMenu actions={menuActions} /> : <ActionMenuSkeleton />}
       </Stack>
     </Stack>

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -7,6 +7,7 @@ import { StatusChip } from '@/components/shared/StatusChip'
 import { Link, type RouteKey } from '@/router'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
+import { match } from 'ts-pattern'
 
 export type PageBackToAction = {
   label: string
@@ -148,18 +149,45 @@ const BreadcrumbsSection: React.FC<BreadcrumbsSectionProps> = ({ backToAction })
 const ActionsSection: React.FC<ActionsSectionProps> = ({ topSideActions }) => {
   if (!topSideActions) return null
 
-  const primaryActions = topSideActions?.filter((action) => action.hierarchy === 'primary')
-  const secondaryActions = topSideActions?.filter((action) => action.hierarchy === 'secondary')
-  const menuActions = topSideActions?.filter((action) => action.hierarchy === undefined)
+  const primaryActions: Array<ActionItemButton> = []
+  const secondaryActions: Array<ActionItemButton> = []
+  const menuActions: Array<ActionItemButton> = []
 
-  const getButtonWrapper = (tooltip?: string, disabled?: boolean) => {
-    return tooltip
+  topSideActions.forEach((action) => {
+    match(action.variant)
+      .with('contained', () => {
+        primaryActions.push(action)
+      })
+      .with('outlined', () => secondaryActions.push(action))
+      .otherwise(() => menuActions.push(action))
+  })
+
+  const renderActionButton = (
+    { action, label, color, icon: Icon, tooltip, disabled, variant, ...props }: ActionItemButton,
+    index: number
+  ) => {
+    const Wrapper = tooltip
       ? ({ children }: { children: React.ReactElement }) => (
           <Tooltip arrow title={tooltip}>
             <span tabIndex={disabled ? 0 : undefined}>{children}</span>
           </Tooltip>
         )
       : React.Fragment
+
+    return (
+      <Wrapper key={index}>
+        <Button
+          onClick={action}
+          variant={variant}
+          size="small"
+          color={color}
+          startIcon={Icon && <Icon />}
+          {...props}
+        >
+          {label}
+        </Button>
+      </Wrapper>
+    )
   }
 
   return (
@@ -171,42 +199,8 @@ const ActionsSection: React.FC<ActionsSectionProps> = ({ topSideActions }) => {
       flex={1}
     >
       <Stack direction="row" spacing={2}>
-        {secondaryActions &&
-          secondaryActions.map(({ action, label, color, icon: Icon, tooltip, ...props }, index) => {
-            const Wrapper = getButtonWrapper(tooltip, props.disabled)
-            return (
-              <Wrapper key={index}>
-                <Button
-                  onClick={action}
-                  variant="outlined"
-                  size="small"
-                  color={color}
-                  startIcon={Icon && <Icon />}
-                  {...props}
-                >
-                  {label}
-                </Button>
-              </Wrapper>
-            )
-          })}
-        {primaryActions &&
-          primaryActions.map(({ action, label, color, icon: Icon, tooltip, ...props }, index) => {
-            const Wrapper = getButtonWrapper(tooltip, props.disabled)
-            return (
-              <Wrapper key={index}>
-                <Button
-                  onClick={action}
-                  variant="contained"
-                  size="small"
-                  color={color}
-                  startIcon={Icon && <Icon />}
-                  {...props}
-                >
-                  {label}
-                </Button>
-              </Wrapper>
-            )
-          })}
+        {secondaryActions.map(renderActionButton)}
+        {primaryActions.map(renderActionButton)}
         {menuActions ? <ActionMenu actions={menuActions} /> : <ActionMenuSkeleton />}
       </Stack>
     </Stack>

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -7,7 +7,7 @@ import { StatusChip } from '@/components/shared/StatusChip'
 import type { useParams } from '@/router'
 import { Link, type RouteKey } from '@/router'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
+import { ActionMenu } from '@/components/shared/ActionMenu'
 
 type RouteParams<TRouteKey extends RouteKey> = ReturnType<typeof useParams<TRouteKey>>
 
@@ -23,7 +23,7 @@ export type PageBackToAction = {
 type ActionsSectionProps = {
   primaryAction?: ActionItemButton
   secondaryAction?: ActionItemButton
-  menuActions?: Array<ActionItemButton>
+  menuActions: Array<ActionItemButton>
 }
 
 type BreadcrumbsSectionProps = {
@@ -49,7 +49,7 @@ type ShortCutProps =
 type HeaderInfoSectionProps = {
   label: string
   shortcut: ShortCutProps
-  actions?: Array<ActionItemButton>
+  actions: Array<ActionItemButton>
   statusChip?: React.ComponentProps<typeof StatusChip>
 }
 
@@ -172,7 +172,7 @@ const ActionsSection: React.FC<ActionsSectionProps> = ({
   secondaryAction,
   menuActions,
 }) => {
-  if (!menuActions && !primaryAction) return null
+  if (menuActions.length === 0 && !primaryAction) return null
 
   const renderActionButton = ({
     action,
@@ -219,7 +219,7 @@ const ActionsSection: React.FC<ActionsSectionProps> = ({
       <Stack direction="row" spacing={2}>
         {secondaryAction && renderActionButton(secondaryAction)}
         {primaryAction && renderActionButton(primaryAction)}
-        {menuActions ? <ActionMenu actions={menuActions} /> : <ActionMenuSkeleton />}
+        {menuActions.length !== 0 && <ActionMenu actions={menuActions} />}
       </Stack>
     </Stack>
   )

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -4,16 +4,21 @@ import { Box, Button, Skeleton, Stack, Tooltip, Typography } from '@mui/material
 import type { ActionItemButton } from '@/types/common.types'
 import { Breadcrumbs } from '../Breadcrumbs'
 import { StatusChip } from '@/components/shared/StatusChip'
+import type { useParams } from '@/router'
 import { Link, type RouteKey } from '@/router'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
 
+type RouteParams<TRouteKey extends RouteKey> = ReturnType<typeof useParams<TRouteKey>>
+
 export type PageBackToAction = {
-  label: string
-  to: RouteKey
-  params?: Record<string, string>
-  urlParams?: Record<string, string>
-}
+  [K in RouteKey]: {
+    label: string
+    to: K // the specified route
+    params?: RouteParams<K> // params corresponding to that route
+    urlParams?: Record<string, string>
+  }
+}[RouteKey]
 
 type ActionsSectionProps = {
   primaryAction?: ActionItemButton
@@ -145,12 +150,8 @@ const BreadcrumbsSection: React.FC<BreadcrumbsSectionProps> = ({ backToAction })
   return (
     <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 1 }}>
       {backToAction && (
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         <Link
           to={backToAction.to}
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
           params={backToAction.params}
           options={backToAction.urlParams ? { urlParams: backToAction.urlParams } : undefined}
           as="button"

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -23,7 +23,7 @@ export type PageBackToAction = {
 type ActionsSectionProps = {
   primaryAction?: ActionItemButton
   secondaryAction?: ActionItemButton
-  menuActions: Array<ActionItemButton>
+  menuActions?: Array<ActionItemButton>
 }
 
 type BreadcrumbsSectionProps = {
@@ -49,7 +49,7 @@ type ShortCutProps =
 type HeaderInfoSectionProps = {
   label: string
   shortcut: ShortCutProps
-  actions: Array<ActionItemButton>
+  actions?: Array<ActionItemButton>
   statusChip?: React.ComponentProps<typeof StatusChip>
 }
 
@@ -170,7 +170,7 @@ const BreadcrumbsSection: React.FC<BreadcrumbsSectionProps> = ({ backToAction })
 const ActionsSection: React.FC<ActionsSectionProps> = ({
   primaryAction,
   secondaryAction,
-  menuActions,
+  menuActions = [],
 }) => {
   if (menuActions.length === 0 && !primaryAction) return null
 

--- a/src/components/layout/containers/PageContainer.tsx
+++ b/src/components/layout/containers/PageContainer.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import type { SxProps } from '@mui/material'
-import { Box, Button, Skeleton, Stack, Tooltip, Typography } from '@mui/material'
-import type { ActionItemButton } from '@/types/common.types'
+import { Box, Button, Skeleton, Stack, Typography } from '@mui/material'
+import type { ActionItem, ActionItemButton } from '@/types/common.types'
 import { Breadcrumbs } from '../Breadcrumbs'
 import { StatusChip } from '@/components/shared/StatusChip'
 import { Link, type RouteKey } from '@/router'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
 
 export type PageBackToAction = {
   label: string
@@ -23,17 +24,27 @@ type PageContainerBreadcrumbsProps = {
   backToAction?: PageBackToAction
 }
 
+type PageContainerSecondaryIntroProps = {
+  label: string
+  link: {
+    label: string
+    onClink: () => void
+  }
+  actions: Array<ActionItemButton>
+  statusChip?: React.ComponentProps<typeof StatusChip>
+}
+
 type PageContainerIntroProps = {
   title?: string
   description?: string | React.ReactNode
-}
+  secondaryIntro?: PageContainerSecondaryIntroProps
+} & PageContainerActionsProps
 
 type PageContainerProps = {
   isLoading?: boolean
   sx?: SxProps
   children: React.ReactNode
-} & PageContainerActionsProps &
-  PageContainerBreadcrumbsProps &
+} & PageContainerBreadcrumbsProps &
   PageContainerIntroProps
 
 type PageContainerSkeletonProps = {
@@ -43,12 +54,12 @@ type PageContainerSkeletonProps = {
 
 export const PageContainer: React.FC<PageContainerProps> = ({ children, isLoading, ...props }) => {
   return (
-    <Box>
+    <Stack direction={'column'} spacing={3}>
       <PageContainerBreadcrumbs {...props} />
       {isLoading ? <PageContainerIntroSkeleton /> : <PageContainerIntro {...props} />}
-      {!isLoading && <PageContainerActions {...props} />}
-      <Box sx={{ mt: 1 }}>{children}</Box>
-    </Box>
+      {/* {!isLoading && <PageContainerActions {...props} />} */}
+      <Box>{children}</Box>
+    </Stack>
   )
 }
 
@@ -65,19 +76,25 @@ export const PageContainerSkeleton: React.FC<PageContainerSkeletonProps> = ({
   )
 }
 
-const PageContainerIntro: React.FC<PageContainerIntroProps> = ({ title, description }) => {
+const PageContainerIntro: React.FC<PageContainerIntroProps> = ({
+  title,
+  description,
+  statusChip,
+  topSideActions,
+  secondaryIntro,
+}) => {
   return (
-    <Box>
-      <Stack direction="row" alignItems="end" spacing={2}>
-        <Box sx={{ flex: 1 }}>
-          {title && (
-            <Typography component="h1" variant="h4">
-              {title}
-            </Typography>
-          )}
-          {description && <PageContainerSubtitle description={description} />}
-        </Box>
+    <Box sx={{ flex: 1 }}>
+      <Stack direction="row" spacing={2}>
+        {title && (
+          <Typography component="h1" variant="h4">
+            {title}
+          </Typography>
+        )}
+        {<PageContainerActions statusChip={statusChip} topSideActions={topSideActions} />}
       </Stack>
+      {description && <PageContainerSubtitle description={description} />}
+      {secondaryIntro && <PageContainerSecondaryIntro {...secondaryIntro} />}
     </Box>
   )
 }
@@ -126,42 +143,105 @@ const PageContainerActions: React.FC<PageContainerActionsProps> = ({
 }) => {
   if (!statusChip && !topSideActions) return null
 
+  const primaryActions = topSideActions?.filter(
+    (action) => action.hierarchy && action.hierarchy === 'primary'
+  )
+  const secondaryActions = topSideActions?.filter(
+    (action) => action.hierarchy && action.hierarchy === 'secondary'
+  )
+  const menuActions = topSideActions?.filter((action) => action.hierarchy === undefined)
+
   return (
     <Stack
-      sx={{ mt: 1, minHeight: 40 }}
+      sx={{ minHeight: 40 }}
       direction="row"
       alignItems="center"
       justifyContent="space-between"
+      flex={1}
     >
       <Box>{statusChip && <StatusChip {...statusChip} />}</Box>
-      <Stack direction="row" spacing={1}>
-        {topSideActions &&
-          topSideActions.map(({ action, label, color, icon: Icon, tooltip, ...props }, i) => {
-            const Wrapper = tooltip
-              ? ({ children }: { children: React.ReactElement }) => (
-                  <Tooltip arrow title={tooltip}>
-                    <span tabIndex={props.disabled ? 0 : undefined}>{children}</span>
-                  </Tooltip>
-                )
-              : React.Fragment
-
+      <Stack direction="row" spacing={2}>
+        {secondaryActions &&
+          secondaryActions.map(({ action, label, color, icon: Icon, ...props }, index) => {
             return (
-              <Wrapper key={i}>
-                <Button
-                  onClick={action}
-                  variant="text"
-                  size="small"
-                  color={color}
-                  startIcon={Icon && <Icon />}
-                  {...props}
-                >
-                  {label}
-                </Button>
-              </Wrapper>
+              <Button
+                key={index}
+                onClick={action}
+                variant="outlined"
+                size="small"
+                color={color}
+                startIcon={Icon && <Icon />}
+                {...props}
+              >
+                {label}
+              </Button>
             )
           })}
+        {primaryActions &&
+          primaryActions.map(({ action, label, color, icon: Icon, ...props }, index) => {
+            return (
+              <Button
+                key={index}
+                onClick={action}
+                variant="contained"
+                size="small"
+                color={color}
+                startIcon={Icon && <Icon />}
+                {...props}
+              >
+                {label}
+              </Button>
+            )
+          })}
+        {menuActions ? <ActionMenu actions={menuActions} /> : <ActionMenuSkeleton />}
       </Stack>
     </Stack>
+  )
+}
+
+export const PageContainerSecondaryIntro: React.FC<PageContainerSecondaryIntroProps> = ({
+  label,
+  link,
+  statusChip,
+  actions,
+}) => {
+  return (
+    <Box bgcolor="ThreeDFace" py={2} px={2} borderRadius={1} mt={3}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Stack direction="row" spacing={4} alignItems="center">
+          <Typography component="h2" variant="body2" textTransform="uppercase">
+            {label}
+          </Typography>
+          <Button
+            component="a"
+            type="button"
+            variant="naked"
+            sx={{ textDecoration: 'underline' }}
+            onClick={link.onClink}
+          >
+            {link.label}
+          </Button>
+          {statusChip && <StatusChip {...statusChip} />}
+        </Stack>
+        <Stack direction="row" spacing={3}>
+          {actions.map(({ action, label, color, icon: Icon, ...props }, index) => {
+            return (
+              <Button
+                key={index}
+                onClick={action}
+                variant="text"
+                size="small"
+                color={color}
+                startIcon={Icon && <Icon />}
+                {...props}
+              >
+                {label}
+              </Button>
+            )
+          })}
+        </Stack>
+      </Stack>
+    </Box>
   )
 }
 

--- a/src/components/layout/containers/PageContainer.tsx
+++ b/src/components/layout/containers/PageContainer.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { SxProps } from '@mui/material'
 import { Box, Button, Skeleton, Stack, Typography } from '@mui/material'
-import type { ActionItem, ActionItemButton } from '@/types/common.types'
+import type { ActionItemButton } from '@/types/common.types'
 import { Breadcrumbs } from '../Breadcrumbs'
 import { StatusChip } from '@/components/shared/StatusChip'
 import { Link, type RouteKey } from '@/router'

--- a/src/components/layout/containers/PageContainer.tsx
+++ b/src/components/layout/containers/PageContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { SxProps } from '@mui/material'
-import { Box, Button, Skeleton, Stack, Typography } from '@mui/material'
+import { Box, Button, Skeleton, Stack, Tooltip, Typography } from '@mui/material'
 import type { ActionItemButton } from '@/types/common.types'
 import { Breadcrumbs } from '../Breadcrumbs'
 import { StatusChip } from '@/components/shared/StatusChip'
@@ -151,6 +151,16 @@ const PageContainerActions: React.FC<PageContainerActionsProps> = ({
   )
   const menuActions = topSideActions?.filter((action) => action.hierarchy === undefined)
 
+  const getButtonWrapper = (tooltip?: string, disabled?: boolean) => {
+    return tooltip
+      ? ({ children }: { children: React.ReactElement }) => (
+          <Tooltip arrow title={tooltip}>
+            <span tabIndex={disabled ? 0 : undefined}>{children}</span>
+          </Tooltip>
+        )
+      : React.Fragment
+  }
+
   return (
     <Stack
       sx={{ minHeight: 40 }}
@@ -162,35 +172,39 @@ const PageContainerActions: React.FC<PageContainerActionsProps> = ({
       <Box>{statusChip && <StatusChip {...statusChip} />}</Box>
       <Stack direction="row" spacing={2}>
         {secondaryActions &&
-          secondaryActions.map(({ action, label, color, icon: Icon, ...props }, index) => {
+          secondaryActions.map(({ action, label, color, icon: Icon, tooltip, ...props }, index) => {
+            const Wrapper = getButtonWrapper(tooltip, props.disabled)
             return (
-              <Button
-                key={index}
-                onClick={action}
-                variant="outlined"
-                size="small"
-                color={color}
-                startIcon={Icon && <Icon />}
-                {...props}
-              >
-                {label}
-              </Button>
+              <Wrapper key={index}>
+                <Button
+                  onClick={action}
+                  variant="outlined"
+                  size="small"
+                  color={color}
+                  startIcon={Icon && <Icon />}
+                  {...props}
+                >
+                  {label}
+                </Button>
+              </Wrapper>
             )
           })}
         {primaryActions &&
-          primaryActions.map(({ action, label, color, icon: Icon, ...props }, index) => {
+          primaryActions.map(({ action, label, color, icon: Icon, tooltip, ...props }, index) => {
+            const Wrapper = getButtonWrapper(tooltip, props.disabled)
             return (
-              <Button
-                key={index}
-                onClick={action}
-                variant="contained"
-                size="small"
-                color={color}
-                startIcon={Icon && <Icon />}
-                {...props}
-              >
-                {label}
-              </Button>
+              <Wrapper key={index}>
+                <Button
+                  onClick={action}
+                  variant="contained"
+                  size="small"
+                  color={color}
+                  startIcon={Icon && <Icon />}
+                  {...props}
+                >
+                  {label}
+                </Button>
+              </Wrapper>
             )
           })}
         {menuActions ? <ActionMenu actions={menuActions} /> : <ActionMenuSkeleton />}

--- a/src/components/layout/containers/PageContainer.tsx
+++ b/src/components/layout/containers/PageContainer.tsx
@@ -6,7 +6,6 @@ import { Breadcrumbs } from '../Breadcrumbs'
 import { StatusChip } from '@/components/shared/StatusChip'
 import { Link, type RouteKey } from '@/router'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
 
 export type PageBackToAction = {
   label: string
@@ -24,27 +23,17 @@ type PageContainerBreadcrumbsProps = {
   backToAction?: PageBackToAction
 }
 
-type PageContainerSecondaryIntroProps = {
-  label: string
-  link: {
-    label: string
-    onClink: () => void
-  }
-  actions: Array<ActionItemButton>
-  statusChip?: React.ComponentProps<typeof StatusChip>
-}
-
 type PageContainerIntroProps = {
   title?: string
   description?: string | React.ReactNode
-  secondaryIntro?: PageContainerSecondaryIntroProps
-} & PageContainerActionsProps
+}
 
 type PageContainerProps = {
   isLoading?: boolean
   sx?: SxProps
   children: React.ReactNode
-} & PageContainerBreadcrumbsProps &
+} & PageContainerActionsProps &
+  PageContainerBreadcrumbsProps &
   PageContainerIntroProps
 
 type PageContainerSkeletonProps = {
@@ -54,12 +43,12 @@ type PageContainerSkeletonProps = {
 
 export const PageContainer: React.FC<PageContainerProps> = ({ children, isLoading, ...props }) => {
   return (
-    <Stack direction={'column'} spacing={3}>
+    <Box>
       <PageContainerBreadcrumbs {...props} />
       {isLoading ? <PageContainerIntroSkeleton /> : <PageContainerIntro {...props} />}
-      {/* {!isLoading && <PageContainerActions {...props} />} */}
-      <Box>{children}</Box>
-    </Stack>
+      {!isLoading && <PageContainerActions {...props} />}
+      <Box sx={{ mt: 1 }}>{children}</Box>
+    </Box>
   )
 }
 
@@ -76,25 +65,19 @@ export const PageContainerSkeleton: React.FC<PageContainerSkeletonProps> = ({
   )
 }
 
-const PageContainerIntro: React.FC<PageContainerIntroProps> = ({
-  title,
-  description,
-  statusChip,
-  topSideActions,
-  secondaryIntro,
-}) => {
+const PageContainerIntro: React.FC<PageContainerIntroProps> = ({ title, description }) => {
   return (
-    <Box sx={{ flex: 1 }}>
-      <Stack direction="row" spacing={2}>
-        {title && (
-          <Typography component="h1" variant="h4">
-            {title}
-          </Typography>
-        )}
-        {<PageContainerActions statusChip={statusChip} topSideActions={topSideActions} />}
+    <Box>
+      <Stack direction="row" alignItems="end" spacing={2}>
+        <Box sx={{ flex: 1 }}>
+          {title && (
+            <Typography component="h1" variant="h4">
+              {title}
+            </Typography>
+          )}
+          {description && <PageContainerSubtitle description={description} />}
+        </Box>
       </Stack>
-      {description && <PageContainerSubtitle description={description} />}
-      {secondaryIntro && <PageContainerSecondaryIntro {...secondaryIntro} />}
     </Box>
   )
 }
@@ -143,42 +126,30 @@ const PageContainerActions: React.FC<PageContainerActionsProps> = ({
 }) => {
   if (!statusChip && !topSideActions) return null
 
-  const primaryActions = topSideActions?.filter(
-    (action) => action.hierarchy && action.hierarchy === 'primary'
-  )
-  const secondaryActions = topSideActions?.filter(
-    (action) => action.hierarchy && action.hierarchy === 'secondary'
-  )
-  const menuActions = topSideActions?.filter((action) => action.hierarchy === undefined)
-
-  const getButtonWrapper = (tooltip?: string, disabled?: boolean) => {
-    return tooltip
-      ? ({ children }: { children: React.ReactElement }) => (
-          <Tooltip arrow title={tooltip}>
-            <span tabIndex={disabled ? 0 : undefined}>{children}</span>
-          </Tooltip>
-        )
-      : React.Fragment
-  }
-
   return (
     <Stack
-      sx={{ minHeight: 40 }}
+      sx={{ mt: 1, minHeight: 40 }}
       direction="row"
       alignItems="center"
       justifyContent="space-between"
-      flex={1}
     >
       <Box>{statusChip && <StatusChip {...statusChip} />}</Box>
-      <Stack direction="row" spacing={2}>
-        {secondaryActions &&
-          secondaryActions.map(({ action, label, color, icon: Icon, tooltip, ...props }, index) => {
-            const Wrapper = getButtonWrapper(tooltip, props.disabled)
+      <Stack direction="row" spacing={1}>
+        {topSideActions &&
+          topSideActions.map(({ action, label, color, icon: Icon, tooltip, ...props }, i) => {
+            const Wrapper = tooltip
+              ? ({ children }: { children: React.ReactElement }) => (
+                  <Tooltip arrow title={tooltip}>
+                    <span tabIndex={props.disabled ? 0 : undefined}>{children}</span>
+                  </Tooltip>
+                )
+              : React.Fragment
+
             return (
-              <Wrapper key={index}>
+              <Wrapper key={i}>
                 <Button
                   onClick={action}
-                  variant="outlined"
+                  variant="text"
                   size="small"
                   color={color}
                   startIcon={Icon && <Icon />}
@@ -189,73 +160,8 @@ const PageContainerActions: React.FC<PageContainerActionsProps> = ({
               </Wrapper>
             )
           })}
-        {primaryActions &&
-          primaryActions.map(({ action, label, color, icon: Icon, tooltip, ...props }, index) => {
-            const Wrapper = getButtonWrapper(tooltip, props.disabled)
-            return (
-              <Wrapper key={index}>
-                <Button
-                  onClick={action}
-                  variant="contained"
-                  size="small"
-                  color={color}
-                  startIcon={Icon && <Icon />}
-                  {...props}
-                >
-                  {label}
-                </Button>
-              </Wrapper>
-            )
-          })}
-        {menuActions ? <ActionMenu actions={menuActions} /> : <ActionMenuSkeleton />}
       </Stack>
     </Stack>
-  )
-}
-
-export const PageContainerSecondaryIntro: React.FC<PageContainerSecondaryIntroProps> = ({
-  label,
-  link,
-  statusChip,
-  actions,
-}) => {
-  return (
-    <Box bgcolor="ThreeDFace" py={2} px={2} borderRadius={1} mt={3}>
-      <Stack direction="row" alignItems="center" justifyContent="space-between">
-        <Stack direction="row" spacing={4} alignItems="center">
-          <Typography component="h2" variant="body2" textTransform="uppercase">
-            {label}
-          </Typography>
-          <Button
-            component="a"
-            type="button"
-            variant="naked"
-            sx={{ textDecoration: 'underline' }}
-            onClick={link.onClink}
-          >
-            {link.label}
-          </Button>
-          {statusChip && <StatusChip {...statusChip} />}
-        </Stack>
-        <Stack direction="row" spacing={3}>
-          {actions.map(({ action, label, color, icon: Icon, ...props }, index) => {
-            return (
-              <Button
-                key={index}
-                onClick={action}
-                variant="text"
-                size="small"
-                color={color}
-                startIcon={Icon && <Icon />}
-                {...props}
-              >
-                {label}
-              </Button>
-            )
-          })}
-        </Stack>
-      </Stack>
-    </Box>
   )
 }
 

--- a/src/components/layout/containers/__tests__/NewPageContainer.test.tsx
+++ b/src/components/layout/containers/__tests__/NewPageContainer.test.tsx
@@ -1,0 +1,240 @@
+import userEvent from '@testing-library/user-event'
+import { NewPageContainer, type PageContainerProps } from '../NewPageContainer'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import type { ActionItemButton } from '@/types/common.types'
+
+const renderComponent = ({
+  children,
+  title,
+  backToAction,
+  statusChip,
+  primaryAction,
+  secondaryAction,
+  menuActions,
+  description,
+  infoSection,
+}: PageContainerProps) => {
+  return renderWithApplicationContext(
+    <NewPageContainer
+      title={title}
+      backToAction={backToAction}
+      statusChip={statusChip}
+      primaryAction={primaryAction}
+      secondaryAction={secondaryAction}
+      menuActions={menuActions}
+      description={description}
+      infoSection={infoSection}
+    >
+      {children}
+    </NewPageContainer>,
+    { withRouterContext: true }
+  )
+}
+
+describe('NewPageContainer', () => {
+  it('should correctly render title and children', () => {
+    const screen = renderComponent({ children: 'Test children', title: 'Test title' })
+    const title = screen.getByText('Test title')
+    const children = screen.getByText('Test children')
+
+    expect(title).toBeInTheDocument()
+    expect(children).toBeInTheDocument()
+  })
+
+  it('should correctly render the statusChip when passed PUBLISHED for e-service', () => {
+    const screen = renderComponent({
+      children: 'Test children',
+      title: 'Test title',
+      statusChip: { for: 'eservice', state: 'PUBLISHED' },
+    })
+
+    const statusChip = screen.getByText('status.eservice.PUBLISHED')
+
+    expect(statusChip).toBeInTheDocument()
+  })
+
+  it('should correctly render the statusChip when passed SUSPENDED for e-service', () => {
+    const screen = renderComponent({
+      children: 'Test children',
+      title: 'Test title',
+      statusChip: { for: 'eservice', state: 'SUSPENDED' },
+    })
+
+    const statusChip = screen.getByText('status.eservice.SUSPENDED')
+
+    expect(statusChip).toBeInTheDocument()
+  })
+
+  it('should correctly render the backToAction link that navigate to the DEFAULT route passed', async () => {
+    const { history, ...screen } = renderComponent({
+      children: 'Test children',
+      title: 'Test title',
+      backToAction: {
+        label: 'test backToAction',
+        to: 'DEFAULT',
+      },
+    })
+
+    const user = userEvent.setup()
+
+    const backToActionButton = screen.getByRole('link', { name: 'test backToAction' })
+
+    expect(backToActionButton).toBeInTheDocument()
+
+    await user.click(backToActionButton)
+
+    expect(history.location.pathname).toEqual('/it/')
+  })
+
+  it('should correctly render the description', () => {
+    const screen = renderComponent({
+      children: 'Test children',
+      title: 'Test title',
+      description: 'Test description',
+    })
+
+    const description = screen.getByText('Test description')
+
+    expect(description).toBeInTheDocument()
+  })
+
+  it('should correctly render primary and secondary action when passed', () => {
+    const primaryAction = vi.fn()
+    const primaryActionMock: ActionItemButton = {
+      action: primaryAction,
+      label: 'test primary action',
+      variant: 'contained',
+    }
+    const secondaryAction = vi.fn()
+    const secondaryActionMock: ActionItemButton = {
+      action: secondaryAction,
+      label: 'test secondary action',
+      variant: 'outlined',
+    }
+
+    const screen = renderComponent({
+      children: 'Test children',
+      title: 'Test title',
+      primaryAction: primaryActionMock,
+      secondaryAction: secondaryActionMock,
+    })
+
+    const primaryActionButton = screen.getByRole('button', { name: 'test primary action' })
+    const secondaryActionButton = screen.getByRole('button', { name: 'test secondary action' })
+
+    expect(primaryActionButton).toBeInTheDocument()
+    expect(secondaryActionButton).toBeInTheDocument()
+  })
+
+  it('should correctly render the menuAction that contains the actions passed', async () => {
+    const menuAction1Mock: ActionItemButton = {
+      action: vi.fn(),
+      label: 'test menu action 1',
+    }
+    const menuAction2Mock: ActionItemButton = {
+      action: vi.fn(),
+      label: 'test menu action 2',
+    }
+    const screen = renderComponent({
+      children: 'Test children',
+      title: 'Test title',
+      menuActions: [menuAction1Mock, menuAction2Mock],
+    })
+
+    const user = userEvent.setup()
+
+    const actionMenuIcon = screen.getByTestId('MoreVertIcon')
+
+    expect(actionMenuIcon).toBeInTheDocument()
+
+    await user.click(actionMenuIcon)
+
+    const menuAction1 = screen.getByRole('menuitem', { name: 'test menu action 1' })
+    const menuAction2 = screen.getByRole('menuitem', { name: 'test menu action 2' })
+
+    expect(menuAction1).toBeInTheDocument()
+    expect(menuAction2).toBeInTheDocument()
+  })
+
+  it('should correctly render the infoSection with the label and the shortcut passed. That shortcut should be a link and navigate to the DEFAULT route passed', async () => {
+    const { history, ...screen } = renderComponent({
+      children: 'Test children',
+      title: 'Test title',
+      infoSection: {
+        label: 'Test label',
+        shortcut: { type: 'link', label: 'Test link', to: 'DEFAULT' },
+      },
+    })
+
+    const user = userEvent.setup()
+
+    const infoSectionLabel = screen.getByText('Test label')
+    const infoSectionShortcut = screen.getByRole('link', { name: 'Test link' })
+
+    expect(infoSectionLabel).toBeInTheDocument()
+    expect(infoSectionShortcut).toBeInTheDocument()
+
+    await user.click(infoSectionShortcut)
+
+    expect(history.location.pathname).toEqual('/it/')
+  })
+
+  it('should correctly render the infoSection with the label and the shortcut passed. That shortcut should be a button', () => {
+    const screen = renderComponent({
+      children: 'Test children',
+      title: 'Test title',
+      infoSection: {
+        label: 'Test label',
+        shortcut: { type: 'button', label: 'Test button', onClick: vi.fn() },
+      },
+    })
+
+    const infoSectionShortcut = screen.getByRole('button', { name: 'Test button' })
+
+    expect(infoSectionShortcut).toBeInTheDocument()
+  })
+
+  it('should correctly render the infoSection with the statusChip with state PUBLISHED for e-service passed', () => {
+    const screen = renderComponent({
+      children: 'Test children',
+      title: 'Test title',
+      infoSection: {
+        label: 'Test label',
+        shortcut: { type: 'link', label: 'Test link', to: 'DEFAULT' },
+        statusChip: { for: 'eservice', state: 'PUBLISHED' },
+      },
+    })
+
+    const statusChip = screen.getByText('status.eservice.PUBLISHED')
+
+    expect(statusChip).toBeInTheDocument()
+  })
+
+  it('should correctly render the infoSection with the label and the shortcut passed. That shortcut should be a button', () => {
+    const primaryAction = vi.fn()
+    const action1Mock: ActionItemButton = {
+      action: primaryAction,
+      label: 'Test action 1',
+    }
+    const secondaryAction = vi.fn()
+    const action2Mock: ActionItemButton = {
+      action: secondaryAction,
+      label: 'Test action 2',
+    }
+    const screen = renderComponent({
+      children: 'Test children',
+      title: 'Test title',
+      infoSection: {
+        label: 'Test label',
+        shortcut: { type: 'link', label: 'Test link', to: 'DEFAULT' },
+        actions: [action1Mock, action2Mock],
+      },
+    })
+
+    const infoSectionAction1 = screen.getByRole('button', { name: 'Test action 1' })
+    const infoSectionAction2 = screen.getByRole('button', { name: 'Test action 2' })
+
+    expect(infoSectionAction1).toBeInTheDocument()
+    expect(infoSectionAction2).toBeInTheDocument()
+  })
+})

--- a/src/components/shared/ActionMenu.tsx
+++ b/src/components/shared/ActionMenu.tsx
@@ -7,9 +7,14 @@ import { useTranslation } from 'react-i18next'
 type ActionMenuProps = {
   actions: Array<ActionItem>
   iconColor?: ExtendedMUIColor
+  hasIconBorder?: boolean
 }
 
-export const ActionMenu: React.FC<ActionMenuProps> = ({ actions, iconColor = 'primary' }) => {
+export const ActionMenu: React.FC<ActionMenuProps> = ({
+  actions,
+  iconColor = 'primary',
+  hasIconBorder = false,
+}) => {
   const [open, setOpen] = React.useState(false)
   const anchorRef = React.useRef<HTMLButtonElement>(null)
   const compositionButtonId = useId() + '-composition-button'
@@ -54,8 +59,8 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ actions, iconColor = 'pr
         id={compositionButtonId}
         sx={{
           visibility: actions.length > 0 ? 'visible' : 'hidden',
-          border: 2,
-          borderRadius: 1,
+          border: hasIconBorder ? 2 : undefined,
+          borderRadius: hasIconBorder ? 1 : undefined,
         }}
         aria-controls={open ? compositionMenuId : undefined}
         aria-expanded={open ? 'true' : undefined}
@@ -63,7 +68,11 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ actions, iconColor = 'pr
         onClick={handleToggle}
         aria-label={t('iconButtonAriaLabel')}
       >
-        <MoreVertIcon color={iconColor} fontSize="small" sx={{ marginX: 0.5 }} />
+        <MoreVertIcon
+          color={iconColor}
+          fontSize="small"
+          sx={{ marginX: hasIconBorder ? 0.5 : 0 }}
+        />
       </IconButton>
       <ClickAwayListener onClickAway={handleClose}>
         <Menu

--- a/src/components/shared/ActionMenu.tsx
+++ b/src/components/shared/ActionMenu.tsx
@@ -75,7 +75,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ actions, iconColor = 'pr
           anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
           transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         >
-          {actions.map(({ label, action, fontColor }) => (
+          {actions.map(({ label, action, fontColor, icon: Icon }) => (
             <MenuItem
               sx={{ color: fontColor ?? 'inherit' }}
               key={label}
@@ -84,6 +84,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ actions, iconColor = 'pr
                 handleClose(e)
               }}
             >
+              {Icon && <Icon sx={{ marginRight: 1 }} />}
               {label}
             </MenuItem>
           ))}

--- a/src/components/shared/ActionMenu.tsx
+++ b/src/components/shared/ActionMenu.tsx
@@ -52,14 +52,18 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({ actions, iconColor = 'pr
       <IconButton
         ref={anchorRef}
         id={compositionButtonId}
-        sx={{ visibility: actions.length > 0 ? 'visible' : 'hidden' }}
+        sx={{
+          visibility: actions.length > 0 ? 'visible' : 'hidden',
+          border: 2,
+          borderRadius: 1,
+        }}
         aria-controls={open ? compositionMenuId : undefined}
         aria-expanded={open ? 'true' : undefined}
         aria-haspopup="true"
         onClick={handleToggle}
         aria-label={t('iconButtonAriaLabel')}
       >
-        <MoreVertIcon color={iconColor} fontSize="small" />
+        <MoreVertIcon color={iconColor} fontSize="small" sx={{ marginX: 0.5 }} />
       </IconButton>
       <ClickAwayListener onClickAway={handleClose}>
         <Menu

--- a/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
+++ b/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
@@ -57,7 +57,7 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
   it('should return no actions if no descriptor is passed', () => {
     mockUseJwt({ isAdmin: true })
     const { result } = renderUseGetEServiceConsumerActionsHook(undefined)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return inspect agreement action if the user has just an agreement with state ACTIVE, SUSPENDED or PENDING', async () => {
@@ -78,8 +78,8 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     const { result, history } = renderUseGetEServiceConsumerActionsHook(
       createMockEServiceDescriptorCatalog({ eservice: eserviceMock })
     )
-    expect(result.current.actions).toHaveLength(1)
-    const goToAgreementAction = result.current.actions[0]!
+    expect(result.current.menuActions).toHaveLength(1)
+    const goToAgreementAction = result.current.menuActions[0]!
     expect(goToAgreementAction.label).toBe('tableEServiceCatalog.inspect')
 
     goToAgreementAction.action()
@@ -117,8 +117,8 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
       false
     )
 
-    expect(result.current.actions).toHaveLength(1)
-    const goToAgreementAction = result.current.actions[0]!
+    expect(result.current.menuActions).toHaveLength(1)
+    const goToAgreementAction = result.current.menuActions[0]!
     expect(goToAgreementAction.label).toBe('tableEServiceCatalog.inspect')
 
     act(() => {
@@ -147,8 +147,8 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     const { result, history } = renderUseGetEServiceConsumerActionsHook(
       createMockEServiceDescriptorCatalog({ eservice: eserviceMock })
     )
-    expect(result.current.actions).toHaveLength(1)
-    const goToAgreementAction = result.current.actions[0]!
+    expect(result.current.menuActions).toHaveLength(1)
+    const goToAgreementAction = result.current.menuActions[0]!
     expect(goToAgreementAction.label).toBe('tableEServiceCatalog.editDraft')
 
     goToAgreementAction.action()
@@ -180,8 +180,8 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     const { result } = renderUseGetEServiceConsumerActionsHook(
       createMockEServiceDescriptorCatalog({ eservice: eserviceMock })
     )
-    expect(result.current.actions).toHaveLength(1)
-    const goToAgreementEditAction = result.current.actions[0]!
+    expect(result.current.menuActions).toHaveLength(1)
+    const goToAgreementEditAction = result.current.menuActions[0]!
     expect(goToAgreementEditAction.label).toBe('tableEServiceCatalog.editDraft')
 
     act(() => {
@@ -210,7 +210,7 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     const { result } = renderUseGetEServiceConsumerActionsHook(
       createMockEServiceDescriptorCatalog({ eservice: eserviceMock })
     )
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it("should return the create agreement draft action if the user doesn't have agreements", async () => {
@@ -225,8 +225,8 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     const { result, history } = renderUseGetEServiceConsumerActionsHook(
       createMockEServiceDescriptorCatalog({ eservice: eserviceMock })
     )
-    expect(result.current.actions).toHaveLength(1)
-    const createAgreementDraftAction = result.current.actions[0]!
+    expect(result.current.menuActions).toHaveLength(1)
+    const createAgreementDraftAction = result.current.menuActions[0]!
     expect(createAgreementDraftAction.label).toBe('tableEServiceCatalog.subscribe')
 
     act(() => {
@@ -265,8 +265,8 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     const { result, history } = renderUseGetEServiceConsumerActionsHook(
       createMockEServiceDescriptorCatalog({ eservice: eserviceMock })
     )
-    expect(result.current.actions).toHaveLength(1)
-    const createAgreementDraftAction = result.current.actions[0]!
+    expect(result.current.menuActions).toHaveLength(1)
+    const createAgreementDraftAction = result.current.menuActions[0]!
     expect(createAgreementDraftAction.label).toBe('tableEServiceCatalog.subscribe')
 
     act(() => {
@@ -305,8 +305,8 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     const { result, history } = renderUseGetEServiceConsumerActionsHook(
       createMockEServiceDescriptorCatalog({ eservice: eserviceMock })
     )
-    expect(result.current.actions).toHaveLength(1)
-    const createAgreementDraftAction = result.current.actions[0]!
+    expect(result.current.menuActions).toHaveLength(1)
+    const createAgreementDraftAction = result.current.menuActions[0]!
     expect(createAgreementDraftAction.label).toBe('tableEServiceCatalog.subscribe')
 
     act(() => {
@@ -341,8 +341,8 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
       [{ id: 'delegator-id', name: 'Delegator Name' }],
       false
     )
-    expect(result.current.actions).toHaveLength(1)
-    const createAgreementDraftAction = result.current.actions[0]!
+    expect(result.current.menuActions).toHaveLength(1)
+    const createAgreementDraftAction = result.current.menuActions[0]!
     expect(createAgreementDraftAction.label).toBe('tableEServiceCatalog.subscribe')
 
     act(() => {
@@ -365,8 +365,8 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     const { result, history } = renderUseGetEServiceConsumerActionsHook(
       createMockEServiceDescriptorCatalog({ eservice: eserviceMock })
     )
-    expect(result.current.actions).toHaveLength(1)
-    const createAgreementDraftAction = result.current.actions[0]!
+    expect(result.current.menuActions).toHaveLength(1)
+    const createAgreementDraftAction = result.current.menuActions[0]!
     expect(createAgreementDraftAction.label).toBe('tableEServiceCatalog.subscribe')
 
     act(() => {
@@ -399,7 +399,7 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     const { result } = renderUseGetEServiceConsumerActionsHook(
       createMockEServiceDescriptorCatalog({ eservice: eserviceMock })
     )
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return the inspect agreement action and the edit agreement action if the user has an agreement with state ACTIVE and another agreement with state DRAFT', async () => {
@@ -428,9 +428,9 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
       [{ id: 'delegator-id', name: 'Delegator Name' }],
       false
     )
-    expect(result.current.actions).toHaveLength(2)
-    const goToAgreementAction = result.current.actions[0]!
-    const goToEditAgreementAction = result.current.actions[1]!
+    expect(result.current.menuActions).toHaveLength(2)
+    const goToAgreementAction = result.current.menuActions[0]!
+    const goToEditAgreementAction = result.current.menuActions[1]!
     expect(goToAgreementAction.label).toBe('tableEServiceCatalog.inspect')
     expect(goToEditAgreementAction.label).toBe('tableEServiceCatalog.editDraft')
   })
@@ -466,10 +466,10 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
       false
     )
 
-    expect(result.current.actions).toHaveLength(3)
-    const goToAgreementAction = result.current.actions[0]!
-    const goToEditAgreementAction = result.current.actions[1]!
-    const goToCreateAgreementAction = result.current.actions[2]!
+    expect(result.current.menuActions).toHaveLength(3)
+    const goToAgreementAction = result.current.menuActions[0]!
+    const goToEditAgreementAction = result.current.menuActions[1]!
+    const goToCreateAgreementAction = result.current.menuActions[2]!
     expect(goToAgreementAction.label).toBe('tableEServiceCatalog.inspect')
     expect(goToEditAgreementAction.label).toBe('tableEServiceCatalog.editDraft')
     expect(goToCreateAgreementAction.label).toBe('tableEServiceCatalog.subscribe')

--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -68,8 +68,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('delete')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('delete')
   })
 
   it('should not return actions if user is admin and delegator, e-service is DRAFT with no active descriptors', () => {
@@ -83,7 +83,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return the correct actions if user is admin and delegate, e-service is DRAFT with no active descriptors', () => {
@@ -97,7 +97,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is admin and e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
@@ -106,7 +106,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return the correct actions if user is admin and delegator, e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
@@ -120,9 +120,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(2)
-    expect(result.current.actions[0].label).toBe('approve')
-    expect(result.current.actions[1].label).toBe('reject')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('approve')
+    expect(result.current.menuActions[1].label).toBe('reject')
   })
 
   it('should not return actions if user is admin and delegate, e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
@@ -136,7 +136,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is admin and e-service is ARCHIVED', () => {
@@ -145,7 +145,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is admin and delegator, e-service is ARCHIVED', () => {
@@ -159,7 +159,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is admin and delegate, e-service is ARCHIVED', () => {
@@ -173,7 +173,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return the correct actions if user is admin and e-service is DEPRECATED', () => {
@@ -182,8 +182,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('suspend')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('suspend')
   })
 
   it('should not return actions if user is admin and delegator, e-service is DEPRECATED', () => {
@@ -197,7 +197,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return the correct actions if user is admin and delegate, e-service is DEPRECATED', () => {
@@ -211,8 +211,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('suspend')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('suspend')
   })
 
   it('should return the correct actions if user is admin and e-service is PUBLISHED with no draft descriptors', () => {
@@ -221,10 +221,10 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(3)
-    expect(result.current.actions[0].label).toBe('clone')
-    expect(result.current.actions[1].label).toBe('createNewDraft')
-    expect(result.current.actions[2].label).toBe('suspend')
+    expect(result.current.menuActions).toHaveLength(3)
+    expect(result.current.menuActions[0].label).toBe('clone')
+    expect(result.current.menuActions[1].label).toBe('createNewDraft')
+    expect(result.current.menuActions[2].label).toBe('suspend')
   })
 
   it('should return the correct actions if user is admin and e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
@@ -234,11 +234,11 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(4)
-    expect(result.current.actions[0].label).toBe('clone')
-    expect(result.current.actions[1].label).toBe('manageDraft')
-    expect(result.current.actions[2].label).toBe('deleteDraft')
-    expect(result.current.actions[3].label).toBe('suspend')
+    expect(result.current.menuActions).toHaveLength(4)
+    expect(result.current.menuActions[0].label).toBe('clone')
+    expect(result.current.menuActions[1].label).toBe('manageDraft')
+    expect(result.current.menuActions[2].label).toBe('deleteDraft')
+    expect(result.current.menuActions[3].label).toBe('suspend')
   })
 
   it('should not return actions if user is admin and delegator, e-service is PUBLISHED with no draft descriptors', () => {
@@ -252,7 +252,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is admin and delegator, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
@@ -267,8 +267,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is admin and delegator, e-service is PUBLISHED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -283,8 +283,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is admin and delegate, e-service is PUBLISHED with no draft descriptors', () => {
@@ -298,9 +298,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(2)
-    expect(result.current.actions[0].label).toBe('createNewDraft')
-    expect(result.current.actions[1].label).toBe('suspend')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('createNewDraft')
+    expect(result.current.menuActions[1].label).toBe('suspend')
   })
 
   it('should return the correct actions if user is admin and delegate, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
@@ -315,10 +315,10 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(3)
-    expect(result.current.actions[0].label).toBe('manageDraft')
-    expect(result.current.actions[1].label).toBe('deleteDraft')
-    expect(result.current.actions[2].label).toBe('suspend')
+    expect(result.current.menuActions).toHaveLength(3)
+    expect(result.current.menuActions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions[1].label).toBe('deleteDraft')
+    expect(result.current.menuActions[2].label).toBe('suspend')
   })
 
   it('should return the correct actions if user is admin and delegate, e-service is PUBLISHED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -333,8 +333,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('suspend')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('suspend')
   })
 
   it('should return the correct actions if user is admin and e-service is SUSPENDED with no draft descriptors', () => {
@@ -343,10 +343,10 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(3)
-    expect(result.current.actions[0].label).toBe('activate')
-    expect(result.current.actions[1].label).toBe('clone')
-    expect(result.current.actions[2].label).toBe('createNewDraft')
+    expect(result.current.menuActions).toHaveLength(3)
+    expect(result.current.menuActions[0].label).toBe('activate')
+    expect(result.current.menuActions[1].label).toBe('clone')
+    expect(result.current.menuActions[2].label).toBe('createNewDraft')
   })
 
   it('should return the correct actions if user is admin and e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
@@ -356,11 +356,11 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(4)
-    expect(result.current.actions[0].label).toBe('activate')
-    expect(result.current.actions[1].label).toBe('clone')
-    expect(result.current.actions[2].label).toBe('manageDraft')
-    expect(result.current.actions[3].label).toBe('deleteDraft')
+    expect(result.current.menuActions).toHaveLength(4)
+    expect(result.current.menuActions[0].label).toBe('activate')
+    expect(result.current.menuActions[1].label).toBe('clone')
+    expect(result.current.menuActions[2].label).toBe('manageDraft')
+    expect(result.current.menuActions[3].label).toBe('deleteDraft')
   })
 
   it('should not return actions if user is admin and delegator, e-service is SUSPENDED with no draft descriptors', () => {
@@ -374,7 +374,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is admin and delegator, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
@@ -389,7 +389,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return the correct actions if user is admin and delegator, e-service is SUSPENDED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -404,8 +404,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is admin and delegate, e-service is SUSPENDED with no draft descriptors', () => {
@@ -419,9 +419,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(2)
-    expect(result.current.actions[0].label).toBe('activate')
-    expect(result.current.actions[1].label).toBe('createNewDraft')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('activate')
+    expect(result.current.menuActions[1].label).toBe('createNewDraft')
   })
 
   it('should return the correct actions if user is admin and delegate, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
@@ -436,10 +436,10 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(3)
-    expect(result.current.actions[0].label).toBe('activate')
-    expect(result.current.actions[1].label).toBe('manageDraft')
-    expect(result.current.actions[2].label).toBe('deleteDraft')
+    expect(result.current.menuActions).toHaveLength(3)
+    expect(result.current.menuActions[0].label).toBe('activate')
+    expect(result.current.menuActions[1].label).toBe('manageDraft')
+    expect(result.current.menuActions[2].label).toBe('deleteDraft')
   })
 
   it('should return the correct actions if user is admin and delegate, e-service is SUSPENDED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -454,8 +454,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('activate')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('activate')
   })
 
   it('should return the correct actions if user is an api operator and e-service is DRAFT with no active descriptors', () => {
@@ -465,8 +465,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('delete')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('delete')
   })
 
   it('should not return actions if user is an api operator and delegator, e-service is DRAFT with no active descriptors', () => {
@@ -481,7 +481,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return the correct actions if user is an api operator and delegate, e-service is DRAFT with no active descriptors', () => {
@@ -496,7 +496,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is an api operator and e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
@@ -506,7 +506,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return the correct actions if user is an api operator and delegator, e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
@@ -521,9 +521,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(2)
-    expect(result.current.actions[0].label).toBe('approve')
-    expect(result.current.actions[1].label).toBe('reject')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('approve')
+    expect(result.current.menuActions[1].label).toBe('reject')
   })
 
   it('should not return actions if user is an api operator and delegate, e-service is WAITING_FOR_APPROVAL with no active descriptors', () => {
@@ -538,7 +538,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is an api operator and e-service is ARCHIVED', () => {
@@ -548,7 +548,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is an api operator and delegator, e-service is ARCHIVED', () => {
@@ -563,7 +563,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is an api operator and delegate, e-service is ARCHIVED', () => {
@@ -578,7 +578,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is an api operator and e-service is DEPRECATED', () => {
@@ -588,7 +588,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is an api operator and delegator, e-service is DEPRECATED', () => {
@@ -603,7 +603,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is an api operator and delegate, e-service is DEPRECATED', () => {
@@ -618,7 +618,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return the correct actions if user is an api operator and e-service is PUBLISHED with no draft descriptors', () => {
@@ -628,9 +628,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(2)
-    expect(result.current.actions[0].label).toBe('clone')
-    expect(result.current.actions[1].label).toBe('createNewDraft')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('clone')
+    expect(result.current.menuActions[1].label).toBe('createNewDraft')
   })
 
   it('should return the correct actions if user is an api operator and e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
@@ -641,10 +641,10 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(3)
-    expect(result.current.actions[0].label).toBe('clone')
-    expect(result.current.actions[1].label).toBe('manageDraft')
-    expect(result.current.actions[2].label).toBe('deleteDraft')
+    expect(result.current.menuActions).toHaveLength(3)
+    expect(result.current.menuActions[0].label).toBe('clone')
+    expect(result.current.menuActions[1].label).toBe('manageDraft')
+    expect(result.current.menuActions[2].label).toBe('deleteDraft')
   })
 
   it('should not return actions if user is an api operator and delegator, e-service is PUBLISHED with no draft descriptors', () => {
@@ -659,7 +659,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is an api operator and delegator, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
@@ -675,8 +675,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is an api operator and delegator, e-service is PUBLISHED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -692,8 +692,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is an api operator and delegate, e-service is PUBLISHED with no draft descriptors', () => {
@@ -708,8 +708,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('createNewDraft')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('createNewDraft')
   })
 
   it('should return the correct actions if user is an api operator and delegate, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
@@ -725,9 +725,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(2)
-    expect(result.current.actions[0].label).toBe('manageDraft')
-    expect(result.current.actions[1].label).toBe('deleteDraft')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions[1].label).toBe('deleteDraft')
   })
 
   it('should not return actions if user is an api operator and delegate, e-service is PUBLISHED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -743,7 +743,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return the correct actions if user is an api operator and e-service is SUSPENDED with no draft descriptors', () => {
@@ -753,9 +753,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(2)
-    expect(result.current.actions[0].label).toBe('clone')
-    expect(result.current.actions[1].label).toBe('createNewDraft')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('clone')
+    expect(result.current.menuActions[1].label).toBe('createNewDraft')
   })
 
   it('should return the correct actions if user is an api operator and e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
@@ -766,10 +766,10 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(3)
-    expect(result.current.actions[0].label).toBe('clone')
-    expect(result.current.actions[1].label).toBe('manageDraft')
-    expect(result.current.actions[2].label).toBe('deleteDraft')
+    expect(result.current.menuActions).toHaveLength(3)
+    expect(result.current.menuActions[0].label).toBe('clone')
+    expect(result.current.menuActions[1].label).toBe('manageDraft')
+    expect(result.current.menuActions[2].label).toBe('deleteDraft')
   })
 
   it('should not return actions if user is an api operator and delegator, e-service is SUSPENDED with no draft descriptors', () => {
@@ -784,7 +784,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should not return actions if user is an api operator and delegator, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
@@ -800,7 +800,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should return the correct actions if user is an api operator and delegator, e-service is SUSPENDED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -816,8 +816,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is an api operator and delegate, e-service is SUSPENDED with no draft descriptors', () => {
@@ -832,8 +832,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].label).toBe('createNewDraft')
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('createNewDraft')
   })
 
   it('should return the correct actions if user is an api operator and delegate, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
@@ -849,9 +849,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(2)
-    expect(result.current.actions[0].label).toBe('manageDraft')
-    expect(result.current.actions[1].label).toBe('deleteDraft')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions[1].label).toBe('deleteDraft')
   })
 
   it('should not return actions if user is an api operator and delegate, e-service is SUSPENDED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -867,7 +867,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 
   it('should navigate to PROVIDE_ESERVICE_EDIT page on clone action success', async () => {
@@ -879,7 +879,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
     })
     const { result, history } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
 
-    const cloneAction = result.current.actions[1]
+    const cloneAction = result.current.menuActions[1]
 
     expect(cloneAction.label).toBe('clone')
 
@@ -906,7 +906,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
     })
     const { result, history } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
 
-    const cloneAction = result.current.actions[2]
+    const cloneAction = result.current.menuActions[2]
 
     expect(cloneAction.label).toBe('createNewDraft')
 
@@ -933,6 +933,6 @@ describe('useGetProviderEServiceTableActions tests', () => {
       delegation: undefined,
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.actions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(0)
   })
 })

--- a/src/hooks/useGetEServiceConsumerActions.ts
+++ b/src/hooks/useGetEServiceConsumerActions.ts
@@ -202,7 +202,7 @@ function useGetEServiceConsumerActions(
 
   const tenants: DelegationTenant[] = jwt
     ? [{ id: jwt.organizationId as string, name: jwt.organization.name }, ...(delegators ?? [])]
-    : delegators ?? []
+    : (delegators ?? [])
 
   const tenantsWithoutAgreement = tenants.filter(
     (tenant) => !existingAgreements.some((agreement) => agreement.consumerId === tenant.id)

--- a/src/hooks/useGetEServiceConsumerActions.ts
+++ b/src/hooks/useGetEServiceConsumerActions.ts
@@ -23,7 +23,12 @@ function useGetEServiceConsumerActions(
   descriptor?: CatalogEServiceDescriptor,
   delegators?: Array<DelegationTenant>,
   isDelegator?: boolean
-) {
+): {
+  primaryAction: ActionItemButton | undefined
+  secondaryAction: ActionItemButton | undefined
+  menuActions: Array<ActionItemButton>
+  headerInfoActions: Array<ActionItemButton>
+} {
   const { t } = useTranslation('eservice')
   const { jwt, isAdmin } = AuthHooks.useJwt()
 
@@ -36,7 +41,13 @@ function useGetEServiceConsumerActions(
 
   const actions: Array<ActionItemButton> = []
 
-  if (!descriptor || !isAdmin) return { actions: [] satisfies Array<ActionItemButton> }
+  if (!descriptor || !isAdmin)
+    return {
+      primaryAction: undefined,
+      secondaryAction: undefined,
+      menuActions: [],
+      headerInfoActions: [],
+    }
 
   const isMine = Boolean(descriptor.eservice.isMine)
   const isSubscribed = descriptor.eservice.isSubscribed
@@ -261,7 +272,12 @@ function useGetEServiceConsumerActions(
     })
   }
 
-  return { actions }
+  return {
+    primaryAction: undefined,
+    secondaryAction: undefined,
+    menuActions: actions,
+    headerInfoActions: [],
+  }
 }
 
 export default useGetEServiceConsumerActions

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -31,7 +31,12 @@ export function useGetProviderEServiceActions(
   delegation?: DelegationWithCompactTenants,
   hasPersonalData?: boolean,
   where?: 'tableRow' | 'detailsPage'
-): { actions: Array<ActionItemButton> } {
+): {
+  primaryAction: ActionItemButton | undefined
+  secondaryAction: ActionItemButton | undefined
+  menuActions: Array<ActionItemButton>
+  headerInfoActions: Array<ActionItemButton>
+} {
   const { t } = useTranslation('common', { keyPrefix: 'actions' })
   const { t: tDialogApproveDelegatedVersionDraft } = useTranslation('shared-components', {
     keyPrefix: 'dialogApproveDelegatedVersionDraft',
@@ -67,7 +72,13 @@ export function useGetProviderEServiceActions(
   const isDraftWaitingForApproval = draftDescriptorState === 'WAITING_FOR_APPROVAL'
 
   // Only admin and operatorAPI can see actions
-  if (!isAdmin && !isOperatorAPI) return { actions: [] }
+  if (!isAdmin && !isOperatorAPI)
+    return {
+      primaryAction: undefined,
+      secondaryAction: undefined,
+      menuActions: [],
+      headerInfoActions: [],
+    }
 
   const deleteDraftAction: ActionItemButton = {
     action: deleteDraft.bind(null, { eserviceId }),
@@ -1013,5 +1024,10 @@ export function useGetProviderEServiceActions(
     ? availableFromTemplateEserviceAction
     : availableClassicEServiceAction
 
-  return { actions: availableAction }
+  return {
+    primaryAction: undefined,
+    secondaryAction: undefined,
+    menuActions: availableAction,
+    headerInfoActions: [],
+  }
 }

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { EServiceQueries } from '@/api/eservice'
-import { PageContainer } from '@/components/layout/containers'
 import useGetEServiceConsumerActions from '@/hooks/useGetEServiceConsumerActions'
 import { useParams } from '@/router'
 import { useTranslation } from 'react-i18next'
@@ -14,7 +13,7 @@ import { useActiveTab } from '@/hooks/useActiveTab'
 import ConsumerEServiceDetailsTab from './components/ConsumerEServiceDetailsTab/ConsumerEServiceDetailsTab'
 import ConsumerLinkedPurposeTemplatesTab from './components/ConsumerLinkedPurposeTemplatesTab.tsx/ConsumerLinkedPurposeTemplatesTab'
 import { useMarkNotificationsAsRead } from '@/hooks/useMarkNotificationsAsRead'
-import type { StatusChip } from '@/components/shared/StatusChip'
+import { NewPageContainer } from '@/components/layout/containers/NewPageContainer'
 
 const ConsumerEServiceDetailsPage: React.FC = () => {
   const { t } = useTranslation('eservice', { keyPrefix: 'read' })
@@ -61,38 +60,11 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
     descriptorId: descriptor?.id,
   })
 
-  const getStatusChips = () => {
-    let eserviceChip: React.ComponentProps<typeof StatusChip> | undefined
-    let versionChip: React.ComponentProps<typeof StatusChip> | undefined
-
-    if (descriptor && descriptor.eservice.activeDescriptor) {
-      eserviceChip = {
-        for: 'eservice',
-        state: descriptor.eservice.activeDescriptor.state,
-      }
-
-      if (
-        descriptor.id !== descriptor.eservice.activeDescriptor.id &&
-        descriptor.state !== descriptor.eservice.activeDescriptor.state
-      ) {
-        versionChip = { for: 'eservice', state: descriptor.state }
-      }
-    }
-
-    return {
-      eserviceChip,
-      versionChip,
-    }
-  }
-
-  const statusChips = getStatusChips()
-
   return (
-    <PageContainer
+    <NewPageContainer
       title={descriptor?.eservice.name || ''}
       topSideActions={actions}
       isLoading={!descriptor}
-      statusChip={statusChips.eserviceChip}
       backToAction={{
         label: t('actions.backToCatalogLabel'),
         to: 'SUBSCRIBE_CATALOG_LIST',
@@ -103,7 +75,7 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
               label: t('versionHeaderLabel'),
               link: { label: descriptor.version, onClink: () => {} }, // TODO navigation function
               actions: [], // TODO actions for secondHeader
-              statusChip: statusChips.versionChip,
+              statusChip: { for: 'eservice', state: descriptor.state },
             }
           : undefined
       }
@@ -126,7 +98,7 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
           <ConsumerLinkedPurposeTemplatesTab />
         </TabPanel>
       </TabContext>
-    </PageContainer>
+    </NewPageContainer>
   )
 }
 

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -69,7 +69,7 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
         label: t('actions.backToCatalogLabel'),
         to: 'SUBSCRIBE_CATALOG_LIST',
       }}
-      secondaryIntro={
+      infoSection={
         descriptor
           ? {
               label: t('versionHeaderLabel'),

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -73,8 +73,8 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
         descriptor
           ? {
               label: t('versionHeaderLabel'),
-              link: { label: descriptor.version, onClink: () => {} }, // TODO navigation function
               actions: [], // TODO actions for secondHeader
+              link: { label: descriptor.version, onClick: () => {} }, // TODO navigation function,
               statusChip: { for: 'eservice', state: descriptor.state },
             }
           : undefined

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -14,6 +14,7 @@ import { useActiveTab } from '@/hooks/useActiveTab'
 import ConsumerEServiceDetailsTab from './components/ConsumerEServiceDetailsTab/ConsumerEServiceDetailsTab'
 import ConsumerLinkedPurposeTemplatesTab from './components/ConsumerLinkedPurposeTemplatesTab.tsx/ConsumerLinkedPurposeTemplatesTab'
 import { useMarkNotificationsAsRead } from '@/hooks/useMarkNotificationsAsRead'
+import type { StatusChip } from '@/components/shared/StatusChip'
 
 const ConsumerEServiceDetailsPage: React.FC = () => {
   const { t } = useTranslation('eservice', { keyPrefix: 'read' })
@@ -60,16 +61,52 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
     descriptorId: descriptor?.id,
   })
 
+  const getStatusChips = () => {
+    let eserviceChip: React.ComponentProps<typeof StatusChip> | undefined
+    let versionChip: React.ComponentProps<typeof StatusChip> | undefined
+
+    if (descriptor && descriptor.eservice.activeDescriptor) {
+      eserviceChip = {
+        for: 'eservice',
+        state: descriptor.eservice.activeDescriptor.state,
+      }
+
+      if (
+        descriptor.id !== descriptor.eservice.activeDescriptor.id &&
+        descriptor.state !== descriptor.eservice.activeDescriptor.state
+      ) {
+        versionChip = { for: 'eservice', state: descriptor.state }
+      }
+    }
+
+    return {
+      eserviceChip,
+      versionChip,
+    }
+  }
+
+  const statusChips = getStatusChips()
+
   return (
     <PageContainer
       title={descriptor?.eservice.name || ''}
       topSideActions={actions}
       isLoading={!descriptor}
-      statusChip={descriptor ? { for: 'eservice', state: descriptor?.state } : undefined}
+      statusChip={statusChips.eserviceChip}
       backToAction={{
         label: t('actions.backToCatalogLabel'),
         to: 'SUBSCRIBE_CATALOG_LIST',
       }}
+      secondaryIntro={
+        descriptor
+          ? {
+              label: t('versionHeaderLabel'),
+              link: { label: descriptor.version, onClink: () => {} }, // TODO navigation function
+              actions: [], // TODO actions for secondHeader
+              statusChip: statusChips.versionChip,
+            }
+          : undefined
+      }
     >
       <TabContext value={activeTab}>
         <TabList

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -73,8 +73,8 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
         descriptor
           ? {
               label: t('versionHeaderLabel'),
-              actions: [], // TODO actions for secondHeader
               link: { label: descriptor.version, onClick: () => {} }, // TODO navigation function,
+              // // TODO actions for secondHeader
               statusChip: { for: 'eservice', state: descriptor.state },
             }
           : undefined

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -65,18 +65,8 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
     <NewPageContainer
       title={descriptor?.eservice.name || ''}
       statusChip={descriptor && { for: 'eservice', state: descriptor.state }}
-      primaryAction={{
-        action: () => {},
-        label: 'test button primary',
-        color: 'primary',
-        variant: 'contained',
-      }} // TODO remove for variable
-      secondaryAction={{
-        action: () => {},
-        label: 'test button secondary',
-        color: 'primary',
-        variant: 'outlined',
-      }} // TODO remove for variable
+      primaryAction={primaryAction}
+      secondaryAction={secondaryAction}
       menuActions={menuActions}
       isLoading={!descriptor}
       backToAction={{
@@ -87,7 +77,7 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
         descriptor
           ? {
               label: t('versionHeaderLabel'),
-              link: { label: descriptor.version, onClick: () => {} }, // TODO navigation function,
+              shortcut: { type: 'button', label: descriptor.version, onClick: () => {} }, // TODO navigation function
               actions: headerInfoActions,
               statusChip: { for: 'eservice', state: descriptor.state },
             }

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -64,7 +64,6 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
   return (
     <NewPageContainer
       title={descriptor?.eservice.name || ''}
-      statusChip={descriptor && { for: 'eservice', state: descriptor.state }}
       primaryAction={primaryAction}
       secondaryAction={secondaryAction}
       menuActions={menuActions}

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -53,7 +53,8 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
 
   const isDelegator = delegations.length > 0
 
-  const { actions } = useGetEServiceConsumerActions(descriptor, delegators, isDelegator)
+  const { primaryAction, secondaryAction, menuActions, headerInfoActions } =
+    useGetEServiceConsumerActions(descriptor, delegators, isDelegator)
 
   useTrackPageViewEvent('INTEROP_CATALOG_READ', {
     eserviceId: descriptor?.eservice.id,
@@ -63,7 +64,20 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
   return (
     <NewPageContainer
       title={descriptor?.eservice.name || ''}
-      topSideActions={actions}
+      statusChip={descriptor && { for: 'eservice', state: descriptor.state }}
+      primaryAction={{
+        action: () => {},
+        label: 'test button primary',
+        color: 'primary',
+        variant: 'contained',
+      }} // TODO remove for variable
+      secondaryAction={{
+        action: () => {},
+        label: 'test button secondary',
+        color: 'primary',
+        variant: 'outlined',
+      }} // TODO remove for variable
+      menuActions={menuActions}
       isLoading={!descriptor}
       backToAction={{
         label: t('actions.backToCatalogLabel'),
@@ -74,7 +88,7 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
           ? {
               label: t('versionHeaderLabel'),
               link: { label: descriptor.version, onClick: () => {} }, // TODO navigation function,
-              // // TODO actions for secondHeader
+              actions: headerInfoActions,
               statusChip: { for: 'eservice', state: descriptor.state },
             }
           : undefined

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -27,23 +27,26 @@ const ProviderEServiceDetailsPage: React.FC = () => {
   const isEserviceFromTemplate = Boolean(descriptor?.templateRef)
 
   descriptor?.delegation
-  const { actions } = useGetProviderEServiceActions(
-    eserviceId,
-    descriptor?.state,
-    descriptor?.eservice.draftDescriptor?.state,
-    descriptorId,
-    descriptor?.eservice.draftDescriptor?.id,
-    descriptor?.eservice.mode,
-    descriptor?.eservice.name,
-    descriptor?.templateRef?.isNewTemplateVersionAvailable ?? false,
-    isEserviceFromTemplate,
-    descriptor?.delegation
-  )
+  const { primaryAction, secondaryAction, menuActions, headerInfoActions } =
+    useGetProviderEServiceActions(
+      eserviceId,
+      descriptor?.state,
+      descriptor?.eservice.draftDescriptor?.state,
+      descriptorId,
+      descriptor?.eservice.draftDescriptor?.id,
+      descriptor?.eservice.mode,
+      descriptor?.eservice.name,
+      descriptor?.templateRef?.isNewTemplateVersionAvailable ?? false,
+      isEserviceFromTemplate,
+      descriptor?.delegation
+    )
 
   return (
     <NewPageContainer
       title={descriptor?.eservice.name || ''}
-      topSideActions={actions}
+      primaryAction={primaryAction}
+      secondaryAction={secondaryAction}
+      menuActions={menuActions}
       isLoading={!descriptor}
       backToAction={{
         label: t('actions.backToListLabel'),
@@ -54,7 +57,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
           ? {
               label: t('versionHeaderLabel'),
               link: { label: descriptor.version, onClick: () => {} }, // TODO navigation function
-              // TODO actions for secondHeader
+              actions: headerInfoActions,
               statusChip: { for: 'eservice', state: descriptor.state },
             }
           : undefined

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -54,7 +54,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
           ? {
               label: t('versionHeaderLabel'),
               link: { label: descriptor.version, onClick: () => {} }, // TODO navigation function
-              actions: [], // TODO actions for secondHeader
+              // TODO actions for secondHeader
               statusChip: { for: 'eservice', state: descriptor.state },
             }
           : undefined

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -56,7 +56,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
         descriptor
           ? {
               label: t('versionHeaderLabel'),
-              link: { label: descriptor.version, onClick: () => {} }, // TODO navigation function
+              shortcut: { type: 'button', label: descriptor.version, onClick: () => {} }, // TODO navigation function
               actions: headerInfoActions,
               statusChip: { for: 'eservice', state: descriptor.state },
             }

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -11,6 +11,8 @@ import { TabContext, TabList, TabPanel } from '@mui/lab'
 import { useActiveTab } from '@/hooks/useActiveTab'
 import { ProviderEserviceDetailsTab } from './components/ProviderEServiceDetailsTab/ProviderEServiceDetailsTab'
 import { ProviderEserviceKeychainsTab } from './components/ProviderEServiceKeychainsTab/ProviderEServiceKeychainsTab'
+import type { StatusChip } from '@/components/shared/StatusChip'
+import type { CompactDescriptor } from '@/api/api.generatedTypes'
 
 const ProviderEServiceDetailsPage: React.FC = () => {
   const { t } = useTranslation('eservice', { keyPrefix: 'read' })
@@ -40,23 +42,65 @@ const ProviderEServiceDetailsPage: React.FC = () => {
     descriptor?.delegation
   )
 
+  const getStatusChips = () => {
+    let eserviceChip: React.ComponentProps<typeof StatusChip> | undefined
+    let versionChip: React.ComponentProps<typeof StatusChip> | undefined
+
+    if (descriptor) {
+      const lastActiveDescriptor = descriptor.eservice.descriptors.reduce<
+        CompactDescriptor | undefined
+      >((acc, curr) => {
+        if (curr.state !== 'DRAFT') {
+          if (!acc || curr.version > acc.version) {
+            return curr
+          }
+        }
+        return acc
+      }, undefined)
+
+      eserviceChip = lastActiveDescriptor
+        ? {
+            for: 'eservice',
+            state: lastActiveDescriptor?.state,
+          }
+        : undefined
+
+      if (
+        descriptor.id !== lastActiveDescriptor?.id &&
+        descriptor.state !== lastActiveDescriptor?.state
+      ) {
+        versionChip = { for: 'eservice', state: descriptor.state }
+      }
+    }
+
+    return {
+      eserviceChip,
+      versionChip,
+    }
+  }
+
+  const statusChips = getStatusChips()
+
   return (
     <PageContainer
       title={descriptor?.eservice.name || ''}
       topSideActions={actions}
       isLoading={!descriptor}
-      statusChip={
-        descriptor
-          ? {
-              for: 'eservice',
-              state: descriptor?.state,
-            }
-          : undefined
-      }
+      statusChip={statusChips.eserviceChip}
       backToAction={{
         label: t('actions.backToListLabel'),
         to: 'PROVIDE_ESERVICE_LIST',
       }}
+      secondaryIntro={
+        descriptor
+          ? {
+              label: t('versionHeaderLabel'),
+              link: { label: descriptor.version, onClink: () => {} }, // TODO navigation function
+              actions: [], // TODO actions for secondHeader
+              statusChip: statusChips.versionChip,
+            }
+          : undefined
+      }
     >
       <TabContext value={activeTab}>
         <TabList onChange={updateActiveTab} aria-label={t('tabs.ariaLabel')} variant="fullWidth">

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -26,7 +26,6 @@ const ProviderEServiceDetailsPage: React.FC = () => {
 
   const isEserviceFromTemplate = Boolean(descriptor?.templateRef)
 
-  descriptor?.delegation
   const { primaryAction, secondaryAction, menuActions, headerInfoActions } =
     useGetProviderEServiceActions(
       eserviceId,

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -53,7 +53,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
         descriptor
           ? {
               label: t('versionHeaderLabel'),
-              link: { label: descriptor.version, onClink: () => {} }, // TODO navigation function
+              link: { label: descriptor.version, onClick: () => {} }, // TODO navigation function
               actions: [], // TODO actions for secondHeader
               statusChip: { for: 'eservice', state: descriptor.state },
             }

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { EServiceQueries } from '@/api/eservice'
-import { PageContainer } from '@/components/layout/containers'
 import { useParams } from '@/router'
 import { useMarkNotificationsAsRead } from '@/hooks/useMarkNotificationsAsRead'
 import { Tab } from '@mui/material'
@@ -11,8 +10,7 @@ import { TabContext, TabList, TabPanel } from '@mui/lab'
 import { useActiveTab } from '@/hooks/useActiveTab'
 import { ProviderEserviceDetailsTab } from './components/ProviderEServiceDetailsTab/ProviderEServiceDetailsTab'
 import { ProviderEserviceKeychainsTab } from './components/ProviderEServiceKeychainsTab/ProviderEServiceKeychainsTab'
-import type { StatusChip } from '@/components/shared/StatusChip'
-import type { CompactDescriptor } from '@/api/api.generatedTypes'
+import { NewPageContainer } from '@/components/layout/containers/NewPageContainer'
 
 const ProviderEServiceDetailsPage: React.FC = () => {
   const { t } = useTranslation('eservice', { keyPrefix: 'read' })
@@ -42,51 +40,11 @@ const ProviderEServiceDetailsPage: React.FC = () => {
     descriptor?.delegation
   )
 
-  const getStatusChips = () => {
-    let eserviceChip: React.ComponentProps<typeof StatusChip> | undefined
-    let versionChip: React.ComponentProps<typeof StatusChip> | undefined
-
-    if (descriptor) {
-      const lastActiveDescriptor = descriptor.eservice.descriptors.reduce<
-        CompactDescriptor | undefined
-      >((acc, curr) => {
-        if (curr.state !== 'DRAFT') {
-          if (!acc || curr.version > acc.version) {
-            return curr
-          }
-        }
-        return acc
-      }, undefined)
-
-      eserviceChip = lastActiveDescriptor
-        ? {
-            for: 'eservice',
-            state: lastActiveDescriptor?.state,
-          }
-        : undefined
-
-      if (
-        descriptor.id !== lastActiveDescriptor?.id &&
-        descriptor.state !== lastActiveDescriptor?.state
-      ) {
-        versionChip = { for: 'eservice', state: descriptor.state }
-      }
-    }
-
-    return {
-      eserviceChip,
-      versionChip,
-    }
-  }
-
-  const statusChips = getStatusChips()
-
   return (
-    <PageContainer
+    <NewPageContainer
       title={descriptor?.eservice.name || ''}
       topSideActions={actions}
       isLoading={!descriptor}
-      statusChip={statusChips.eserviceChip}
       backToAction={{
         label: t('actions.backToListLabel'),
         to: 'PROVIDE_ESERVICE_LIST',
@@ -97,7 +55,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
               label: t('versionHeaderLabel'),
               link: { label: descriptor.version, onClink: () => {} }, // TODO navigation function
               actions: [], // TODO actions for secondHeader
-              statusChip: statusChips.versionChip,
+              statusChip: { for: 'eservice', state: descriptor.state },
             }
           : undefined
       }
@@ -116,7 +74,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
           <ProviderEserviceKeychainsTab />
         </TabPanel>
       </TabContext>
-    </PageContainer>
+    </NewPageContainer>
   )
 }
 

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -49,7 +49,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
         label: t('actions.backToListLabel'),
         to: 'PROVIDE_ESERVICE_LIST',
       }}
-      secondaryIntro={
+      infoSection={
         descriptor
           ? {
               label: t('versionHeaderLabel'),

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableRow.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableRow.tsx
@@ -34,7 +34,7 @@ export const EServiceTableRow: React.FC<EServiceTableRow> = ({ eservice }) => {
   const { data: eserviceWithPersonalData } = useQuery(EServiceQueries.getSingle(eservice.id))
   const hasPersonalData = eserviceWithPersonalData?.personalData !== undefined
 
-  const { actions } = useGetProviderEServiceActions(
+  const { primaryAction, secondaryAction, menuActions } = useGetProviderEServiceActions(
     eservice.id,
     eservice.activeDescriptor?.state,
     eservice.draftDescriptor?.state,
@@ -64,6 +64,12 @@ export const EServiceTableRow: React.FC<EServiceTableRow> = ({ eservice }) => {
       EServiceQueries.getDescriptorProvider(eservice.id, eservice.activeDescriptor.id)
     )
   }
+
+  const actions = [
+    ...(primaryAction ? [primaryAction] : []),
+    ...(secondaryAction ? [secondaryAction] : []),
+    ...menuActions,
+  ]
 
   return (
     <TableRow

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -508,6 +508,7 @@
     "disabledTooltip": "Test e-service archived from the catalog and not usable."
   },
   "read": {
+    "versionHeaderLabel": "Version",
     "tabs": {
       "ariaLabel": "Two different tabs for e-service details and associated keychains",
       "eserviceDetails": "E-service details",

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -508,6 +508,7 @@
     "disabledTooltip": "E-service di test archiviato dal catalogo e non utilizzabile"
   },
   "read": {
+    "versionHeaderLabel": "Versione",
     "tabs": {
       "ariaLabel": "Due tab diverse per i dettagli dell'e-service e i portachiavi associati",
       "eserviceDetails": "Dettagli e-service",

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -53,7 +53,6 @@ export type ActionItem = {
   label: string
   fontColor?: string
   icon?: SvgIconComponent
-  hierarchy?: 'primary' | 'secondary'
 }
 export type ActionItemButton = ActionItem & {
   color?: ButtonProps['color']

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -48,10 +48,15 @@ export type Provider = 'provider'
 export type Consumer = 'consumer'
 export type ProviderOrConsumer = Provider | Consumer
 
-export type ActionItem = { action: VoidFunction; label: string; fontColor?: string }
+export type ActionItem = {
+  action: VoidFunction
+  label: string
+  fontColor?: string
+  icon?: SvgIconComponent
+  hierarchy?: 'primary' | 'secondary'
+}
 export type ActionItemButton = ActionItem & {
   color?: ButtonProps['color']
-  icon?: SvgIconComponent
   tooltip?: string
   disabled?: boolean
   variant?: ButtonProps['variant']


### PR DESCRIPTION
## 🔗 Issue

[PIN-9937](https://pagopa.atlassian.net/browse/PIN-9937)

## 📝 Description / Context

Implement component NewPageContainer that is a redesign of the PageContaier to include the new secondary header for eservice version. The new component can be used also for eservice information in the agreement details page or purpose details page but for now it is implemented only in consumer and provider eservice details pages. For now it is used only in eservice details pages

## 🛠 List of changes

- added new strings for version label
- implement NewPageContainer component to reflect the design.
- implemented new PageContainerSecondaryIntro component that show data about version or eventually eservice with some personalization allowed

## 🧪 How to test

- Open an e-service detail page.
- The component should show the eservice name, state and actions on the first row and a box with version informations and eventually actions
- Verify Italian and English copy.

## ⚠️ Notes

The get actions hooks are not updated because the BE is not ready so the integration is not done yet


[PIN-9937]: https://pagopa.atlassian.net/browse/PIN-9937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ