### PR TITLE
fix: added check about descriptors for rulesetExpiration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interop-dashboard-frontend",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "scripts": {

--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -72,6 +72,7 @@ const ProviderEServiceSummaryPage: React.FC = () => {
 
   const isEServiceFromTemplate = descriptor?.templateRef
 
+  // In this case "draft" version is the actual version that user is creating, so if the e-service has only one draft it means that it has never been published before.
   const hasOnlyOneDraft = descriptor?.eservice.descriptors.length === 0
 
   const handleDeleteDraft = () => {
@@ -196,8 +197,8 @@ const ProviderEServiceSummaryPage: React.FC = () => {
 
   const isRulesetExpired =
     // check if the e-service had already been published. In this case we have to skip ruleset expiration check (https://pagopa.atlassian.net/browse/PIN-9966)
-    descriptor?.eservice.descriptors.length === 0 &&
-    eserviceRiskAnalyses &&
+    hasOnlyOneDraft
+  eserviceRiskAnalyses &&
     eserviceRiskAnalyses.some(
       (riskAnalysis) =>
         riskAnalysis.rulesetExpiration && new Date(riskAnalysis.rulesetExpiration) < new Date()

--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -195,6 +195,8 @@ const ProviderEServiceSummaryPage: React.FC = () => {
   const eserviceRiskAnalyses = descriptor?.eservice.riskAnalysis
 
   const isRulesetExpired =
+    // check if the e-service had already been published. In this case we have to skip ruleset expiration check (https://pagopa.atlassian.net/browse/PIN-9966)
+    descriptor?.eservice.descriptors.length === 0 &&
     eserviceRiskAnalyses &&
     eserviceRiskAnalyses.some(
       (riskAnalysis) =>

--- a/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
@@ -275,6 +275,14 @@ describe('ProviderEServiceSummaryPage', () => {
       useQueryMock.mockReturnValue({
         data: createMockEServiceDescriptorProvider({
           eservice: {
+            descriptors: [
+              {
+                id: 'descriptor-id-001',
+                state: 'PUBLISHED',
+                version: '1',
+                audience: [],
+              },
+            ],
             riskAnalysis: [
               {
                 id: 'risk-analysis-id-001',

--- a/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
@@ -238,4 +238,67 @@ describe('ProviderEServiceSummaryPage', () => {
     expect(screen.queryByTestId('DeleteOutlineIcon')).not.toBeInTheDocument()
     expect(screen.queryByTestId('CreateIcon')).not.toBeInTheDocument()
   })
+
+  describe('isRulesetExpired', () => {
+    it('should be true when there are no other descriptors and riskAnalysis rulesetExpiration is expired', () => {
+      const mock = createMockEServiceDescriptorProvider()
+      mock.eservice.descriptors = []
+      mock.eservice.riskAnalysis = [
+        {
+          id: 'risk-analysis-id-001',
+          name: 'Risk Analysis 1',
+          riskAnalysisForm: {
+            riskAnalysisId: 'form-id-001',
+            version: 'version-001',
+            answers: 'answers-001',
+          },
+          createdAt: '',
+          rulesetExpiration: '2020-01-01T00:00:00Z',
+        },
+      ]
+
+      useQueryMock.mockReturnValue({
+        data: mock,
+        isLoading: false,
+      })
+
+      renderWithApplicationContext(<ProviderEServiceSummaryPage />, {
+        withReactQueryContext: true,
+        withRouterContext: true,
+      })
+
+      const publishButton = screen.getByRole('button', { name: 'publish' })
+      expect(publishButton).toBeDisabled()
+    })
+
+    it('should be false when there are other descriptors even if riskAnalysis rulesetExpiration is expired', () => {
+      useQueryMock.mockReturnValue({
+        data: createMockEServiceDescriptorProvider({
+          eservice: {
+            riskAnalysis: [
+              {
+                id: 'risk-analysis-id-001',
+                name: 'Risk Analysis 1',
+                riskAnalysisForm: {
+                  riskAnalysisId: 'form-id-001',
+                  version: 'version-001',
+                },
+                createdAt: '',
+                rulesetExpiration: '2020-01-01T00:00:00Z',
+              },
+            ],
+          },
+        }),
+        isLoading: false,
+      })
+
+      renderWithApplicationContext(<ProviderEServiceSummaryPage />, {
+        withReactQueryContext: true,
+        withRouterContext: true,
+      })
+
+      const publishButton = screen.getByRole('button', { name: 'publish' })
+      expect(publishButton).toBeEnabled()
+    })
+  })
 })


### PR DESCRIPTION
## 🔗 Issue
[PIN-9966](https://pagopa.atlassian.net/browse/PIN-9966)

## 📝 Description / Context

This PR fixes the ruleset expiration evaluation in Provider E-Service Summary.

Before this change, `isRulesetExpired` was evaluated only on `riskAnalysis.rulesetExpiration` which could incorrectly block publication even when the e-service already had published descriptors (new version flow).

Now isRulesetExpired is evaluated as true only when:

1. there are no other descriptors already published descriptors.length === 0
2. at least one riskAnalysis.rulesetExpiration is expired
 
This aligns the behavior with the expected business rule for first publication vs new version publication.



[PIN-9966]: https://pagopa.atlassian.net/browse/PIN-9966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ