### PR TITLE
fix: purpose creation from template required field (PIN-9838)

### DIFF
--- a/src/pages/ConsumerPurposeFromTemplateEditPage/components/PurposeFromTemplateEditStepGeneral/PurposeFromTemplateEditStepGeneralForm.tsx
+++ b/src/pages/ConsumerPurposeFromTemplateEditPage/components/PurposeFromTemplateEditStepGeneral/PurposeFromTemplateEditStepGeneralForm.tsx
@@ -113,6 +113,7 @@ const PurposeFromTemplateEditStepGeneralForm: React.FC<PurposeEditStepGeneralFor
             fullWidth
             inputProps={{ maxLength: 60 }}
             rules={{ required: true, minLength: 5 }}
+            required
           />
         </SectionContainer>
         <PurposeLoadEstimationSection


### PR DESCRIPTION
## Jira Issue
[PIN-9838](https://pagopa.atlassian.net/browse/PIN-9838)

## Context/Why
- Minor ui fix


## Key Changes
 - Add `required` flag to instance name field in `PurposeFromTemplateEditStepGeneralForm`



[PIN-9838]: https://pagopa.atlassian.net/browse/PIN-9838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ