### PR TITLE
feat: simulate token drawer (PIN-9879)

### DIFF
--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralForm.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralForm.tsx
@@ -312,6 +312,8 @@ export const VoucherInstructionsGeneralForm: React.FC = () => {
         onClose={closeDrawer}
         clientId={values.clientId || ''}
         purposeId={values.purposeId || ''}
+        eserviceId={values.eserviceId || ''}
+        producerKeychainId={values.producerKeychainId || ''}
       />
     </FormProvider>
   )

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
@@ -48,32 +48,32 @@ export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
           <>
             <InformationContainer
               direction="column"
-              label="eserviceId"
-              labelDescription={t('eserviceIdDescription')}
+              label={t('purposeEserviceId.label')}
+              labelDescription={t('purposeEserviceId.description')}
               copyToClipboard={{ value: purpose.eservice.id }}
               content={purpose.eservice.id}
             />
 
             <InformationContainer
               direction="column"
-              label="descriptorId"
-              labelDescription={t('descriptorIdDescription')}
+              label={t('descriptorId.label')}
+              labelDescription={t('descriptorId.description')}
               copyToClipboard={{ value: purpose.eservice.descriptor.id }}
               content={purpose.eservice.descriptor.id}
             />
 
             <InformationContainer
               direction="column"
-              label="agreementId"
-              labelDescription={t('agreementIdDescription')}
+              label={t('agreementId.label')}
+              labelDescription={t('agreementId.description')}
               copyToClipboard={{ value: purpose.agreement.id }}
               content={purpose.agreement.id}
             />
 
             <InformationContainer
               direction="column"
-              label="purposeId"
-              labelDescription={t('purposeIdDescription')}
+              label={t('purposeId.label')}
+              labelDescription={t('purposeId.description')}
               copyToClipboard={{ value: purpose.id }}
               content={purpose.id}
             />
@@ -82,8 +82,8 @@ export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
         {clientId && (
           <InformationContainer
             direction="column"
-            label="clientId"
-            labelDescription={t('clientIdDescription')}
+            label={t('clientId.label')}
+            labelDescription={t('clientId.description')}
             copyToClipboard={{ value: clientId }}
             content={clientId}
           />

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
@@ -6,22 +6,30 @@ import { Trans, useTranslation } from 'react-i18next'
 import { Link, Stack } from '@mui/material'
 import { apiGuideLink } from '@/config/constants'
 import { useQuery } from '@tanstack/react-query'
+import { KeychainQueries } from '@/api/keychain'
 
 type VoucherInstructionsGeneralFormCurrentIdsDrawerProps = {
   isOpen: boolean
   onClose: VoidFunction
   clientId: string
   purposeId: string
+  eserviceId: string
+  producerKeychainId: string
 }
 
 export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
   VoucherInstructionsGeneralFormCurrentIdsDrawerProps
-> = ({ isOpen, onClose, clientId, purposeId }) => {
+> = ({ isOpen, onClose, clientId, purposeId, eserviceId, producerKeychainId }) => {
   const { t } = useTranslation('voucher', { keyPrefix: 'generalForm.currentIdsDrawer' })
 
   const { data: purpose } = useQuery({
     ...PurposeQueries.getSingle(purposeId || ''),
     enabled: Boolean(purposeId),
+  })
+
+  const { data: keychain } = useQuery({
+    ...KeychainQueries.getSingle(producerKeychainId),
+    enabled: Boolean(producerKeychainId),
   })
 
   return (
@@ -71,14 +79,17 @@ export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
             />
           </>
         )}
-
-        <InformationContainer
-          direction="column"
-          label="clientId"
-          labelDescription={t('clientIdDescription')}
-          copyToClipboard={{ value: clientId }}
-          content={clientId}
-        />
+        {clientId && (
+          <>
+            <InformationContainer
+              direction="column"
+              label="clientId"
+              labelDescription={t('clientIdDescription')}
+              copyToClipboard={{ value: clientId }}
+              content={clientId}
+            />
+          </>
+        )}
 
         {purpose && (
           <>
@@ -96,6 +107,39 @@ export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
               labelDescription={t('consumerOrganizationId.description')}
               copyToClipboard={{ value: purpose.consumer.id }}
               content={purpose.consumer.id}
+            />
+          </>
+        )}
+        {producerKeychainId && (
+          <>
+            <InformationContainer
+              direction="column"
+              label="producerKeychainId"
+              labelDescription={t('producerKeychainId')}
+              copyToClipboard={{ value: producerKeychainId }}
+              content={producerKeychainId}
+            />
+          </>
+        )}
+        {keychain && (
+          <>
+            <InformationContainer
+              direction="column"
+              label={'producerId'}
+              labelDescription={t('producerId')}
+              copyToClipboard={{ value: keychain.producer.id }}
+              content={keychain.producer.id}
+            />
+          </>
+        )}
+        {eserviceId && (
+          <>
+            <InformationContainer
+              direction="column"
+              label="eserviceId"
+              labelDescription={t('eserviceId')}
+              copyToClipboard={{ value: eserviceId }}
+              content={eserviceId}
             />
           </>
         )}

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
@@ -117,7 +117,7 @@ export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
             content={producerKeychainId}
           />
         )}
-        {keychain && (
+        {keychain?.producer?.id && (
           <InformationContainer
             direction="column"
             label={t('producerId.label')}

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
@@ -80,15 +80,13 @@ export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
           </>
         )}
         {clientId && (
-          <>
-            <InformationContainer
-              direction="column"
-              label="clientId"
-              labelDescription={t('clientIdDescription')}
-              copyToClipboard={{ value: clientId }}
-              content={clientId}
-            />
-          </>
+          <InformationContainer
+            direction="column"
+            label="clientId"
+            labelDescription={t('clientIdDescription')}
+            copyToClipboard={{ value: clientId }}
+            content={clientId}
+          />
         )}
 
         {purpose && (
@@ -111,37 +109,31 @@ export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
           </>
         )}
         {producerKeychainId && (
-          <>
-            <InformationContainer
-              direction="column"
-              label="producerKeychainId"
-              labelDescription={t('producerKeychainId')}
-              copyToClipboard={{ value: producerKeychainId }}
-              content={producerKeychainId}
-            />
-          </>
+          <InformationContainer
+            direction="column"
+            label="producerKeychainId"
+            labelDescription={t('producerKeychainId')}
+            copyToClipboard={{ value: producerKeychainId }}
+            content={producerKeychainId}
+          />
         )}
         {keychain && (
-          <>
-            <InformationContainer
-              direction="column"
-              label={'producerId'}
-              labelDescription={t('producerId')}
-              copyToClipboard={{ value: keychain.producer.id }}
-              content={keychain.producer.id}
-            />
-          </>
+          <InformationContainer
+            direction="column"
+            label={'producerId'}
+            labelDescription={t('producerId')}
+            copyToClipboard={{ value: keychain.producer.id }}
+            content={keychain.producer.id}
+          />
         )}
         {eserviceId && !purposeId && (
-          <>
-            <InformationContainer
-              direction="column"
-              label="eserviceId"
-              labelDescription={t('eserviceId')}
-              copyToClipboard={{ value: eserviceId }}
-              content={eserviceId}
-            />
-          </>
+          <InformationContainer
+            direction="column"
+            label="eserviceId"
+            labelDescription={t('eserviceId')}
+            copyToClipboard={{ value: eserviceId }}
+            content={eserviceId}
+          />
         )}
       </Stack>
     </Drawer>

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
@@ -111,8 +111,8 @@ export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
         {producerKeychainId && (
           <InformationContainer
             direction="column"
-            label="producerKeychainId"
-            labelDescription={t('producerKeychainId')}
+            label={t('producerKeychainId.label')}
+            labelDescription={t('producerKeychainId.description')}
             copyToClipboard={{ value: producerKeychainId }}
             content={producerKeychainId}
           />
@@ -120,8 +120,8 @@ export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
         {keychain && (
           <InformationContainer
             direction="column"
-            label={'producerId'}
-            labelDescription={t('producerId')}
+            label={t('producerId.label')}
+            labelDescription={t('producerId.description')}
             copyToClipboard={{ value: keychain.producer.id }}
             content={keychain.producer.id}
           />
@@ -129,8 +129,8 @@ export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
         {eserviceId && !purposeId && (
           <InformationContainer
             direction="column"
-            label="eserviceId"
-            labelDescription={t('eserviceId')}
+            label={t('eserviceId.label')}
+            labelDescription={t('eserviceId.description')}
             copyToClipboard={{ value: eserviceId }}
             content={eserviceId}
           />

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/VoucherInstructionsGeneralFormCurrentIdsDrawer.tsx
@@ -132,7 +132,7 @@ export const VoucherInstructionsGeneralFormCurrentIdsDrawer: React.FC<
             />
           </>
         )}
-        {eserviceId && (
+        {eserviceId && !purposeId && (
           <>
             <InformationContainer
               direction="column"

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/__tests__/VoucherInstructionsGeneralFormCurrentIdsDrawer.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/__tests__/VoucherInstructionsGeneralFormCurrentIdsDrawer.test.tsx
@@ -1,7 +1,9 @@
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import { VoucherInstructionsGeneralFormCurrentIdsDrawer } from '../VoucherInstructionsGeneralFormCurrentIdsDrawer'
-import { screen } from '@testing-library/react'
-import { vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, vi } from 'vitest'
+
+const keychainMock = vi.fn()
 
 vi.mock('@/api/purpose', () => ({
   PurposeQueries: {
@@ -11,22 +13,12 @@ vi.mock('@/api/purpose', () => ({
         id: 'purpose-1',
         eservice: {
           id: 'purpose-eservice-1',
-          descriptor: {
-            id: 'descriptor-1',
-          },
-          producer: {
-            id: 'producer-1',
-          },
+          descriptor: { id: 'descriptor-1' },
+          producer: { id: 'producer-1' },
         },
-        agreement: {
-          id: 'agreement-1',
-        },
-        producer: {
-          id: 'producer-1',
-        },
-        consumer: {
-          id: 'consumer-1',
-        },
+        agreement: { id: 'agreement-1' },
+        producer: { id: 'producer-1' },
+        consumer: { id: 'consumer-1' },
       }),
     })),
   },
@@ -34,15 +26,7 @@ vi.mock('@/api/purpose', () => ({
 
 vi.mock('@/api/keychain', () => ({
   KeychainQueries: {
-    getSingle: vi.fn(() => ({
-      queryKey: ['keychain', 'keychain-1'],
-      queryFn: async () => ({
-        id: 'keychain-1',
-        producer: {
-          id: 'keychain-producer-1',
-        },
-      }),
-    })),
+    getSingle: (...args: unknown[]) => keychainMock(...args),
   },
 }))
 
@@ -56,27 +40,33 @@ describe('VoucherInstructionsGeneralFormCurrentIdsDrawer', () => {
     producerKeychainId: 'keychain-1',
   }
 
-  it('renders title and subtitle', async () => {
-    const props = {
-      ...defaultProps,
-    }
+  beforeEach(() => {
+    vi.clearAllMocks()
 
-    renderWithApplicationContext(<VoucherInstructionsGeneralFormCurrentIdsDrawer {...props} />, {
-      withReactQueryContext: true,
+    keychainMock.mockReturnValue({
+      queryKey: ['keychain', 'keychain-1'],
+      queryFn: async () => ({
+        id: 'keychain-1',
+        producer: { id: 'keychain-producer-1' },
+      }),
     })
+  })
+
+  it('renders title and subtitle', async () => {
+    renderWithApplicationContext(
+      <VoucherInstructionsGeneralFormCurrentIdsDrawer {...defaultProps} />,
+      { withReactQueryContext: true }
+    )
 
     expect(await screen.findByText('title')).toBeInTheDocument()
     expect(await screen.findByText('subtitle')).toBeInTheDocument()
   })
 
   it('renders purpose fields when data is present', async () => {
-    const props = {
-      ...defaultProps,
-    }
-
-    renderWithApplicationContext(<VoucherInstructionsGeneralFormCurrentIdsDrawer {...props} />, {
-      withReactQueryContext: true,
-    })
+    renderWithApplicationContext(
+      <VoucherInstructionsGeneralFormCurrentIdsDrawer {...defaultProps} />,
+      { withReactQueryContext: true }
+    )
 
     expect(await screen.findByText('client-1')).toBeInTheDocument()
     expect(await screen.findByText('purpose-1')).toBeInTheDocument()
@@ -85,17 +75,42 @@ describe('VoucherInstructionsGeneralFormCurrentIdsDrawer', () => {
     expect(await screen.findByText('consumer-1')).toBeInTheDocument()
   })
 
-  it('renders clientId, keychain and eserviceId props', async () => {
-    const props = {
-      ...defaultProps,
-    }
-
-    renderWithApplicationContext(<VoucherInstructionsGeneralFormCurrentIdsDrawer {...props} />, {
-      withReactQueryContext: true,
-    })
+  it('renders eserviceId, keychainId and producer keychain id props', async () => {
+    renderWithApplicationContext(
+      <VoucherInstructionsGeneralFormCurrentIdsDrawer {...defaultProps} purposeId="" />,
+      { withReactQueryContext: true }
+    )
 
     expect(await screen.findByText('keychain-1')).toBeInTheDocument()
     expect(await screen.findByText('eservice-1')).toBeInTheDocument()
     expect(await screen.findByText('keychain-producer-1')).toBeInTheDocument()
+  })
+
+  it('does not render keychain id, producer keychain id and eserviceId', async () => {
+    keychainMock.mockReturnValueOnce({
+      queryKey: ['keychain', 'empty'],
+      queryFn: async () => ({
+        id: '',
+        producer: {
+          id: '',
+        },
+      }),
+    })
+
+    renderWithApplicationContext(
+      <VoucherInstructionsGeneralFormCurrentIdsDrawer
+        {...defaultProps}
+        purposeId=""
+        eserviceId=""
+        producerKeychainId=""
+      />,
+      { withReactQueryContext: true }
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('keychain-1')).not.toBeInTheDocument()
+      expect(screen.queryByText('eservice-1')).not.toBeInTheDocument()
+      expect(screen.queryByText('keychain-producer-1')).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/__tests__/VoucherInstructionsGeneralFormCurrentIdsDrawer.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/__tests__/VoucherInstructionsGeneralFormCurrentIdsDrawer.test.tsx
@@ -10,7 +10,7 @@ vi.mock('@/api/purpose', () => ({
       queryFn: async () => ({
         id: 'purpose-1',
         eservice: {
-          id: 'eservice-1',
+          id: 'purpose-eservice-1',
           descriptor: {
             id: 'descriptor-1',
           },
@@ -32,12 +32,28 @@ vi.mock('@/api/purpose', () => ({
   },
 }))
 
+vi.mock('@/api/keychain', () => ({
+  KeychainQueries: {
+    getSingle: vi.fn(() => ({
+      queryKey: ['keychain', 'keychain-1'],
+      queryFn: async () => ({
+        id: 'keychain-1',
+        producer: {
+          id: 'keychain-producer-1',
+        },
+      }),
+    })),
+  },
+}))
+
 describe('VoucherInstructionsGeneralFormCurrentIdsDrawer', () => {
   const defaultProps = {
     isOpen: true,
     onClose: vi.fn(),
     clientId: 'client-1',
     purposeId: 'purpose-1',
+    eserviceId: 'eservice-1',
+    producerKeychainId: 'keychain-1',
   }
 
   it('renders title and subtitle', async () => {
@@ -67,5 +83,19 @@ describe('VoucherInstructionsGeneralFormCurrentIdsDrawer', () => {
     expect(await screen.findByText('agreement-1')).toBeInTheDocument()
     expect(await screen.findByText('producer-1')).toBeInTheDocument()
     expect(await screen.findByText('consumer-1')).toBeInTheDocument()
+  })
+
+  it('renders clientId, keychain and eserviceId props', async () => {
+    const props = {
+      ...defaultProps,
+    }
+
+    renderWithApplicationContext(<VoucherInstructionsGeneralFormCurrentIdsDrawer {...props} />, {
+      withReactQueryContext: true,
+    })
+
+    expect(await screen.findByText('keychain-1')).toBeInTheDocument()
+    expect(await screen.findByText('eservice-1')).toBeInTheDocument()
+    expect(await screen.findByText('keychain-producer-1')).toBeInTheDocument()
   })
 })

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/__tests__/VoucherInstructionsGeneralFormCurrentIdsDrawer.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/__tests__/VoucherInstructionsGeneralFormCurrentIdsDrawer.test.tsx
@@ -67,12 +67,13 @@ describe('VoucherInstructionsGeneralFormCurrentIdsDrawer', () => {
       <VoucherInstructionsGeneralFormCurrentIdsDrawer {...defaultProps} />,
       { withReactQueryContext: true }
     )
-
+    expect(await screen.findByText('purpose-eservice-1')).toBeInTheDocument()
     expect(await screen.findByText('client-1')).toBeInTheDocument()
     expect(await screen.findByText('purpose-1')).toBeInTheDocument()
     expect(await screen.findByText('agreement-1')).toBeInTheDocument()
     expect(await screen.findByText('producer-1')).toBeInTheDocument()
     expect(await screen.findByText('consumer-1')).toBeInTheDocument()
+    expect(screen.queryByText('eservice-1')).not.toBeInTheDocument()
   })
 
   it('renders eserviceId, keychainId and producer keychain id props', async () => {

--- a/src/static/locales/en/voucher.json
+++ b/src/static/locales/en/voucher.json
@@ -123,7 +123,10 @@
       "consumerOrganizationId": {
         "label": "organizationId (consumer)",
         "description": "The ID of your party"
-      }
+      },
+      "eserviceId": "The ID of the selected e-service",
+      "producerKeychainId": "The ID of the selected producer keychain",
+      "producerId": "The ID of the producer"
     }
   },
   "firstDPoPProofStep": {

--- a/src/static/locales/en/voucher.json
+++ b/src/static/locales/en/voucher.json
@@ -111,11 +111,26 @@
     "currentIdsDrawer": {
       "title": "View current selection IDs",
       "subtitle": "Useful parameters to obtain information through PDND APIs. Have questions? <1>Check the guide</1>.",
-      "eserviceIdDescription": "The ID of the e-service linked to the selected purpose",
-      "descriptorIdDescription": "The ID of the e-service version linked to the selected purpose",
-      "agreementIdDescription": "The ID of the service request linked to the selected purpose",
-      "purposeIdDescription": "The ID of the selected purpose",
-      "clientIdDescription": "The ID of this client",
+      "purposeEserviceId": {
+        "label": "eserviceId",
+        "description": "The ID of the e-service linked to the selected purpose"
+      },
+      "descriptorId": {
+        "label": "descriptorId",
+        "description": "The ID of the e-service version linked to the selected purpose"
+      },
+      "agreementId": {
+        "label": "agreementId",
+        "description": "The ID of the service request linked to the selected purpose"
+      },
+      "purposeId": {
+        "label": "purposeId",
+        "description": "The ID of the selected purpose"
+      },
+      "clientId": {
+        "label": "clientId",
+        "description": "The ID of this client"
+      },
       "producerOrganizationId": {
         "label": "organizationId (producer)",
         "description": "The ID of the producing party"

--- a/src/static/locales/en/voucher.json
+++ b/src/static/locales/en/voucher.json
@@ -124,9 +124,18 @@
         "label": "organizationId (consumer)",
         "description": "The ID of your party"
       },
-      "eserviceId": "The ID of the selected e-service",
-      "producerKeychainId": "The ID of the selected producer keychain",
-      "producerId": "The ID of the producer"
+      "eserviceId": {
+        "label": "eserviceId",
+        "description": "The ID of the selected e-service"
+      },
+      "producerKeychainId": {
+        "label": "producerKeychainId",
+        "description": "The ID of the selected producer keychain"
+      },
+      "producerId": {
+        "label": "producerId",
+        "description": "The ID of the producer"
+      }
     }
   },
   "firstDPoPProofStep": {

--- a/src/static/locales/it/voucher.json
+++ b/src/static/locales/it/voucher.json
@@ -111,11 +111,26 @@
     "currentIdsDrawer": {
       "title": "Visualizza id selezione corrente",
       "subtitle": "Parametri utili per ottenere informazioni attraverso le API di PDND Interoperabilità. Hai dubbi? <1>Consulta la guida</1>.",
-      "eserviceIdDescription": "L’id dell’e-service collegato alla finalità selezionata",
-      "descriptorIdDescription": "L’id della versione dell’e-service collegata alla finalità selezionata",
-      "agreementIdDescription": "L’id della richiesta di fruizione collegata alla finalità selezionata",
-      "purposeIdDescription": "L’id della finalità selezionata",
-      "clientIdDescription": "L’id di questo client",
+      "purposeEserviceId": {
+        "label": "eserviceId",
+        "description": "L’id dell’e-service collegato alla finalità selezionata"
+      },
+      "descriptorId": {
+        "label": "descriptorId",
+        "description": "L’id della versione dell’e-service collegata alla finalità selezionata"
+      },
+      "agreementId": {
+        "label": "agreementId",
+        "description": "L’id della richiesta di fruizione collegata alla finalità selezionata"
+      },
+      "purposeId": {
+        "label": "purposeId",
+        "description": "L’id della finalità selezionata"
+      },
+      "clientId": {
+        "label": "clientId",
+        "description": "L’id di questo client"
+      },
       "producerOrganizationId": {
         "label": "organizationId (erogatore)",
         "description": "L’id dell’ente erogatore"

--- a/src/static/locales/it/voucher.json
+++ b/src/static/locales/it/voucher.json
@@ -123,7 +123,10 @@
       "consumerOrganizationId": {
         "label": "organizationId (fruitore)",
         "description": "L’id del tuo ente"
-      }
+      },
+      "eserviceId": "L'id dell'e-service selezionato",
+      "producerKeychainId": "L'id del portachiavi erogatore selezionato",
+      "producerId": "L'id dell'erogatore selezionato"
     }
   },
   "firstDPoPProofStep": {

--- a/src/static/locales/it/voucher.json
+++ b/src/static/locales/it/voucher.json
@@ -124,9 +124,18 @@
         "label": "organizationId (fruitore)",
         "description": "L’id del tuo ente"
       },
-      "eserviceId": "L'id dell'e-service selezionato",
-      "producerKeychainId": "L'id del portachiavi erogatore selezionato",
-      "producerId": "L'id dell'erogatore selezionato"
+      "eserviceId": {
+        "label": "eserviceId",
+        "description": "L'id dell'e-service selezionato"
+      },
+      "producerKeychainId": {
+        "label": "producerKeychainId",
+        "description": "L'id del portachiavi erogatore selezionato"
+      },
+      "producerId": {
+        "label": "producerId",
+        "description": "L'id dell'erogatore selezionato"
+      }
     }
   },
   "firstDPoPProofStep": {


### PR DESCRIPTION
## Issue
- [PIN-9879](https://pagopa.atlassian.net/browse/PIN-9879)
## Description / Context / Why
- Updated general form drawer rendering logic for InterationType: "ASYNC" and memberType: "PRODUCER" in order to show the following fields when open:
```
producerKeychainId
producerId
eserviceId
```
- Updated tests

[PIN-9879]: https://pagopa.atlassian.net/browse/PIN-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ