### PR TITLE
feat: added first DPoP simulate voucher step (PIN-9819)

### DIFF
--- a/public/data/it/dpop/preview/create_dpop_proof_auth_server.txt
+++ b/public/data/it/dpop/preview/create_dpop_proof_auth_server.txt
@@ -1,0 +1,6 @@
+python create_dpop_proof_auth_server.py \
+  --alg=INSERISCI_VALORE_ALG \
+  --typ=INSERISCI_VALORE_TYP \
+  --htm=INSERISCI_VALORE_HTM \
+  --htu=INSERISCI_VALORE_HTU \
+  --keyPath=PATH_CHIAVE_PRIVATA

--- a/public/data/it/dpop/preview/create_dpop_proof_resource_server.txt
+++ b/public/data/it/dpop/preview/create_dpop_proof_resource_server.txt
@@ -1,0 +1,7 @@
+python create_dpop_proof_resource_server.py \
+  --alg=INSERISCI_VALORE_ALG \
+  --typ=INSERISCI_VALORE_TYP \
+  --htm=INSERISCI_VALORE_HTM \
+  --htu=INSERISCI_VALORE_HTU \
+  --accessToken=INSERISCI_VALORE_ACCESS_TOKEN \
+  --keyPath=PATH_CHIAVE_PRIVATA

--- a/public/data/it/dpop/script/create_dpop_proof_auth_server.py
+++ b/public/data/it/dpop/script/create_dpop_proof_auth_server.py
@@ -1,0 +1,107 @@
+# La versione di Python in uso e' la 3.8
+# Prima di lanciare lo script, pip3 install python-jose cryptography
+# Attenzione: nella versione di Python 3.10,
+# la sintassi cambia e questo script non funziona
+
+from jose import jwt
+import datetime
+import argparse
+import uuid
+import os
+import base64
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa, ec
+from cryptography.hazmat.backends import default_backend
+
+
+def clear():
+  os.system('clear')
+
+
+def to_base64url(value):
+  return base64.urlsafe_b64encode(value).rstrip(b'=').decode('ascii')
+
+
+def int_to_bytes(value):
+  if value == 0:
+    return b'\x00'
+  length = (value.bit_length() + 7) // 8
+  return value.to_bytes(length, byteorder='big')
+
+
+def get_private_key(key_path):
+  with open(key_path, "rb") as private_key:
+    return private_key.read()
+
+
+def build_jwk_from_private_key(private_key_pem):
+  private_key = serialization.load_pem_private_key(
+    private_key_pem,
+    password=None,
+    backend=default_backend()
+  )
+
+  public_key = private_key.public_key()
+
+  if isinstance(public_key, rsa.RSAPublicKey):
+    numbers = public_key.public_numbers()
+    return {
+      "kty": "RSA",
+      "n": to_base64url(int_to_bytes(numbers.n)),
+      "e": to_base64url(int_to_bytes(numbers.e))
+    }
+
+  if isinstance(public_key, ec.EllipticCurvePublicKey):
+    numbers = public_key.public_numbers()
+
+    if not isinstance(numbers.curve, ec.SECP256R1):
+      raise ValueError("Only EC P-256 keys are supported by this script")
+
+    return {
+      "kty": "EC",
+      "crv": "P-256",
+      "x": to_base64url(int_to_bytes(numbers.x).rjust(32, b'\x00')),
+      "y": to_base64url(int_to_bytes(numbers.y).rjust(32, b'\x00'))
+    }
+
+  raise ValueError("Only RSA and EC P-256 keys are supported by this script")
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='Inputs')
+  parser.add_argument('--alg', required=True)
+  parser.add_argument('--typ', required=True)
+  parser.add_argument('--htm', required=True)
+  parser.add_argument('--htu', required=True)
+  parser.add_argument('--keyPath', required=True)
+
+  args = parser.parse_args()
+
+  issued = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+  jti = uuid.uuid4()
+
+  rsa_key = get_private_key(args.keyPath)
+  jwk = build_jwk_from_private_key(rsa_key)
+
+  headers_rsa = {
+    "alg": args.alg,
+    "typ": args.typ,
+    "jwk": jwk
+  }
+
+  payload = {
+    "htm": args.htm,
+    "htu": args.htu,
+    "jti": str(jti),
+    "iat": issued
+  }
+
+  dpop_proof = jwt.encode(
+    payload,
+    rsa_key,
+    algorithm=args.alg,
+    headers=headers_rsa
+  )
+
+  clear()
+  print(dpop_proof)

--- a/public/data/it/dpop/script/create_dpop_proof_resource_server.py
+++ b/public/data/it/dpop/script/create_dpop_proof_resource_server.py
@@ -1,0 +1,114 @@
+# La versione di Python in uso e' la 3.8
+# Prima di lanciare lo script, pip3 install python-jose cryptography
+# Attenzione: nella versione di Python 3.10,
+# la sintassi cambia e questo script non funziona
+
+from jose import jwt
+import datetime
+import argparse
+import uuid
+import os
+import base64
+import hashlib
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa, ec
+from cryptography.hazmat.backends import default_backend
+
+
+def clear():
+  os.system('clear')
+
+
+def to_base64url(value):
+  return base64.urlsafe_b64encode(value).rstrip(b'=').decode('ascii')
+
+
+def int_to_bytes(value):
+  if value == 0:
+    return b'\x00'
+  length = (value.bit_length() + 7) // 8
+  return value.to_bytes(length, byteorder='big')
+
+
+def get_private_key(key_path):
+  with open(key_path, "rb") as private_key:
+    return private_key.read()
+
+
+def build_jwk_from_private_key(private_key_pem):
+  private_key = serialization.load_pem_private_key(
+    private_key_pem,
+    password=None,
+    backend=default_backend()
+  )
+
+  public_key = private_key.public_key()
+
+  if isinstance(public_key, rsa.RSAPublicKey):
+    numbers = public_key.public_numbers()
+    return {
+      "kty": "RSA",
+      "n": to_base64url(int_to_bytes(numbers.n)),
+      "e": to_base64url(int_to_bytes(numbers.e))
+    }
+
+  if isinstance(public_key, ec.EllipticCurvePublicKey):
+    numbers = public_key.public_numbers()
+
+    if not isinstance(numbers.curve, ec.SECP256R1):
+      raise ValueError("Only EC P-256 keys are supported by this script")
+
+    return {
+      "kty": "EC",
+      "crv": "P-256",
+      "x": to_base64url(int_to_bytes(numbers.x).rjust(32, b'\x00')),
+      "y": to_base64url(int_to_bytes(numbers.y).rjust(32, b'\x00'))
+    }
+
+  raise ValueError("Only RSA and EC P-256 keys are supported by this script")
+
+
+def calculate_ath(access_token):
+  return to_base64url(hashlib.sha256(access_token.encode('utf-8')).digest())
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='Inputs')
+  parser.add_argument('--alg', required=True)
+  parser.add_argument('--typ', required=True)
+  parser.add_argument('--htm', required=True)
+  parser.add_argument('--htu', required=True)
+  parser.add_argument('--accessToken', required=True)
+  parser.add_argument('--keyPath', required=True)
+
+  args = parser.parse_args()
+
+  issued = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+  jti = uuid.uuid4()
+
+  rsa_key = get_private_key(args.keyPath)
+  jwk = build_jwk_from_private_key(rsa_key)
+
+  headers_rsa = {
+    "alg": args.alg,
+    "typ": args.typ,
+    "jwk": jwk
+  }
+
+  payload = {
+    "htm": args.htm,
+    "htu": args.htu,
+    "ath": calculate_ath(args.accessToken),
+    "jti": str(jti),
+    "iat": issued
+  }
+
+  dpop_proof = jwt.encode(
+    payload,
+    rsa_key,
+    algorithm=args.alg,
+    headers=headers_rsa
+  )
+
+  clear()
+  print(dpop_proof)

--- a/src/components/shared/StepActions.tsx
+++ b/src/components/shared/StepActions.tsx
@@ -32,34 +32,50 @@ type ActionSubmit = {
 }
 
 export type BackAction = ActionButton | ActionLink
+export type SecondaryAction = ActionButton | ActionLink
 export type ForwardAction = ActionButton | ActionSubmit
 
 type StepActionsProps = {
   back?: BackAction
+  secondaryAction?: SecondaryAction
   forward?: ForwardAction
 }
 
-export function StepActions({ back, forward }: StepActionsProps) {
+export function StepActions({ back, secondaryAction, forward }: StepActionsProps) {
   const forwardProps =
     forward &&
     (forward.type === 'button'
       ? { onClick: forward.onClick, disabled: forward.disabled }
       : { type: 'submit', disabled: forward.disabled })
+
+  const secondaryActionProps =
+    secondaryAction &&
+    (secondaryAction.type === 'link'
+      ? { component: Link, to: secondaryAction.to }
+      : { onClick: secondaryAction.onClick })
+
   const backProps =
     back && (back.type === 'link' ? { component: Link, to: back.to } : { onClick: back.onClick })
 
   const getJustifyContentProp = () => {
-    if (back && forward) return 'space-between'
+    const hasRightActions = secondaryAction || forward
 
-    if (!back && forward) return 'end'
+    if (back && hasRightActions) return 'space-between'
 
-    if (back && !forward) return 'start'
+    if (!back && hasRightActions) return 'end'
+
+    if (back && !hasRightActions) return 'start'
 
     return undefined
   }
 
   return (
-    <Stack direction="row" justifyContent={getJustifyContentProp()} spacing={2} sx={{ mt: 5 }}>
+    <Stack
+      direction="row"
+      justifyContent={getJustifyContentProp()}
+      spacing={2}
+      sx={{ mt: 5, alignItems: 'center' }}
+    >
       {back && (
         <Tooltip open={back.tooltip ? undefined : false} title={back.tooltip}>
           <span tabIndex={back.disabled ? 0 : undefined}>
@@ -75,20 +91,42 @@ export function StepActions({ back, forward }: StepActionsProps) {
         </Tooltip>
       )}
 
-      {forward && (
-        <Tooltip arrow open={forward.tooltip ? undefined : false} title={forward.tooltip}>
-          <span tabIndex={forward.disabled ? 0 : undefined}>
-            <Button
-              variant="contained"
-              startIcon={forward.startIcon}
-              endIcon={forward.endIcon}
-              {...forwardProps}
-              type={forwardProps?.type as 'submit' | 'button'}
+      {(secondaryAction || forward) && (
+        <Stack direction="row" spacing={3} sx={{ alignItems: 'center' }}>
+          {secondaryAction && (
+            <Tooltip
+              open={secondaryAction.tooltip ? undefined : false}
+              title={secondaryAction.tooltip}
             >
-              {forward.label}
-            </Button>
-          </span>
-        </Tooltip>
+              <span tabIndex={secondaryAction.disabled ? 0 : undefined}>
+                <Button
+                  variant="text"
+                  startIcon={secondaryAction.startIcon}
+                  endIcon={secondaryAction.endIcon}
+                  {...secondaryActionProps}
+                >
+                  {secondaryAction.label}
+                </Button>
+              </span>
+            </Tooltip>
+          )}
+
+          {forward && (
+            <Tooltip arrow open={forward.tooltip ? undefined : false} title={forward.tooltip}>
+              <span tabIndex={forward.disabled ? 0 : undefined}>
+                <Button
+                  variant="contained"
+                  startIcon={forward.startIcon}
+                  endIcon={forward.endIcon}
+                  {...forwardProps}
+                  type={forwardProps?.type as 'submit' | 'button'}
+                >
+                  {forward.label}
+                </Button>
+              </span>
+            </Tooltip>
+          )}
+        </Stack>
       )}
     </Stack>
   )

--- a/src/components/shared/VerticalInformationContainer.tsx
+++ b/src/components/shared/VerticalInformationContainer.tsx
@@ -1,4 +1,5 @@
-import { Box, Stack, Typography } from '@mui/material'
+import type { GridProps } from '@mui/material'
+import { Box, Grid, Stack, Typography } from '@mui/material'
 import { CopyToClipboardButton } from '@pagopa/mui-italia'
 import React from 'react'
 
@@ -7,6 +8,7 @@ type VerticalInformationContainerProps = {
   labelDescription?: string
   content?: string
   copyToClipboard?: { value: string; tooltipTitle: string }
+  gridProps?: GridProps
 }
 
 export const VerticalInformationContainer: React.FC<VerticalInformationContainerProps> = ({
@@ -14,49 +16,52 @@ export const VerticalInformationContainer: React.FC<VerticalInformationContainer
   labelDescription,
   content,
   copyToClipboard,
+  gridProps = { xs: 12, md: 6 },
 }) => {
   return (
-    <Stack sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ pb: 2 }}>
-        <Typography variant="body2" fontWeight={600}>
-          {label}
-        </Typography>
-
-        {labelDescription && (
-          <Typography variant="caption" color="text.secondary" sx={{ pt: 1 }}>
-            {labelDescription}
-          </Typography>
-        )}
-      </Box>
-
-      {content && (
-        <Box
-          sx={{
-            mt: 'auto',
-            display: 'flex',
-            alignItems: 'center',
-            alignSelf: 'flex-start',
-            justifyContent: 'space-between',
-            borderRadius: 1,
-            bgcolor: 'grey.50',
-            pl: 1.5,
-            py: copyToClipboard ? 0.5 : 1.5,
-            pr: copyToClipboard ? 0.5 : 1.5,
-          }}
-        >
-          <Typography variant="body2" fontWeight={600} sx={{ whiteSpace: 'break-spaces' }}>
-            {content}
+    <Grid item {...gridProps}>
+      <Stack sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        <Box sx={{ pb: 2 }}>
+          <Typography variant="body2" fontWeight={600}>
+            {label}
           </Typography>
 
-          {copyToClipboard && (
-            <CopyToClipboardButton
-              value={copyToClipboard.value}
-              tooltipTitle={copyToClipboard.tooltipTitle}
-              sx={{ m: 0 }}
-            />
+          {labelDescription && (
+            <Typography variant="caption" color="text.secondary" sx={{ pt: 1 }}>
+              {labelDescription}
+            </Typography>
           )}
         </Box>
-      )}
-    </Stack>
+
+        {content && (
+          <Box
+            sx={{
+              mt: 'auto',
+              display: 'flex',
+              alignItems: 'center',
+              alignSelf: 'flex-start',
+              justifyContent: 'space-between',
+              borderRadius: 1,
+              bgcolor: 'grey.50',
+              pl: 1.5,
+              py: copyToClipboard ? 0.5 : 1.5,
+              pr: copyToClipboard ? 0.5 : 1.5,
+            }}
+          >
+            <Typography variant="body2" fontWeight={600} sx={{ whiteSpace: 'break-spaces' }}>
+              {content}
+            </Typography>
+
+            {copyToClipboard && (
+              <CopyToClipboardButton
+                value={copyToClipboard.value}
+                tooltipTitle={copyToClipboard.tooltipTitle}
+                sx={{ m: 0 }}
+              />
+            )}
+          </Box>
+        )}
+      </Stack>
+    </Grid>
   )
 }

--- a/src/components/shared/VerticalInformationContainer.tsx
+++ b/src/components/shared/VerticalInformationContainer.tsx
@@ -8,7 +8,7 @@ type VerticalInformationContainerProps = {
   labelDescription?: string
   content?: string
   copyToClipboard?: { value: string; tooltipTitle: string }
-  gridProps?: GridProps
+  gridProps?: Pick<GridProps, 'xs' | 'sm' | 'md' | 'lg' | 'xl'>
 }
 
 export const VerticalInformationContainer: React.FC<VerticalInformationContainerProps> = ({

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -77,3 +77,8 @@ export const apiSignalhubPullLink =
 
 export const ESERVICE_TEMPLATE_NAME_MAX_LENGTH = 45
 export const INSTANCE_LABEL_MAX_LENGTH = 12
+
+export const CLIENT_ASSERTION_TYP = 'dpop+jwt'
+export const CLIENT_ASSERTION_ALG = 'RS256'
+export const CLIENT_ASSERTION_HTM = 'POST'
+export const VOUCHER_FIRST_DPOP_FILENAME = 'create_dpop_proof_auth_server'

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherScriptPreviewSection.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherScriptPreviewSection.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { Box, Typography, Link } from '@mui/material'
+import { Trans, useTranslation } from 'react-i18next'
+import { CodeSnippetPreview } from './CodeSnippetPreview'
+import { SectionContainer } from '@/components/layout/containers'
+
+type Props = {
+  fileUrl: string
+  previewUrl: string
+  fileName: string
+  substitutions: Record<string, string>
+}
+
+export const VoucherScriptPreviewSection: React.FC<Props> = ({
+  fileUrl,
+  previewUrl,
+  fileName,
+  substitutions,
+}) => {
+  const { t } = useTranslation('voucher')
+  return (
+    <SectionContainer title={t('assertionScript.title')}>
+      <Box sx={{ pl: 2 }} component="ol">
+        <Typography component="li" variant="body2">
+          {t('assertionScript.steps.1')}
+        </Typography>
+
+        <Typography component="li" variant="body2">
+          <Trans components={{ 1: <Link download href={fileUrl} /> }}>
+            {t('assertionScript.steps.2', { filename: `${fileName}.py` })}
+          </Trans>
+        </Typography>
+
+        <Typography component="li" variant="body2" sx={{ whiteSpace: 'break-spaces' }}>
+          {t('assertionScript.steps.3')}
+        </Typography>
+
+        <Typography component="li" variant="body2">
+          {t('assertionScript.steps.4')}
+        </Typography>
+
+        <Typography component="li" variant="body2">
+          {t('assertionScript.steps.5')}
+        </Typography>
+      </Box>
+
+      <CodeSnippetPreview
+        sx={{ mt: 2 }}
+        title={t('assertionScript.exampleLabel')}
+        activeLang="python"
+        entries={[
+          {
+            url: previewUrl,
+            value: 'python',
+          },
+        ]}
+        scriptSubstitutionValues={substitutions}
+      />
+      <Typography sx={{ mt: 2 }} variant="body2">
+        {t('assertionScript.steps.result')}
+      </Typography>
+    </SectionContainer>
+  )
+}

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/__test__/VoucherScriptPreviewSection.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/__test__/VoucherScriptPreviewSection.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+
+import { VoucherScriptPreviewSection } from '../VoucherScriptPreviewSection'
+
+// Mock di CodeSnippetPreview
+vi.mock('../CodeSnippetPreview', () => ({
+  CodeSnippetPreview: () => <div data-testid="code-snippet-preview" />,
+}))
+
+describe('VoucherScriptPreviewSection', () => {
+  const defaultProps = {
+    fileUrl: '/test/file.py',
+    previewUrl: '/test/preview.txt',
+    fileName: 'file',
+    substitutions: {
+      VAR1: 'value1',
+    },
+  }
+
+  it('renders section title', () => {
+    render(
+      <MemoryRouter>
+        <VoucherScriptPreviewSection {...defaultProps} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('assertionScript.title')).toBeInTheDocument()
+  })
+
+  it('renders all steps', () => {
+    render(
+      <MemoryRouter>
+        <VoucherScriptPreviewSection {...defaultProps} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('assertionScript.steps.1')).toBeInTheDocument()
+    expect(screen.getByText('assertionScript.steps.2')).toBeInTheDocument()
+    expect(screen.getByText('assertionScript.steps.3')).toBeInTheDocument()
+    expect(screen.getByText('assertionScript.steps.4')).toBeInTheDocument()
+    expect(screen.getByText('assertionScript.steps.5')).toBeInTheDocument()
+  })
+
+  it('renders CodeSnippetPreview', () => {
+    render(
+      <MemoryRouter>
+        <VoucherScriptPreviewSection {...defaultProps} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByTestId('code-snippet-preview')).toBeInTheDocument()
+  })
+
+  it('renders result step', () => {
+    render(
+      <MemoryRouter>
+        <VoucherScriptPreviewSection {...defaultProps} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('assertionScript.steps.result')).toBeInTheDocument()
+  })
+})

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsClientAssertionStep.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsClientAssertionStep.tsx
@@ -74,20 +74,6 @@ export const VoucherInstructionsClientAssertionStep: React.FC = () => {
     }))
   }
 
-  const JtiField = () => (
-    <>
-      <VerticalInformationContainer
-        label={t('clientAssertionStep.assertionPayload.jtiField.label')}
-        labelDescription={t('clientAssertionStep.assertionPayload.jtiField.description')}
-        content={t('clientAssertionStep.assertionPayload.jtiField.suggestionLabel')}
-      />
-      {/* Empty Grid item for this case: https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW/Interop-%E2%80%94-Delivery-FE---QA?node-id=4078-16065&t=RqfS1AkOeuYRe9id-4 */}
-      {asyncExchangeStep === ASYNC_EXCHANGE_STEP.START_INTERACTION && (
-        <Grid item xs={12} md={6}></Grid>
-      )}
-    </>
-  )
-
   const asyncScriptSubstitutionValues = {
     ...(asyncParams.urlCallback && {
       INSERISCI_VALORE_URL_CALLBACK: asyncParams.urlCallback,
@@ -231,7 +217,13 @@ export const VoucherInstructionsClientAssertionStep: React.FC = () => {
                 }}
               />
             )}
-            {asyncExchangeStep !== ASYNC_EXCHANGE_STEP.START_INTERACTION && JtiField()}
+            {asyncExchangeStep !== ASYNC_EXCHANGE_STEP.START_INTERACTION && (
+              <VerticalInformationContainer
+                label={t('clientAssertionStep.assertionPayload.jtiField.label')}
+                labelDescription={t('clientAssertionStep.assertionPayload.jtiField.description')}
+                content={t('clientAssertionStep.assertionPayload.jtiField.suggestionLabel')}
+              />
+            )}
             {interactionType === INTERACTION_TYPE.ASYNC && (
               <>
                 <VerticalInformationContainer
@@ -276,7 +268,17 @@ export const VoucherInstructionsClientAssertionStep: React.FC = () => {
                 )}
               </>
             )}
-            {asyncExchangeStep === ASYNC_EXCHANGE_STEP.START_INTERACTION && JtiField()}
+            {asyncExchangeStep === ASYNC_EXCHANGE_STEP.START_INTERACTION && (
+              <>
+                <VerticalInformationContainer
+                  label={t('clientAssertionStep.assertionPayload.jtiField.label')}
+                  labelDescription={t('clientAssertionStep.assertionPayload.jtiField.description')}
+                  content={t('clientAssertionStep.assertionPayload.jtiField.suggestionLabel')}
+                />
+                {/* Empty Grid item for this case: https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW/Interop-%E2%80%94-Delivery-FE---QA?node-id=4078-16065&t=RqfS1AkOeuYRe9id-4 */}
+                <Grid item xs={12} md={6}></Grid>
+              </>
+            )}
             <VerticalInformationContainer
               label={t('clientAssertionStep.assertionPayload.iatField.label')}
               labelDescription={t('clientAssertionStep.assertionPayload.iatField.description')}

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsClientAssertionStep.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsClientAssertionStep.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react'
-import { Box, Grid, Link, TextField, Typography } from '@mui/material'
+import { Grid, Link, TextField } from '@mui/material'
 import { SectionContainer } from '@/components/layout/containers'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { CLIENT_ASSERTION_JWT_AUDIENCE, FE_URL } from '@/config/env'
 import { useClientKind } from '@/hooks/useClientKind'
-import { CodeSnippetPreview } from '../CodeSnippetPreview'
 import { StepActions } from '@/components/shared/StepActions'
 import { useVoucherInstructionsContext } from '../VoucherInstructionsContext'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
@@ -16,6 +15,7 @@ import {
   INTERACTION_TYPE,
   MEMBER_TYPE,
 } from '../VoucherInstructionsGeneralForm'
+import { VoucherScriptPreviewSection } from '../VoucherScriptPreviewSection'
 
 const CLIENT_ASSERTION_TYP = 'JWT'
 const CLIENT_ASSERTION_ALG = 'RS256'
@@ -317,54 +317,21 @@ export const VoucherInstructionsClientAssertionStep: React.FC = () => {
           </Grid>
         </SectionContainer>
       </SectionContainer>
-      <SectionContainer title={t('clientAssertionStep.assertionScript.title')}>
-        <Box sx={{ pl: 2 }} component="ol">
-          <Typography component="li" variant="body2">
-            {t('clientAssertionStep.assertionScript.steps.1')}
-          </Typography>
-          <Typography component="li" variant="body2">
-            <Trans components={{ 1: <Link download href={getFilePath('script')} /> }}>
-              {t('clientAssertionStep.assertionScript.steps.2', {
-                filename: `${getFileName()}.py`,
-              })}
-            </Trans>
-          </Typography>
-          <Typography component="li" variant="body2" sx={{ whiteSpace: 'break-spaces' }}>
-            {t('clientAssertionStep.assertionScript.steps.3')}
-          </Typography>
-          <Typography component="li" variant="body2">
-            {t('clientAssertionStep.assertionScript.steps.4')}
-          </Typography>
-          <Typography component="li" variant="body2">
-            {t('clientAssertionStep.assertionScript.steps.5')}
-          </Typography>
-        </Box>
-
-        <CodeSnippetPreview
-          sx={{ mt: 2 }}
-          title={t('clientAssertionStep.assertionScript.exampleLabel')}
-          activeLang={'python'}
-          entries={[
-            {
-              url: getFilePath('preview'),
-              value: 'python',
-            },
-          ]}
-          scriptSubstitutionValues={{
-            INSERISCI_VALORE_KID: keyId,
-            INSERISCI_VALORE_ALG: CLIENT_ASSERTION_ALG,
-            INSERISCI_VALORE_TYP: CLIENT_ASSERTION_TYP,
-            INSERISCI_VALORE_ISS: clientId!,
-            INSERISCI_VALORE_SUB: clientId!,
-            INSERISCI_VALORE_AUD: CLIENT_ASSERTION_JWT_AUDIENCE,
-            INSERISCI_VALORE_PUR: purposeId,
-            ...asyncScriptSubstitutionValues,
-          }}
-        />
-        <Typography sx={{ mt: 2 }} variant="body2">
-          {t('clientAssertionStep.assertionScript.steps.result')}
-        </Typography>
-      </SectionContainer>
+      <VoucherScriptPreviewSection
+        fileUrl={getFilePath('script')}
+        previewUrl={getFilePath('preview')}
+        fileName={getFileName()}
+        substitutions={{
+          INSERISCI_VALORE_KID: keyId,
+          INSERISCI_VALORE_ALG: CLIENT_ASSERTION_ALG,
+          INSERISCI_VALORE_TYP: CLIENT_ASSERTION_TYP,
+          INSERISCI_VALORE_ISS: clientId!,
+          INSERISCI_VALORE_SUB: clientId!,
+          INSERISCI_VALORE_AUD: CLIENT_ASSERTION_JWT_AUDIENCE,
+          INSERISCI_VALORE_PUR: purposeId,
+          ...asyncScriptSubstitutionValues,
+        }}
+      />
       <StepActions
         back={{
           label: t('backBtn'),

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsClientAssertionStep.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsClientAssertionStep.tsx
@@ -76,13 +76,11 @@ export const VoucherInstructionsClientAssertionStep: React.FC = () => {
 
   const JtiField = () => (
     <>
-      <Grid item xs={12} md={6}>
-        <VerticalInformationContainer
-          label={t('clientAssertionStep.assertionPayload.jtiField.label')}
-          labelDescription={t('clientAssertionStep.assertionPayload.jtiField.description')}
-          content={t('clientAssertionStep.assertionPayload.jtiField.suggestionLabel')}
-        />
-      </Grid>
+      <VerticalInformationContainer
+        label={t('clientAssertionStep.assertionPayload.jtiField.label')}
+        labelDescription={t('clientAssertionStep.assertionPayload.jtiField.description')}
+        content={t('clientAssertionStep.assertionPayload.jtiField.suggestionLabel')}
+      />
       {asyncExchangeStep === ASYNC_EXCHANGE_STEP.START_INTERACTION && (
         <Grid item xs={12} md={6}></Grid>
       )}
@@ -150,45 +148,40 @@ export const VoucherInstructionsClientAssertionStep: React.FC = () => {
       >
         <SectionContainer variant="outlined" title={t('clientAssertionStep.assertionHeader.title')}>
           <Grid container columnSpacing={4.5} rowSpacing={3}>
-            <Grid item xs={12}>
-              <VerticalInformationContainer
-                label={t('clientAssertionStep.assertionHeader.kidField.label')}
-                labelDescription={t('clientAssertionStep.assertionHeader.kidField.description')}
-                content={keyId}
-                copyToClipboard={{
-                  value: keyId,
-                  tooltipTitle: t(
-                    'clientAssertionStep.assertionHeader.kidField.copySuccessFeedbackText'
-                  ),
-                }}
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <VerticalInformationContainer
-                label={t('clientAssertionStep.assertionHeader.algField.label')}
-                labelDescription={t('clientAssertionStep.assertionHeader.algField.description')}
-                content={CLIENT_ASSERTION_ALG}
-                copyToClipboard={{
-                  value: CLIENT_ASSERTION_ALG,
-                  tooltipTitle: t(
-                    'clientAssertionStep.assertionHeader.algField.copySuccessFeedbackText'
-                  ),
-                }}
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <VerticalInformationContainer
-                label={t('clientAssertionStep.assertionHeader.typField.label')}
-                labelDescription={t('clientAssertionStep.assertionHeader.typField.description')}
-                content={CLIENT_ASSERTION_TYP}
-                copyToClipboard={{
-                  value: CLIENT_ASSERTION_TYP,
-                  tooltipTitle: t(
-                    'clientAssertionStep.assertionHeader.typField.copySuccessFeedbackText'
-                  ),
-                }}
-              />
-            </Grid>
+            <VerticalInformationContainer
+              label={t('clientAssertionStep.assertionHeader.kidField.label')}
+              labelDescription={t('clientAssertionStep.assertionHeader.kidField.description')}
+              content={keyId}
+              copyToClipboard={{
+                value: keyId,
+                tooltipTitle: t(
+                  'clientAssertionStep.assertionHeader.kidField.copySuccessFeedbackText'
+                ),
+              }}
+              gridProps={{ md: 12 }}
+            />
+            <VerticalInformationContainer
+              label={t('clientAssertionStep.assertionHeader.algField.label')}
+              labelDescription={t('clientAssertionStep.assertionHeader.algField.description')}
+              content={CLIENT_ASSERTION_ALG}
+              copyToClipboard={{
+                value: CLIENT_ASSERTION_ALG,
+                tooltipTitle: t(
+                  'clientAssertionStep.assertionHeader.algField.copySuccessFeedbackText'
+                ),
+              }}
+            />
+            <VerticalInformationContainer
+              label={t('clientAssertionStep.assertionHeader.typField.label')}
+              labelDescription={t('clientAssertionStep.assertionHeader.typField.description')}
+              content={CLIENT_ASSERTION_TYP}
+              copyToClipboard={{
+                value: CLIENT_ASSERTION_TYP,
+                tooltipTitle: t(
+                  'clientAssertionStep.assertionHeader.typField.copySuccessFeedbackText'
+                ),
+              }}
+            />
           </Grid>
         </SectionContainer>
         <SectionContainer
@@ -196,81 +189,71 @@ export const VoucherInstructionsClientAssertionStep: React.FC = () => {
           title={t('clientAssertionStep.assertionPayload.title')}
         >
           <Grid container spacing={4.5}>
-            <Grid item xs={12} md={6}>
-              <VerticalInformationContainer
-                label={t('clientAssertionStep.assertionPayload.issField.label')}
-                labelDescription={t('clientAssertionStep.assertionPayload.issField.description')}
-                content={clientId}
-                copyToClipboard={{
-                  value: clientId,
-                  tooltipTitle: t(
-                    'clientAssertionStep.assertionPayload.issField.copySuccessFeedbackText'
-                  ),
-                }}
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <VerticalInformationContainer
-                label={t('clientAssertionStep.assertionPayload.subField.label')}
-                labelDescription={t('clientAssertionStep.assertionPayload.subField.description')}
-                content={clientId}
-                copyToClipboard={{
-                  value: clientId,
-                  tooltipTitle: t(
-                    'clientAssertionStep.assertionPayload.subField.copySuccessFeedbackText'
-                  ),
-                }}
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <VerticalInformationContainer
-                label={t('clientAssertionStep.assertionPayload.audField.label')}
-                labelDescription={t('clientAssertionStep.assertionPayload.audField.description')}
-                content={CLIENT_ASSERTION_JWT_AUDIENCE}
-                copyToClipboard={{
-                  value: CLIENT_ASSERTION_JWT_AUDIENCE,
-                  tooltipTitle: t(
-                    'clientAssertionStep.assertionPayload.audField.copySuccessFeedbackText'
-                  ),
-                }}
-              />
-            </Grid>
+            <VerticalInformationContainer
+              label={t('clientAssertionStep.assertionPayload.issField.label')}
+              labelDescription={t('clientAssertionStep.assertionPayload.issField.description')}
+              content={clientId}
+              copyToClipboard={{
+                value: clientId,
+                tooltipTitle: t(
+                  'clientAssertionStep.assertionPayload.issField.copySuccessFeedbackText'
+                ),
+              }}
+            />
+            <VerticalInformationContainer
+              label={t('clientAssertionStep.assertionPayload.subField.label')}
+              labelDescription={t('clientAssertionStep.assertionPayload.subField.description')}
+              content={clientId}
+              copyToClipboard={{
+                value: clientId,
+                tooltipTitle: t(
+                  'clientAssertionStep.assertionPayload.subField.copySuccessFeedbackText'
+                ),
+              }}
+            />
+            <VerticalInformationContainer
+              label={t('clientAssertionStep.assertionPayload.audField.label')}
+              labelDescription={t('clientAssertionStep.assertionPayload.audField.description')}
+              content={CLIENT_ASSERTION_JWT_AUDIENCE}
+              copyToClipboard={{
+                value: CLIENT_ASSERTION_JWT_AUDIENCE,
+                tooltipTitle: t(
+                  'clientAssertionStep.assertionPayload.audField.copySuccessFeedbackText'
+                ),
+              }}
+            />
             {clientKind === 'CONSUMER' && Boolean(purposeId) && showPurposeId && (
-              <Grid item xs={12} md={6}>
-                <VerticalInformationContainer
-                  label={t('clientAssertionStep.assertionPayload.purposeIdField.label')}
-                  labelDescription={t(
-                    'clientAssertionStep.assertionPayload.purposeIdField.description'
-                  )}
-                  content={purposeId}
-                  copyToClipboard={{
-                    value: purposeId,
-                    tooltipTitle: t(
-                      'clientAssertionStep.assertionPayload.purposeIdField.copySuccessFeedbackText'
-                    ),
-                  }}
-                />
-              </Grid>
+              <VerticalInformationContainer
+                label={t('clientAssertionStep.assertionPayload.purposeIdField.label')}
+                labelDescription={t(
+                  'clientAssertionStep.assertionPayload.purposeIdField.description'
+                )}
+                content={purposeId}
+                copyToClipboard={{
+                  value: purposeId,
+                  tooltipTitle: t(
+                    'clientAssertionStep.assertionPayload.purposeIdField.copySuccessFeedbackText'
+                  ),
+                }}
+              />
             )}
             {asyncExchangeStep !== ASYNC_EXCHANGE_STEP.START_INTERACTION && <JtiField />}
             {interactionType === INTERACTION_TYPE.ASYNC && (
               <>
-                <Grid
-                  item
-                  xs={asyncExchangeStep === ASYNC_EXCHANGE_STEP.CALLBACK_INVOCATION ? 12 : 6}
-                >
-                  <VerticalInformationContainer
-                    label={t('clientAssertionStep.assertionPayload.scope.label')}
-                    labelDescription={t('clientAssertionStep.assertionPayload.scope.description')}
-                    content={asyncExchangeStep}
-                    copyToClipboard={{
-                      value: asyncExchangeStep,
-                      tooltipTitle: t(
-                        'clientAssertionStep.assertionPayload.purposeIdField.copySuccessFeedbackText'
-                      ),
-                    }}
-                  />
-                </Grid>
+                <VerticalInformationContainer
+                  label={t('clientAssertionStep.assertionPayload.scope.label')}
+                  labelDescription={t('clientAssertionStep.assertionPayload.scope.description')}
+                  content={asyncExchangeStep}
+                  copyToClipboard={{
+                    value: asyncExchangeStep,
+                    tooltipTitle: t(
+                      'clientAssertionStep.assertionPayload.purposeIdField.copySuccessFeedbackText'
+                    ),
+                  }}
+                  gridProps={{
+                    xs: asyncExchangeStep === ASYNC_EXCHANGE_STEP.CALLBACK_INVOCATION ? 12 : 6,
+                  }}
+                />
                 <Grid item xs={12} md={6} sx={{ display: 'flex', alignItems: 'center' }}>
                   <TextField
                     sx={{ my: 0, width: '100%', flexShrink: 1 }}
@@ -300,20 +283,16 @@ export const VoucherInstructionsClientAssertionStep: React.FC = () => {
               </>
             )}
             {asyncExchangeStep === ASYNC_EXCHANGE_STEP.START_INTERACTION && <JtiField />}
-            <Grid item xs={12} md={6}>
-              <VerticalInformationContainer
-                label={t('clientAssertionStep.assertionPayload.iatField.label')}
-                labelDescription={t('clientAssertionStep.assertionPayload.iatField.description')}
-                content={t('clientAssertionStep.assertionPayload.iatField.suggestionLabel')}
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <VerticalInformationContainer
-                label={t('clientAssertionStep.assertionPayload.expField.label')}
-                labelDescription={t('clientAssertionStep.assertionPayload.expField.description')}
-                content={t('clientAssertionStep.assertionPayload.expField.suggestionLabel')}
-              />
-            </Grid>
+            <VerticalInformationContainer
+              label={t('clientAssertionStep.assertionPayload.iatField.label')}
+              labelDescription={t('clientAssertionStep.assertionPayload.iatField.description')}
+              content={t('clientAssertionStep.assertionPayload.iatField.suggestionLabel')}
+            />
+            <VerticalInformationContainer
+              label={t('clientAssertionStep.assertionPayload.expField.label')}
+              labelDescription={t('clientAssertionStep.assertionPayload.expField.description')}
+              content={t('clientAssertionStep.assertionPayload.expField.suggestionLabel')}
+            />
           </Grid>
         </SectionContainer>
       </SectionContainer>

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsFirstDPoPProofStep.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsFirstDPoPProofStep.tsx
@@ -1,21 +1,174 @@
 import React from 'react'
 import { StepActions } from '@/components/shared/StepActions'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { useVoucherInstructionsContext } from '../VoucherInstructionsContext'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+import { SectionContainer } from '@/components/layout/containers'
+import { Box, Grid, Link, Typography } from '@mui/material'
+import { VerticalInformationContainer } from '@/components/shared/VerticalInformationContainer'
+import { CodeSnippetPreview } from '../CodeSnippetPreview'
+import { FE_URL } from '@/config/env'
+
+const CLIENT_ASSERTION_TYP = 'dpop+jwt'
+const CLIENT_ASSERTION_ALG = 'RS256'
+const CLIENT_ASSERTION_HTM = 'POST'
+const CLIENT_ASSERTION_HTU = 'https://auth.dev.interop.PagoPA.it/token.oauth2'
+const FILENAME = 'create_dpop_proof_auth_server'
 
 export const VoucherInstructionsFirstDPoPProofStep: React.FC = () => {
   const { t } = useTranslation('voucher')
   const { goToPreviousStep, goToNextStep } = useVoucherInstructionsContext()
+
+  const getFilePath = (type: 'script' | 'preview') => {
+    const base = `${FE_URL}/data/it`
+
+    const ext = type === 'script' ? 'py' : 'txt'
+
+    return `${base}/dpop/${type}/${FILENAME}.${ext}`
+  }
+
   return (
-    <>
+    <SectionContainer
+      title={t('firstDPoPProofStep.title')}
+      description={<>{t('firstDPoPProofStep.description')}</>}
+    >
+      <SectionContainer variant="outlined" title={t('firstDPoPProofStep.assertionHeader.title')}>
+        <Grid container columnSpacing={4.5} rowSpacing={3}>
+          <Grid item xs={12} md={6}>
+            <VerticalInformationContainer
+              label={t('firstDPoPProofStep.assertionHeader.typField.label')}
+              labelDescription={t('firstDPoPProofStep.assertionHeader.typField.description')}
+              content={CLIENT_ASSERTION_TYP}
+              copyToClipboard={{
+                value: CLIENT_ASSERTION_TYP,
+                tooltipTitle: t(
+                  'firstDPoPProofStep.assertionHeader.typField.copySuccessFeedbackText'
+                ),
+              }}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <VerticalInformationContainer
+              label={t('firstDPoPProofStep.assertionHeader.algField.label')}
+              labelDescription={t('firstDPoPProofStep.assertionHeader.algField.description')}
+              content={CLIENT_ASSERTION_ALG}
+              copyToClipboard={{
+                value: CLIENT_ASSERTION_ALG,
+                tooltipTitle: t(
+                  'firstDPoPProofStep.assertionHeader.algField.copySuccessFeedbackText'
+                ),
+              }}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <VerticalInformationContainer
+              label={t('firstDPoPProofStep.assertionHeader.jwkField.label')}
+              labelDescription={t('firstDPoPProofStep.assertionHeader.jwkField.description')}
+              content={t('firstDPoPProofStep.assertionHeader.jwkField.suggestionLabel')}
+            />
+          </Grid>
+        </Grid>
+      </SectionContainer>
+      <SectionContainer variant="outlined" title={t('firstDPoPProofStep.assertionPayload.title')}>
+        <Grid container columnSpacing={4.5} rowSpacing={3}>
+          <Grid item xs={12} md={6}>
+            <VerticalInformationContainer
+              label={t('firstDPoPProofStep.assertionPayload.htmField.label')}
+              labelDescription={t('firstDPoPProofStep.assertionPayload.htmField.description')}
+              content={CLIENT_ASSERTION_HTM}
+              copyToClipboard={{
+                value: CLIENT_ASSERTION_HTM,
+                tooltipTitle: t(
+                  'firstDPoPProofStep.assertionPayload.htmField.copySuccessFeedbackText'
+                ),
+              }}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <VerticalInformationContainer
+              label={t('firstDPoPProofStep.assertionPayload.htuField.label')}
+              labelDescription={t('firstDPoPProofStep.assertionPayload.htuField.description')}
+              content={CLIENT_ASSERTION_HTU}
+              copyToClipboard={{
+                value: CLIENT_ASSERTION_HTU,
+                tooltipTitle: t(
+                  'firstDPoPProofStep.assertionPayload.htuField.copySuccessFeedbackText'
+                ),
+              }}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <VerticalInformationContainer
+              label={t('firstDPoPProofStep.assertionPayload.jtiField.label')}
+              labelDescription={t('firstDPoPProofStep.assertionPayload.jtiField.description')}
+              content={t('firstDPoPProofStep.assertionPayload.jtiField.suggestionLabel')}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <VerticalInformationContainer
+              label={t('firstDPoPProofStep.assertionPayload.iatField.label')}
+              labelDescription={t('firstDPoPProofStep.assertionPayload.iatField.description')}
+              content={t('firstDPoPProofStep.assertionPayload.iatField.suggestionLabel')}
+            />
+          </Grid>
+        </Grid>
+      </SectionContainer>
+      <SectionContainer title={t('firstDPoPProofStep.assertionScript.title')}>
+        <Box sx={{ pl: 2 }} component="ol">
+          <Typography component="li" variant="body2">
+            {t('firstDPoPProofStep.assertionScript.steps.1')}
+          </Typography>
+          <Typography component="li" variant="body2">
+            <Trans components={{ 1: <Link download href={getFilePath('script')} /> }}>
+              {t('firstDPoPProofStep.assertionScript.steps.2', {
+                filename: `${FILENAME}.py`,
+              })}
+            </Trans>
+          </Typography>
+          <Typography component="li" variant="body2" sx={{ whiteSpace: 'break-spaces' }}>
+            {t('firstDPoPProofStep.assertionScript.steps.3')}
+          </Typography>
+          <Typography component="li" variant="body2">
+            {t('firstDPoPProofStep.assertionScript.steps.4')}
+          </Typography>
+          <Typography component="li" variant="body2">
+            {t('firstDPoPProofStep.assertionScript.steps.5')}
+          </Typography>
+        </Box>
+
+        <CodeSnippetPreview
+          sx={{ mt: 2 }}
+          title={t('firstDPoPProofStep.assertionScript.exampleLabel')}
+          activeLang={'python'}
+          entries={[
+            {
+              url: getFilePath('preview'),
+              value: 'python',
+            },
+          ]}
+          scriptSubstitutionValues={{
+            INSERISCI_VALORE_ALG: CLIENT_ASSERTION_ALG,
+            INSERISCI_VALORE_TYP: CLIENT_ASSERTION_TYP,
+            INSERISCI_VALORE_HTM: CLIENT_ASSERTION_HTM,
+            INSERISCI_VALORE_HTU: CLIENT_ASSERTION_HTU,
+          }}
+        />
+        <Typography sx={{ mt: 2 }} variant="body2">
+          {t('firstDPoPProofStep.assertionScript.steps.result')}
+        </Typography>
+      </SectionContainer>
       <StepActions
         back={{
           label: t('backBtn'),
           type: 'button',
           onClick: goToPreviousStep,
           startIcon: <ArrowBackIcon />,
+        }}
+        secondaryAction={{
+          label: t('firstDPoPProofStep.navigateToDebugButton.label'),
+          type: 'link',
+          to: 'SUBSCRIBE_DEBUG_VOUCHER',
         }}
         forward={{
           label: t('proceedBtn'),
@@ -24,6 +177,6 @@ export const VoucherInstructionsFirstDPoPProofStep: React.FC = () => {
           endIcon: <ArrowForwardIcon />,
         }}
       />
-    </>
+    </SectionContainer>
   )
 }

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsFirstDPoPProofStep.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsFirstDPoPProofStep.tsx
@@ -7,14 +7,14 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { SectionContainer } from '@/components/layout/containers'
 import { Grid } from '@mui/material'
 import { VerticalInformationContainer } from '@/components/shared/VerticalInformationContainer'
-import { FE_URL } from '@/config/env'
+import { AUTHORIZATION_SERVER_TOKEN_CREATION_URL, FE_URL } from '@/config/env'
 import { VoucherScriptPreviewSection } from '../VoucherScriptPreviewSection'
-
-const CLIENT_ASSERTION_TYP = 'dpop+jwt'
-const CLIENT_ASSERTION_ALG = 'RS256'
-const CLIENT_ASSERTION_HTM = 'POST'
-const CLIENT_ASSERTION_HTU = 'https://auth.dev.interop.PagoPA.it/token.oauth2'
-const FILENAME = 'create_dpop_proof_auth_server'
+import {
+  CLIENT_ASSERTION_ALG,
+  CLIENT_ASSERTION_HTM,
+  CLIENT_ASSERTION_TYP,
+  VOUCHER_FIRST_DPOP_FILENAME,
+} from '@/config/constants'
 
 export const VoucherInstructionsFirstDPoPProofStep: React.FC = () => {
   const { t } = useTranslation('voucher')
@@ -25,7 +25,7 @@ export const VoucherInstructionsFirstDPoPProofStep: React.FC = () => {
 
     const ext = type === 'script' ? 'py' : 'txt'
 
-    return `${base}/dpop/${type}/${FILENAME}.${ext}`
+    return `${base}/dpop/${type}/${VOUCHER_FIRST_DPOP_FILENAME}.${ext}`
   }
 
   return (
@@ -80,9 +80,9 @@ export const VoucherInstructionsFirstDPoPProofStep: React.FC = () => {
           <VerticalInformationContainer
             label={t('firstDPoPProofStep.assertionPayload.htuField.label')}
             labelDescription={t('firstDPoPProofStep.assertionPayload.htuField.description')}
-            content={CLIENT_ASSERTION_HTU}
+            content={AUTHORIZATION_SERVER_TOKEN_CREATION_URL}
             copyToClipboard={{
-              value: CLIENT_ASSERTION_HTU,
+              value: AUTHORIZATION_SERVER_TOKEN_CREATION_URL,
               tooltipTitle: t(
                 'firstDPoPProofStep.assertionPayload.htuField.copySuccessFeedbackText'
               ),
@@ -103,12 +103,12 @@ export const VoucherInstructionsFirstDPoPProofStep: React.FC = () => {
       <VoucherScriptPreviewSection
         fileUrl={getFilePath('script')}
         previewUrl={getFilePath('preview')}
-        fileName={FILENAME}
+        fileName={VOUCHER_FIRST_DPOP_FILENAME}
         substitutions={{
           INSERISCI_VALORE_ALG: CLIENT_ASSERTION_ALG,
           INSERISCI_VALORE_TYP: CLIENT_ASSERTION_TYP,
           INSERISCI_VALORE_HTM: CLIENT_ASSERTION_HTM,
-          INSERISCI_VALORE_HTU: CLIENT_ASSERTION_HTU,
+          INSERISCI_VALORE_HTU: AUTHORIZATION_SERVER_TOKEN_CREATION_URL,
         }}
       />
       <StepActions

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsFirstDPoPProofStep.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsFirstDPoPProofStep.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { StepActions } from '@/components/shared/StepActions'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { useVoucherInstructionsContext } from '../VoucherInstructionsContext'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { SectionContainer } from '@/components/layout/containers'
-import { Box, Grid, Link, Typography } from '@mui/material'
+import { Grid } from '@mui/material'
 import { VerticalInformationContainer } from '@/components/shared/VerticalInformationContainer'
-import { CodeSnippetPreview } from '../CodeSnippetPreview'
 import { FE_URL } from '@/config/env'
+import { VoucherScriptPreviewSection } from '../VoucherScriptPreviewSection'
 
 const CLIENT_ASSERTION_TYP = 'dpop+jwt'
 const CLIENT_ASSERTION_ALG = 'RS256'
@@ -114,50 +114,17 @@ export const VoucherInstructionsFirstDPoPProofStep: React.FC = () => {
           </Grid>
         </Grid>
       </SectionContainer>
-      <SectionContainer title={t('firstDPoPProofStep.assertionScript.title')}>
-        <Box sx={{ pl: 2 }} component="ol">
-          <Typography component="li" variant="body2">
-            {t('firstDPoPProofStep.assertionScript.steps.1')}
-          </Typography>
-          <Typography component="li" variant="body2">
-            <Trans components={{ 1: <Link download href={getFilePath('script')} /> }}>
-              {t('firstDPoPProofStep.assertionScript.steps.2', {
-                filename: `${FILENAME}.py`,
-              })}
-            </Trans>
-          </Typography>
-          <Typography component="li" variant="body2" sx={{ whiteSpace: 'break-spaces' }}>
-            {t('firstDPoPProofStep.assertionScript.steps.3')}
-          </Typography>
-          <Typography component="li" variant="body2">
-            {t('firstDPoPProofStep.assertionScript.steps.4')}
-          </Typography>
-          <Typography component="li" variant="body2">
-            {t('firstDPoPProofStep.assertionScript.steps.5')}
-          </Typography>
-        </Box>
-
-        <CodeSnippetPreview
-          sx={{ mt: 2 }}
-          title={t('firstDPoPProofStep.assertionScript.exampleLabel')}
-          activeLang={'python'}
-          entries={[
-            {
-              url: getFilePath('preview'),
-              value: 'python',
-            },
-          ]}
-          scriptSubstitutionValues={{
-            INSERISCI_VALORE_ALG: CLIENT_ASSERTION_ALG,
-            INSERISCI_VALORE_TYP: CLIENT_ASSERTION_TYP,
-            INSERISCI_VALORE_HTM: CLIENT_ASSERTION_HTM,
-            INSERISCI_VALORE_HTU: CLIENT_ASSERTION_HTU,
-          }}
-        />
-        <Typography sx={{ mt: 2 }} variant="body2">
-          {t('firstDPoPProofStep.assertionScript.steps.result')}
-        </Typography>
-      </SectionContainer>
+      <VoucherScriptPreviewSection
+        fileUrl={getFilePath('script')}
+        previewUrl={getFilePath('preview')}
+        fileName={FILENAME}
+        substitutions={{
+          INSERISCI_VALORE_ALG: CLIENT_ASSERTION_ALG,
+          INSERISCI_VALORE_TYP: CLIENT_ASSERTION_TYP,
+          INSERISCI_VALORE_HTM: CLIENT_ASSERTION_HTM,
+          INSERISCI_VALORE_HTU: CLIENT_ASSERTION_HTU,
+        }}
+      />
       <StepActions
         back={{
           label: t('backBtn'),

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsFirstDPoPProofStep.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsFirstDPoPProofStep.tsx
@@ -35,83 +35,69 @@ export const VoucherInstructionsFirstDPoPProofStep: React.FC = () => {
     >
       <SectionContainer variant="outlined" title={t('firstDPoPProofStep.assertionHeader.title')}>
         <Grid container columnSpacing={4.5} rowSpacing={3}>
-          <Grid item xs={12} md={6}>
-            <VerticalInformationContainer
-              label={t('firstDPoPProofStep.assertionHeader.typField.label')}
-              labelDescription={t('firstDPoPProofStep.assertionHeader.typField.description')}
-              content={CLIENT_ASSERTION_TYP}
-              copyToClipboard={{
-                value: CLIENT_ASSERTION_TYP,
-                tooltipTitle: t(
-                  'firstDPoPProofStep.assertionHeader.typField.copySuccessFeedbackText'
-                ),
-              }}
-            />
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <VerticalInformationContainer
-              label={t('firstDPoPProofStep.assertionHeader.algField.label')}
-              labelDescription={t('firstDPoPProofStep.assertionHeader.algField.description')}
-              content={CLIENT_ASSERTION_ALG}
-              copyToClipboard={{
-                value: CLIENT_ASSERTION_ALG,
-                tooltipTitle: t(
-                  'firstDPoPProofStep.assertionHeader.algField.copySuccessFeedbackText'
-                ),
-              }}
-            />
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <VerticalInformationContainer
-              label={t('firstDPoPProofStep.assertionHeader.jwkField.label')}
-              labelDescription={t('firstDPoPProofStep.assertionHeader.jwkField.description')}
-              content={t('firstDPoPProofStep.assertionHeader.jwkField.suggestionLabel')}
-            />
-          </Grid>
+          <VerticalInformationContainer
+            label={t('firstDPoPProofStep.assertionHeader.typField.label')}
+            labelDescription={t('firstDPoPProofStep.assertionHeader.typField.description')}
+            content={CLIENT_ASSERTION_TYP}
+            copyToClipboard={{
+              value: CLIENT_ASSERTION_TYP,
+              tooltipTitle: t(
+                'firstDPoPProofStep.assertionHeader.typField.copySuccessFeedbackText'
+              ),
+            }}
+          />
+          <VerticalInformationContainer
+            label={t('firstDPoPProofStep.assertionHeader.algField.label')}
+            labelDescription={t('firstDPoPProofStep.assertionHeader.algField.description')}
+            content={CLIENT_ASSERTION_ALG}
+            copyToClipboard={{
+              value: CLIENT_ASSERTION_ALG,
+              tooltipTitle: t(
+                'firstDPoPProofStep.assertionHeader.algField.copySuccessFeedbackText'
+              ),
+            }}
+          />
+          <VerticalInformationContainer
+            label={t('firstDPoPProofStep.assertionHeader.jwkField.label')}
+            labelDescription={t('firstDPoPProofStep.assertionHeader.jwkField.description')}
+            content={t('firstDPoPProofStep.assertionHeader.jwkField.suggestionLabel')}
+          />
         </Grid>
       </SectionContainer>
       <SectionContainer variant="outlined" title={t('firstDPoPProofStep.assertionPayload.title')}>
         <Grid container columnSpacing={4.5} rowSpacing={3}>
-          <Grid item xs={12} md={6}>
-            <VerticalInformationContainer
-              label={t('firstDPoPProofStep.assertionPayload.htmField.label')}
-              labelDescription={t('firstDPoPProofStep.assertionPayload.htmField.description')}
-              content={CLIENT_ASSERTION_HTM}
-              copyToClipboard={{
-                value: CLIENT_ASSERTION_HTM,
-                tooltipTitle: t(
-                  'firstDPoPProofStep.assertionPayload.htmField.copySuccessFeedbackText'
-                ),
-              }}
-            />
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <VerticalInformationContainer
-              label={t('firstDPoPProofStep.assertionPayload.htuField.label')}
-              labelDescription={t('firstDPoPProofStep.assertionPayload.htuField.description')}
-              content={CLIENT_ASSERTION_HTU}
-              copyToClipboard={{
-                value: CLIENT_ASSERTION_HTU,
-                tooltipTitle: t(
-                  'firstDPoPProofStep.assertionPayload.htuField.copySuccessFeedbackText'
-                ),
-              }}
-            />
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <VerticalInformationContainer
-              label={t('firstDPoPProofStep.assertionPayload.jtiField.label')}
-              labelDescription={t('firstDPoPProofStep.assertionPayload.jtiField.description')}
-              content={t('firstDPoPProofStep.assertionPayload.jtiField.suggestionLabel')}
-            />
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <VerticalInformationContainer
-              label={t('firstDPoPProofStep.assertionPayload.iatField.label')}
-              labelDescription={t('firstDPoPProofStep.assertionPayload.iatField.description')}
-              content={t('firstDPoPProofStep.assertionPayload.iatField.suggestionLabel')}
-            />
-          </Grid>
+          <VerticalInformationContainer
+            label={t('firstDPoPProofStep.assertionPayload.htmField.label')}
+            labelDescription={t('firstDPoPProofStep.assertionPayload.htmField.description')}
+            content={CLIENT_ASSERTION_HTM}
+            copyToClipboard={{
+              value: CLIENT_ASSERTION_HTM,
+              tooltipTitle: t(
+                'firstDPoPProofStep.assertionPayload.htmField.copySuccessFeedbackText'
+              ),
+            }}
+          />
+          <VerticalInformationContainer
+            label={t('firstDPoPProofStep.assertionPayload.htuField.label')}
+            labelDescription={t('firstDPoPProofStep.assertionPayload.htuField.description')}
+            content={CLIENT_ASSERTION_HTU}
+            copyToClipboard={{
+              value: CLIENT_ASSERTION_HTU,
+              tooltipTitle: t(
+                'firstDPoPProofStep.assertionPayload.htuField.copySuccessFeedbackText'
+              ),
+            }}
+          />
+          <VerticalInformationContainer
+            label={t('firstDPoPProofStep.assertionPayload.jtiField.label')}
+            labelDescription={t('firstDPoPProofStep.assertionPayload.jtiField.description')}
+            content={t('firstDPoPProofStep.assertionPayload.jtiField.suggestionLabel')}
+          />
+          <VerticalInformationContainer
+            label={t('firstDPoPProofStep.assertionPayload.iatField.label')}
+            labelDescription={t('firstDPoPProofStep.assertionPayload.iatField.description')}
+            content={t('firstDPoPProofStep.assertionPayload.iatField.suggestionLabel')}
+          />
         </Grid>
       </SectionContainer>
       <VoucherScriptPreviewSection

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsClientAssertionStep.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsClientAssertionStep.test.tsx
@@ -221,15 +221,4 @@ describe('VoucherInstructionsClientAssertionStep', () => {
       screen.getByLabelText('clientAssertionStep.assertionPayload.entityNumberField.label')
     ).toBeInTheDocument()
   })
-
-  it('renders script section', async () => {
-    renderWithApplicationContext(
-      <MemoryRouter>
-        <VoucherInstructionsClientAssertionStep />
-      </MemoryRouter>,
-      { withReactQueryContext: true }
-    )
-
-    expect(await screen.findByText('clientAssertionStep.assertionScript.title')).toBeInTheDocument()
-  })
 })

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsClientAssertionStep.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsClientAssertionStep.test.tsx
@@ -248,15 +248,4 @@ describe('VoucherInstructionsClientAssertionStep', () => {
     expect(screen.getAllByText('producer-1')).toHaveLength(2)
     expect(screen.getByText('pubkey-1')).toBeInTheDocument()
   })
-
-  it('renders script section', async () => {
-    renderWithApplicationContext(
-      <MemoryRouter>
-        <VoucherInstructionsClientAssertionStep />
-      </MemoryRouter>,
-      { withReactQueryContext: true }
-    )
-
-    expect(await screen.findByText('clientAssertionStep.assertionScript.title')).toBeInTheDocument()
-  })
 })

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsFirstDPoPProofStep.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsFirstDPoPProofStep.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import { VoucherInstructionsFirstDPoPProofStep } from '../VoucherInstructionsFirstDPoPProofStep'
 
-vi.mock('../CodeSnippetPreview', () => ({
+vi.mock('../../CodeSnippetPreview', () => ({
   CodeSnippetPreview: () => null,
   default: () => null,
 }))

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsFirstDPoPProofStep.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsFirstDPoPProofStep.test.tsx
@@ -33,7 +33,6 @@ describe('VoucherInstructionsFirstDPoPProofStep', () => {
     expect(await screen.findByText('firstDPoPProofStep.title')).toBeInTheDocument()
     expect(await screen.findByText('firstDPoPProofStep.assertionHeader.title')).toBeInTheDocument()
     expect(await screen.findByText('firstDPoPProofStep.assertionPayload.title')).toBeInTheDocument()
-    expect(await screen.findByText('firstDPoPProofStep.assertionScript.title')).toBeInTheDocument()
   })
 
   it('renders assertion header fields', async () => {

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsFirstDPoPProofStep.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsFirstDPoPProofStep.test.tsx
@@ -1,0 +1,100 @@
+import { vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { VoucherInstructionsFirstDPoPProofStep } from '../VoucherInstructionsFirstDPoPProofStep'
+
+vi.mock('../CodeSnippetPreview', () => ({
+  CodeSnippetPreview: () => null,
+  default: () => null,
+}))
+
+vi.mock('../../VoucherInstructionsContext', () => ({
+  useVoucherInstructionsContext: () => ({
+    goToPreviousStep: vi.fn(),
+    goToNextStep: vi.fn(),
+  }),
+}))
+
+describe('VoucherInstructionsFirstDPoPProofStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders main sections', async () => {
+    renderWithApplicationContext(
+      <MemoryRouter>
+        <VoucherInstructionsFirstDPoPProofStep />
+      </MemoryRouter>,
+      { withReactQueryContext: true }
+    )
+
+    expect(await screen.findByText('firstDPoPProofStep.title')).toBeInTheDocument()
+    expect(await screen.findByText('firstDPoPProofStep.assertionHeader.title')).toBeInTheDocument()
+    expect(await screen.findByText('firstDPoPProofStep.assertionPayload.title')).toBeInTheDocument()
+    expect(await screen.findByText('firstDPoPProofStep.assertionScript.title')).toBeInTheDocument()
+  })
+
+  it('renders assertion header fields', async () => {
+    renderWithApplicationContext(
+      <MemoryRouter>
+        <VoucherInstructionsFirstDPoPProofStep />
+      </MemoryRouter>,
+      { withReactQueryContext: true }
+    )
+
+    expect(
+      await screen.findByText('firstDPoPProofStep.assertionHeader.typField.label')
+    ).toBeInTheDocument()
+
+    expect(
+      await screen.findByText('firstDPoPProofStep.assertionHeader.algField.label')
+    ).toBeInTheDocument()
+
+    expect(
+      await screen.findByText('firstDPoPProofStep.assertionHeader.jwkField.label')
+    ).toBeInTheDocument()
+  })
+
+  it('renders assertion payload fields', async () => {
+    renderWithApplicationContext(
+      <MemoryRouter>
+        <VoucherInstructionsFirstDPoPProofStep />
+      </MemoryRouter>,
+      { withReactQueryContext: true }
+    )
+
+    expect(
+      await screen.findByText('firstDPoPProofStep.assertionPayload.htmField.label')
+    ).toBeInTheDocument()
+
+    expect(
+      await screen.findByText('firstDPoPProofStep.assertionPayload.htuField.label')
+    ).toBeInTheDocument()
+
+    expect(
+      await screen.findByText('firstDPoPProofStep.assertionPayload.jtiField.label')
+    ).toBeInTheDocument()
+
+    expect(
+      await screen.findByText('firstDPoPProofStep.assertionPayload.iatField.label')
+    ).toBeInTheDocument()
+  })
+
+  it('renders navigation buttons', async () => {
+    renderWithApplicationContext(
+      <MemoryRouter>
+        <VoucherInstructionsFirstDPoPProofStep />
+      </MemoryRouter>,
+      { withReactQueryContext: true }
+    )
+
+    expect(await screen.findByText('backBtn')).toBeInTheDocument()
+    expect(await screen.findByText('proceedBtn')).toBeInTheDocument()
+
+    expect(
+      await screen.findByText('firstDPoPProofStep.navigateToDebugButton.label')
+    ).toBeInTheDocument()
+  })
+})

--- a/src/static/locales/en/voucher.json
+++ b/src/static/locales/en/voucher.json
@@ -129,7 +129,63 @@
   "firstDPoPProofStep": {
     "stepperLabel": "First DPoP Proof",
     "title": "DPoP Proof",
-    "description": "Now you need to generate the DPoP Proof (a signed JWT) to securely bind the session to your cryptographic keys and proceed with the voucher redemption. The key pair used is different from the one used for client assertion."
+    "description": "Now you need to generate the DPoP Proof (a signed JWT) to securely bind the session to your cryptographic keys and proceed with the voucher redemption. The key pair used is different from the one used for client assertion.",
+    "assertionHeader": {
+      "title": "Header",
+      "typField": {
+        "label": "TYP (Type)",
+        "description": "The type of object you are sending, in this case, a JWT.",
+        "copySuccessFeedbackText": "String successfully copied"
+      },
+      "algField": {
+        "label": "ALG (Algorithm)",
+        "description": "The algorithm used to sign this JWT. It can only be signed with RS256",
+        "copySuccessFeedbackText": "String successfully copied"
+      },
+      "jwkField": {
+        "label": "JWK (public key)",
+        "description": "The public key in JWK format corresponding to the private key used to sign the DPoP.",
+        "suggestionLabel": "Generate this parameter yourself.\nThe code starts with \"ey\""
+      }
+    },
+    "assertionPayload": {
+      "title": "Payload",
+      "htmField": {
+        "label": "HTM",
+        "description": "Indicates the HTTP method being invoked; in this case POST",
+        "copySuccessFeedbackText": "String successfully copied"
+      },
+      "htuField": {
+        "label": "HTU",
+        "description": "The URL being invoked; in this case a PDND Interoperability resource",
+        "copySuccessFeedbackText": "String successfully copied"
+      },
+      "jtiField": {
+        "label": "JTI (Unique Identifier)",
+        "description": "A unique identifier (UUID) for the DPoP. This is used to identify the token itself.",
+        "suggestionLabel": "Generate this parameter yourself.\nExample: 261cd445-3da6-421b-9ef4-7ba556efda5f"
+      },
+      "iatField": {
+        "label": "IAT (Creation Date and Time)",
+        "description": "Issued at, the timestamp reporting the date and time the token was created, expressed in UNIX epoch (numeric value, not string)",
+        "suggestionLabel": "Generate this parameter yourself.\nExample: 1651659340"
+      }
+    },
+    "assertionScript": {
+      "title": "Terminal generation example",
+      "steps": {
+        "1": "Create a folder and name it “client_assertion_test”",
+        "2": "Place the script <1>{{ filename }}</1> in the folder (Python 3.8 required)",
+        "3": "Create a “keys” folder and place the private key inside, naming it “client-test-keypair.rsa.priv”.\nMake sure the private key matches the public key you selected in the previous step.",
+        "4": "Open the terminal and navigate to the client_assertion_test folder",
+        "5": "Paste the command below and press enter",
+        "result": "6. You'll receive a client assertion signed with your private key. Save this data for the next step.."
+      },
+      "exampleLabel": "Example usage"
+    },
+    "navigateToDebugButton": {
+      "label": "Debug"
+    }
   },
   "secondDPoPProofStep": {
     "stepperLabel": "Second DPoP",

--- a/src/static/locales/en/voucher.json
+++ b/src/static/locales/en/voucher.json
@@ -126,6 +126,18 @@
       }
     }
   },
+  "assertionScript": {
+    "title": "Terminal generation example",
+    "steps": {
+      "1": "Create a folder and name it “client_assertion_test”",
+      "2": "Place the script <1>{{ filename }}</1> in the folder (Python 3.8 required)",
+      "3": "Create a “keys” folder and place the private key inside, naming it “client-test-keypair.rsa.priv”.\nMake sure the private key matches the public key you selected in the previous step.",
+      "4": "Open the terminal and navigate to the client_assertion_test folder",
+      "5": "Paste the command below and press enter",
+      "result": "6. You'll receive a client assertion signed with your private key. Save this data for the next step.."
+    },
+    "exampleLabel": "Example usage"
+  },
   "firstDPoPProofStep": {
     "stepperLabel": "First DPoP Proof",
     "title": "DPoP Proof",
@@ -170,18 +182,6 @@
         "description": "Issued at, the timestamp reporting the date and time the token was created, expressed in UNIX epoch (numeric value, not string)",
         "suggestionLabel": "Generate this parameter yourself.\nExample: 1651659340"
       }
-    },
-    "assertionScript": {
-      "title": "Terminal generation example",
-      "steps": {
-        "1": "Create a folder and name it “client_assertion_test”",
-        "2": "Place the script <1>{{ filename }}</1> in the folder (Python 3.8 required)",
-        "3": "Create a “keys” folder and place the private key inside, naming it “client-test-keypair.rsa.priv”.\nMake sure the private key matches the public key you selected in the previous step.",
-        "4": "Open the terminal and navigate to the client_assertion_test folder",
-        "5": "Paste the command below and press enter",
-        "result": "6. You'll receive a client assertion signed with your private key. Save this data for the next step.."
-      },
-      "exampleLabel": "Example usage"
     },
     "navigateToDebugButton": {
       "label": "Debug"
@@ -274,18 +274,6 @@
         "label": "EntityNumber",
         "description": "The number of entities present in the response."
       }
-    },
-    "assertionScript": {
-      "title": "Terminal generation example",
-      "steps": {
-        "1": "Create a folder and name it “client_assertion_test”",
-        "2": "Place the script <1>{{ filename }}</1> in the folder (Python 3.8 required)",
-        "3": "Create a “keys” folder and place the private key inside, naming it “client-test-keypair.rsa.priv”.\nMake sure the private key matches the public key you selected in the previous step.",
-        "4": "Open the terminal and navigate to the client_assertion_test folder",
-        "5": "Paste the command below and press enter",
-        "result": "6. You'll receive a client assertion signed with your private key. Save this data for the next step.."
-      },
-      "exampleLabel": "Example usage"
     }
   },
   "accessTokenStep": {

--- a/src/static/locales/it/voucher.json
+++ b/src/static/locales/it/voucher.json
@@ -129,7 +129,63 @@
   "firstDPoPProofStep": {
     "stepperLabel": "Prima DPoP Proof",
     "title": "DPoP Proof",
-    "description": "Ora è necessario generare la DPoP Proof (un JWT firmato) per legare in modo sicuro la sessione alle tue chiavi crittografiche e procedere con il riscatto del voucher. La coppia di chiavi utilizzate è diversa da quelle utilizzate per la client assertion."
+    "description": "Ora è necessario generare la DPoP Proof (un JWT firmato) per legare in modo sicuro la sessione alle tue chiavi crittografiche e procedere con il riscatto del voucher. La coppia di chiavi utilizzate è diversa da quelle utilizzate per la client assertion.",
+    "assertionHeader": {
+      "title": "Header",
+      "typField": {
+        "label": "TYP (Type)",
+        "description": "Il tipo di oggetto che si sta inviando, in questo caso, un JWT.",
+        "copySuccessFeedbackText": "Testo copiato correttamente"
+      },
+      "algField": {
+        "label": "ALG (Algorithm)",
+        "description": "L’algoritmo usato per firmare questo JWT. Si può firmare solo con RS256",
+        "copySuccessFeedbackText": "Testo copiato correttamente"
+      },
+      "jwkField": {
+        "label": "JWK (chiave pubblica)",
+        "description": "La chiave pubblica in formato JWK corrispondente alla chiave privata utilizzata per firmare la DPoP.",
+        "suggestionLabel": "Genera tu questo parametro.\nIl codice inizia per \"ey\""
+      }
+    },
+    "assertionPayload": {
+      "title": "Payload",
+      "htmField": {
+        "label": "HTM",
+        "description": "Indica il metodo HTTP che si sta invocando; in questo caso POST",
+        "copySuccessFeedbackText": "Testo copiato correttamente"
+      },
+      "htuField": {
+        "label": "HTU",
+        "description": "L'URL che si sta invocando; in questo caso una risorsa di PDND Interoperabilità",
+        "copySuccessFeedbackText": "Testo copiato correttamente"
+      },
+      "jtiField": {
+        "label": "JTI (Identificativo univoco)",
+        "description": "Un id unico (UUID) della DPoP. Serve per identificare il token stesso",
+        "suggestionLabel": "Genera tu questo parametro.\nEsempio: 261cd445-3da6-421b-9ef4-7ba556efda5f"
+      },
+      "iatField": {
+        "label": "IAT (Data e ora di creazione)",
+        "description": "Issued at, il timestamp riportante data e ora in cui viene creato il token, espresso in UNIX epoch (valore numerico, non stringa)",
+        "suggestionLabel": "Genera tu questo parametro.\nEsempio: 1651659340"
+      }
+    },
+    "assertionScript": {
+      "title": "Esempio di generazione da terminale",
+      "steps": {
+        "1": "Crea una cartella e nominala “client_assertion_test”",
+        "2": "Inserisci nella cartella lo script <1>{{ filename }}</1> (è richiesto Python 3.8)",
+        "3": "Crea una cartella “keys” e inserisci al suo interno la chiave privata, nominandola “client-test-keypair.rsa.priv”.\nAssicurati che la chiave privata corrisponda alla pubblica che hai selezionato nel passaggio precedente.",
+        "4": "Apri il terminale e naviga fino alla cartella client_assertion_test",
+        "5": "Incolla il comando sotto e premi invio",
+        "result": "6. Otterrai una client assertion firmata con la tua chiave privata. Salva questo dato per lo step successivo."
+      },
+      "exampleLabel": "Esempio di utilizzo"
+    },
+    "navigateToDebugButton": {
+      "label": "Effettua debug"
+    }
   },
   "secondDPoPProofStep": {
     "stepperLabel": "Seconda DPoP",

--- a/src/static/locales/it/voucher.json
+++ b/src/static/locales/it/voucher.json
@@ -126,6 +126,18 @@
       }
     }
   },
+  "assertionScript": {
+    "title": "Esempio di generazione da terminale",
+    "steps": {
+      "1": "Crea una cartella e nominala “client_assertion_test”",
+      "2": "Inserisci nella cartella lo script <1>{{ filename }}</1> (è richiesto Python 3.8)",
+      "3": "Crea una cartella “keys” e inserisci al suo interno la chiave privata, nominandola “client-test-keypair.rsa.priv”.\nAssicurati che la chiave privata corrisponda alla pubblica che hai selezionato nel passaggio precedente.",
+      "4": "Apri il terminale e naviga fino alla cartella client_assertion_test",
+      "5": "Incolla il comando sotto e premi invio",
+      "result": "6. Otterrai una client assertion firmata con la tua chiave privata. Salva questo dato per lo step successivo."
+    },
+    "exampleLabel": "Esempio di utilizzo"
+  },
   "firstDPoPProofStep": {
     "stepperLabel": "Prima DPoP Proof",
     "title": "DPoP Proof",
@@ -170,18 +182,6 @@
         "description": "Issued at, il timestamp riportante data e ora in cui viene creato il token, espresso in UNIX epoch (valore numerico, non stringa)",
         "suggestionLabel": "Genera tu questo parametro.\nEsempio: 1651659340"
       }
-    },
-    "assertionScript": {
-      "title": "Esempio di generazione da terminale",
-      "steps": {
-        "1": "Crea una cartella e nominala “client_assertion_test”",
-        "2": "Inserisci nella cartella lo script <1>{{ filename }}</1> (è richiesto Python 3.8)",
-        "3": "Crea una cartella “keys” e inserisci al suo interno la chiave privata, nominandola “client-test-keypair.rsa.priv”.\nAssicurati che la chiave privata corrisponda alla pubblica che hai selezionato nel passaggio precedente.",
-        "4": "Apri il terminale e naviga fino alla cartella client_assertion_test",
-        "5": "Incolla il comando sotto e premi invio",
-        "result": "6. Otterrai una client assertion firmata con la tua chiave privata. Salva questo dato per lo step successivo."
-      },
-      "exampleLabel": "Esempio di utilizzo"
     },
     "navigateToDebugButton": {
       "label": "Effettua debug"
@@ -274,18 +274,6 @@
         "label": "EntityNumber",
         "description": "Il numero di entità presenti nella risposta."
       }
-    },
-    "assertionScript": {
-      "title": "Esempio di generazione da terminale",
-      "steps": {
-        "1": "Crea una cartella e nominala “client_assertion_test”",
-        "2": "Inserisci nella cartella lo script <1>{{ filename }}</1> (è richiesto Python 3.8)",
-        "3": "Crea una cartella “keys” e inserisci al suo interno la chiave privata, nominandola “client-test-keypair.rsa.priv”.\nAssicurati che la chiave privata corrisponda alla pubblica che hai selezionato nel passaggio precedente.",
-        "4": "Apri il terminale e naviga fino alla cartella client_assertion_test",
-        "5": "Incolla il comando sotto e premi invio",
-        "result": "6. Otterrai una client assertion firmata con la tua chiave privata. Salva questo dato per lo step successivo."
-      },
-      "exampleLabel": "Esempio di utilizzo"
     }
   },
   "accessTokenStep": {


### PR DESCRIPTION
## Issue
- [PIN-9819](https://pagopa.atlassian.net/browse/PIN-9819)
## Description / Context / Why

- Added DPOP python scripts (.py) and preview files (.txt)
- Created simulate voucher second step component (first DPoP)
- Refactored VerticalInformationContainer to have a Grid item (to avoid duplication)
- Added a CodeSnippetPreview wrapper component (to avoid duplication)
- Added tests

[PIN-9819]: https://pagopa.atlassian.net/browse/PIN-9819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ