### PR TITLE
feat: add async exchange selector to e-service creation (PIN-10027)

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/EServiceCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/EServiceCreateStepGeneral.tsx
@@ -36,6 +36,7 @@ export type EServiceCreateStepGeneralFormValues = {
   description: string
   technology: EServiceTechnology
   mode: EServiceMode
+  asyncExchange: boolean
   personalData: boolean | undefined
   isSignalHubEnabled: boolean
   isConsumerDelegable: boolean
@@ -255,6 +256,7 @@ function evaluateFormDefaultValues(
       description: descriptor?.eservice.description ?? '',
       technology: descriptor?.eservice.technology ?? 'REST',
       mode: eserviceMode,
+      asyncExchange: descriptor?.eservice.asyncExchange ?? false,
       personalData: descriptor?.eservice.personalData,
       isSignalHubEnabled: descriptor?.eservice.isSignalHubEnabled ?? false,
       isConsumerDelegable: descriptor?.eservice.isConsumerDelegable ?? true,
@@ -267,6 +269,7 @@ function evaluateFormDefaultValues(
     description: eserviceTemplate?.description,
     technology: eserviceTemplate?.technology,
     mode: eserviceTemplate?.mode,
+    asyncExchange: eserviceTemplate?.asyncExchange ?? false,
     personalData: eserviceTemplate?.personalData,
     isSignalHubEnabled: eserviceTemplate?.isSignalHubEnabled ?? false,
     isConsumerDelegable: true,

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/EServiceCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepGeneral/EServiceCreateStepGeneral.tsx
@@ -250,26 +250,29 @@ function evaluateFormDefaultValues(
   descriptor: ProducerEServiceDescriptor | undefined,
   eserviceMode: EServiceMode
 ): EServiceCreateStepGeneralFormValues {
-  if (!eserviceTemplate)
+  if (!eserviceTemplate) {
+    const asyncExchange = descriptor?.eservice.asyncExchange ?? false
     return {
       name: descriptor?.eservice.name ?? '',
       description: descriptor?.eservice.description ?? '',
       technology: descriptor?.eservice.technology ?? 'REST',
-      mode: eserviceMode,
-      asyncExchange: descriptor?.eservice.asyncExchange ?? false,
+      mode: asyncExchange ? 'DELIVER' : eserviceMode,
+      asyncExchange,
       personalData: descriptor?.eservice.personalData,
       isSignalHubEnabled: descriptor?.eservice.isSignalHubEnabled ?? false,
       isConsumerDelegable: descriptor?.eservice.isConsumerDelegable ?? true,
       isClientAccessDelegable: descriptor?.eservice.isClientAccessDelegable ?? true,
       instanceLabel: '', //instanceLabel will not be used
     }
+  }
 
+  const asyncExchange = eserviceTemplate?.asyncExchange ?? false
   return {
     name: eserviceTemplate?.name,
     description: eserviceTemplate?.description,
     technology: eserviceTemplate?.technology,
-    mode: eserviceTemplate?.mode,
-    asyncExchange: eserviceTemplate?.asyncExchange ?? false,
+    mode: asyncExchange ? 'DELIVER' : eserviceTemplate?.mode,
+    asyncExchange,
     personalData: eserviceTemplate?.personalData,
     isSignalHubEnabled: eserviceTemplate?.isSignalHubEnabled ?? false,
     isConsumerDelegable: true,

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSection.tsx
@@ -1,9 +1,12 @@
 import type { EServiceMode, ProducerEServiceDescriptor } from '@/api/api.generatedTypes'
+import { AuthHooks } from '@/api/auth'
 import { SectionContainer } from '@/components/layout/containers'
 import { RHFRadioGroup } from '@/components/shared/react-hook-form-inputs'
 import { Alert, Stack } from '@mui/material'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
+import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import type { EServiceCreateStepGeneralFormValues } from '../EServiceCreateStepGeneral/EServiceCreateStepGeneral'
 
 type EServiceDetailsSectionProps = {
   areEServiceGeneralInfoEditable: boolean
@@ -20,11 +23,22 @@ export const EServiceDetailsSection: React.FC<EServiceDetailsSectionProps> = ({
 }) => {
   const { t } = useTranslation('eservice', { keyPrefix: 'create.step1.detailsSection' })
   const { t: tCommon } = useTranslation('common', { keyPrefix: 'validation.mixed' })
+  const { isOperatorAPI } = AuthHooks.useJwt()
+  const { watch, setValue } = useFormContext<EServiceCreateStepGeneralFormValues>()
+
+  const asyncExchange = watch('asyncExchange')
+  const technology = watch('technology')
 
   if (!areEServiceGeneralInfoEditable && descriptor)
     return (
       <SectionContainer title={t('title')} description={t('readOnlyDescription')}>
         <Stack spacing={2}>
+          <InformationContainer
+            label={t('asyncExchangeField.readOnlyLabel')}
+            content={t(
+              `asyncExchangeField.readOnlyOptions.${Boolean(descriptor.eservice.asyncExchange)}`
+            )}
+          />
           <InformationContainer
             label={t('technologyField.readOnlyLabel')}
             content={descriptor.eservice.technology}
@@ -51,6 +65,33 @@ export const EServiceDetailsSection: React.FC<EServiceDetailsSectionProps> = ({
         {t('firstVersionOnlyEditableInfo')}
       </Alert>
       <RHFRadioGroup
+        name="asyncExchange"
+        row
+        required
+        label={t('asyncExchangeField.label')}
+        options={[
+          { label: t('asyncExchangeField.options.false'), value: false },
+          { label: t('asyncExchangeField.options.true'), value: true },
+        ]}
+        disabled={!areEServiceGeneralInfoEditable}
+        rules={{
+          validate: (value) => value === true || value === false || tCommon('required'),
+        }}
+        sx={{ mb: 0, mt: 3 }}
+        isOptionValueAsBoolean
+        onValueChange={(value) => {
+          if (value === 'true') {
+            setValue('mode', 'DELIVER')
+            onEserviceModeChange?.('DELIVER')
+          }
+        }}
+      />
+      {asyncExchange && isOperatorAPI && (
+        <Alert severity="warning" sx={{ mb: 0, mt: 3 }}>
+          {t('asyncExchangeField.operatorApiWarning')}
+        </Alert>
+      )}
+      <RHFRadioGroup
         name="technology"
         row
         required
@@ -63,7 +104,11 @@ export const EServiceDetailsSection: React.FC<EServiceDetailsSectionProps> = ({
         rules={{ required: true }}
         sx={{ mb: 0, mt: 3 }}
       />
-
+      {asyncExchange && technology === 'SOAP' && (
+        <Alert severity="warning" sx={{ mb: 0, mt: 3 }}>
+          {t('asyncExchangeField.soapWarning')}
+        </Alert>
+      )}
       <RHFRadioGroup
         name="mode"
         row
@@ -79,7 +124,7 @@ export const EServiceDetailsSection: React.FC<EServiceDetailsSectionProps> = ({
             value: 'RECEIVE',
           },
         ]}
-        disabled={!areEServiceGeneralInfoEditable}
+        disabled={!areEServiceGeneralInfoEditable || asyncExchange}
         rules={{ required: true }}
         sx={{ mb: 0, mt: 3 }}
         onValueChange={(mode) => onEserviceModeChange?.(mode as EServiceMode)}

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSection.tsx
@@ -4,6 +4,7 @@ import { SectionContainer } from '@/components/layout/containers'
 import { RHFRadioGroup } from '@/components/shared/react-hook-form-inputs'
 import { Alert, Stack } from '@mui/material'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
+import { useEffect } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import type { EServiceCreateStepGeneralFormValues } from '../EServiceCreateStepGeneral/EServiceCreateStepGeneral'
@@ -28,6 +29,14 @@ export const EServiceDetailsSection: React.FC<EServiceDetailsSectionProps> = ({
 
   const asyncExchange = watch('asyncExchange')
   const technology = watch('technology')
+  const mode = watch('mode')
+
+  useEffect(() => {
+    if (asyncExchange && mode !== 'DELIVER') {
+      setValue('mode', 'DELIVER', { shouldDirty: true, shouldValidate: true })
+      onEserviceModeChange?.('DELIVER')
+    }
+  }, [asyncExchange, mode, setValue, onEserviceModeChange])
 
   if (!areEServiceGeneralInfoEditable && descriptor)
     return (
@@ -79,12 +88,6 @@ export const EServiceDetailsSection: React.FC<EServiceDetailsSectionProps> = ({
         }}
         sx={{ mb: 0, mt: 3 }}
         isOptionValueAsBoolean
-        onValueChange={(value) => {
-          if (value === 'true') {
-            setValue('mode', 'DELIVER')
-            onEserviceModeChange?.('DELIVER')
-          }
-        }}
       />
       {asyncExchange && isOperatorAPI && (
         <Alert severity="warning" sx={{ mb: 0, mt: 3 }}>

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSection.tsx
@@ -27,9 +27,7 @@ export const EServiceDetailsSection: React.FC<EServiceDetailsSectionProps> = ({
   const { isOperatorAPI } = AuthHooks.useJwt()
   const { watch, setValue } = useFormContext<EServiceCreateStepGeneralFormValues>()
 
-  const asyncExchange = watch('asyncExchange')
-  const technology = watch('technology')
-  const mode = watch('mode')
+  const [asyncExchange, technology, mode] = watch(['asyncExchange', 'technology', 'mode'])
 
   useEffect(() => {
     if (asyncExchange && mode !== 'DELIVER') {

--- a/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceDetailsSection.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceDetailsSection.test.tsx
@@ -1,7 +1,12 @@
 import type { EServiceMode, ProducerEServiceDescriptor } from '@/api/api.generatedTypes'
-import { ReactHookFormWrapper, renderWithApplicationContext } from '@/utils/testing.utils'
+import {
+  mockUseJwt,
+  ReactHookFormWrapper,
+  renderWithApplicationContext,
+} from '@/utils/testing.utils'
 import { EServiceDetailsSection } from '../EServiceDetailsSection'
 import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createMockEServiceDescriptorProvider } from '@/../__mocks__/data/eservice.mocks'
 
 const descriptor: ProducerEServiceDescriptor = createMockEServiceDescriptorProvider()
@@ -9,10 +14,19 @@ const descriptor: ProducerEServiceDescriptor = createMockEServiceDescriptorProvi
 const renderComponent = (
   eserviceMode: EServiceMode,
   areEServiceGeneralInfoEditable: boolean = true,
-  descriptor?: ProducerEServiceDescriptor
+  descriptor?: ProducerEServiceDescriptor,
+  defaultValues: Record<string, unknown> = {}
 ) => {
   return renderWithApplicationContext(
-    <ReactHookFormWrapper>
+    <ReactHookFormWrapper
+      defaultValues={{
+        technology: 'REST',
+        mode: eserviceMode,
+        asyncExchange: false,
+        personalData: undefined,
+        ...defaultValues,
+      }}
+    >
       <EServiceDetailsSection
         areEServiceGeneralInfoEditable={areEServiceGeneralInfoEditable}
         eserviceMode={eserviceMode}
@@ -27,6 +41,10 @@ const renderComponent = (
 }
 
 describe('EServiceDetailsSection', () => {
+  beforeEach(() => {
+    mockUseJwt()
+  })
+
   it('should render the title w/o eserviceTemplate', () => {
     renderComponent('DELIVER')
     expect(screen.getByText('title')).toBeInTheDocument()
@@ -37,8 +55,9 @@ describe('EServiceDetailsSection', () => {
     expect(screen.getByText('firstVersionOnlyEditableInfo')).toBeInTheDocument()
   })
 
-  it('should render input (technology, mode) w/o eserviceTemplate', () => {
+  it('should render input (asyncExchange, technology, mode) w/o eserviceTemplate', () => {
     renderComponent('DELIVER')
+    expect(screen.getByText('asyncExchangeField.label')).toBeInTheDocument()
     expect(screen.getByText('technologyField.label')).toBeInTheDocument()
     expect(screen.getByText('modeField.label')).toBeInTheDocument()
   })
@@ -49,10 +68,68 @@ describe('EServiceDetailsSection', () => {
     expect(screen.getByText('readOnlyDescription')).toBeInTheDocument()
   })
 
-  it('should render 3 information containers (technology, mode, personalData) when not editable', () => {
+  it('should render 4 information containers (asyncExchange, technology, mode, personalData) when not editable', () => {
     renderComponent('DELIVER', false, descriptor)
+    expect(screen.getByText('asyncExchangeField.readOnlyLabel')).toBeInTheDocument()
     expect(screen.getByText('technologyField.readOnlyLabel')).toBeInTheDocument()
     expect(screen.getByText('modeField.label')).toBeInTheDocument()
     expect(screen.getByText('personalDataField.DELIVER.readOnlyLabel')).toBeInTheDocument()
+  })
+
+  it('should disable mode radios and force DELIVER when asyncExchange is selected', async () => {
+    const user = userEvent.setup()
+    renderComponent('RECEIVE', true, undefined, { mode: 'RECEIVE' })
+
+    const asyncOption = screen.getByRole('radio', { name: 'asyncExchangeField.options.true' })
+    await user.click(asyncOption)
+
+    const deliverRadio = screen.getByRole('radio', { name: 'modeField.options.DELIVER' })
+    const receiveRadio = screen.getByRole('radio', { name: 'modeField.options.RECEIVE' })
+
+    expect(deliverRadio).toBeDisabled()
+    expect(receiveRadio).toBeDisabled()
+    expect(deliverRadio).toBeChecked()
+  })
+
+  it('should show SOAP warning when asyncExchange is true and technology is SOAP', () => {
+    renderComponent('DELIVER', true, undefined, {
+      asyncExchange: true,
+      technology: 'SOAP',
+    })
+    expect(screen.getByText('asyncExchangeField.soapWarning')).toBeInTheDocument()
+  })
+
+  it('should not show SOAP warning when asyncExchange is true and technology is REST', () => {
+    renderComponent('DELIVER', true, undefined, {
+      asyncExchange: true,
+      technology: 'REST',
+    })
+    expect(screen.queryByText('asyncExchangeField.soapWarning')).not.toBeInTheDocument()
+  })
+
+  it('should not show SOAP warning when asyncExchange is false', () => {
+    renderComponent('DELIVER', true, undefined, {
+      asyncExchange: false,
+      technology: 'SOAP',
+    })
+    expect(screen.queryByText('asyncExchangeField.soapWarning')).not.toBeInTheDocument()
+  })
+
+  it('should show operator API warning only when asyncExchange is true and user is operator API', () => {
+    mockUseJwt({ isOperatorAPI: true, isAdmin: false, currentRoles: ['api'] })
+    renderComponent('DELIVER', true, undefined, { asyncExchange: true })
+    expect(screen.getByText('asyncExchangeField.operatorApiWarning')).toBeInTheDocument()
+  })
+
+  it('should not show operator API warning when user is not operator API', () => {
+    mockUseJwt({ isOperatorAPI: false })
+    renderComponent('DELIVER', true, undefined, { asyncExchange: true })
+    expect(screen.queryByText('asyncExchangeField.operatorApiWarning')).not.toBeInTheDocument()
+  })
+
+  it('should not show operator API warning when asyncExchange is false', () => {
+    mockUseJwt({ isOperatorAPI: true, isAdmin: false, currentRoles: ['api'] })
+    renderComponent('DELIVER', true, undefined, { asyncExchange: false })
+    expect(screen.queryByText('asyncExchangeField.operatorApiWarning')).not.toBeInTheDocument()
   })
 })

--- a/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceDetailsSection.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceDetailsSection.test.tsx
@@ -76,6 +76,17 @@ describe('EServiceDetailsSection', () => {
     expect(screen.getByText('personalDataField.DELIVER.readOnlyLabel')).toBeInTheDocument()
   })
 
+  it('should disable mode radios and force DELIVER on mount when asyncExchange is already true with mode=RECEIVE', async () => {
+    renderComponent('RECEIVE', true, undefined, { asyncExchange: true, mode: 'RECEIVE' })
+
+    const deliverRadio = screen.getByRole('radio', { name: 'modeField.options.DELIVER' })
+    const receiveRadio = screen.getByRole('radio', { name: 'modeField.options.RECEIVE' })
+
+    expect(deliverRadio).toBeDisabled()
+    expect(receiveRadio).toBeDisabled()
+    expect(await screen.findByRole('radio', { name: 'modeField.options.DELIVER' })).toBeChecked()
+  })
+
   it('should disable mode radios and force DELIVER when asyncExchange is selected', async () => {
     const user = userEvent.setup()
     renderComponent('RECEIVE', true, undefined, { mode: 'RECEIVE' })

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -44,6 +44,20 @@
         "description": "This information has been pre-populated by the template creator and cannot be edited.",
         "readOnlyDescription": "The following information is no longer editable.",
         "firstVersionOnlyEditableInfo": "This data will no longer be editable after the first version of the e-service is published.",
+        "asyncExchangeField": {
+          "label": "How do you want to exchange the e-service data?",
+          "readOnlyLabel": "Data exchange type",
+          "options": {
+            "false": "Synchronous (standard)",
+            "true": "Asynchronous / bulk (deferred)"
+          },
+          "readOnlyOptions": {
+            "false": "Synchronous",
+            "true": "Asynchronous"
+          },
+          "soapWarning": "SOAP technology does not allow enabling bulk download during asynchronous data exchange.",
+          "operatorApiWarning": "For asynchronous exchanges, a keychain must be linked to the e-service. Only those with the administrator role can do this: ask to link it before or after publication to enable data exchange."
+        },
         "technologyField": {
           "label": "What technology is your API built with?",
           "readOnlyLabel": "API Technology"

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -44,6 +44,20 @@
         "description": "Queste informazioni sono state precompilate da chi ha creato il template e non sono modificabili.",
         "readOnlyDescription": "Le seguenti informazioni non sono più modificabili.",
         "firstVersionOnlyEditableInfo": "Questi dati non saranno più modificabili dopo la pubblicazione della prima versione dell’e-service.",
+        "asyncExchangeField": {
+          "label": "In che modo vuoi scambiare i dati dell’e-service?",
+          "readOnlyLabel": "Tipologia di scambio dati",
+          "options": {
+            "false": "Sincrono (standard)",
+            "true": "Asincrono / massivo (in differita)"
+          },
+          "readOnlyOptions": {
+            "false": "Sincrono",
+            "true": "Asincrono"
+          },
+          "soapWarning": "La tecnologia SOAP non permette di abilitare il download a blocchi durante lo scambio asincrono dei dati.",
+          "operatorApiWarning": "Per gli scambi asincroni è necessario collegare un portachiavi all’e-service. Solo chi ha il ruolo di amministratore può farlo: chiedi di collegarlo prima o dopo la pubblicazione per abilitare lo scambio dei dati."
+        },
         "technologyField": {
           "label": "Con quale tecnologia è costruita la tua API?",
           "readOnlyLabel": "Tecnologia API"


### PR DESCRIPTION
## 🔗 Issue                                                                                                                                                                                                                                                                     
  [PIN-10027](https://pagopa.atlassian.net/browse/PIN-10027)
                                                                                                                                                                                                                                                                                    
  ## 📝 Description / Context
  The "E-service details" card in the e-service creation/edit step now lets the provider declare whether the data exchange is synchronous or asynchronous. Choosing asynchronous affects related fields (mode is forced to DELIVER and disabled) and surfaces dedicated warnings depending on technology and current user role.                                                                                                                                                                                                                                    
   
  ## 🛠 List of changes                                                                                                                                                                                                                                                              
  - Added a new `asyncExchange` boolean field to the step-general form values and default values (both descriptor and template branches).                                                                                                                                         
  - Added a Synchronous / Asynchronous radio selector at the top of `EServiceDetailsSection`, before the technology field.                                                                                                                                                          
  - When Asynchronous is selected, the Deliver / Receive radios are disabled and `mode` is forced to `DELIVER`.                                                                                                                                                                     
  - Added a conditional warning when technology is SOAP and Asynchronous is selected.                                                                                                                                                                                               
  - Added a conditional warning for users with the API operator role when Asynchronous is selected, informing them that an administrator must link a keychain to the e-service.                                                                                                     
  - Added the async exchange value as a read-only `InformationContainer` for non-editable e-services.                                                                                                                                                                               
  - Added IT and EN i18n keys under `create.step1.detailsSection.asyncExchangeField`.                                                                                                                                                                                               
  - Updated and extended unit tests in `EServiceDetailsSection.test.tsx`.                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                    
  ## 🧪 How to test                                                                                                                                                                                                                                                                 
  - Start the e-service creation flow as a provider and open the "E-service details" card.                                                                                                                                                                                          
  - Verify the new Synchronous / Asynchronous selector is rendered first and defaults to Synchronous.                                                                                                                                                                               
  - Select Asynchronous and verify Deliver / Receive radios are disabled and Deliver is selected.                                                                                                                                                                                   
  - Toggle technology to SOAP with Asynchronous selected and verify the SOAP warning appears; switch back to REST and verify it disappears.                                                                                                                                         
  - Log in as an API-role operator (non-admin), select Asynchronous and verify the keychain warning appears; with Synchronous selected the warning must not appear.                                                                                                                 
  - Open an already-published e-service in read-only mode and verify the new "Data exchange type" row is rendered with the correct value.                                                                                                                                           
  - Save a draft and verify the `asyncExchange` value is persisted (create and update flows).        

<img width="946" height="797" alt="Screenshot 2026-05-12 alle 10 15 48" src="https://github.com/user-attachments/assets/7d59dc94-cdfb-4990-b452-114d02afdc8b" />
                                                                                                                                                                               
                                                                                                                                                                                                                                                                                    
  [PIN-10027]: https://pagopa.atlassian.net/browse/PIN-10027        

[PIN-10027]: https://pagopa.atlassian.net/browse/PIN-10027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-10027]: https://pagopa.atlassian.net/browse/PIN-10027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ