### PR TITLE
fix: added maxLength rule on client_id field (PIN-10060)

### DIFF
--- a/src/pages/ConsumerDebugVoucherPage/components/DebugVoucherForm.tsx
+++ b/src/pages/ConsumerDebugVoucherPage/components/DebugVoucherForm.tsx
@@ -100,6 +100,7 @@ export const DebugVoucherForm: React.FC<DebugVoucherFormProps> = ({ setDebugVouc
               name="clientId"
               label={t('clientIdLabel')}
               infoLabel={t('clientIdInfoLabel')}
+              inputProps={{ maxLength: 36 }}
             />
 
             {/* The input will be disabled for this release: https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW?node-id=4078-14921#1712917799 */}


### PR DESCRIPTION
## Issue
- [PIN-10060](https://pagopa.atlassian.net/browse/PIN-10060)
## Description / Context / Why

- Added maxLength to 36 characters rule to client_id field on Debug Client Assertion page form

[PIN-10060]: https://pagopa.atlassian.net/browse/PIN-10060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ