### PR TITLE
feat: add producer keychain warnings (PIN-10034)

### DIFF
--- a/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetailsAlerts.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetailsAlerts.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  createMockEServiceDescriptorProvider,
+  createMockEServiceDescriptorProviderAsync,
+} from '../../../../__mocks__/data/eservice.mocks'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { ProviderEServiceDetailsAlerts } from '../components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts'
+
+describe('ProviderEServiceDetailsAlerts', () => {
+  it('shows a warning when an async eservice has no associated producer keychain', () => {
+    const descriptor = createMockEServiceDescriptorProviderAsync({
+      eservice: {
+        hasProducerKeychain: false,
+        hasProducerKeychainKeys: false,
+      },
+    })
+
+    renderWithApplicationContext(<ProviderEServiceDetailsAlerts descriptor={descriptor} />, {})
+
+    expect(screen.getByText('missingProducerKeychain')).toBeInTheDocument()
+    expect(screen.queryByText('missingProducerKeychainKeys')).not.toBeInTheDocument()
+  })
+
+  it('shows a warning when an async eservice has an associated producer keychain without keys', () => {
+    const descriptor = createMockEServiceDescriptorProviderAsync({
+      eservice: {
+        hasProducerKeychain: true,
+        hasProducerKeychainKeys: false,
+      },
+    })
+
+    renderWithApplicationContext(<ProviderEServiceDetailsAlerts descriptor={descriptor} />, {})
+
+    expect(screen.getByText('missingProducerKeychainKeys')).toBeInTheDocument()
+    expect(screen.queryByText('missingProducerKeychain')).not.toBeInTheDocument()
+  })
+
+  it('does not show producer keychain warnings when an async eservice has a keychain with keys', () => {
+    const descriptor = createMockEServiceDescriptorProviderAsync({
+      eservice: {
+        hasProducerKeychain: true,
+        hasProducerKeychainKeys: true,
+      },
+    })
+
+    renderWithApplicationContext(<ProviderEServiceDetailsAlerts descriptor={descriptor} />, {})
+
+    expect(screen.queryByText('missingProducerKeychain')).not.toBeInTheDocument()
+    expect(screen.queryByText('missingProducerKeychainKeys')).not.toBeInTheDocument()
+  })
+
+  it('does not show producer keychain warnings for sync eservices', () => {
+    const descriptor = createMockEServiceDescriptorProvider({
+      eservice: {
+        asyncExchange: false,
+        hasProducerKeychain: false,
+        hasProducerKeychainKeys: false,
+      },
+    })
+
+    renderWithApplicationContext(<ProviderEServiceDetailsAlerts descriptor={descriptor} />, {})
+
+    expect(screen.queryByText('missingProducerKeychain')).not.toBeInTheDocument()
+    expect(screen.queryByText('missingProducerKeychainKeys')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts.tsx
@@ -16,11 +16,23 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
 
   const isSuspended = descriptor?.state === 'SUSPENDED'
   const isDeprecated = descriptor?.state === 'DEPRECATED'
+  const shouldShowMissingKeychainAlert =
+    descriptor.eservice.asyncExchange && !descriptor.eservice.hasProducerKeychain
+  const shouldShowMissingKeychainKeysAlert =
+    descriptor.eservice.asyncExchange &&
+    descriptor.eservice.hasProducerKeychain &&
+    !descriptor.eservice.hasProducerKeychainKeys
 
   return (
     <Stack spacing={2}>
       {isSuspended && <Alert severity="error">{t('suspended')}</Alert>}
       {isDeprecated && <Alert severity="info">{t('deprecated')}</Alert>}
+      {shouldShowMissingKeychainAlert && (
+        <Alert severity="warning">{t('missingProducerKeychain')}</Alert>
+      )}
+      {shouldShowMissingKeychainKeysAlert && (
+        <Alert severity="warning">{t('missingProducerKeychainKeys')}</Alert>
+      )}
     </Stack>
   )
 }

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -532,7 +532,9 @@
     },
     "alert": {
       "suspended": "This e-service version is discontinued. Until its reactivation, no consumer will be able to access the data provided through the API.",
-      "deprecated": "This e-service version is obsolete but still active. It will be automatically discontinued by PDND Interoperabilità when the last agreement on this version is archived."
+      "deprecated": "This e-service version is obsolete but still active. It will be automatically discontinued by PDND Interoperabilità when the last agreement on this version is archived.",
+      "missingProducerKeychain": "Associate a keychain with this e-service to enable data exchange.",
+      "missingProducerKeychainKeys": "Add at least one key to the keychain linked to this e-service to enable data exchange."
     },
     "actions": {
       "backToListLabel": "Back to the e-services",

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -532,7 +532,9 @@
     },
     "alert": {
       "suspended": "Questa versione di e-service è sospesa. Fino alla sua riattivazione nessun fruitore potrà accedere ai dati erogati attraverso l’API.",
-      "deprecated": "Questa versione di e-service è obsoleta ma ancora attiva. Verrà dismessa automaticamente da PDND Interoperabilità quando l’ultima richiesta di fruizione presente su questa versione sarà archiviata."
+      "deprecated": "Questa versione di e-service è obsoleta ma ancora attiva. Verrà dismessa automaticamente da PDND Interoperabilità quando l’ultima richiesta di fruizione presente su questa versione sarà archiviata.",
+      "missingProducerKeychain": "Associa un portachiavi a questo e-service per abilitare lo scambio dati.",
+      "missingProducerKeychainKeys": "Associa almeno una chiave al portachiavi collegato a questo e-service per abilitare lo scambio dati."
     },
     "actions": {
       "backToListLabel": "Torna agli e-service",


### PR DESCRIPTION
## 🔗 Issue

[PIN-10034](https://pagopa.atlassian.net/browse/PIN-10034)

## 📝 Description / Context

Adds producer keychain warning alerts to the provider e-service details page for asynchronous e-services, so producers are informed when data exchange is not enabled due to missing keychain setup.

## 🛠 List of changes

- Added warning alerts for async e-services without an associated producer keychain.
- Added warning alerts for async e-services with an associated producer keychain but no keys.
- Added Italian and English locale entries for the new warning messages.
- Added focused tests for missing keychain, empty keychain, valid keychain, and sync e-service cases.

## 🧪 How to test

- Open the provider e-service details page for an asynchronous e-service without an associated keychain and verify that the missing keychain warning is shown.
- Open the same page for an asynchronous e-service with a keychain but no keys and verify that the missing keys warning is shown.
- Verify that no producer keychain warning is shown when the async e-service has a keychain with at least one key.
- Verify that synchronous e-services do not show these warnings.

[PIN-10034]: https://pagopa.atlassian.net/browse/PIN-10034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ