### PR TITLE
feat: add async fields to eservice details (PIN-10033)

### DIFF
--- a/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceTechnicalInfoSection.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceTechnicalInfoSection.test.tsx
@@ -1,0 +1,105 @@
+import { EServiceQueries } from '@/api/eservice'
+import { mockUseJwt, mockUseParams, renderWithApplicationContext } from '@/utils/testing.utils'
+import { screen } from '@testing-library/react'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+import { ProviderEServiceTechnicalInfoSection } from '../components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection'
+import {
+  createMockEServiceDescriptorProvider,
+  createMockEServiceDescriptorProviderAsync,
+} from '@/../__mocks__/data/eservice.mocks'
+
+mockUseJwt({ currentRoles: ['admin'], isAdmin: true, jwt: { organizationId: 'producer-id' } })
+mockUseParams({ eserviceId: 'eservice-id', descriptorId: 'descriptor-id' })
+
+vi.mock('@/api/eservice', () => ({
+  EServiceQueries: {
+    getDescriptorProvider: vi.fn(),
+  },
+  EServiceMutations: {
+    useUpdateVersion: () => ({ mutate: vi.fn() }),
+    useUpdateInstanceVersion: () => ({ mutate: vi.fn() }),
+    useUpdateAgreementApprovalPolicy: () => ({ mutate: vi.fn() }),
+    useUpdateEServiceDelegationFlagsAfterPublication: () => ({ mutate: vi.fn() }),
+  },
+  EServiceDownloads: {
+    useDownloadVersionDocument: () => vi.fn(),
+  },
+}))
+
+vi.mock('@/hooks/useGetProducerDelegationUserRole', () => ({
+  useGetProducerDelegationUserRole: () => ({
+    isDelegator: false,
+  }),
+}))
+
+vi.mock('@/components/shared/UpdateVoucherDrawer', () => ({
+  UpdateVoucherDrawer: () => <div data-testid="update-voucher-drawer" />,
+}))
+
+vi.mock(
+  '../components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceUpdateDocumentationDrawer',
+  () => ({
+    ProviderEServiceUpdateDocumentationDrawer: () => (
+      <div data-testid="update-documentation-drawer" />
+    ),
+  })
+)
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useSuspenseQuery: vi.fn(),
+  }
+})
+
+describe('ProviderEServiceTechnicalInfoSection', () => {
+  it('does not render async exchange fields for synchronous e-services', () => {
+    vi.mocked(EServiceQueries.getDescriptorProvider).mockReturnValue({ queryKey: [] } as never)
+    vi.mocked(useSuspenseQuery).mockReturnValue({
+      data: createMockEServiceDescriptorProvider(),
+    } as never)
+
+    renderWithApplicationContext(<ProviderEServiceTechnicalInfoSection />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('exchangeType.label')).toBeInTheDocument()
+    expect(screen.getByText('exchangeType.value.sync')).toBeInTheDocument()
+    expect(screen.queryByText('asyncExchange.responseTime.label')).not.toBeInTheDocument()
+    expect(screen.queryByText('callbackInterface.label')).not.toBeInTheDocument()
+  })
+
+  it('renders async exchange fields for asynchronous e-services', () => {
+    const descriptor = createMockEServiceDescriptorProviderAsync()
+    vi.mocked(EServiceQueries.getDescriptorProvider).mockReturnValue({ queryKey: [] } as never)
+    vi.mocked(useSuspenseQuery).mockReturnValue({ data: descriptor } as never)
+
+    renderWithApplicationContext(<ProviderEServiceTechnicalInfoSection />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('exchangeType.label')).toBeInTheDocument()
+    expect(screen.getByText('exchangeType.value.async')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchange.responseTime.label')).toBeInTheDocument()
+    expect(
+      screen.getByText(`${descriptor.asyncExchangeProperties!.responseTime} time.second`)
+    ).toBeInTheDocument()
+    expect(screen.getByText('asyncExchange.resourceAvailableTime.label')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchange.confirmation.label')).toBeInTheDocument()
+    expect(screen.getAllByText('asyncExchange.booleanValue.true').length).toBeGreaterThan(0)
+    expect(screen.getByText('asyncExchange.bulk.label')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchange.maxResultSet.label')).toBeInTheDocument()
+    expect(
+      screen.getByText(String(descriptor.asyncExchangeProperties!.maxResultSet))
+    ).toBeInTheDocument()
+    expect(screen.getByText('callbackInterface.label')).toBeInTheDocument()
+    expect(
+      screen.getByText(descriptor.asyncExchangeCallbackInterface!.prettyName)
+    ).toBeInTheDocument()
+  })
+})

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDocumentationSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDocumentationSection.tsx
@@ -93,6 +93,27 @@ export const ProviderEServiceDocumentationSection: React.FC<
             </Stack>
           }
         />
+        {descriptor.eservice.asyncExchange && (
+          <InformationContainer
+            label={t('callbackInterface.label')}
+            content={
+              descriptor.asyncExchangeCallbackInterface ? (
+                <IconLink
+                  component="button"
+                  onClick={handleDownloadDocument.bind(
+                    null,
+                    descriptor.asyncExchangeCallbackInterface
+                  )}
+                  startIcon={<AttachFileIcon fontSize="small" />}
+                >
+                  {descriptor.asyncExchangeCallbackInterface.prettyName}
+                </IconLink>
+              ) : (
+                '-'
+              )
+            }
+          />
+        )}
         {descriptor.interface?.checksum && (
           <InformationContainer
             label={t('documentation.interfaceChecksum')}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceTechnicalInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceTechnicalInfoSection.tsx
@@ -21,11 +21,14 @@ export const ProviderEServiceTechnicalInfoSection: React.FC = () => {
   const { t } = useTranslation('eservice', {
     keyPrefix: 'read.sections.technicalInformations',
   })
+  const { t: tCommon } = useTranslation('common')
 
   const { eserviceId, descriptorId } = useParams<'PROVIDE_ESERVICE_MANAGE'>()
   const { data: descriptor } = useSuspenseQuery(
     EServiceQueries.getDescriptorProvider(eserviceId, descriptorId)
   )
+
+  const asyncExchangeProperties = descriptor.asyncExchangeProperties
 
   return (
     <SectionContainer title={t('title')} description={t('description')}>
@@ -84,6 +87,12 @@ export const ProviderEServiceTechnicalInfoSection: React.FC = () => {
               label={t('technology')}
               content={descriptor.eservice.technology}
             />
+            <InformationContainer
+              label={t('exchangeType.label')}
+              content={t(
+                `exchangeType.value.${descriptor.eservice.asyncExchange ? 'async' : 'sync'}`
+              )}
+            />
 
             <InformationContainer label={t('audience')} content={descriptor.audience[0]} />
 
@@ -92,6 +101,52 @@ export const ProviderEServiceTechnicalInfoSection: React.FC = () => {
               labelDescription={t('mode.labelDescription')}
               content={t(`mode.value.${descriptor.eservice.mode}`)}
             />
+            {descriptor.eservice.asyncExchange && (
+              <>
+                <InformationContainer
+                  label={t('asyncExchange.responseTime.label')}
+                  content={
+                    asyncExchangeProperties
+                      ? `${asyncExchangeProperties.responseTime} ${tCommon('time.second', {
+                          count: asyncExchangeProperties.responseTime,
+                        })}`
+                      : '-'
+                  }
+                />
+                <InformationContainer
+                  label={t('asyncExchange.resourceAvailableTime.label')}
+                  content={
+                    asyncExchangeProperties
+                      ? `${asyncExchangeProperties.resourceAvailableTime} ${tCommon('time.second', {
+                          count: asyncExchangeProperties.resourceAvailableTime,
+                        })}`
+                      : '-'
+                  }
+                />
+                <InformationContainer
+                  label={t('asyncExchange.confirmation.label')}
+                  content={
+                    asyncExchangeProperties
+                      ? t(`asyncExchange.booleanValue.${asyncExchangeProperties.confirmation}`)
+                      : '-'
+                  }
+                />
+                <InformationContainer
+                  label={t('asyncExchange.bulk.label')}
+                  content={
+                    asyncExchangeProperties
+                      ? t(`asyncExchange.booleanValue.${asyncExchangeProperties.bulk}`)
+                      : '-'
+                  }
+                />
+                <InformationContainer
+                  label={t('asyncExchange.maxResultSet.label')}
+                  content={
+                    asyncExchangeProperties ? String(asyncExchangeProperties.maxResultSet) : '-'
+                  }
+                />
+              </>
+            )}
           </Stack>
         </SectionContainer>
         <Divider />

--- a/src/static/locales/en/common.json
+++ b/src/static/locales/en/common.json
@@ -158,7 +158,9 @@
   },
   "time": {
     "minute_one": "minute",
-    "minute_other": "minutes"
+    "minute_other": "minutes",
+    "second_one": "second",
+    "second_other": "seconds"
   },
   "tos": {
     "title": "Terms of service"

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -599,6 +599,13 @@
         "description": "In this section you can check the specifications of the e-service and make changes.",
         "technology": "Technology",
         "audience": "Audience",
+        "exchangeType": {
+          "label": "Exchange type",
+          "value": {
+            "sync": "Synchronous",
+            "async": "Asynchronous"
+          }
+        },
         "eserviceId": {
           "label": "E-service ID",
           "copySuccessFeedbackText": "E-service ID copied successfully"
@@ -650,6 +657,30 @@
           "title": "Documentation",
           "label": "Documents list",
           "interfaceChecksum": "Interface file checksum"
+        },
+        "callbackInterface": {
+          "label": "Callback interface"
+        },
+        "asyncExchange": {
+          "responseTime": {
+            "label": "Maximum callback time"
+          },
+          "resourceAvailableTime": {
+            "label": "Resource availability time"
+          },
+          "confirmation": {
+            "label": "Require receipt acknowledgement"
+          },
+          "bulk": {
+            "label": "Enable bulk download"
+          },
+          "maxResultSet": {
+            "label": "Maximum entities per response"
+          },
+          "booleanValue": {
+            "true": "Yes",
+            "false": "No"
+          }
         },
         "usefulLinks": {
           "title": "Useful links",

--- a/src/static/locales/it/common.json
+++ b/src/static/locales/it/common.json
@@ -158,7 +158,9 @@
   },
   "time": {
     "minute_one": "minuto",
-    "minute_other": "minuti"
+    "minute_other": "minuti",
+    "second_one": "secondo",
+    "second_other": "secondi"
   },
   "tos": {
     "title": "Termini di servizio"

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -599,6 +599,13 @@
         "description": "In questa sezione potrai verificare le specifiche dell’e-service ed apportare modifiche.",
         "technology": "Tecnologia",
         "audience": "Audience",
+        "exchangeType": {
+          "label": "Tipologia scambio",
+          "value": {
+            "sync": "Sincrono",
+            "async": "Asincrono"
+          }
+        },
         "eserviceId": {
           "label": "ID e-service",
           "copySuccessFeedbackText": "ID copiato correttamente"
@@ -650,6 +657,30 @@
           "title": "Documentazione",
           "label": "Elenco documenti",
           "interfaceChecksum": "Checksum file di interfaccia"
+        },
+        "callbackInterface": {
+          "label": "Interfaccia di callback"
+        },
+        "asyncExchange": {
+          "responseTime": {
+            "label": "Tempo massimo di callback"
+          },
+          "resourceAvailableTime": {
+            "label": "Tempo disponibilità risorsa"
+          },
+          "confirmation": {
+            "label": "Richiedi conferma di ricezione"
+          },
+          "bulk": {
+            "label": "Abilita download a blocchi"
+          },
+          "maxResultSet": {
+            "label": "Limite massimo di entità per risposta"
+          },
+          "booleanValue": {
+            "true": "Sì",
+            "false": "No"
+          }
         },
         "usefulLinks": {
           "title": "Link utili",


### PR DESCRIPTION
## 🔗 Issue

[PIN-10033](https://pagopa.atlassian.net/browse/PIN-10033)

## 📝 Description / Context

This PR updates the provider e-service details page to show async exchange information in the technical specifications area, aligned with the async labels introduced in the summary flow.

## 🛠 List of changes

- Added exchange type to provider e-service technical information.
- Added async exchange fields for asynchronous e-services: maximum callback time, resource availability time, receipt acknowledgement, bulk download, and maximum entities per response.
- Added callback interface display in the documentation section.
- Added IT/EN translations for the new details labels and second-based time unit.
- Added focused tests for synchronous and asynchronous e-service details rendering.

## 🧪 How to test

- Open the provider e-service details page for a synchronous e-service. Verify that the technical specifications show the exchange type as synchronous and do not show async-only fields.
- Open the provider e-service details page for an asynchronous e-service. Verify that the technical specifications show the exchange type as asynchronous and display the async exchange fields.
- In the documentation section of an asynchronous e-service, verify that the callback interface is shown and can be selected like the main interface document.


[PIN-10033]: https://pagopa.atlassian.net/browse/PIN-10033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ