### PR TITLE
feat: update publish thank you page for async flows (PIN-10031, PIN-10035)

### DIFF
--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -106,6 +106,7 @@ const ProviderEServiceSummaryPage: React.FC = () => {
     if (!descriptor) return
 
     const isFirstVersion = descriptor.version === '1'
+    const isAsyncExchange = descriptor.eservice.asyncExchange === true
 
     publishVersion(
       {
@@ -123,20 +124,34 @@ const ProviderEServiceSummaryPage: React.FC = () => {
               descriptorId: descriptor.id,
             },
             state: {
-              ...match(isFirstVersion)
-                .with(true, () => ({
+              ...match({ isFirstVersion, isAsyncExchange })
+                .with({ isFirstVersion: true, isAsyncExchange: false }, () => ({
                   title: t('publishThankYou.firstVersion.title'),
                   description: t('publishThankYou.firstVersion.description'),
+                  buttonLabel: t('publishThankYou.action'),
                 }))
-                .with(false, () => ({
+                .with({ isFirstVersion: true, isAsyncExchange: true }, () => ({
+                  title: t('publishThankYou.firstVersionAsync.title'),
+                  description: t('publishThankYou.firstVersionAsync.description'),
+                  buttonLabel: t('publishThankYou.asyncAction'),
+                }))
+                .with({ isFirstVersion: false, isAsyncExchange: false }, () => ({
                   title: t('publishThankYou.newVersion.title'),
                   subtitle: t('publishThankYou.newVersion.subtitle'),
                   bulletPoints: t('publishThankYou.newVersion.bulletPoints', {
                     returnObjects: true,
                   }),
+                  buttonLabel: t('publishThankYou.action'),
+                }))
+                .with({ isFirstVersion: false, isAsyncExchange: true }, () => ({
+                  title: t('publishThankYou.newVersionAsync.title'),
+                  subtitle: t('publishThankYou.newVersionAsync.subtitle'),
+                  bulletPoints: t('publishThankYou.newVersionAsync.bulletPoints', {
+                    returnObjects: true,
+                  }),
+                  buttonLabel: t('publishThankYou.asyncAction'),
                 }))
                 .exhaustive(),
-              buttonLabel: t('publishThankYou.action'),
               closeRouteKey: 'PROVIDE_ESERVICE_MANAGE',
               closeRouteParams: { eserviceId: descriptor.eservice.id, descriptorId: descriptor.id },
             },

--- a/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import ProviderEServiceSummaryPage from '../ProviderEServiceSummary.page'
 import { mockUseJwt, mockUseParams, renderWithApplicationContext } from '@/utils/testing.utils'
 import * as router from '@/router'
@@ -237,6 +238,87 @@ describe('ProviderEServiceSummaryPage', () => {
     expect(screen.queryByRole('button', { name: 'publish' })).not.toBeInTheDocument()
     expect(screen.queryByTestId('DeleteOutlineIcon')).not.toBeInTheDocument()
     expect(screen.queryByTestId('CreateIcon')).not.toBeInTheDocument()
+  })
+
+  describe('handlePublishDraft navigation state', () => {
+    const setupAndPublish = async (
+      descriptor: ReturnType<typeof createMockEServiceDescriptorProvider>
+    ) => {
+      const user = userEvent.setup()
+      useQueryMock.mockReturnValue({ data: descriptor, isLoading: false })
+      usePublishVersionDraftMock.mockImplementationOnce(
+        (_params: unknown, { onSuccess }: { onSuccess: () => void }) => {
+          onSuccess()
+        }
+      )
+
+      renderWithApplicationContext(<ProviderEServiceSummaryPage />, {
+        withReactQueryContext: true,
+        withRouterContext: true,
+      })
+
+      await user.click(screen.getByRole('button', { name: 'publish' }))
+    }
+
+    it('navigates with firstVersion state when publishing sync first version', async () => {
+      await setupAndPublish(createMockEServiceDescriptorProvider({ version: '1' }))
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'PROVIDE_ESERVICE_PUBLISH_THANK_YOU',
+        expect.objectContaining({
+          state: expect.objectContaining({
+            title: 'publishThankYou.firstVersion.title',
+            description: 'publishThankYou.firstVersion.description',
+          }),
+        })
+      )
+    })
+
+    it('navigates with firstVersionAsync state when publishing async first version (PIN-10031)', async () => {
+      await setupAndPublish(
+        createMockEServiceDescriptorProvider({ version: '1', eservice: { asyncExchange: true } })
+      )
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'PROVIDE_ESERVICE_PUBLISH_THANK_YOU',
+        expect.objectContaining({
+          state: expect.objectContaining({
+            title: 'publishThankYou.firstVersionAsync.title',
+            description: 'publishThankYou.firstVersionAsync.description',
+          }),
+        })
+      )
+    })
+
+    it('navigates with newVersion state when publishing sync new version', async () => {
+      await setupAndPublish(createMockEServiceDescriptorProvider())
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'PROVIDE_ESERVICE_PUBLISH_THANK_YOU',
+        expect.objectContaining({
+          state: expect.objectContaining({
+            title: 'publishThankYou.newVersion.title',
+            subtitle: 'publishThankYou.newVersion.subtitle',
+          }),
+        })
+      )
+    })
+
+    it('navigates with newVersionAsync state when publishing async new version (PIN-10035)', async () => {
+      await setupAndPublish(
+        createMockEServiceDescriptorProvider({ eservice: { asyncExchange: true } })
+      )
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'PROVIDE_ESERVICE_PUBLISH_THANK_YOU',
+        expect.objectContaining({
+          state: expect.objectContaining({
+            title: 'publishThankYou.newVersionAsync.title',
+            subtitle: 'publishThankYou.newVersionAsync.subtitle',
+          }),
+        })
+      )
+    })
   })
 
   describe('isRulesetExpired', () => {

--- a/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
@@ -274,7 +274,7 @@ describe('ProviderEServiceSummaryPage', () => {
       )
     })
 
-    it('navigates with firstVersionAsync state when publishing async first version (PIN-10031)', async () => {
+    it('navigates with firstVersionAsync state when publishing async first version', async () => {
       await setupAndPublish(
         createMockEServiceDescriptorProvider({ version: '1', eservice: { asyncExchange: true } })
       )
@@ -304,7 +304,7 @@ describe('ProviderEServiceSummaryPage', () => {
       )
     })
 
-    it('navigates with newVersionAsync state when publishing async new version (PIN-10035)', async () => {
+    it('navigates with newVersionAsync state when publishing async new version', async () => {
       await setupAndPublish(
         createMockEServiceDescriptorProvider({ eservice: { asyncExchange: true } })
       )

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -972,6 +972,10 @@
       "title": "You have published the e-service",
       "description": "The e-service is now available in the catalog and you will be able to receive subscription requests."
     },
+    "firstVersionAsync": {
+      "title": "You have published the async e-service",
+      "description": "The e-service is now available in the catalog and you will be able to receive subscription requests. Make sure you have linked a keychain to the e-service to enable data exchange."
+    },
     "newVersion": {
       "title": "You have published a new version of the e-service",
       "subtitle": "What happens now:",
@@ -981,6 +985,16 @@
         "the previous version becomes obsolete but remains active as long as there are subscribers."
       ]
     },
-    "action": "Close"
+    "newVersionAsync": {
+      "title": "You have published a new version of the e-service",
+      "subtitle": "What happens now:",
+      "bulletPoints": [
+        "the new version is available in the catalog;",
+        "subscribers receive an update notification;",
+        "the previous version becomes obsolete but remains active as long as there are subscribers."
+      ]
+    },
+    "action": "Close",
+    "asyncAction": "Go to the e-service"
   }
 }

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -972,6 +972,10 @@
       "title": "Hai pubblicato l'e-service",
       "description": "Ora l'e-service è disponibile nel catalogo e potrai ricevere richieste di fruizione."
     },
+    "firstVersionAsync": {
+      "title": "Hai pubblicato l'e-service asincrono",
+      "description": "Ora l'e-service è disponibile nel catalogo e potrai ricevere richieste di fruizione. Assicurati di aver collegato un portachiavi all'e-service per rendere possibile lo scambio dei dati."
+    },
     "newVersion": {
       "title": "Hai pubblicato una nuova versione dell'e-service",
       "subtitle": "Cosa succede ora:",
@@ -981,6 +985,16 @@
         "la versione precedente diventa obsoleta ma attiva fino a quando ci sono fruitori."
       ]
     },
-    "action": "Chiudi"
+    "newVersionAsync": {
+      "title": "Hai pubblicato una nuova versione dell'e-service",
+      "subtitle": "Cosa succede ora:",
+      "bulletPoints": [
+        "la nuova versione è disponibile nel catalogo;",
+        "i fruitori ricevono una notifica di aggiornamento;",
+        "la versione precedente diventa obsoleta ma attiva fino a quando ci sono fruitori."
+      ]
+    },
+    "action": "Chiudi",
+    "asyncAction": "Vai all'e-service"
   }
 }


### PR DESCRIPTION
## 🔗 Issue

[PIN-10031](https://pagopa.atlassian.net/browse/PIN-10031)  
[PIN-10035](https://pagopa.atlassian.net/browse/PIN-10035)

## 📝 Description / Context

This PR updates the publish thank-you flow for asynchronous e-services, covering both first-version publication and new-version publication while reusing the existing `PublishThankYouPage`.

## 🛠 List of changes

- Added async-specific navigation state for first-version and new-version e-service publication.
- Added async-specific thank-you page copy and CTA labels in Italian and English locales.
- Covered sync and async publish navigation states with focused tests.

## 🧪 How to test

- Publish the first version of an asynchronous e-service from the provider e-service summary page and verify that the thank-you page shows the async first-version copy and the “Go to the e-service” CTA.
- Publish a new version of an asynchronous e-service and verify that the thank-you page shows the async new-version copy with bullet points and the “Go to the e-service” CTA.
- Verify that synchronous e-service publication still shows the existing thank-you copy and “Close” CTA.

[PIN-10031]: https://pagopa.atlassian.net/browse/PIN-10031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-10035]: https://pagopa.atlassian.net/browse/PIN-10035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ