### PR TITLE
feat: add async eservice details drawers (PIN-10038)

### DIFF
--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceAsyncExchangeCallbackInterfaceInfo.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceAsyncExchangeCallbackInterfaceInfo.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import type { EServiceDoc } from '@/api/api.generatedTypes'
+import { IconLink } from '@/components/shared/IconLink'
+import AttachFileIcon from '@mui/icons-material/AttachFile'
+import { Stack } from '@mui/material'
+import { InformationContainer } from '@pagopa/interop-fe-commons'
+
+type ConsumerEServiceAsyncExchangeCallbackInterfaceInfoProps = {
+  callbackInterface?: EServiceDoc
+  callbackInterfaceLabel: string
+  callbackInterfaceChecksumLabel: string
+  onDownloadDocument: (document: EServiceDoc) => void
+}
+
+export const ConsumerEServiceAsyncExchangeCallbackInterfaceInfo: React.FC<
+  ConsumerEServiceAsyncExchangeCallbackInterfaceInfoProps
+> = ({
+  callbackInterface,
+  callbackInterfaceLabel,
+  callbackInterfaceChecksumLabel,
+  onDownloadDocument,
+}) => {
+  return (
+    <>
+      {callbackInterface && (
+        <InformationContainer
+          label={callbackInterfaceLabel}
+          content={
+            <Stack spacing={1} mt={1} alignItems="start">
+              <IconLink
+                component="button"
+                onClick={onDownloadDocument.bind(null, callbackInterface)}
+                startIcon={<AttachFileIcon fontSize="small" />}
+              >
+                {callbackInterface.prettyName}
+              </IconLink>
+            </Stack>
+          }
+          direction="column"
+        />
+      )}
+      {callbackInterface?.checksum && (
+        <InformationContainer
+          label={callbackInterfaceChecksumLabel}
+          content={callbackInterface.checksum}
+          copyToClipboard={{
+            value: callbackInterface.checksum,
+          }}
+        />
+      )}
+    </>
+  )
+}

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceAsyncExchangeDetailsDrawer.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceAsyncExchangeDetailsDrawer.tsx
@@ -2,13 +2,12 @@ import React from 'react'
 import type { CatalogEServiceDescriptor, EServiceDoc } from '@/api/api.generatedTypes'
 import { EServiceDownloads } from '@/api/eservice'
 import { Drawer } from '@/components/shared/Drawer'
-import { IconLink } from '@/components/shared/IconLink'
 import { getDownloadDocumentName } from '@/utils/eservice.utils'
-import AttachFileIcon from '@mui/icons-material/AttachFile'
 import { Stack } from '@mui/material'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
 import { useTranslation } from 'react-i18next'
 import { formatThousands } from '@/utils/format.utils'
+import { ConsumerEServiceAsyncExchangeCallbackInterfaceInfo } from './ConsumerEServiceAsyncExchangeCallbackInterfaceInfo'
 
 type ConsumerEServiceAsyncExchangeDetailsDrawerProps = {
   isOpen: boolean
@@ -72,36 +71,12 @@ export const ConsumerEServiceAsyncExchangeDetailsDrawer: React.FC<
           </>
         )}
 
-        {descriptor.asyncExchangeCallbackInterface && (
-          <InformationContainer
-            label={t('callbackInterface')}
-            content={
-              <Stack spacing={1} mt={1} alignItems="start">
-                <IconLink
-                  component="button"
-                  onClick={handleDownloadDocument.bind(
-                    null,
-                    descriptor.asyncExchangeCallbackInterface
-                  )}
-                  startIcon={<AttachFileIcon fontSize="small" />}
-                >
-                  {descriptor.asyncExchangeCallbackInterface.prettyName}
-                </IconLink>
-              </Stack>
-            }
-            direction="column"
-          />
-        )}
-
-        {descriptor.asyncExchangeCallbackInterface?.checksum && (
-          <InformationContainer
-            label={t('callbackInterfaceChecksum')}
-            content={descriptor.asyncExchangeCallbackInterface.checksum}
-            copyToClipboard={{
-              value: descriptor.asyncExchangeCallbackInterface.checksum,
-            }}
-          />
-        )}
+        <ConsumerEServiceAsyncExchangeCallbackInterfaceInfo
+          callbackInterface={descriptor.asyncExchangeCallbackInterface}
+          callbackInterfaceLabel={t('callbackInterface')}
+          callbackInterfaceChecksumLabel={t('callbackInterfaceChecksum')}
+          onDownloadDocument={handleDownloadDocument}
+        />
       </Stack>
     </Drawer>
   )

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceAsyncExchangeDetailsDrawer.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceAsyncExchangeDetailsDrawer.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import type { CatalogEServiceDescriptor, EServiceDoc } from '@/api/api.generatedTypes'
+import { EServiceDownloads } from '@/api/eservice'
+import { Drawer } from '@/components/shared/Drawer'
+import { IconLink } from '@/components/shared/IconLink'
+import { getDownloadDocumentName } from '@/utils/eservice.utils'
+import AttachFileIcon from '@mui/icons-material/AttachFile'
+import { Stack } from '@mui/material'
+import { InformationContainer } from '@pagopa/interop-fe-commons'
+import { useTranslation } from 'react-i18next'
+import { formatThousands } from '@/utils/format.utils'
+
+type ConsumerEServiceAsyncExchangeDetailsDrawerProps = {
+  isOpen: boolean
+  onClose: VoidFunction
+  descriptor: CatalogEServiceDescriptor
+}
+
+export const ConsumerEServiceAsyncExchangeDetailsDrawer: React.FC<
+  ConsumerEServiceAsyncExchangeDetailsDrawerProps
+> = ({ descriptor, isOpen, onClose }) => {
+  const { t } = useTranslation('eservice', {
+    keyPrefix: 'read.drawers.asyncExchangeDetailsDrawer',
+  })
+
+  const downloadDocument = EServiceDownloads.useDownloadVersionDocument()
+  const asyncExchangeProperties = descriptor.asyncExchangeProperties
+
+  const handleDownloadDocument = (document: EServiceDoc) => {
+    downloadDocument(
+      {
+        eserviceId: descriptor.eservice.id,
+        descriptorId: descriptor.id,
+        documentId: document.id,
+      },
+      getDownloadDocumentName(document)
+    )
+  }
+
+  return (
+    <Drawer isOpen={isOpen} onClose={onClose} title={t('title')}>
+      <Stack spacing={3}>
+        {asyncExchangeProperties && (
+          <>
+            <InformationContainer
+              label={t('responseTime')}
+              content={`${formatThousands(asyncExchangeProperties.responseTime)} ${t('seconds')}`}
+              direction="column"
+            />
+            <InformationContainer
+              label={t('resourceAvailableTime')}
+              content={`${formatThousands(asyncExchangeProperties.resourceAvailableTime)} ${t(
+                'seconds'
+              )}`}
+              direction="column"
+            />
+            <InformationContainer
+              label={t('confirmation')}
+              content={t(`booleanValue.${asyncExchangeProperties.confirmation}`)}
+              direction="column"
+            />
+            <InformationContainer
+              label={t('bulk')}
+              content={t(`booleanValue.${asyncExchangeProperties.bulk}`)}
+              direction="column"
+            />
+            <InformationContainer
+              label={t('maxResultSet')}
+              content={formatThousands(asyncExchangeProperties.maxResultSet)}
+              direction="column"
+            />
+          </>
+        )}
+
+        {descriptor.asyncExchangeCallbackInterface && (
+          <InformationContainer
+            label={t('callbackInterface')}
+            content={
+              <Stack spacing={1} mt={1} alignItems="start">
+                <IconLink
+                  component="button"
+                  onClick={handleDownloadDocument.bind(
+                    null,
+                    descriptor.asyncExchangeCallbackInterface
+                  )}
+                  startIcon={<AttachFileIcon fontSize="small" />}
+                >
+                  {descriptor.asyncExchangeCallbackInterface.prettyName}
+                </IconLink>
+              </Stack>
+            }
+            direction="column"
+          />
+        )}
+
+        {descriptor.asyncExchangeCallbackInterface?.checksum && (
+          <InformationContainer
+            label={t('callbackInterfaceChecksum')}
+            content={descriptor.asyncExchangeCallbackInterface.checksum}
+            copyToClipboard={{
+              value: descriptor.asyncExchangeCallbackInterface.checksum,
+            }}
+          />
+        )}
+      </Stack>
+    </Drawer>
+  )
+}

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
@@ -8,8 +8,10 @@ import { useParams } from '@/router'
 import FileCopyIcon from '@mui/icons-material/FileCopy'
 import EngineeringIcon from '@mui/icons-material/Engineering'
 import ContactMailIcon from '@mui/icons-material/ContactMail'
+import SyncIcon from '@mui/icons-material/Sync'
 import { useDrawerState } from '@/hooks/useDrawerState'
 import { ConsumerEServiceTechnicalInfoDrawer } from './ConsumerEServiceTechnicalInfoDrawer'
+import { ConsumerEServiceAsyncExchangeDetailsDrawer } from './ConsumerEServiceAsyncExchangeDetailsDrawer'
 import { ConsumerEServiceProducerContactsDrawer } from './ConsumerEServiceProducerContactsDrawer'
 import { EServiceVersionSelectorDrawer } from '@/components/shared/EServiceVersionSelectorDrawer'
 import { useSuspenseQuery } from '@tanstack/react-query'
@@ -37,6 +39,12 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
   } = useDrawerState()
 
   const {
+    isOpen: isAsyncExchangeDetailsDrawerOpen,
+    openDrawer: openAsyncExchangeDetailsDrawer,
+    closeDrawer: closeAsyncExchangeDetailsDrawer,
+  } = useDrawerState()
+
+  const {
     isOpen: isVersionSelectorDrawerOpen,
     openDrawer: openVersionSelectorDrawer,
     closeDrawer: closeVersionSelectorDrawer,
@@ -61,6 +69,13 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
     label: t('bottomActions.showTechnicalDetails'),
   }
 
+  const showAsyncExchangeDetailsAction = {
+    startIcon: <SyncIcon fontSize="small" />,
+    component: 'button',
+    onClick: openAsyncExchangeDetailsDrawer,
+    label: t('bottomActions.showAsyncExchangeDetails'),
+  }
+
   const showProducerContactsAction = {
     startIcon: <ContactMailIcon fontSize="small" />,
     component: 'button',
@@ -75,6 +90,7 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
         bottomActions={[
           ...(!hasSingleVersion ? [navigateVersionsAction] : []),
           showTechnicalDetailsAction,
+          ...(descriptor.eservice.asyncExchange ? [showAsyncExchangeDetailsAction] : []),
           ...(hasContactInformations ? [showProducerContactsAction] : []),
         ]}
       >
@@ -103,6 +119,11 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
       <ConsumerEServiceTechnicalInfoDrawer
         isOpen={isTechnicalInfoDrawerOpen}
         onClose={closeTechnicalInfoDrawer}
+        descriptor={descriptor}
+      />
+      <ConsumerEServiceAsyncExchangeDetailsDrawer
+        isOpen={isAsyncExchangeDetailsDrawerOpen}
+        onClose={closeAsyncExchangeDetailsDrawer}
         descriptor={descriptor}
       />
       <ConsumerEServiceProducerContactsDrawer

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceTechnicalInfoDrawer.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceTechnicalInfoDrawer.tsx
@@ -11,6 +11,7 @@ import { InformationContainer } from '@pagopa/interop-fe-commons'
 import { useTranslation } from 'react-i18next'
 import { interfaceVerificationGuideLink, manageEServiceGuideLink } from '@/config/constants'
 import { formatDateString, secondsToMinutes } from '@/utils/format.utils'
+import { ConsumerEServiceAsyncExchangeCallbackInterfaceInfo } from './ConsumerEServiceAsyncExchangeCallbackInterfaceInfo'
 
 type ConsumerEServiceTechnicalInfoDrawerProps = {
   isOpen: boolean
@@ -97,35 +98,12 @@ export const ConsumerEServiceTechnicalInfoDrawer: React.FC<
               content={t(`asyncExchange.value.${descriptor.eservice.asyncExchange}`)}
               direction="column"
             />
-            {descriptor.asyncExchangeCallbackInterface && (
-              <InformationContainer
-                label={t('asyncExchangeCallbackInterface')}
-                content={
-                  <Stack spacing={1} mt={1} alignItems="start">
-                    <IconLink
-                      component="button"
-                      onClick={handleDownloadDocument.bind(
-                        null,
-                        descriptor.asyncExchangeCallbackInterface
-                      )}
-                      startIcon={<AttachFileIcon fontSize="small" />}
-                    >
-                      {descriptor.asyncExchangeCallbackInterface.prettyName}
-                    </IconLink>
-                  </Stack>
-                }
-                direction="column"
-              />
-            )}
-            {descriptor.asyncExchangeCallbackInterface?.checksum && (
-              <InformationContainer
-                label={t('asyncExchangeCallbackInterfaceChecksum')}
-                content={descriptor.asyncExchangeCallbackInterface.checksum}
-                copyToClipboard={{
-                  value: descriptor.asyncExchangeCallbackInterface.checksum,
-                }}
-              />
-            )}
+            <ConsumerEServiceAsyncExchangeCallbackInterfaceInfo
+              callbackInterface={descriptor.asyncExchangeCallbackInterface}
+              callbackInterfaceLabel={t('asyncExchangeCallbackInterface')}
+              callbackInterfaceChecksumLabel={t('asyncExchangeCallbackInterfaceChecksum')}
+              onDownloadDocument={handleDownloadDocument}
+            />
           </>
         )}
         {isSignalHubFlagEnabled && (

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceTechnicalInfoDrawer.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceTechnicalInfoDrawer.tsx
@@ -90,6 +90,44 @@ export const ConsumerEServiceTechnicalInfoDrawer: React.FC<
           content={t(`mode.value.${descriptor.eservice.mode}`)}
           direction="column"
         />
+        {descriptor.eservice.asyncExchange && (
+          <>
+            <InformationContainer
+              label={t('asyncExchange.label')}
+              content={t(`asyncExchange.value.${descriptor.eservice.asyncExchange}`)}
+              direction="column"
+            />
+            {descriptor.asyncExchangeCallbackInterface && (
+              <InformationContainer
+                label={t('asyncExchangeCallbackInterface')}
+                content={
+                  <Stack spacing={1} mt={1} alignItems="start">
+                    <IconLink
+                      component="button"
+                      onClick={handleDownloadDocument.bind(
+                        null,
+                        descriptor.asyncExchangeCallbackInterface
+                      )}
+                      startIcon={<AttachFileIcon fontSize="small" />}
+                    >
+                      {descriptor.asyncExchangeCallbackInterface.prettyName}
+                    </IconLink>
+                  </Stack>
+                }
+                direction="column"
+              />
+            )}
+            {descriptor.asyncExchangeCallbackInterface?.checksum && (
+              <InformationContainer
+                label={t('asyncExchangeCallbackInterfaceChecksum')}
+                content={descriptor.asyncExchangeCallbackInterface.checksum}
+                copyToClipboard={{
+                  value: descriptor.asyncExchangeCallbackInterface.checksum,
+                }}
+              />
+            )}
+          </>
+        )}
         {isSignalHubFlagEnabled && (
           <InformationContainer
             label={t('isSignalHubEnabled.label')}

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/__tests__/ConsumerEServiceGeneralInfoSection.test.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/__tests__/ConsumerEServiceGeneralInfoSection.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ConsumerEServiceGeneralInfoSection } from '../ConsumerEServiceGeneralInfoSection'
+import {
+  mockUseCurrentRoute,
+  mockUseParams,
+  renderWithApplicationContext,
+} from '@/utils/testing.utils'
+import {
+  createMockEServiceDescriptorCatalog,
+  createMockEServiceDescriptorCatalogAsync,
+} from '@/../__mocks__/data/eservice.mocks'
+
+mockUseParams({
+  eserviceId: 'eservice-id-001',
+  descriptorId: 'descriptor-id-001',
+})
+
+mockUseCurrentRoute({ mode: 'consumer' })
+
+const useSuspenseQueryMock = vi.fn()
+const downloadDocumentMock = vi.fn()
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useSuspenseQuery: () => useSuspenseQueryMock(),
+  }
+})
+
+vi.mock('@/api/eservice', () => ({
+  EServiceQueries: {
+    getDescriptorCatalog: (id: string, descriptorId: string) => [
+      'eservice',
+      'catalog',
+      id,
+      descriptorId,
+    ],
+  },
+  EServiceDownloads: {
+    useDownloadVersionDocument: () => downloadDocumentMock,
+  },
+}))
+
+function renderComponent() {
+  return renderWithApplicationContext(<ConsumerEServiceGeneralInfoSection />, {
+    withReactQueryContext: true,
+    withRouterContext: true,
+  })
+}
+
+describe('ConsumerEServiceGeneralInfoSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not render async exchange details action for synchronous eservices', () => {
+    useSuspenseQueryMock.mockReturnValue({ data: createMockEServiceDescriptorCatalog() })
+
+    renderComponent()
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'bottomActions.showAsyncExchangeDetails',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders async exchange details action for asynchronous eservices', () => {
+    useSuspenseQueryMock.mockReturnValue({ data: createMockEServiceDescriptorCatalogAsync() })
+
+    renderComponent()
+
+    expect(
+      screen.getByRole('button', {
+        name: 'bottomActions.showAsyncExchangeDetails',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('opens async exchange details drawer from the async action', async () => {
+    const user = userEvent.setup()
+    useSuspenseQueryMock.mockReturnValue({ data: createMockEServiceDescriptorCatalogAsync() })
+
+    renderComponent()
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'bottomActions.showAsyncExchangeDetails',
+      })
+    )
+
+    expect(screen.getByText('responseTime')).toBeInTheDocument()
+    expect(screen.getByText('callbackInterface')).toBeInTheDocument()
+  })
+
+  it('closes async exchange details drawer from the close button', async () => {
+    const user = userEvent.setup()
+    useSuspenseQueryMock.mockReturnValue({ data: createMockEServiceDescriptorCatalogAsync() })
+
+    renderComponent()
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'bottomActions.showAsyncExchangeDetails',
+      })
+    )
+
+    expect(screen.getByText('responseTime')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'closeIconAriaLabel' }))
+
+    await waitForElementToBeRemoved(() => screen.queryByText('responseTime'))
+  })
+
+  it('does not show async exchange information in the technical details drawer for synchronous eservices', async () => {
+    const user = userEvent.setup()
+    useSuspenseQueryMock.mockReturnValue({ data: createMockEServiceDescriptorCatalog() })
+
+    renderComponent()
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'bottomActions.showTechnicalDetails',
+      })
+    )
+
+    expect(screen.queryByText('asyncExchange.label')).not.toBeInTheDocument()
+    expect(screen.queryByText('asyncExchangeCallbackInterface')).not.toBeInTheDocument()
+  })
+
+  it('shows async exchange information in the technical details drawer for asynchronous eservices', async () => {
+    const user = userEvent.setup()
+    useSuspenseQueryMock.mockReturnValue({ data: createMockEServiceDescriptorCatalogAsync() })
+
+    renderComponent()
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'bottomActions.showTechnicalDetails',
+      })
+    )
+
+    expect(screen.getByText('asyncExchange.label')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchange.value.true')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchangeCallbackInterface')).toBeInTheDocument()
+    expect(screen.getByText('Specifica callback')).toBeInTheDocument()
+  })
+})

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -590,6 +590,7 @@
         "bottomActions": {
           "navigateVersions": "Navigate to another e-service version",
           "showTechnicalDetails": "Show e-service technical details",
+          "showAsyncExchangeDetails": "Show asynchronous exchange details",
           "downloadConsumerList": "Download consumer list",
           "showProducerContacts": "Show producer contacts",
           "exportVersion": "Download this e-service version",
@@ -871,6 +872,14 @@
             "RECEIVE": "Receive"
           }
         },
+        "asyncExchange": {
+          "label": "Data exchange type",
+          "value": {
+            "true": "Asynchronous"
+          }
+        },
+        "asyncExchangeCallbackInterface": "Callback interface",
+        "asyncExchangeCallbackInterfaceChecksum": "Callback interface checksum",
         "isSignalHubEnabled": {
           "label": "Is the data update system (Signal Hub) available?",
           "value": {
@@ -888,6 +897,21 @@
           "verifyVoucher": "How do I verify a consumer's voucher?",
           "wellKnown": "URL .well-known",
           "interfaceChecksum": "How to calculate the interface file checksum yourself?"
+        }
+      },
+      "asyncExchangeDetailsDrawer": {
+        "title": "Asynchronous exchange details",
+        "responseTime": "Maximum response time",
+        "resourceAvailableTime": "Maximum result availability time",
+        "confirmation": "Receipt confirmation",
+        "bulk": "Bulk download",
+        "maxResultSet": "Maximum number of results",
+        "callbackInterface": "Callback interface",
+        "callbackInterfaceChecksum": "Callback interface checksum",
+        "seconds": "seconds",
+        "booleanValue": {
+          "true": "Yes",
+          "false": "No"
         }
       },
       "producerContactsInfoDrawer": {

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -590,6 +590,7 @@
         "bottomActions": {
           "navigateVersions": "Naviga a un’altra versione dell’e-service",
           "showTechnicalDetails": "Vedi i dettagli tecnici dell’e-service",
+          "showAsyncExchangeDetails": "Vedi i dettagli sullo scambio asincrono",
           "downloadConsumerList": "Scarica l'elenco dei fruitori",
           "showProducerContacts": "Visualizza i contatti dell’erogatore",
           "exportVersion": "Scarica questa versione dell’e-service",
@@ -871,6 +872,14 @@
             "RECEIVE": "Riceve"
           }
         },
+        "asyncExchange": {
+          "label": "Tipologia di scambio dati",
+          "value": {
+            "true": "Asincrono"
+          }
+        },
+        "asyncExchangeCallbackInterface": "Interfaccia di callback",
+        "asyncExchangeCallbackInterfaceChecksum": "Checksum interfaccia di callback",
         "isSignalHubEnabled": {
           "label": "È disponibile il servizio di aggiornamento dati (Signal Hub)?",
           "value": {
@@ -888,6 +897,21 @@
           "verifyVoucher": "Come faccio a verificare il voucher di un fruitore?",
           "wellKnown": "URL .well-known",
           "interfaceChecksum": "Come calcolo autonomamente il checksum del file di interfaccia?"
+        }
+      },
+      "asyncExchangeDetailsDrawer": {
+        "title": "Dettagli scambio asincrono",
+        "responseTime": "Tempo massimo di risposta",
+        "resourceAvailableTime": "Tempo massimo di disponibilità del risultato",
+        "confirmation": "Conferma di ricezione",
+        "bulk": "Download a blocchi",
+        "maxResultSet": "Numero massimo di risultati",
+        "callbackInterface": "Interfaccia di callback",
+        "callbackInterfaceChecksum": "Checksum interfaccia di callback",
+        "seconds": "secondi",
+        "booleanValue": {
+          "true": "Sì",
+          "false": "No"
         }
       },
       "producerContactsInfoDrawer": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10038](https://pagopa.atlassian.net/browse/PIN-10038)  
[PIN-10039](https://pagopa.atlassian.net/browse/PIN-10039)

## 📝 Description / Context

Adds the asynchronous exchange details experience in the consumer e-service catalog details page. The existing technical details drawer now includes async-specific information when the e-service is asynchronous, and a new dedicated drawer can be opened from the general information section.

## 🛠 List of changes

- Added the “Show asynchronous exchange details” action for asynchronous e-services only.
- Added a new async exchange details drawer with async properties and callback interface data.
- Extended the technical details drawer with async exchange type and callback interface information.
- Updated Italian and English translations.
- Added focused tests for sync/async visibility, drawer open/close, and async technical details rendering.

## 🧪 How to test

- Open the consumer catalog e-service details page for an asynchronous e-service: the general information section should show “Show e-service technical details” and “Show asynchronous exchange details”.
- Click “Show asynchronous exchange details”: the new drawer should open, display async exchange fields and callback interface data, and close correctly from the close icon.
- Open the same page for a synchronous e-service: the asynchronous exchange action should not be visible, and the technical details drawer should not show async fields.

[PIN-10038]: https://pagopa.atlassian.net/browse/PIN-10038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-10039]: https://pagopa.atlassian.net/browse/PIN-10039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ