### PR TITLE
feature: show data exchange in template details (PIN-10052)

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceTemplateDetailsSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceTemplateDetailsSection.tsx
@@ -17,6 +17,12 @@ export const EServiceTemplateDetailsSection: React.FC<EServiceTemplateDetailsSec
     <SectionContainer title={t('title')} description={t('description')}>
       <Stack spacing={2}>
         <InformationContainer
+          label={t('asyncExchangeField.readOnlyLabel')}
+          content={t(
+            `asyncExchangeField.readOnlyOptions.${Boolean(eserviceTemplate.asyncExchange)}`
+          )}
+        />
+        <InformationContainer
           label={t('technologyField.readOnlyLabel')}
           content={eserviceTemplate.technology}
         />

--- a/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceTemplateDetailsSection.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceTemplateDetailsSection.test.tsx
@@ -1,14 +1,17 @@
 import type { EServiceTemplateDetails } from '@/api/api.generatedTypes'
 import { EServiceTemplateDetailsSection } from '../EServiceTemplateDetailsSection'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
-import { createMockEServiceTemplateDetails } from '@/../__mocks__/data/eserviceTemplate.mocks'
+import {
+  createMockEServiceTemplateDetails,
+  createMockEServiceTemplateDetailsAsync,
+} from '@/../__mocks__/data/eserviceTemplate.mocks'
 import { screen } from '@testing-library/react'
 
 const eserviceTemplate: EServiceTemplateDetails = createMockEServiceTemplateDetails()
 
-const renderComponent = (personalData?: boolean) => {
+const renderComponent = (overwrites: Partial<EServiceTemplateDetails> = {}) => {
   return renderWithApplicationContext(
-    <EServiceTemplateDetailsSection eserviceTemplate={{ ...eserviceTemplate, personalData }} />,
+    <EServiceTemplateDetailsSection eserviceTemplate={{ ...eserviceTemplate, ...overwrites }} />,
     {}
   )
 }
@@ -19,17 +22,36 @@ describe('TemplateDetailsSection', () => {
     expect(screen.getByText('title')).toBeInTheDocument()
   })
 
-  it('should render 2 info container (technology, mode)', () => {
+  it('should render 3 info container (asyncExchange, technology, mode)', () => {
     renderComponent()
+    expect(screen.getByText('asyncExchangeField.readOnlyLabel')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchangeField.readOnlyOptions.false')).toBeInTheDocument()
     expect(screen.getByText('technologyField.readOnlyLabel')).toBeInTheDocument()
     expect(screen.getByText(eserviceTemplate.technology)).toBeInTheDocument()
     expect(screen.getByText('modeField.label')).toBeInTheDocument()
     expect(screen.getByText(`modeField.options.${eserviceTemplate.mode}`)).toBeInTheDocument()
   })
 
+  it('should render async data exchange type', () => {
+    renderComponent(createMockEServiceTemplateDetailsAsync())
+
+    expect(screen.getByText('asyncExchangeField.readOnlyLabel')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchangeField.readOnlyOptions.true')).toBeInTheDocument()
+  })
+
+  it('should render sync data exchange type when asyncExchange is missing', () => {
+    const eserviceTemplateWithoutAsyncExchange = createMockEServiceTemplateDetails()
+    delete eserviceTemplateWithoutAsyncExchange.asyncExchange
+
+    renderComponent(eserviceTemplateWithoutAsyncExchange)
+
+    expect(screen.getByText('asyncExchangeField.readOnlyLabel')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchangeField.readOnlyOptions.false')).toBeInTheDocument()
+  })
+
   it('should render personalData info container when [personalData] is defined', () => {
     const personalData = true
-    renderComponent(personalData)
+    renderComponent({ personalData })
     expect(
       screen.getByText(`personalDataField.${eserviceTemplate.mode}.readOnlyLabel`)
     ).toBeInTheDocument()

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -46,7 +46,7 @@
         "firstVersionOnlyEditableInfo": "This data will no longer be editable after the first version of the e-service is published.",
         "asyncExchangeField": {
           "label": "How do you want to exchange the e-service data?",
-          "readOnlyLabel": "Data exchange type",
+          "readOnlyLabel": "Data exchange",
           "options": {
             "false": "Synchronous (standard)",
             "true": "Asynchronous / bulk (deferred)"

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -46,7 +46,7 @@
         "firstVersionOnlyEditableInfo": "Questi dati non saranno più modificabili dopo la pubblicazione della prima versione dell’e-service.",
         "asyncExchangeField": {
           "label": "In che modo vuoi scambiare i dati dell’e-service?",
-          "readOnlyLabel": "Tipologia di scambio dati",
+          "readOnlyLabel": "Scambio dati",
           "options": {
             "false": "Sincrono (standard)",
             "true": "Asincrono / massivo (in differita)"


### PR DESCRIPTION
## 🔗 Issue

[PIN-10052](https://pagopa.atlassian.net/browse/PIN-10052)

## 📝 Description / Context

This PR adds the data exchange information to the e-service template details card shown in the e-service creation/edit flow when the details come from a template.

## 🛠 List of changes

- Added the readonly data exchange field to `EServiceTemplateDetailsSection`.
- Render synchronous/asynchronous values using the existing `asyncExchangeField` translations.
- Treated templates without an explicit `asyncExchange` value as synchronous.
- Updated IT/EN readonly label copy for the data exchange field.
- Added focused tests for synchronous, asynchronous, and missing `asyncExchange` template cases.

## 🧪 How to test

- Open the e-service creation/edit flow using an e-service template.
- Check the “E-service details” card: it should show the “Data exchange” / “Scambio dati” field together with technology, mode, and personal data information.
- Verify that synchronous templates show “Synchronous” / “Sincrono”.
- Verify that asynchronous templates show “Asynchronous” / “Asincrono”.
- Verify that old templates without an explicit `asyncExchange` value still render correctly as synchronous.

[PIN-10052]: https://pagopa.atlassian.net/browse/PIN-10052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ