### PR TITLE
refactor: share eservice details card (PIN-10053)

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSection.tsx
@@ -1,13 +1,7 @@
 import type { EServiceMode, ProducerEServiceDescriptor } from '@/api/api.generatedTypes'
 import { AuthHooks } from '@/api/auth'
-import { SectionContainer } from '@/components/layout/containers'
-import { RHFRadioGroup } from '@/components/shared/react-hook-form-inputs'
-import { Alert, Stack } from '@mui/material'
-import { InformationContainer } from '@pagopa/interop-fe-commons'
-import { useEffect } from 'react'
-import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import type { EServiceCreateStepGeneralFormValues } from '../EServiceCreateStepGeneral/EServiceCreateStepGeneral'
+import { EServiceDetailsSectionBase } from './EServiceDetailsSectionBase'
 
 type EServiceDetailsSectionProps = {
   areEServiceGeneralInfoEditable: boolean
@@ -23,135 +17,17 @@ export const EServiceDetailsSection: React.FC<EServiceDetailsSectionProps> = ({
   onEserviceModeChange,
 }) => {
   const { t } = useTranslation('eservice', { keyPrefix: 'create.step1.detailsSection' })
-  const { t: tCommon } = useTranslation('common', { keyPrefix: 'validation.mixed' })
   const { isOperatorAPI } = AuthHooks.useJwt()
-  const { watch, setValue } = useFormContext<EServiceCreateStepGeneralFormValues>()
-
-  const [asyncExchange, technology, mode] = watch(['asyncExchange', 'technology', 'mode'])
-
-  useEffect(() => {
-    if (asyncExchange && mode !== 'DELIVER') {
-      setValue('mode', 'DELIVER', { shouldDirty: true, shouldValidate: true })
-      onEserviceModeChange?.('DELIVER')
-    }
-  }, [asyncExchange, mode, setValue, onEserviceModeChange])
-
-  if (!areEServiceGeneralInfoEditable && descriptor)
-    return (
-      <SectionContainer title={t('title')} description={t('readOnlyDescription')}>
-        <Stack spacing={2}>
-          <InformationContainer
-            label={t('asyncExchangeField.readOnlyLabel')}
-            content={t(
-              `asyncExchangeField.readOnlyOptions.${Boolean(descriptor.eservice.asyncExchange)}`
-            )}
-          />
-          <InformationContainer
-            label={t('technologyField.readOnlyLabel')}
-            content={descriptor.eservice.technology}
-          />
-          <InformationContainer
-            label={t('modeField.label')}
-            content={t(`modeField.options.${eserviceMode}`)}
-          />
-          {descriptor.eservice.personalData !== undefined && (
-            <InformationContainer
-              label={t(`personalDataField.${eserviceMode}.readOnlyLabel`)}
-              content={t(
-                `personalDataField.${eserviceMode}.readOnlyOptions.${descriptor.eservice.personalData}`
-              )}
-            />
-          )}
-        </Stack>
-      </SectionContainer>
-    )
 
   return (
-    <SectionContainer title={t('title')}>
-      <Alert severity="warning" sx={{ mb: 0, mt: 3 }}>
-        {t('firstVersionOnlyEditableInfo')}
-      </Alert>
-      <RHFRadioGroup
-        name="asyncExchange"
-        row
-        required
-        label={t('asyncExchangeField.label')}
-        options={[
-          { label: t('asyncExchangeField.options.false'), value: false },
-          { label: t('asyncExchangeField.options.true'), value: true },
-        ]}
-        disabled={!areEServiceGeneralInfoEditable}
-        rules={{
-          validate: (value) => value === true || value === false || tCommon('required'),
-        }}
-        sx={{ mb: 0, mt: 3 }}
-        isOptionValueAsBoolean
-      />
-      {asyncExchange && isOperatorAPI && (
-        <Alert severity="warning" sx={{ mb: 0, mt: 3 }}>
-          {t('asyncExchangeField.operatorApiWarning')}
-        </Alert>
-      )}
-      <RHFRadioGroup
-        name="technology"
-        row
-        required
-        label={t('technologyField.label')}
-        options={[
-          { label: 'REST', value: 'REST' },
-          { label: 'SOAP', value: 'SOAP' },
-        ]}
-        disabled={!areEServiceGeneralInfoEditable}
-        rules={{ required: true }}
-        sx={{ mb: 0, mt: 3 }}
-      />
-      {asyncExchange && technology === 'SOAP' && (
-        <Alert severity="warning" sx={{ mb: 0, mt: 3 }}>
-          {t('asyncExchangeField.soapWarning')}
-        </Alert>
-      )}
-      <RHFRadioGroup
-        name="mode"
-        row
-        required
-        label={t('modeField.label')}
-        options={[
-          {
-            label: t('modeField.options.DELIVER'),
-            value: 'DELIVER',
-          },
-          {
-            label: t('modeField.options.RECEIVE'),
-            value: 'RECEIVE',
-          },
-        ]}
-        disabled={!areEServiceGeneralInfoEditable || asyncExchange}
-        rules={{ required: true }}
-        sx={{ mb: 0, mt: 3 }}
-        onValueChange={(mode) => onEserviceModeChange?.(mode as EServiceMode)}
-      />
-      <RHFRadioGroup
-        name="personalData"
-        row
-        required
-        label={t(`personalDataField.${eserviceMode}.label`)}
-        options={[
-          {
-            label: t(`personalDataField.${eserviceMode}.options.true`),
-            value: true,
-          },
-          {
-            label: t(`personalDataField.${eserviceMode}.options.false`),
-            value: false,
-          },
-        ]}
-        disabled={!areEServiceGeneralInfoEditable}
-        rules={{
-          validate: (value) => value === true || value === false || tCommon('required'),
-        }}
-        sx={{ mb: 3, mt: 3 }}
-        isOptionValueAsBoolean
-      />
-    </SectionContainer>
+    <EServiceDetailsSectionBase
+      isEditable={areEServiceGeneralInfoEditable}
+      eserviceMode={eserviceMode}
+      details={descriptor?.eservice}
+      readOnlyDescription={t('readOnlyDescription')}
+      showFirstVersionOnlyEditableInfo
+      showOperatorApiWarning={isOperatorAPI}
+      onEserviceModeChange={onEserviceModeChange}
+    />
   )
 }

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSectionBase.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSectionBase.tsx
@@ -7,7 +7,7 @@ import { useEffect } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
-type EServiceDetails = {
+export type EServiceDetails = {
   asyncExchange?: boolean
   technology: EServiceTechnology
   mode: EServiceMode

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSectionBase.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSectionBase.tsx
@@ -1,0 +1,215 @@
+import type { EServiceMode, EServiceTechnology } from '@/api/api.generatedTypes'
+import { SectionContainer } from '@/components/layout/containers'
+import { RHFRadioGroup } from '@/components/shared/react-hook-form-inputs'
+import { Alert, Stack } from '@mui/material'
+import { InformationContainer } from '@pagopa/interop-fe-commons'
+import { useEffect } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+
+type EServiceDetails = {
+  asyncExchange?: boolean
+  technology: EServiceTechnology
+  mode: EServiceMode
+  personalData?: boolean
+}
+
+type EServiceDetailsSectionBaseProps = {
+  isEditable: boolean
+  eserviceMode: EServiceMode
+  details?: EServiceDetails
+  description?: string
+  readOnlyDescription?: string
+  missingPersonalDataTenantName?: string
+  showFirstVersionOnlyEditableInfo?: boolean
+  showOperatorApiWarning?: boolean
+  onEserviceModeChange?: (value: EServiceMode) => void
+}
+
+const isEServiceMode = (value: string): value is EServiceMode =>
+  value === 'DELIVER' || value === 'RECEIVE'
+
+export const EServiceDetailsSectionBase: React.FC<EServiceDetailsSectionBaseProps> = ({
+  isEditable,
+  eserviceMode,
+  details,
+  description,
+  readOnlyDescription,
+  missingPersonalDataTenantName,
+  showFirstVersionOnlyEditableInfo = false,
+  showOperatorApiWarning = false,
+  onEserviceModeChange,
+}) => {
+  const { t } = useTranslation('eservice', { keyPrefix: 'create.step1.detailsSection' })
+
+  if (!isEditable && details) {
+    return (
+      <SectionContainer title={t('title')} description={readOnlyDescription ?? description}>
+        <Stack spacing={2}>
+          <InformationContainer
+            label={t('asyncExchangeField.readOnlyLabel')}
+            content={t(`asyncExchangeField.readOnlyOptions.${Boolean(details.asyncExchange)}`)}
+          />
+          <InformationContainer
+            label={t('technologyField.readOnlyLabel')}
+            content={details.technology}
+          />
+          <InformationContainer
+            label={t('modeField.label')}
+            content={t(`modeField.options.${details.mode}`)}
+          />
+          {details.personalData !== undefined ? (
+            <InformationContainer
+              label={t(`personalDataField.${details.mode}.readOnlyLabel`)}
+              content={t(
+                `personalDataField.${details.mode}.readOnlyOptions.${details.personalData}`
+              )}
+            />
+          ) : (
+            missingPersonalDataTenantName && (
+              <Alert severity="error" variant="outlined">
+                {t('personalDataField.alertMissingPersonalData', {
+                  tenantName: missingPersonalDataTenantName,
+                })}
+              </Alert>
+            )
+          )}
+        </Stack>
+      </SectionContainer>
+    )
+  }
+
+  return (
+    <SectionContainer title={t('title')} description={description}>
+      <EServiceDetailsEditableFields
+        eserviceMode={eserviceMode}
+        showFirstVersionOnlyEditableInfo={showFirstVersionOnlyEditableInfo}
+        showOperatorApiWarning={showOperatorApiWarning}
+        isEditable={isEditable}
+        onEserviceModeChange={onEserviceModeChange}
+      />
+    </SectionContainer>
+  )
+}
+
+type EServiceDetailsEditableFieldsProps = {
+  isEditable: boolean
+  eserviceMode: EServiceMode
+  showFirstVersionOnlyEditableInfo: boolean
+  showOperatorApiWarning: boolean
+  onEserviceModeChange?: (value: EServiceMode) => void
+}
+
+const EServiceDetailsEditableFields: React.FC<EServiceDetailsEditableFieldsProps> = ({
+  isEditable,
+  eserviceMode,
+  showFirstVersionOnlyEditableInfo,
+  showOperatorApiWarning,
+  onEserviceModeChange,
+}) => {
+  const { t } = useTranslation('eservice', { keyPrefix: 'create.step1.detailsSection' })
+  const { t: tCommon } = useTranslation('common', { keyPrefix: 'validation.mixed' })
+  const { watch, setValue } = useFormContext()
+
+  const [asyncExchange, technology, mode] = watch(['asyncExchange', 'technology', 'mode'])
+
+  useEffect(() => {
+    if (asyncExchange && mode !== 'DELIVER') {
+      setValue('mode', 'DELIVER', { shouldDirty: true, shouldValidate: true })
+      onEserviceModeChange?.('DELIVER')
+    }
+  }, [asyncExchange, mode, setValue, onEserviceModeChange])
+
+  return (
+    <>
+      {showFirstVersionOnlyEditableInfo && (
+        <Alert severity="warning" sx={{ mb: 0, mt: 3 }}>
+          {t('firstVersionOnlyEditableInfo')}
+        </Alert>
+      )}
+      <RHFRadioGroup
+        name="asyncExchange"
+        row
+        required
+        label={t('asyncExchangeField.label')}
+        options={[
+          { label: t('asyncExchangeField.options.false'), value: false },
+          { label: t('asyncExchangeField.options.true'), value: true },
+        ]}
+        disabled={!isEditable}
+        rules={{
+          validate: (value) => value === true || value === false || tCommon('required'),
+        }}
+        sx={{ mb: 0, mt: 3 }}
+        isOptionValueAsBoolean
+      />
+      {asyncExchange && showOperatorApiWarning && (
+        <Alert severity="warning" sx={{ mb: 0, mt: 3 }}>
+          {t('asyncExchangeField.operatorApiWarning')}
+        </Alert>
+      )}
+      <RHFRadioGroup
+        name="technology"
+        row
+        required
+        label={t('technologyField.label')}
+        options={[
+          { label: 'REST', value: 'REST' },
+          { label: 'SOAP', value: 'SOAP' },
+        ]}
+        disabled={!isEditable}
+        rules={{ required: true }}
+        sx={{ mb: 0, mt: 3 }}
+      />
+      {asyncExchange && technology === 'SOAP' && (
+        <Alert severity="warning" sx={{ mb: 0, mt: 3 }}>
+          {t('asyncExchangeField.soapWarning')}
+        </Alert>
+      )}
+      <RHFRadioGroup
+        name="mode"
+        row
+        required
+        label={t('modeField.label')}
+        options={[
+          {
+            label: t('modeField.options.DELIVER'),
+            value: 'DELIVER',
+          },
+          {
+            label: t('modeField.options.RECEIVE'),
+            value: 'RECEIVE',
+          },
+        ]}
+        disabled={!isEditable || asyncExchange}
+        rules={{ required: true }}
+        sx={{ mb: 0, mt: 3 }}
+        onValueChange={(mode) => {
+          if (isEServiceMode(mode)) onEserviceModeChange?.(mode)
+        }}
+      />
+      <RHFRadioGroup
+        name="personalData"
+        row
+        required
+        label={t(`personalDataField.${eserviceMode}.label`)}
+        options={[
+          {
+            label: t(`personalDataField.${eserviceMode}.options.true`),
+            value: true,
+          },
+          {
+            label: t(`personalDataField.${eserviceMode}.options.false`),
+            value: false,
+          },
+        ]}
+        disabled={!isEditable}
+        rules={{
+          validate: (value) => value === true || value === false || tCommon('required'),
+        }}
+        sx={{ mb: 3, mt: 3 }}
+        isOptionValueAsBoolean
+      />
+    </>
+  )
+}

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceTemplateDetailsSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceTemplateDetailsSection.tsx
@@ -1,8 +1,6 @@
 import type { EServiceTemplateDetails } from '@/api/api.generatedTypes'
-import { SectionContainer } from '@/components/layout/containers'
-import { Alert, Stack } from '@mui/material'
-import { InformationContainer } from '@pagopa/interop-fe-commons'
 import { useTranslation } from 'react-i18next'
+import { EServiceDetailsSectionBase } from './EServiceDetailsSectionBase'
 
 type EServiceTemplateDetailsSectionProps = {
   eserviceTemplate: EServiceTemplateDetails
@@ -14,37 +12,12 @@ export const EServiceTemplateDetailsSection: React.FC<EServiceTemplateDetailsSec
   const { t } = useTranslation('eservice', { keyPrefix: 'create.step1.detailsSection' })
 
   return (
-    <SectionContainer title={t('title')} description={t('description')}>
-      <Stack spacing={2}>
-        <InformationContainer
-          label={t('asyncExchangeField.readOnlyLabel')}
-          content={t(
-            `asyncExchangeField.readOnlyOptions.${Boolean(eserviceTemplate.asyncExchange)}`
-          )}
-        />
-        <InformationContainer
-          label={t('technologyField.readOnlyLabel')}
-          content={eserviceTemplate.technology}
-        />
-        <InformationContainer
-          label={t('modeField.label')}
-          content={t(`modeField.options.${eserviceTemplate.mode}`)}
-        />
-        {eserviceTemplate.personalData !== undefined ? (
-          <InformationContainer
-            label={t(`personalDataField.${eserviceTemplate.mode}.readOnlyLabel`)}
-            content={t(
-              `personalDataField.${eserviceTemplate.mode}.readOnlyOptions.${eserviceTemplate.personalData}`
-            )}
-          />
-        ) : (
-          <Alert severity="error" variant="outlined">
-            {t('personalDataField.alertMissingPersonalData', {
-              tenantName: eserviceTemplate.creator.name,
-            })}
-          </Alert>
-        )}
-      </Stack>
-    </SectionContainer>
+    <EServiceDetailsSectionBase
+      isEditable={false}
+      eserviceMode={eserviceTemplate.mode}
+      details={eserviceTemplate}
+      description={t('description')}
+      missingPersonalDataTenantName={eserviceTemplate.creator.name}
+    />
   )
 }

--- a/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceDetailsSectionBase.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceDetailsSectionBase.test.tsx
@@ -1,0 +1,149 @@
+import type { EServiceDetails } from '../EServiceDetailsSectionBase'
+import { EServiceDetailsSectionBase } from '../EServiceDetailsSectionBase'
+import { ReactHookFormWrapper, renderWithApplicationContext } from '@/utils/testing.utils'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+
+const details: EServiceDetails = {
+  asyncExchange: true,
+  technology: 'REST',
+  mode: 'RECEIVE',
+  personalData: false,
+}
+
+const renderReadOnlyComponent = ({
+  details = {
+    asyncExchange: true,
+    technology: 'REST',
+    mode: 'RECEIVE',
+    personalData: false,
+  },
+  missingPersonalDataTenantName,
+}: {
+  details?: EServiceDetails
+  missingPersonalDataTenantName?: string
+} = {}) => {
+  return renderWithApplicationContext(
+    <EServiceDetailsSectionBase
+      isEditable={false}
+      eserviceMode="RECEIVE"
+      details={details}
+      description="description"
+      missingPersonalDataTenantName={missingPersonalDataTenantName}
+    />,
+    {
+      withRouterContext: false,
+      withReactQueryContext: false,
+    }
+  )
+}
+
+const renderEditableComponent = ({
+  defaultValues = {},
+  showFirstVersionOnlyEditableInfo = false,
+  showOperatorApiWarning = false,
+  onEserviceModeChange,
+}: {
+  defaultValues?: Record<string, unknown>
+  showFirstVersionOnlyEditableInfo?: boolean
+  showOperatorApiWarning?: boolean
+  onEserviceModeChange?: (mode: 'DELIVER' | 'RECEIVE') => void
+} = {}) => {
+  return renderWithApplicationContext(
+    <ReactHookFormWrapper
+      defaultValues={{
+        asyncExchange: false,
+        technology: 'REST',
+        mode: 'RECEIVE',
+        personalData: undefined,
+        ...defaultValues,
+      }}
+    >
+      <EServiceDetailsSectionBase
+        isEditable
+        eserviceMode="RECEIVE"
+        showFirstVersionOnlyEditableInfo={showFirstVersionOnlyEditableInfo}
+        showOperatorApiWarning={showOperatorApiWarning}
+        onEserviceModeChange={onEserviceModeChange}
+      />
+    </ReactHookFormWrapper>,
+    {
+      withRouterContext: false,
+      withReactQueryContext: false,
+    }
+  )
+}
+
+describe('EServiceDetailsSectionBase', () => {
+  it('renders read-only details', () => {
+    renderReadOnlyComponent()
+
+    expect(screen.getByText('title')).toBeInTheDocument()
+    expect(screen.getByText('description')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchangeField.readOnlyLabel')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchangeField.readOnlyOptions.true')).toBeInTheDocument()
+    expect(screen.getByText('technologyField.readOnlyLabel')).toBeInTheDocument()
+    expect(screen.getByText(details.technology)).toBeInTheDocument()
+    expect(screen.getByText('modeField.label')).toBeInTheDocument()
+    expect(screen.getByText('modeField.options.RECEIVE')).toBeInTheDocument()
+    expect(screen.getByText('personalDataField.RECEIVE.readOnlyLabel')).toBeInTheDocument()
+    expect(screen.getByText('personalDataField.RECEIVE.readOnlyOptions.false')).toBeInTheDocument()
+  })
+
+  it('renders the missing personal data alert when tenant name is provided', () => {
+    renderReadOnlyComponent({
+      details: {
+        asyncExchange: false,
+        technology: 'SOAP',
+        mode: 'DELIVER',
+        personalData: undefined,
+      },
+      missingPersonalDataTenantName: 'Tenant Name',
+    })
+
+    expect(screen.getByText('personalDataField.alertMissingPersonalData')).toBeInTheDocument()
+  })
+
+  it('renders editable fields and the optional first-version-only alert', () => {
+    renderEditableComponent({ showFirstVersionOnlyEditableInfo: true })
+
+    expect(screen.getByText('firstVersionOnlyEditableInfo')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchangeField.label')).toBeInTheDocument()
+    expect(screen.getByLabelText('asyncExchangeField.options.false')).toBeInTheDocument()
+    expect(screen.getByLabelText('asyncExchangeField.options.true')).toBeInTheDocument()
+    expect(screen.getByText('technologyField.label')).toBeInTheDocument()
+    expect(screen.getByLabelText('REST')).toBeInTheDocument()
+    expect(screen.getByLabelText('SOAP')).toBeInTheDocument()
+    expect(screen.getByText('modeField.label')).toBeInTheDocument()
+    expect(screen.getByLabelText('modeField.options.DELIVER')).toBeInTheDocument()
+    expect(screen.getByLabelText('modeField.options.RECEIVE')).toBeInTheDocument()
+    expect(screen.getByText('personalDataField.RECEIVE.label')).toBeInTheDocument()
+  })
+
+  it('forces DELIVER mode and disables mode options when async exchange is selected', async () => {
+    const user = userEvent.setup()
+    const onEserviceModeChange = vi.fn()
+    renderEditableComponent({ onEserviceModeChange })
+
+    await user.click(screen.getByLabelText('asyncExchangeField.options.true'))
+
+    const deliverRadio = screen.getByRole('radio', { name: 'modeField.options.DELIVER' })
+    const receiveRadio = screen.getByRole('radio', { name: 'modeField.options.RECEIVE' })
+
+    expect(deliverRadio).toBeChecked()
+    expect(deliverRadio).toBeDisabled()
+    expect(receiveRadio).toBeDisabled()
+    expect(onEserviceModeChange).toHaveBeenCalledWith('DELIVER')
+  })
+
+  it('renders async exchange warnings when enabled', () => {
+    renderEditableComponent({
+      defaultValues: { asyncExchange: true, technology: 'SOAP' },
+      showOperatorApiWarning: true,
+    })
+
+    expect(screen.getByText('asyncExchangeField.soapWarning')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchangeField.operatorApiWarning')).toBeInTheDocument()
+  })
+})

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
@@ -4,7 +4,7 @@ import { Box, Stack, Typography } from '@mui/material'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { RHFRadioGroup, RHFSwitch, RHFTextField } from '@/components/shared/react-hook-form-inputs'
+import { RHFSwitch, RHFTextField } from '@/components/shared/react-hook-form-inputs'
 import { StepActions } from '@/components/shared/StepActions'
 import { useNavigate } from '@/router'
 import type { EServiceMode, EServiceTechnology } from '@/api/api.generatedTypes'
@@ -15,6 +15,7 @@ import { useEServiceTemplateCreateContext } from '../ProviderEServiceTemplateCon
 import { EServiceTemplateMutations } from '@/api/eserviceTemplate'
 import { ESERVICE_TEMPLATE_NAME_MAX_LENGTH, SIGNALHUB_GUIDE_URL } from '@/config/constants'
 import { EServiceTemplateDetailsSection } from '@/pages/ProviderEServiceCreatePage/components/sections/EServiceTemplateDetailsSection'
+import { EServiceDetailsSectionBase } from '@/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSectionBase'
 
 export type EServiceTemplateCreateStepGeneralFormValues = {
   name: string
@@ -22,13 +23,13 @@ export type EServiceTemplateCreateStepGeneralFormValues = {
   intendedTarget: string
   technology: EServiceTechnology
   mode: EServiceMode
+  asyncExchange: boolean
   isSignalHubEnabled?: boolean
   personalData?: boolean
 }
 
 export const EServiceTemplateCreateStepGeneral: React.FC = () => {
   const { t } = useTranslation('eserviceTemplate')
-  const { t: tCommon } = useTranslation('common', { keyPrefix: 'validation.mixed' })
   const navigate = useNavigate()
 
   const {
@@ -47,7 +48,10 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
     description: eserviceTemplateVersion?.eserviceTemplate.description ?? '',
     intendedTarget: eserviceTemplateVersion?.eserviceTemplate.intendedTarget ?? '',
     technology: eserviceTemplateVersion?.eserviceTemplate.technology ?? 'REST',
-    mode: eserviceTemplateMode,
+    mode: eserviceTemplateVersion?.eserviceTemplate.asyncExchange
+      ? 'DELIVER'
+      : eserviceTemplateMode,
+    asyncExchange: eserviceTemplateVersion?.eserviceTemplate.asyncExchange ?? false,
     isSignalHubEnabled: eserviceTemplateVersion?.eserviceTemplate.isSignalHubEnabled ?? false,
     personalData: eserviceTemplateVersion?.eserviceTemplate.personalData,
   }
@@ -194,64 +198,11 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
           />
         </SectionContainer>
 
-        <SectionContainer title={t('create.step1.instanceDetailsTitle')} component="div">
-          <RHFRadioGroup
-            name="technology"
-            row
-            required
-            label={t('create.step1.eserviceTemplateTechnologyField.label')}
-            options={[
-              { label: 'REST', value: 'REST' },
-              { label: 'SOAP', value: 'SOAP' },
-            ]}
-            rules={{ required: true }}
-            sx={{ mb: 0, mt: 1 }}
-          />
-          <RHFRadioGroup
-            name="mode"
-            row
-            required
-            label={t('create.step1.eserviceTemplateModeField.label')}
-            options={[
-              {
-                label: t('create.step1.eserviceTemplateModeField.options.DELIVER'),
-                value: 'DELIVER',
-              },
-              {
-                label: t('create.step1.eserviceTemplateModeField.options.RECEIVE'),
-                value: 'RECEIVE',
-              },
-            ]}
-            rules={{ required: true }}
-            sx={{ mb: 0, mt: 3 }}
-            onValueChange={(mode) => onEserviceTemplateModeChange(mode as EServiceMode)}
-          />
-          <RHFRadioGroup
-            name="personalData"
-            row
-            required
-            label={t(`create.step1.eservicePersonalDataField.${eserviceTemplateMode}.label`)}
-            options={[
-              {
-                label: t(
-                  `create.step1.eservicePersonalDataField.${eserviceTemplateMode}.options.true`
-                ),
-                value: true,
-              },
-              {
-                label: t(
-                  `create.step1.eservicePersonalDataField.${eserviceTemplateMode}.options.false`
-                ),
-                value: false,
-              },
-            ]}
-            rules={{
-              validate: (value) => value === true || value === false || tCommon('required'),
-            }}
-            sx={{ mb: 0, mt: 3 }}
-            isOptionValueAsBoolean
-          />
-        </SectionContainer>
+        <EServiceDetailsSectionBase
+          isEditable={areEServiceTemplateGeneralInfoEditable}
+          eserviceMode={eserviceTemplateMode}
+          onEserviceModeChange={onEserviceTemplateModeChange}
+        />
 
         <SectionContainer title={t('create.step1.signalHubTitle')} component="div">
           <RHFSwitch name="isSignalHubEnabled" label={signalHubLabel} />

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import {
   EServiceTemplateCreateStepGeneral,
@@ -27,7 +28,7 @@ describe('EServiceTemplateCreateStepGeneral', () => {
       withRouterContext: true,
     })
     expect(screen.getByText('create.step1.templateInfoTitle')).toBeInTheDocument()
-    expect(screen.getByText('create.step1.instanceDetailsTitle')).toBeInTheDocument()
+    expect(screen.getByText('title')).toBeInTheDocument()
     expect(screen.getByText('create.step1.signalHubTitle')).toBeInTheDocument()
   })
 
@@ -70,18 +71,48 @@ describe('EServiceTemplateCreateStepGeneral', () => {
     expect(screen.getByLabelText('SOAP')).toBeInTheDocument()
   })
 
+  it('renders async exchange radio group', () => {
+    mockUseEServiceTemplateCreateContext()
+    renderWithApplicationContext(<EServiceTemplateCreateStepGeneral />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('asyncExchangeField.label')).toBeInTheDocument()
+    expect(screen.getByLabelText('asyncExchangeField.options.false')).toBeInTheDocument()
+    expect(screen.getByLabelText('asyncExchangeField.options.true')).toBeInTheDocument()
+  })
+
+  it('forces DELIVER mode when async exchange is selected', async () => {
+    const user = userEvent.setup()
+    mockUseEServiceTemplateCreateContext({ eserviceTemplateMode: 'RECEIVE' })
+    renderWithApplicationContext(<EServiceTemplateCreateStepGeneral />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.click(screen.getByLabelText('asyncExchangeField.options.true'))
+
+    const deliverRadio = screen.getByRole('radio', {
+      name: 'modeField.options.DELIVER',
+    })
+    const receiveRadio = screen.getByRole('radio', {
+      name: 'modeField.options.RECEIVE',
+    })
+
+    expect(deliverRadio).toBeChecked()
+    expect(deliverRadio).toBeDisabled()
+    expect(receiveRadio).toBeDisabled()
+  })
+
   it('renders mode radio group with Eroga and Riceve options', () => {
     mockUseEServiceTemplateCreateContext()
     renderWithApplicationContext(<EServiceTemplateCreateStepGeneral />, {
       withReactQueryContext: true,
       withRouterContext: true,
     })
-    expect(
-      screen.getByLabelText('create.step1.eserviceTemplateModeField.options.DELIVER')
-    ).toBeInTheDocument()
-    expect(
-      screen.getByLabelText('create.step1.eserviceTemplateModeField.options.RECEIVE')
-    ).toBeInTheDocument()
+    expect(screen.getByLabelText('modeField.options.DELIVER')).toBeInTheDocument()
+    expect(screen.getByLabelText('modeField.options.RECEIVE')).toBeInTheDocument()
   })
 
   it('renders the Signal Hub switch', () => {

--- a/src/static/locales/en/eserviceTemplate.json
+++ b/src/static/locales/en/eserviceTemplate.json
@@ -223,28 +223,11 @@
     "step1": {
       "templateInfoTitle": "Template information",
       "readOnlyTemplateInfoTitle": "E-service template characterization",
-      "instanceDetailsTitle": "E-service instance details",
-      "readOnlyInstanceDetailsTitle": "E-service details",
       "readOnlyDescription": "This information cannot be modified.",
       "signalHubTitle": "Signal Hub",
       "readOnlyNameLabel": "E-service template name",
       "readOnlyIntendedTargetLabel": "Who is this template intended for?",
       "readOnlyDescriptionLabel": "What does this template allow you to do?",
-      "readOnlyTechnologyLabel": "API Technology",
-      "readOnlyModeLabel": "Does the e-service deliver or receive data?",
-      "readOnlyModeValue": {
-        "DELIVER": "Deliver",
-        "RECEIVE": "Receive"
-      },
-      "readOnlyPersonalDataLabel": {
-        "DELIVER": "Delivers personal data",
-        "RECEIVE": "Receives personal data"
-      },
-      "readOnlyPersonalDataValue": {
-        "true": "Yes",
-        "false": "No",
-        "undefined": "Not specified"
-      },
       "eserviceTemplateNameField": {
         "label": "Template name",
         "infoLabel": "This is the name that will appear in the e-service template catalog and will become the base name of all e-services created from this template. Min 5 characters, max 45 characters."
@@ -257,38 +240,13 @@
         "label": "What does this e-service allow you to do?",
         "infoLabel": "Min 10 characters, max 250 characters"
       },
-      "eserviceTemplateTechnologyField": {
-        "label": "What technology is your API built with?"
-      },
       "eserviceTemplateModeField": {
-        "label": "Does the e-service deliver or receive data?",
-        "tooltipReceiveMode": "Currently, the use of templates is limited to the delivery of data.",
-        "options": {
-          "DELIVER": "Deliver",
-          "RECEIVE": "Receive"
-        },
         "isSignalHubEnabled": {
           "label": "Suggest to those who will use this template to report data changes with Signal Hub",
           "infoLabel": {
             "before": "Signal Hub sends",
             "linkLabel": "push notifications",
             "after": "when there are changes to the e-service data."
-          }
-        }
-      },
-      "eservicePersonalDataField": {
-        "DELIVER": {
-          "label": "Does the e-service deliver personal data?",
-          "options": {
-            "true": "Delivers personal data",
-            "false": "Does not deliver personal data"
-          }
-        },
-        "RECEIVE": {
-          "label": "Does the e-service receive personal data?",
-          "options": {
-            "true": "Receives personal data",
-            "false": "Does not receive personal data"
           }
         }
       }

--- a/src/static/locales/it/eserviceTemplate.json
+++ b/src/static/locales/it/eserviceTemplate.json
@@ -223,28 +223,11 @@
     "step1": {
       "templateInfoTitle": "Informazioni sul template",
       "readOnlyTemplateInfoTitle": "Caratterizzazione template di e-service",
-      "instanceDetailsTitle": "Dettagli dell'istanza di e-service",
-      "readOnlyInstanceDetailsTitle": "Dettagli dell'e-service",
       "readOnlyDescription": "Queste informazioni non sono modificabili.",
       "signalHubTitle": "Signal Hub",
       "readOnlyNameLabel": "Nome del template di e-service",
       "readOnlyIntendedTargetLabel": "A chi è rivolto questo template?",
       "readOnlyDescriptionLabel": "Cosa permette di fare questo template?",
-      "readOnlyTechnologyLabel": "Tecnologia API",
-      "readOnlyModeLabel": "L'e-service eroga o riceve dati?",
-      "readOnlyModeValue": {
-        "DELIVER": "Eroga",
-        "RECEIVE": "Riceve"
-      },
-      "readOnlyPersonalDataLabel": {
-        "DELIVER": "Eroga dati personali",
-        "RECEIVE": "Riceve dati personali"
-      },
-      "readOnlyPersonalDataValue": {
-        "true": "Sì",
-        "false": "No",
-        "undefined": "Non indicato"
-      },
       "eserviceTemplateNameField": {
         "label": "Nome del template",
         "infoLabel": "È il nome che comparirà nel catalogo template e-service e che diventerà il nome di base di tutti gli e-service creati a partire da questo template. Min 5 caratteri, max 45 caratteri."
@@ -257,38 +240,13 @@
         "label": "Cosa permette di fare questo e-service?",
         "infoLabel": "Min 10 caratteri, max 250 caratteri"
       },
-      "eserviceTemplateTechnologyField": {
-        "label": "Con quale tecnologia è costruita la tua API?"
-      },
       "eserviceTemplateModeField": {
-        "label": "L'e-service eroga o riceve dati?",
-        "tooltipReceiveMode": "Al momento l'utilizzo dei template è limitato all'erogazione di dati",
-        "options": {
-          "DELIVER": "Eroga",
-          "RECEIVE": "Riceve"
-        },
         "isSignalHubEnabled": {
           "label": "Suggerisci a chi userà questo template di segnalare le variazioni dei dati con Signal Hub",
           "infoLabel": {
             "before": "Signal Hub invia",
             "linkLabel": "notifiche push",
             "after": "in caso di variazioni dei dati dell'e-service."
-          }
-        }
-      },
-      "eservicePersonalDataField": {
-        "DELIVER": {
-          "label": "L'e-service eroga dati personali?",
-          "options": {
-            "true": "Eroga dati personali",
-            "false": "Non eroga dati personali"
-          }
-        },
-        "RECEIVE": {
-          "label": "L'e-service riceve dati personali?",
-          "options": {
-            "true": "Riceve dati personali",
-            "false": "Non riceve dati personali"
           }
         }
       }


### PR DESCRIPTION
Based on [#1919](https://github.com/pagopa/pdnd-interop-frontend/pull/1919)

## 🔗 Issue

[PIN-10053](https://pagopa.atlassian.net/browse/PIN-10053)

## 📝 Description / Context

Refactors the "E-service details" card so e-service edit, template edit, and create-from-template flows share the same base component instead of maintaining duplicated implementations.

## 🛠 List of changes

- Added a shared `EServiceDetailsSectionBase` component for editable and read-only e-service details.
- Updated e-service and template wrappers to use the shared details card.
- Reused the shared card in the editable e-service template general step, including the async data exchange field.
- Preserved template-specific missing personal data alert behavior.
- Removed no longer used template locale keys for the duplicated details card.
- Added focused tests for async data exchange rendering and DELIVER mode enforcement in the template flow.
- Added focused tests for the new shared component

## 🧪 How to test

- Open the e-service edit general information step and verify the "E-service details" card still shows/edit fields for data exchange, API technology, mode, and personal data.
- Open the e-service template edit general information step and verify the same details card is rendered, including "Data exchange"; selecting async exchange should force and disable DELIVER mode.
- Create an e-service from a template and verify the read-only details card shows data exchange, technology, mode, and personal data consistently.
- Check a template with missing personal data and verify the existing blocking alert is still shown.

[PIN-10053]: https://pagopa.atlassian.net/browse/PIN-10053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ