### PR TITLE
feat: add async fields to template summary (PIN-10051)

### DIFF
--- a/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
@@ -92,7 +92,14 @@ const ProviderEServiceTemplateSummaryPage: React.FC = () => {
   }
 
   const arePersonalDataSet = eserviceTemplate?.eserviceTemplate.personalData !== undefined
-  const hasMissingFields = !eserviceTemplate?.voucherLifespan || !eserviceTemplate?.description
+  const hasMissingAsyncExchangeFields = Boolean(
+    eserviceTemplate?.eserviceTemplate.asyncExchange &&
+    (!eserviceTemplate.asyncExchangeProperties || !eserviceTemplate.asyncExchangeCallbackInterface)
+  )
+  const hasMissingFields =
+    !eserviceTemplate?.voucherLifespan ||
+    !eserviceTemplate?.description ||
+    hasMissingAsyncExchangeFields
 
   const canBePublished = () => {
     return !!(eserviceTemplate?.interface && arePersonalDataSet && !hasMissingFields)
@@ -168,7 +175,11 @@ const ProviderEServiceTemplateSummaryPage: React.FC = () => {
             <SummaryAccordion
               headline={isReceiveMode ? '4' : '3'}
               title={t('summary.technicalSpecsSummary.title')}
-              showWarning={!eserviceTemplate?.voucherLifespan || !eserviceTemplate?.interface}
+              showWarning={
+                !eserviceTemplate?.voucherLifespan ||
+                !eserviceTemplate?.interface ||
+                hasMissingAsyncExchangeFields
+              }
               warningLabel={t('summary.completeInfoChip')}
             >
               <ProviderEServiceTemplateTechnicalSpecsSummarySection />

--- a/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateGeneralInfoSummarySection.test.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateGeneralInfoSummarySection.test.tsx
@@ -4,6 +4,7 @@ import { ProviderEServiceTemplateGeneralInfoSummarySection } from '../components
 import { mockUseJwt, mockUseParams, renderWithApplicationContext } from '@/utils/testing.utils'
 import {
   createMockEServiceTemplateVersionDetails,
+  createMockEServiceTemplateVersionDetailsAsync,
   createMockEServiceTemplateVersionDetailsReceiveMode,
 } from '@/../__mocks__/data/eserviceTemplate.mocks'
 
@@ -82,6 +83,32 @@ describe('ProviderEServiceTemplateGeneralInfoSummarySection', () => {
 
     expect(screen.getByText('apiTechnology.label')).toBeInTheDocument()
     expect(screen.getByText(mockData.eserviceTemplate.technology)).toBeInTheDocument()
+  })
+
+  it('renders synchronous exchange type', () => {
+    const mockData = createMockEServiceTemplateVersionDetails()
+    useSuspenseQueryMock.mockReturnValue({ data: mockData })
+
+    renderWithApplicationContext(<ProviderEServiceTemplateGeneralInfoSummarySection />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('exchangeType.label')).toBeInTheDocument()
+    expect(screen.getByText('exchangeType.value.sync')).toBeInTheDocument()
+  })
+
+  it('renders asynchronous exchange type', () => {
+    const mockData = createMockEServiceTemplateVersionDetailsAsync()
+    useSuspenseQueryMock.mockReturnValue({ data: mockData })
+
+    renderWithApplicationContext(<ProviderEServiceTemplateGeneralInfoSummarySection />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('exchangeType.label')).toBeInTheDocument()
+    expect(screen.getByText('exchangeType.value.async')).toBeInTheDocument()
   })
 
   it('renders Signal Hub enabled status', () => {

--- a/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateSummary.page.test.tsx
@@ -5,6 +5,7 @@ import { mockUseJwt, mockUseParams, renderWithApplicationContext } from '@/utils
 import * as router from '@/router'
 import {
   createMockEServiceTemplateVersionDetails,
+  createMockEServiceTemplateVersionDetailsAsync,
   createMockEServiceTemplateVersionDetailsReceiveMode,
   createMockEServiceTemplateVersionDetailsNoInterface,
   createMockEServiceTemplateVersionDetailsNoPersonalData,
@@ -169,6 +170,39 @@ describe('ProviderEServiceTemplateSummaryPage', () => {
 
     const publishButton = screen.getByRole('button', { name: 'publish' })
     expect(publishButton).toBeEnabled()
+  })
+
+  it('enables publish button when async template required fields are set', () => {
+    useQueryMock.mockReturnValue({
+      data: createMockEServiceTemplateVersionDetailsAsync(),
+      isLoading: false,
+    })
+
+    renderWithApplicationContext(<ProviderEServiceTemplateSummaryPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    const publishButton = screen.getByRole('button', { name: 'publish' })
+    expect(publishButton).toBeEnabled()
+  })
+
+  it('disables publish button when async template required fields are missing', () => {
+    useQueryMock.mockReturnValue({
+      data: createMockEServiceTemplateVersionDetailsAsync({
+        asyncExchangeProperties: undefined,
+        asyncExchangeCallbackInterface: undefined,
+      }),
+      isLoading: false,
+    })
+
+    renderWithApplicationContext(<ProviderEServiceTemplateSummaryPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    const publishButton = screen.getByRole('button', { name: 'publish' })
+    expect(publishButton).toBeDisabled()
   })
 
   it('disables publish button when interface is missing', () => {

--- a/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateTechnicalSpecsSummarySection.test.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateTechnicalSpecsSummarySection.test.tsx
@@ -4,6 +4,7 @@ import { ProviderEServiceTemplateTechnicalSpecsSummarySection } from '../compone
 import { mockUseJwt, mockUseParams, renderWithApplicationContext } from '@/utils/testing.utils'
 import {
   createMockEServiceTemplateVersionDetails,
+  createMockEServiceTemplateVersionDetailsAsync,
   createMockEServiceTemplateVersionDetailsNoInterface,
 } from '@/../__mocks__/data/eserviceTemplate.mocks'
 
@@ -74,5 +75,50 @@ describe('ProviderEServiceTemplateTechnicalSpecsSummarySection', () => {
 
     expect(screen.getByText('interface.label')).toBeInTheDocument()
     expect(screen.getByText('missingField')).toBeInTheDocument()
+  })
+
+  it('renders async callback interface and exchange configuration', () => {
+    const mockData = createMockEServiceTemplateVersionDetailsAsync()
+    useSuspenseQueryMock.mockReturnValue({ data: mockData })
+
+    renderWithApplicationContext(<ProviderEServiceTemplateTechnicalSpecsSummarySection />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('callbackInterface.label')).toBeInTheDocument()
+    expect(
+      screen.getByText(mockData.asyncExchangeCallbackInterface!.prettyName)
+    ).toBeInTheDocument()
+    expect(screen.getByText('asyncExchange.responseTime.label')).toBeInTheDocument()
+    expect(
+      screen.getByText(`${mockData.asyncExchangeProperties!.responseTime} time.second`)
+    ).toBeInTheDocument()
+    expect(screen.getByText('asyncExchange.resourceAvailableTime.label')).toBeInTheDocument()
+    expect(
+      screen.getByText(`${mockData.asyncExchangeProperties!.resourceAvailableTime} time.second`)
+    ).toBeInTheDocument()
+    expect(screen.getByText('asyncExchange.confirmation.label')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchange.bulk.label')).toBeInTheDocument()
+    expect(screen.getByText('asyncExchange.maxResultSet.label')).toBeInTheDocument()
+    expect(
+      screen.getByText(String(mockData.asyncExchangeProperties!.maxResultSet))
+    ).toBeInTheDocument()
+  })
+
+  it('renders missing field warnings when async data is incomplete', () => {
+    const mockData = createMockEServiceTemplateVersionDetailsAsync({
+      asyncExchangeProperties: undefined,
+      asyncExchangeCallbackInterface: undefined,
+    })
+    useSuspenseQueryMock.mockReturnValue({ data: mockData })
+
+    renderWithApplicationContext(<ProviderEServiceTemplateTechnicalSpecsSummarySection />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('callbackInterface.label')).toBeInTheDocument()
+    expect(screen.getAllByText('missingField')).toHaveLength(6)
   })
 })

--- a/src/pages/ProviderEServiceTemplateSummaryPage/components/ProviderEServiceTemplateGeneralInfoSummarySection.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/components/ProviderEServiceTemplateGeneralInfoSummarySection.tsx
@@ -33,6 +33,12 @@ export const ProviderEServiceTemplateGeneralInfoSummarySection: React.FC = () =>
         content={eserviceTemplate.eserviceTemplate.technology}
       />
       <InformationContainer
+        label={t('exchangeType.label')}
+        content={t(
+          `exchangeType.value.${eserviceTemplate.eserviceTemplate.asyncExchange ? 'async' : 'sync'}`
+        )}
+      />
+      <InformationContainer
         label={t(`personalDataField.${eserviceTemplate.eserviceTemplate.mode}.label`)}
         content={t(`personalDataField.value.${eserviceTemplate.eserviceTemplate.personalData}`)}
       />

--- a/src/pages/ProviderEServiceTemplateSummaryPage/components/ProviderEServiceTemplateTechnicalSpecsSummarySection.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/components/ProviderEServiceTemplateTechnicalSpecsSummarySection.tsx
@@ -11,6 +11,7 @@ import { EServiceTemplateDownloads } from '@/api/eserviceTemplate/eserviceTempla
 import { IconLink } from '@/components/shared/IconLink'
 import AttachFileIcon from '@mui/icons-material/AttachFile'
 import { getDownloadDocumentName } from '@/utils/eservice.utils'
+import type { EServiceDoc } from '@/api/api.generatedTypes'
 
 export const ProviderEServiceTemplateTechnicalSpecsSummarySection: React.FC = () => {
   const { t } = useTranslation('eserviceTemplate', {
@@ -27,54 +28,112 @@ export const ProviderEServiceTemplateTechnicalSpecsSummarySection: React.FC = ()
   const downloadDocument = EServiceTemplateDownloads.useDownloadVersionDocument()
   const voucherLifespan = secondsToMinutes(eserviceTemplate.voucherLifespan)
 
-  const handleDownloadInterface = () => {
-    if (!eserviceTemplate.interface) return
+  const asyncExchangeProperties = eserviceTemplate.asyncExchangeProperties
+
+  const handleDownloadDocument = (document: EServiceDoc) => {
     downloadDocument(
       {
         eServiceTemplateId: eserviceTemplate.eserviceTemplate.id,
         eServiceTemplateVersionId: eserviceTemplate.id,
-        documentId: eserviceTemplate.interface.id,
+        documentId: document.id,
       },
-      getDownloadDocumentName(eserviceTemplate.interface)
+      getDownloadDocumentName(document)
     )
   }
+
+  const renderMissingField = () => (
+    <Stack direction="row" alignItems="center" spacing={1}>
+      <WarningAmberIcon color="warning" fontSize="small" />
+      <Typography fontWeight={600}>{tSummary('missingField')}</Typography>
+    </Stack>
+  )
+
+  const renderDocumentLink = (document: EServiceDoc) => (
+    <IconLink
+      component="button"
+      startIcon={<AttachFileIcon fontSize="small" />}
+      onClick={handleDownloadDocument.bind(null, document)}
+    >
+      {document.prettyName}
+    </IconLink>
+  )
 
   return (
     <Stack spacing={2}>
       <InformationContainer
         label={t('interface.label')}
         content={
-          eserviceTemplate.interface ? (
-            <IconLink
-              component="button"
-              startIcon={<AttachFileIcon fontSize="small" />}
-              onClick={handleDownloadInterface}
-            >
-              {eserviceTemplate.interface.prettyName}
-            </IconLink>
-          ) : (
-            <Stack direction="row" alignItems="center" spacing={1}>
-              <WarningAmberIcon color="warning" fontSize="small" />
-              <Typography fontWeight={600}>{tSummary('missingField')}</Typography>
-            </Stack>
-          )
+          eserviceTemplate.interface
+            ? renderDocumentLink(eserviceTemplate.interface)
+            : renderMissingField()
         }
       />
       <InformationContainer
         label={t('voucherLifespan.label')}
         content={
-          !eserviceTemplate.voucherLifespan ? (
-            <Stack direction="row" alignItems="center" spacing={1}>
-              <WarningAmberIcon color="warning" fontSize="small" />
-              <Typography fontWeight={600}>{tSummary('missingField')}</Typography>
-            </Stack>
-          ) : (
-            `${voucherLifespan} ${tCommon('time.minute', {
-              count: voucherLifespan,
-            })}`
-          )
+          !eserviceTemplate.voucherLifespan
+            ? renderMissingField()
+            : `${voucherLifespan} ${tCommon('time.minute', {
+                count: voucherLifespan,
+              })}`
         }
       />
+      {eserviceTemplate.eserviceTemplate.asyncExchange && (
+        <>
+          <InformationContainer
+            label={t('callbackInterface.label')}
+            content={
+              eserviceTemplate.asyncExchangeCallbackInterface
+                ? renderDocumentLink(eserviceTemplate.asyncExchangeCallbackInterface)
+                : renderMissingField()
+            }
+          />
+          <InformationContainer
+            label={t('asyncExchange.responseTime.label')}
+            content={
+              asyncExchangeProperties
+                ? `${asyncExchangeProperties.responseTime} ${tCommon('time.second', {
+                    count: asyncExchangeProperties.responseTime,
+                  })}`
+                : renderMissingField()
+            }
+          />
+          <InformationContainer
+            label={t('asyncExchange.resourceAvailableTime.label')}
+            content={
+              asyncExchangeProperties
+                ? `${asyncExchangeProperties.resourceAvailableTime} ${tCommon('time.second', {
+                    count: asyncExchangeProperties.resourceAvailableTime,
+                  })}`
+                : renderMissingField()
+            }
+          />
+          <InformationContainer
+            label={t('asyncExchange.confirmation.label')}
+            content={
+              asyncExchangeProperties
+                ? t(`asyncExchange.booleanValue.${asyncExchangeProperties.confirmation}`)
+                : renderMissingField()
+            }
+          />
+          <InformationContainer
+            label={t('asyncExchange.bulk.label')}
+            content={
+              asyncExchangeProperties
+                ? t(`asyncExchange.booleanValue.${asyncExchangeProperties.bulk}`)
+                : renderMissingField()
+            }
+          />
+          <InformationContainer
+            label={t('asyncExchange.maxResultSet.label')}
+            content={
+              asyncExchangeProperties
+                ? String(asyncExchangeProperties.maxResultSet)
+                : renderMissingField()
+            }
+          />
+        </>
+      )}
     </Stack>
   )
 }

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -46,7 +46,7 @@
         "firstVersionOnlyEditableInfo": "This data will no longer be editable after the first version of the e-service is published.",
         "asyncExchangeField": {
           "label": "How do you want to exchange the e-service data?",
-          "readOnlyLabel": "Data exchange type",
+          "readOnlyLabel": "Data exchange",
           "options": {
             "false": "Synchronous (standard)",
             "true": "Asynchronous / bulk (deferred)"

--- a/src/static/locales/en/eserviceTemplate.json
+++ b/src/static/locales/en/eserviceTemplate.json
@@ -443,6 +443,13 @@
       "apiTechnology": {
         "label": "API Technology"
       },
+      "exchangeType": {
+        "label": "Exchange type",
+        "value": {
+          "sync": "Synchronous",
+          "async": "Asynchronous"
+        }
+      },
       "personalDataField": {
         "DELIVER": {
           "label": "Delivers personal data"
@@ -505,6 +512,30 @@
       "title": "Technical specifications",
       "interface": {
         "label": "Interface"
+      },
+      "callbackInterface": {
+        "label": "Callback interface"
+      },
+      "asyncExchange": {
+        "responseTime": {
+          "label": "Maximum callback time"
+        },
+        "resourceAvailableTime": {
+          "label": "Resource availability time"
+        },
+        "confirmation": {
+          "label": "Require receipt acknowledgement"
+        },
+        "bulk": {
+          "label": "Enable bulk download"
+        },
+        "maxResultSet": {
+          "label": "Maximum entities per response"
+        },
+        "booleanValue": {
+          "true": "Yes",
+          "false": "No"
+        }
       },
       "voucherLifespan": {
         "label": "Voucher lifespan"

--- a/src/static/locales/en/eserviceTemplate.json
+++ b/src/static/locales/en/eserviceTemplate.json
@@ -444,7 +444,7 @@
         "label": "API Technology"
       },
       "exchangeType": {
-        "label": "Exchange type",
+        "label": "Data exchange",
         "value": {
           "sync": "Synchronous",
           "async": "Asynchronous"

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -46,7 +46,7 @@
         "firstVersionOnlyEditableInfo": "Questi dati non saranno più modificabili dopo la pubblicazione della prima versione dell’e-service.",
         "asyncExchangeField": {
           "label": "In che modo vuoi scambiare i dati dell’e-service?",
-          "readOnlyLabel": "Tipologia di scambio dati",
+          "readOnlyLabel": "Scambio dati",
           "options": {
             "false": "Sincrono (standard)",
             "true": "Asincrono / massivo (in differita)"

--- a/src/static/locales/it/eserviceTemplate.json
+++ b/src/static/locales/it/eserviceTemplate.json
@@ -444,7 +444,7 @@
         "label": "Tecnologia API"
       },
       "exchangeType": {
-        "label": "Tipologia scambio",
+        "label": "Scambio dati",
         "value": {
           "sync": "Sincrono",
           "async": "Asincrono"

--- a/src/static/locales/it/eserviceTemplate.json
+++ b/src/static/locales/it/eserviceTemplate.json
@@ -443,6 +443,13 @@
       "apiTechnology": {
         "label": "Tecnologia API"
       },
+      "exchangeType": {
+        "label": "Tipologia scambio",
+        "value": {
+          "sync": "Sincrono",
+          "async": "Asincrono"
+        }
+      },
       "personalDataField": {
         "DELIVER": {
           "label": "Eroga dati personali"
@@ -505,6 +512,30 @@
       "title": "Specifiche tecniche",
       "interface": {
         "label": "Interfaccia"
+      },
+      "callbackInterface": {
+        "label": "Interfaccia di callback"
+      },
+      "asyncExchange": {
+        "responseTime": {
+          "label": "Tempo massimo di callback"
+        },
+        "resourceAvailableTime": {
+          "label": "Tempo disponibilità risorsa"
+        },
+        "confirmation": {
+          "label": "Richiedi conferma di ricezione"
+        },
+        "bulk": {
+          "label": "Abilita download a blocchi"
+        },
+        "maxResultSet": {
+          "label": "Limite massimo di entità per risposta"
+        },
+        "booleanValue": {
+          "true": "Sì",
+          "false": "No"
+        }
       },
       "voucherLifespan": {
         "label": "Durata del voucher"


### PR DESCRIPTION
## 🔗 Issue

[PIN-10051](https://pagopa.atlassian.net/browse/PIN-10051)

## 📝 Description / Context

Adds asynchronous exchange information to the provider e-service template summary page, aligning the template summary with the async e-service summary behavior.

## 🛠 List of changes

- Added exchange type to the general information summary section.
- Added callback interface and async exchange configuration fields to the technical specifications summary section.
- Added missing-field warnings for incomplete async template data.
- Updated publish availability so async templates require callback interface and async configuration before publication.
- Updated Italian and English translations.
- Added focused tests for synchronous, complete asynchronous, and incomplete asynchronous template summaries.

## 🧪 How to test

- Open the provider e-service template summary page for a synchronous template: the general information section should show “Exchange type” as synchronous and publication behavior should remain unchanged.
- Open the same summary for a complete asynchronous template: the technical specifications section should show callback interface, callback timing, resource availability, confirmation, bulk download, and max result set.
- Open an incomplete asynchronous template: missing async fields should show the missing-field warning and the publish button should be disabled.

[PIN-10051]: https://pagopa.atlassian.net/browse/PIN-10051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ