### PR TITLE
feat: add default async exchange properties (PIN-10152)

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
@@ -20,6 +20,7 @@ import { match } from 'ts-pattern'
 import { EServiceInterfaceSection } from '../sections/EServiceInterfaceSection'
 import { EServiceVoucherSection } from '../sections/EServiceVoucherSection'
 import { EServiceAsyncExchangeSection } from '../sections/EServiceAsyncExchangeSection'
+import { getAsyncExchangePropertiesWithDefaults } from '@/utils/eservice.utils'
 
 type AsyncExchangePropertiesFormValues = {
   responseTime: number | ''
@@ -33,14 +34,6 @@ export type EServiceCreateStepTechSpecFormValues = {
   audience: string
   voucherLifespan: number
   asyncExchangeProperties: AsyncExchangePropertiesFormValues
-}
-
-const defaultAsyncExchangeProperties: AsyncExchangePropertiesFormValues = {
-  responseTime: 60,
-  resourceAvailableTime: 60,
-  maxResultSet: 1,
-  confirmation: false,
-  bulk: true,
 }
 
 export const EServiceCreateStepTechSpec: React.FC<ActiveStepProps> = () => {
@@ -58,21 +51,9 @@ export const EServiceCreateStepTechSpec: React.FC<ActiveStepProps> = () => {
   const defaultValues: EServiceCreateStepTechSpecFormValues = {
     audience: descriptor?.audience?.[0] ?? '',
     voucherLifespan: descriptor ? secondsToMinutes(descriptor.voucherLifespan) : 1,
-    asyncExchangeProperties: {
-      responseTime:
-        descriptor?.asyncExchangeProperties?.responseTime ??
-        defaultAsyncExchangeProperties.responseTime,
-      resourceAvailableTime:
-        descriptor?.asyncExchangeProperties?.resourceAvailableTime ??
-        defaultAsyncExchangeProperties.resourceAvailableTime,
-      maxResultSet:
-        descriptor?.asyncExchangeProperties?.maxResultSet ??
-        defaultAsyncExchangeProperties.maxResultSet,
-      confirmation:
-        descriptor?.asyncExchangeProperties?.confirmation ??
-        defaultAsyncExchangeProperties.confirmation,
-      bulk: descriptor?.asyncExchangeProperties?.bulk ?? defaultAsyncExchangeProperties.bulk,
-    },
+    asyncExchangeProperties: getAsyncExchangePropertiesWithDefaults(
+      descriptor?.asyncExchangeProperties
+    ),
   }
 
   const formMethods = useForm({ defaultValues })

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
@@ -21,16 +21,26 @@ import { EServiceInterfaceSection } from '../sections/EServiceInterfaceSection'
 import { EServiceVoucherSection } from '../sections/EServiceVoucherSection'
 import { EServiceAsyncExchangeSection } from '../sections/EServiceAsyncExchangeSection'
 
+type AsyncExchangePropertiesFormValues = {
+  responseTime: number | ''
+  resourceAvailableTime: number | ''
+  maxResultSet: number | ''
+  confirmation: boolean
+  bulk: boolean
+}
+
 export type EServiceCreateStepTechSpecFormValues = {
   audience: string
   voucherLifespan: number
-  asyncExchangeProperties: {
-    responseTime: number | ''
-    resourceAvailableTime: number | ''
-    maxResultSet: number | ''
-    confirmation: boolean
-    bulk: boolean
-  }
+  asyncExchangeProperties: AsyncExchangePropertiesFormValues
+}
+
+const defaultAsyncExchangeProperties: AsyncExchangePropertiesFormValues = {
+  responseTime: 60,
+  resourceAvailableTime: 60,
+  maxResultSet: 1,
+  confirmation: false,
+  bulk: true,
 }
 
 export const EServiceCreateStepTechSpec: React.FC<ActiveStepProps> = () => {
@@ -49,11 +59,19 @@ export const EServiceCreateStepTechSpec: React.FC<ActiveStepProps> = () => {
     audience: descriptor?.audience?.[0] ?? '',
     voucherLifespan: descriptor ? secondsToMinutes(descriptor.voucherLifespan) : 1,
     asyncExchangeProperties: {
-      responseTime: descriptor?.asyncExchangeProperties?.responseTime ?? '',
-      resourceAvailableTime: descriptor?.asyncExchangeProperties?.resourceAvailableTime ?? '',
-      maxResultSet: descriptor?.asyncExchangeProperties?.maxResultSet ?? '',
-      confirmation: descriptor?.asyncExchangeProperties?.confirmation ?? false,
-      bulk: descriptor?.asyncExchangeProperties?.bulk ?? false,
+      responseTime:
+        descriptor?.asyncExchangeProperties?.responseTime ??
+        defaultAsyncExchangeProperties.responseTime,
+      resourceAvailableTime:
+        descriptor?.asyncExchangeProperties?.resourceAvailableTime ??
+        defaultAsyncExchangeProperties.resourceAvailableTime,
+      maxResultSet:
+        descriptor?.asyncExchangeProperties?.maxResultSet ??
+        defaultAsyncExchangeProperties.maxResultSet,
+      confirmation:
+        descriptor?.asyncExchangeProperties?.confirmation ??
+        defaultAsyncExchangeProperties.confirmation,
+      bulk: descriptor?.asyncExchangeProperties?.bulk ?? defaultAsyncExchangeProperties.bulk,
     },
   }
 

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
@@ -34,12 +34,18 @@ vi.mock('../../sections/EServiceAsyncExchangeSection', () => ({
     isEServiceCreatedFromTemplate,
   }: {
     isEServiceCreatedFromTemplate?: boolean
-  }) => (
-    <div>
-      EServiceAsyncExchangeSection
-      {isEServiceCreatedFromTemplate ? '-template' : ''}
-    </div>
-  ),
+  }) => {
+    const { watch } = useFormContext()
+    const asyncExchangeProperties = watch('asyncExchangeProperties')
+
+    return (
+      <div>
+        EServiceAsyncExchangeSection
+        {isEServiceCreatedFromTemplate ? '-template' : ''}
+        <pre data-testid="async-exchange-properties">{JSON.stringify(asyncExchangeProperties)}</pre>
+      </div>
+    )
+  },
 }))
 
 const updateVersionDraft = vi.fn()
@@ -140,6 +146,29 @@ describe('EServiceCreateStepTechSpec', () => {
     expect(screen.getByText('EServiceAsyncExchangeSection')).toBeInTheDocument()
   })
 
+  it('should render the async exchange section with default values when asyncExchangeProperties are missing', () => {
+    mockUseEServiceCreateContext({
+      descriptor: {
+        ...createMockEServiceDescriptorProviderAsync(),
+        asyncExchangeProperties: undefined,
+      },
+    })
+    renderWithApplicationContext(<EServiceCreateStepTechSpec {...stepProps} />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByTestId('async-exchange-properties')).toHaveTextContent(
+      JSON.stringify({
+        responseTime: 60,
+        resourceAvailableTime: 60,
+        maxResultSet: 1,
+        confirmation: false,
+        bulk: true,
+      })
+    )
+  })
+
   it('should render the async exchange section in template-instance mode when asyncExchange is true and the descriptor comes from a template', () => {
     mockUseEServiceCreateContext({
       descriptor: {
@@ -154,7 +183,7 @@ describe('EServiceCreateStepTechSpec', () => {
     expect(screen.getByText(/EServiceAsyncExchangeSection-template/)).toBeInTheDocument()
   })
 
-  it('should not include asyncExchangeProperties in payload when numeric fields are empty', async () => {
+  it('should include default asyncExchangeProperties in payload when asyncExchange is true and properties are missing', async () => {
     mockUseEServiceCreateContext({
       descriptor: {
         ...createMockEServiceDescriptorProviderAsync(),
@@ -170,7 +199,15 @@ describe('EServiceCreateStepTechSpec', () => {
     await userEvent.click(screen.getByText('forwardWithSaveBtn'))
 
     expect(updateVersionDraft).toHaveBeenCalledWith(
-      expect.not.objectContaining({ asyncExchangeProperties: expect.anything() }),
+      expect.objectContaining({
+        asyncExchangeProperties: {
+          responseTime: 60,
+          resourceAvailableTime: 60,
+          maxResultSet: 1,
+          confirmation: false,
+          bulk: true,
+        },
+      }),
       expect.any(Object)
     )
   })

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateCreateStepTechnicalSpecs.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateCreateStepTechnicalSpecs.tsx
@@ -14,6 +14,7 @@ import { EServiceTemplateMutations } from '@/api/eserviceTemplate'
 import { minutesToSeconds, secondsToMinutes } from '@/utils/format.utils'
 import { remapDescriptorAttributesToDescriptorAttributesSeed } from '@/utils/attribute.utils'
 import type { UpdateEServiceTemplateVersionSeed } from '@/api/api.generatedTypes'
+import { getAsyncExchangePropertiesWithDefaults } from '@/utils/eservice.utils'
 
 type EServiceTemplateCreateStepTechnicalSpecsFormValues = {
   voucherLifespan: number
@@ -48,6 +49,13 @@ export const EServiceTemplateCreateStepTechnicalSpecs: React.FC<ActiveStepProps>
       agreementApprovalPolicy: eserviceTemplateVersion.agreementApprovalPolicy,
       dailyCallsPerConsumer: eserviceTemplateVersion.dailyCallsPerConsumer,
       dailyCallsTotal: eserviceTemplateVersion.dailyCallsTotal,
+      ...(eserviceTemplateVersion.eserviceTemplate.asyncExchange === true
+        ? {
+            asyncExchangeProperties: getAsyncExchangePropertiesWithDefaults(
+              eserviceTemplateVersion.asyncExchangeProperties
+            ),
+          }
+        : {}),
     }
 
     updateVersionDraft(

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/EServiceTemplateCreateStepTechnicalSpecs.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/EServiceTemplateCreateStepTechnicalSpecs.test.tsx
@@ -1,11 +1,15 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import {
   EServiceTemplateCreateStepTechnicalSpecs,
   EServiceTemplateCreateStepTechnicalSpecsSkeleton,
 } from '../EServiceTemplateCreateStepTechnicalSpecs'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
-import { mockUseEServiceTemplateCreateContext } from '@/../__mocks__/data/eserviceTemplate.mocks'
+import {
+  createMockEServiceTemplateVersionDetailsAsync,
+  mockUseEServiceTemplateCreateContext,
+} from '@/../__mocks__/data/eserviceTemplate.mocks'
 
 const mockUpdateVersionDraft = vi.fn()
 
@@ -132,6 +136,32 @@ describe('EServiceTemplateCreateStepTechnicalSpecs', () => {
       withReactQueryContext: true,
     })
     expect(screen.queryByText('create.step4.documentation.title')).not.toBeInTheDocument()
+  })
+
+  it('includes default asyncExchangeProperties in payload when async template properties are missing', async () => {
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetailsAsync({
+        asyncExchangeProperties: undefined,
+      }),
+    })
+    renderWithApplicationContext(<EServiceTemplateCreateStepTechnicalSpecs {...stepProps} />, {
+      withReactQueryContext: true,
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ }))
+
+    expect(mockUpdateVersionDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        asyncExchangeProperties: {
+          responseTime: 60,
+          resourceAvailableTime: 60,
+          maxResultSet: 1,
+          confirmation: false,
+          bulk: true,
+        },
+      }),
+      expect.any(Object)
+    )
   })
 })
 

--- a/src/utils/__tests__/eservice.utils.test.ts
+++ b/src/utils/__tests__/eservice.utils.test.ts
@@ -1,4 +1,8 @@
-import { getDownloadDocumentName, getLastDescriptor } from '../eservice.utils'
+import {
+  getAsyncExchangePropertiesWithDefaults,
+  getDownloadDocumentName,
+  getLastDescriptor,
+} from '../eservice.utils'
 
 describe('getDownloadDocumentName utility function testing', () => {
   it('should correctly get the document namy from a DocumentRead data type', () => {
@@ -23,5 +27,22 @@ describe('getLastDescriptor utility function testing', () => {
     ])
 
     expect(result?.id).toEqual('test-id-3')
+  })
+})
+
+describe('getAsyncExchangePropertiesWithDefaults utility function testing', () => {
+  it('should fill missing async exchange properties with defaults', () => {
+    const result = getAsyncExchangePropertiesWithDefaults({
+      responseTime: 120,
+      bulk: false,
+    })
+
+    expect(result).toEqual({
+      responseTime: 120,
+      resourceAvailableTime: 60,
+      maxResultSet: 1,
+      confirmation: false,
+      bulk: false,
+    })
   })
 })

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -1,4 +1,34 @@
-import type { EServiceDoc, Document, CompactDescriptor } from '@/api/api.generatedTypes'
+import type {
+  AsyncExchangeProperties,
+  EServiceDoc,
+  Document,
+  CompactDescriptor,
+} from '@/api/api.generatedTypes'
+
+export const defaultAsyncExchangeProperties: AsyncExchangeProperties = {
+  responseTime: 60,
+  resourceAvailableTime: 60,
+  maxResultSet: 1,
+  confirmation: false,
+  bulk: true,
+}
+
+export function getAsyncExchangePropertiesWithDefaults(
+  asyncExchangeProperties: Partial<AsyncExchangeProperties> | undefined
+): AsyncExchangeProperties {
+  return {
+    responseTime:
+      asyncExchangeProperties?.responseTime ?? defaultAsyncExchangeProperties.responseTime,
+    resourceAvailableTime:
+      asyncExchangeProperties?.resourceAvailableTime ??
+      defaultAsyncExchangeProperties.resourceAvailableTime,
+    maxResultSet:
+      asyncExchangeProperties?.maxResultSet ?? defaultAsyncExchangeProperties.maxResultSet,
+    confirmation:
+      asyncExchangeProperties?.confirmation ?? defaultAsyncExchangeProperties.confirmation,
+    bulk: asyncExchangeProperties?.bulk ?? defaultAsyncExchangeProperties.bulk,
+  }
+}
 
 export function getDownloadDocumentName(document: EServiceDoc | Document) {
   const filename: string = document.name


### PR DESCRIPTION
## 🔗 Issue

[PIN-10152](https://pagopa.atlassian.net/browse/PIN-10152)

## 📝 Description / Context

This PR adds default values for async bulk exchange properties when creating async e-services and async e-service templates. Missing or partial async exchange properties are completed with the expected defaults while preserving explicitly provided values.

## 🛠 List of changes

- Added shared default async exchange properties.
- Applied defaults in the e-service technical specification step.
- Applied defaults in the e-service template technical specification step.
- Added tests for missing async properties in e-service and template creation.
- Added utility coverage for partial async properties.

## 🧪 How to test

- Create or edit an async e-service without existing async exchange properties and open the technical specification step.
- Verify the async bulk exchange fields use: response time `60`, max result set `1`, resource availability time `60`, receipt acknowledgement disabled, and chunked download enabled.
- Create or edit an async e-service template without existing async exchange properties and save the technical specification step.
- Verify the update payload includes the same default async exchange properties.

[PIN-10152]: https://pagopa.atlassian.net/browse/PIN-10152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ