### PR TITLE
feat: add async template tech specs card (PIN-10183)

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
@@ -49,8 +49,7 @@ export const EServiceCreateStepTechSpec: React.FC<ActiveStepProps> = () => {
 
   const isEServiceCreatedFromTemplate = Boolean(descriptor?.templateRef?.templateVersionId)
   const isEServiceAsync = Boolean(descriptor?.eservice.asyncExchange)
-  const isProducerKeychainSectionVisible =
-    isEServiceAsync && !eserviceTemplate && !isEServiceCreatedFromTemplate
+  const isProducerKeychainSectionVisible = isEServiceAsync && !eserviceTemplate
 
   const { data: initialAssociatedKeychains, isPending } = useQuery({
     ...KeychainQueries.getAllKeychainsList({

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
@@ -391,7 +391,7 @@ describe('EServiceCreateStepTechSpec', () => {
     expect(forward).not.toHaveBeenCalled()
   })
 
-  it('should render the async exchange section in template-instance mode when asyncExchange is true and the descriptor comes from a template', () => {
+  it('should render the async exchange and producer keychain sections in template-instance mode when asyncExchange is true', async () => {
     mockUseEServiceCreateContext({
       descriptor: {
         ...createMockEServiceDescriptorProviderAsync(),
@@ -402,7 +402,7 @@ describe('EServiceCreateStepTechSpec', () => {
       withReactQueryContext: true,
       withRouterContext: true,
     })
-    expect(screen.queryByText('EServiceProducerKeychainSection')).not.toBeInTheDocument()
+    expect(await screen.findByText('EServiceProducerKeychainSection')).toBeInTheDocument()
     expect(screen.getByText(/EServiceAsyncExchangeSection-template/)).toBeInTheDocument()
   })
 

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSection.tsx
@@ -1,13 +1,9 @@
-import { SectionContainer } from '@/components/layout/containers'
-import { RHFCheckbox, RHFTextField } from '@/components/shared/react-hook-form-inputs'
-import { asyncExchangeGuideLink } from '@/config/constants'
-import { Alert, Grid, Link, Stack, Typography } from '@mui/material'
+import { Stack } from '@mui/material'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
-import React from 'react'
-import { useFormContext } from 'react-hook-form'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { useEServiceCreateContext } from '../EServiceCreateContext'
 import { UploadCallbackInterfaceDoc } from '../components/UploadCallbackInterfaceDoc'
+import { EServiceAsyncExchangeSectionBase } from './EServiceAsyncExchangeSectionBase'
 
 type EServiceAsyncExchangeSectionProps = {
   areEServiceGeneralInfoEditable: boolean
@@ -23,175 +19,28 @@ export const EServiceAsyncExchangeSection: React.FC<EServiceAsyncExchangeSection
   })
 
   const { descriptor } = useEServiceCreateContext()
-  const { setValue } = useFormContext()
-
   const isSoap = descriptor?.eservice.technology === 'SOAP'
-
-  React.useEffect(() => {
-    if (isSoap && !isEServiceCreatedFromTemplate) {
-      setValue('asyncExchangeProperties.bulk', false)
-    }
-  }, [isSoap, isEServiceCreatedFromTemplate, setValue])
-
-  const description = (
-    <Trans
-      components={{
-        1: <Link underline="hover" href={asyncExchangeGuideLink} target="_blank" rel="noopener noreferrer"/>,
-      }}
-    >
-      {t('description')}
-    </Trans>
+  const readOnlyCallbackInterfaceContent = <UploadCallbackInterfaceDoc readOnly />
+  const editableCallbackInterfaceContent = isEServiceCreatedFromTemplate ? (
+    <Stack sx={{ mt: 2 }}>
+      <InformationContainer
+        label={t('callbackInterface.readOnlyLabel')}
+        content={readOnlyCallbackInterfaceContent}
+      />
+    </Stack>
+  ) : (
+    <UploadCallbackInterfaceDoc />
   )
 
-  if (!areEServiceGeneralInfoEditable && descriptor) {
-    const props = descriptor.asyncExchangeProperties
-
-    return (
-      <SectionContainer title={t('title')} description={description} sx={{ mt: 3 }}>
-        <Stack spacing={2} sx={{ mt: 2 }}>
-          <InformationContainer
-            label={t('callbackInterface.readOnlyLabel')}
-            content={<UploadCallbackInterfaceDoc readOnly />}
-          />
-          <Typography variant="subtitle1" sx={{ mt: 2 }}>
-            {t('configSubsection.title')}
-          </Typography>
-          <InformationContainer
-            label={t('responseTimeField.label')}
-            content={props?.responseTime?.toString() ?? '-'}
-          />
-          <InformationContainer
-            label={t('maxResultSetField.label')}
-            content={props?.maxResultSet?.toString() ?? '-'}
-          />
-          <InformationContainer
-            label={t('resourceAvailableTimeField.label')}
-            content={props?.resourceAvailableTime?.toString() ?? '-'}
-          />
-          <Typography variant="subtitle1" sx={{ mt: 2 }}>
-            {t('advancedSubsection.title')}
-          </Typography>
-          <InformationContainer
-            label={t('confirmationField.label')}
-            content={props ? t(`readOnlyOptions.${Boolean(props.confirmation)}`) : '-'}
-          />
-          <InformationContainer
-            label={t('bulkField.label')}
-            content={props ? t(`readOnlyOptions.${Boolean(props.bulk)}`) : '-'}
-          />
-        </Stack>
-      </SectionContainer>
-    )
-  }
-
-  const templateProps = descriptor?.asyncExchangeProperties
-
   return (
-    <SectionContainer title={t('title')} description={description} sx={{ mt: 3 }}>
-      <Alert severity="warning" sx={{ mt: 2 }}>
-        {t('editableInfoAlert')}
-      </Alert>
-
-      {isEServiceCreatedFromTemplate ? (
-        <Stack sx={{ mt: 2 }}>
-          <InformationContainer
-            label={t('callbackInterface.readOnlyLabel')}
-            content={<UploadCallbackInterfaceDoc readOnly />}
-          />
-        </Stack>
-      ) : (
-        <UploadCallbackInterfaceDoc />
-      )}
-
-      <Typography variant="subtitle1" sx={{ mt: 3 }}>
-        {t('configSubsection.title')}
-      </Typography>
-      <Grid container spacing={2} sx={{ mt: 1 }}>
-        <Grid item xs={12} sm={6}>
-          <RHFTextField
-            size="small"
-            name="asyncExchangeProperties.responseTime"
-            label={t('responseTimeField.label')}
-            infoLabel={t('responseTimeField.infoLabel')}
-            type="number"
-            inputProps={{ min: 1 }}
-            required
-            rules={{ 
-              required: true, 
-              min: 1,                         
-              validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
-            }}
-            sx={{ flex: 1, my: 0 }}
-          />
-        </Grid>
-        <Grid item xs={12} sm={6}>
-          <RHFTextField
-            size="small"
-            name="asyncExchangeProperties.maxResultSet"
-            label={t('maxResultSetField.label')}
-            infoLabel={t('maxResultSetField.infoLabel')}
-            type="number"
-            inputProps={{ min: 1 }}
-            required
-            rules={{ 
-              required: true, 
-              min: 1,                         
-              validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
-            }}
-            sx={{ flex: 1, my: 0 }}
-          />
-        </Grid>
-        <Grid item xs={12} sm={6}>
-          <RHFTextField
-            size="small"
-            name="asyncExchangeProperties.resourceAvailableTime"
-            label={t('resourceAvailableTimeField.label')}
-            infoLabel={t('resourceAvailableTimeField.infoLabel')}
-            type="number"
-            inputProps={{ min: 1 }}
-            required
-            rules={{ 
-              required: true, 
-              min: 1,                         
-              validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
-            }}
-            sx={{ my: 0 }}
-          />
-        </Grid>
-      </Grid>
-      <Typography variant="subtitle1" sx={{ mt: 3 }}>
-        {t('advancedSubsection.title')}
-      </Typography>
-      {isEServiceCreatedFromTemplate ? (
-        <Stack spacing={2} sx={{ mt: 2 }}>
-          <InformationContainer
-            label={t('confirmationField.label')}
-            content={
-              templateProps ? t(`readOnlyOptions.${Boolean(templateProps.confirmation)}`) : '-'
-            }
-          />
-          <InformationContainer
-            label={t('bulkField.label')}
-            content={templateProps ? t(`readOnlyOptions.${Boolean(templateProps.bulk)}`) : '-'}
-          />
-        </Stack>
-      ) : (
-        <Stack spacing={0} sx={{ mt: 1 }}>
-          <RHFCheckbox
-            name="asyncExchangeProperties.confirmation"
-            label={t('confirmationField.label')}
-            infoLabel={t('confirmationField.infoLabel')}
-            sx={{ my: 0 }}
-          />
-          <RHFCheckbox
-            name="asyncExchangeProperties.bulk"
-            label={t('bulkField.label')}
-            infoLabel={t('bulkField.infoLabel')}
-            disabled={isSoap}
-            sx={{ mb: 0 }}
-          />
-        </Stack>
-      )}
-    </SectionContainer>
+    <EServiceAsyncExchangeSectionBase
+      areGeneralInfoEditable={areEServiceGeneralInfoEditable}
+      areAdvancedOptionsEditable={!isEServiceCreatedFromTemplate}
+      asyncExchangeProperties={descriptor?.asyncExchangeProperties}
+      editableCallbackInterfaceContent={editableCallbackInterfaceContent}
+      readOnlyCallbackInterfaceContent={readOnlyCallbackInterfaceContent}
+      isSoap={isSoap}
+      forceBulkFalse={!isEServiceCreatedFromTemplate}
+    />
   )
 }

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSection.tsx
@@ -1,6 +1,3 @@
-import { Stack } from '@mui/material'
-import { InformationContainer } from '@pagopa/interop-fe-commons'
-import { useTranslation } from 'react-i18next'
 import { useEServiceCreateContext } from '../EServiceCreateContext'
 import { UploadCallbackInterfaceDoc } from '../components/UploadCallbackInterfaceDoc'
 import { EServiceAsyncExchangeSectionBase } from './EServiceAsyncExchangeSectionBase'
@@ -14,20 +11,11 @@ export const EServiceAsyncExchangeSection: React.FC<EServiceAsyncExchangeSection
   areEServiceGeneralInfoEditable,
   isEServiceCreatedFromTemplate = false,
 }) => {
-  const { t } = useTranslation('eservice', {
-    keyPrefix: 'create.step4.asyncExchangeSection',
-  })
-
   const { descriptor } = useEServiceCreateContext()
   const isSoap = descriptor?.eservice.technology === 'SOAP'
   const readOnlyCallbackInterfaceContent = <UploadCallbackInterfaceDoc readOnly />
   const editableCallbackInterfaceContent = isEServiceCreatedFromTemplate ? (
-    <Stack sx={{ mt: 2 }}>
-      <InformationContainer
-        label={t('callbackInterface.readOnlyLabel')}
-        content={readOnlyCallbackInterfaceContent}
-      />
-    </Stack>
+    readOnlyCallbackInterfaceContent
   ) : (
     <UploadCallbackInterfaceDoc />
   )

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
@@ -18,6 +18,31 @@ type EServiceAsyncExchangeSectionBaseProps = {
   forceBulkFalse?: boolean
 }
 
+const asyncExchangeNumericFields = [
+  {
+    name: 'asyncExchangeProperties.responseTime',
+    translationKey: 'responseTimeField',
+    sx: { flex: 1, my: 0 },
+  },
+  {
+    name: 'asyncExchangeProperties.maxResultSet',
+    translationKey: 'maxResultSetField',
+    sx: { flex: 1, my: 0 },
+  },
+  {
+    name: 'asyncExchangeProperties.resourceAvailableTime',
+    translationKey: 'resourceAvailableTimeField',
+    sx: { my: 0 },
+  },
+] satisfies Array<{
+  name: `asyncExchangeProperties.${keyof Pick<
+    AsyncExchangeProperties,
+    'responseTime' | 'maxResultSet' | 'resourceAvailableTime'
+  >}`
+  translationKey: 'responseTimeField' | 'maxResultSetField' | 'resourceAvailableTimeField'
+  sx: { flex?: number; my: number }
+}>
+
 export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSectionBaseProps> = ({
   areGeneralInfoEditable,
   areAdvancedOptionsEditable,
@@ -114,57 +139,25 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
         {t('configSubsection.title')}
       </Typography>
       <Grid container spacing={2} sx={{ mt: 1 }}>
-        <Grid item xs={12} sm={6}>
-          <RHFTextField
-            size="small"
-            name="asyncExchangeProperties.responseTime"
-            label={t('responseTimeField.label')}
-            infoLabel={t('responseTimeField.infoLabel')}
-            type="number"
-            inputProps={{ min: 1 }}
-            required
-            rules={{
-              required: true,
-              min: 1,
-              validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
-            }}
-            sx={{ flex: 1, my: 0 }}
-          />
-        </Grid>
-        <Grid item xs={12} sm={6}>
-          <RHFTextField
-            size="small"
-            name="asyncExchangeProperties.maxResultSet"
-            label={t('maxResultSetField.label')}
-            infoLabel={t('maxResultSetField.infoLabel')}
-            type="number"
-            inputProps={{ min: 1 }}
-            required
-            rules={{
-              required: true,
-              min: 1,
-              validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
-            }}
-            sx={{ flex: 1, my: 0 }}
-          />
-        </Grid>
-        <Grid item xs={12} sm={6}>
-          <RHFTextField
-            size="small"
-            name="asyncExchangeProperties.resourceAvailableTime"
-            label={t('resourceAvailableTimeField.label')}
-            infoLabel={t('resourceAvailableTimeField.infoLabel')}
-            type="number"
-            inputProps={{ min: 1 }}
-            required
-            rules={{
-              required: true,
-              min: 1,
-              validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
-            }}
-            sx={{ my: 0 }}
-          />
-        </Grid>
+        {asyncExchangeNumericFields.map(({ name, translationKey, sx }) => (
+          <Grid item xs={12} sm={6} key={name}>
+            <RHFTextField
+              size="small"
+              name={name}
+              label={t(`${translationKey}.label`)}
+              infoLabel={t(`${translationKey}.infoLabel`)}
+              type="number"
+              inputProps={{ min: 1 }}
+              required
+              rules={{
+                required: true,
+                min: 1,
+                validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
+              }}
+              sx={sx}
+            />
+          </Grid>
+        ))}
       </Grid>
       <Typography variant="subtitle1" sx={{ mt: 3 }}>
         {t('advancedSubsection.title')}

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
@@ -1,0 +1,210 @@
+import type { AsyncExchangeProperties } from '@/api/api.generatedTypes'
+import { SectionContainer } from '@/components/layout/containers'
+import { RHFCheckbox, RHFTextField } from '@/components/shared/react-hook-form-inputs'
+import { asyncExchangeGuideLink } from '@/config/constants'
+import { Alert, Grid, Link, Stack, Typography } from '@mui/material'
+import { InformationContainer } from '@pagopa/interop-fe-commons'
+import React from 'react'
+import { useFormContext } from 'react-hook-form'
+import { Trans, useTranslation } from 'react-i18next'
+
+type EServiceAsyncExchangeSectionBaseProps = {
+  areGeneralInfoEditable: boolean
+  areAdvancedOptionsEditable: boolean
+  asyncExchangeProperties?: AsyncExchangeProperties
+  editableCallbackInterfaceContent: React.ReactNode
+  readOnlyCallbackInterfaceContent: string | React.ReactElement
+  isSoap?: boolean
+  forceBulkFalse?: boolean
+}
+
+export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSectionBaseProps> = ({
+  areGeneralInfoEditable,
+  areAdvancedOptionsEditable,
+  asyncExchangeProperties,
+  editableCallbackInterfaceContent,
+  readOnlyCallbackInterfaceContent,
+  isSoap = false,
+  forceBulkFalse = false,
+}) => {
+  const { t } = useTranslation('eservice', {
+    keyPrefix: 'create.step4.asyncExchangeSection',
+  })
+  const { setValue } = useFormContext()
+
+  React.useEffect(() => {
+    if (isSoap && forceBulkFalse) {
+      setValue('asyncExchangeProperties.bulk', false)
+    }
+  }, [forceBulkFalse, isSoap, setValue])
+
+  const description = (
+    <Trans
+      components={{
+        1: (
+          <Link
+            underline="hover"
+            href={asyncExchangeGuideLink}
+            target="_blank"
+            rel="noopener noreferrer"
+          />
+        ),
+      }}
+    >
+      {t('description')}
+    </Trans>
+  )
+
+  if (!areGeneralInfoEditable) {
+    return (
+      <SectionContainer title={t('title')} description={description} sx={{ mt: 3 }}>
+        <Stack spacing={2} sx={{ mt: 2 }}>
+          <InformationContainer
+            label={t('callbackInterface.readOnlyLabel')}
+            content={readOnlyCallbackInterfaceContent}
+          />
+          <Typography variant="subtitle1" sx={{ mt: 2 }}>
+            {t('configSubsection.title')}
+          </Typography>
+          <InformationContainer
+            label={t('responseTimeField.label')}
+            content={asyncExchangeProperties?.responseTime?.toString() ?? '-'}
+          />
+          <InformationContainer
+            label={t('maxResultSetField.label')}
+            content={asyncExchangeProperties?.maxResultSet?.toString() ?? '-'}
+          />
+          <InformationContainer
+            label={t('resourceAvailableTimeField.label')}
+            content={asyncExchangeProperties?.resourceAvailableTime?.toString() ?? '-'}
+          />
+          <Typography variant="subtitle1" sx={{ mt: 2 }}>
+            {t('advancedSubsection.title')}
+          </Typography>
+          <InformationContainer
+            label={t('confirmationField.label')}
+            content={
+              asyncExchangeProperties
+                ? t(`readOnlyOptions.${Boolean(asyncExchangeProperties.confirmation)}`)
+                : '-'
+            }
+          />
+          <InformationContainer
+            label={t('bulkField.label')}
+            content={
+              asyncExchangeProperties
+                ? t(`readOnlyOptions.${Boolean(asyncExchangeProperties.bulk)}`)
+                : '-'
+            }
+          />
+        </Stack>
+      </SectionContainer>
+    )
+  }
+
+  return (
+    <SectionContainer title={t('title')} description={description} sx={{ mt: 3 }}>
+      <Alert severity="warning" sx={{ mt: 2 }}>
+        {t('editableInfoAlert')}
+      </Alert>
+
+      {editableCallbackInterfaceContent}
+
+      <Typography variant="subtitle1" sx={{ mt: 3 }}>
+        {t('configSubsection.title')}
+      </Typography>
+      <Grid container spacing={2} sx={{ mt: 1 }}>
+        <Grid item xs={12} sm={6}>
+          <RHFTextField
+            size="small"
+            name="asyncExchangeProperties.responseTime"
+            label={t('responseTimeField.label')}
+            infoLabel={t('responseTimeField.infoLabel')}
+            type="number"
+            inputProps={{ min: 1 }}
+            required
+            rules={{
+              required: true,
+              min: 1,
+              validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
+            }}
+            sx={{ flex: 1, my: 0 }}
+          />
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <RHFTextField
+            size="small"
+            name="asyncExchangeProperties.maxResultSet"
+            label={t('maxResultSetField.label')}
+            infoLabel={t('maxResultSetField.infoLabel')}
+            type="number"
+            inputProps={{ min: 1 }}
+            required
+            rules={{
+              required: true,
+              min: 1,
+              validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
+            }}
+            sx={{ flex: 1, my: 0 }}
+          />
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <RHFTextField
+            size="small"
+            name="asyncExchangeProperties.resourceAvailableTime"
+            label={t('resourceAvailableTimeField.label')}
+            infoLabel={t('resourceAvailableTimeField.infoLabel')}
+            type="number"
+            inputProps={{ min: 1 }}
+            required
+            rules={{
+              required: true,
+              min: 1,
+              validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
+            }}
+            sx={{ my: 0 }}
+          />
+        </Grid>
+      </Grid>
+      <Typography variant="subtitle1" sx={{ mt: 3 }}>
+        {t('advancedSubsection.title')}
+      </Typography>
+      {areAdvancedOptionsEditable ? (
+        <Stack spacing={0} sx={{ mt: 1 }}>
+          <RHFCheckbox
+            name="asyncExchangeProperties.confirmation"
+            label={t('confirmationField.label')}
+            infoLabel={t('confirmationField.infoLabel')}
+            sx={{ my: 0 }}
+          />
+          <RHFCheckbox
+            name="asyncExchangeProperties.bulk"
+            label={t('bulkField.label')}
+            infoLabel={t('bulkField.infoLabel')}
+            disabled={isSoap}
+            sx={{ mb: 0 }}
+          />
+        </Stack>
+      ) : (
+        <Stack spacing={2} sx={{ mt: 2 }}>
+          <InformationContainer
+            label={t('confirmationField.label')}
+            content={
+              asyncExchangeProperties
+                ? t(`readOnlyOptions.${Boolean(asyncExchangeProperties.confirmation)}`)
+                : '-'
+            }
+          />
+          <InformationContainer
+            label={t('bulkField.label')}
+            content={
+              asyncExchangeProperties
+                ? t(`readOnlyOptions.${Boolean(asyncExchangeProperties.bulk)}`)
+                : '-'
+            }
+          />
+        </Stack>
+      )}
+    </SectionContainer>
+  )
+}

--- a/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceAsyncExchangeSection.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceAsyncExchangeSection.test.tsx
@@ -31,7 +31,8 @@ const defaultFormValues = {
 const renderComponent = (
   areEServiceGeneralInfoEditable = true,
   descriptorOverrides: Parameters<typeof createMockEServiceDescriptorProviderAsync>[0] = {},
-  formValues: typeof defaultFormValues = defaultFormValues
+  formValues: typeof defaultFormValues = defaultFormValues,
+  isEServiceCreatedFromTemplate = false
 ) => {
   mockUseEServiceCreateContext({
     descriptor: createMockEServiceDescriptorProviderAsync(descriptorOverrides),
@@ -41,6 +42,7 @@ const renderComponent = (
     <ReactHookFormWrapper defaultValues={formValues}>
       <EServiceAsyncExchangeSection
         areEServiceGeneralInfoEditable={areEServiceGeneralInfoEditable}
+        isEServiceCreatedFromTemplate={isEServiceCreatedFromTemplate}
       />
     </ReactHookFormWrapper>,
     { withReactQueryContext: true, withRouterContext: true }
@@ -119,5 +121,12 @@ describe('EServiceAsyncExchangeSection', () => {
     expect(screen.getByText('UploadCallbackInterfaceDoc-readOnly')).toBeInTheDocument()
     expect(screen.queryByLabelText(/responseTimeField.label/)).not.toBeInTheDocument()
     expect(screen.getByText('callbackInterface.readOnlyLabel')).toBeInTheDocument()
+  })
+
+  it('should render the callback interface without an extra label for e-services created from template', () => {
+    renderComponent(true, {}, defaultFormValues, true)
+
+    expect(screen.getByText('UploadCallbackInterfaceDoc-readOnly')).toBeInTheDocument()
+    expect(screen.queryByText('callbackInterface.readOnlyLabel')).not.toBeInTheDocument()
   })
 })

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateAsyncExchangeSection.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateAsyncExchangeSection.tsx
@@ -1,0 +1,20 @@
+import { EServiceAsyncExchangeSectionBase } from '@/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase'
+import { useEServiceTemplateCreateContext } from '../ProviderEServiceTemplateContext'
+import { UploadTemplateCallbackInterfaceDoc } from './UploadTemplateCallbackInterfaceDoc'
+
+export const EServiceTemplateAsyncExchangeSection: React.FC = () => {
+  const { eserviceTemplateVersion } = useEServiceTemplateCreateContext()
+  const isSoap = eserviceTemplateVersion?.eserviceTemplate.technology === 'SOAP'
+
+  return (
+    <EServiceAsyncExchangeSectionBase
+      areGeneralInfoEditable
+      areAdvancedOptionsEditable
+      asyncExchangeProperties={eserviceTemplateVersion?.asyncExchangeProperties}
+      editableCallbackInterfaceContent={<UploadTemplateCallbackInterfaceDoc />}
+      readOnlyCallbackInterfaceContent={<UploadTemplateCallbackInterfaceDoc />}
+      isSoap={isSoap}
+      forceBulkFalse
+    />
+  )
+}

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateCreateStepTechnicalSpecs.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateCreateStepTechnicalSpecs.tsx
@@ -15,9 +15,17 @@ import { minutesToSeconds, secondsToMinutes } from '@/utils/format.utils'
 import { remapDescriptorAttributesToDescriptorAttributesSeed } from '@/utils/attribute.utils'
 import type { UpdateEServiceTemplateVersionSeed } from '@/api/api.generatedTypes'
 import { getAsyncExchangePropertiesWithDefaults } from '@/utils/eservice.utils'
+import { EServiceTemplateAsyncExchangeSection } from './EServiceTemplateAsyncExchangeSection'
 
 type EServiceTemplateCreateStepTechnicalSpecsFormValues = {
   voucherLifespan: number
+  asyncExchangeProperties: {
+    responseTime: number | ''
+    resourceAvailableTime: number | ''
+    maxResultSet: number | ''
+    confirmation: boolean
+    bulk: boolean
+  }
 }
 
 export const EServiceTemplateCreateStepTechnicalSpecs: React.FC<ActiveStepProps> = () => {
@@ -33,12 +41,18 @@ export const EServiceTemplateCreateStepTechnicalSpecs: React.FC<ActiveStepProps>
     voucherLifespan: eserviceTemplateVersion
       ? secondsToMinutes(eserviceTemplateVersion.voucherLifespan)
       : 1,
+    asyncExchangeProperties: getAsyncExchangePropertiesWithDefaults(
+      eserviceTemplateVersion?.asyncExchangeProperties
+    ),
   }
 
   const formMethods = useForm({ defaultValues })
 
   const onSubmit = (values: EServiceTemplateCreateStepTechnicalSpecsFormValues) => {
     if (!eserviceTemplateVersion) return
+    const { asyncExchangeProperties } = values
+    const isAsyncExchange = eserviceTemplateVersion.eserviceTemplate.asyncExchange === true
+    const isSoap = eserviceTemplateVersion.eserviceTemplate.technology === 'SOAP'
 
     const payload: UpdateEServiceTemplateVersionSeed = {
       description: eserviceTemplateVersion.description,
@@ -49,11 +63,15 @@ export const EServiceTemplateCreateStepTechnicalSpecs: React.FC<ActiveStepProps>
       agreementApprovalPolicy: eserviceTemplateVersion.agreementApprovalPolicy,
       dailyCallsPerConsumer: eserviceTemplateVersion.dailyCallsPerConsumer,
       dailyCallsTotal: eserviceTemplateVersion.dailyCallsTotal,
-      ...(eserviceTemplateVersion.eserviceTemplate.asyncExchange === true
+      ...(isAsyncExchange
         ? {
-            asyncExchangeProperties: getAsyncExchangePropertiesWithDefaults(
-              eserviceTemplateVersion.asyncExchangeProperties
-            ),
+            asyncExchangeProperties: {
+              responseTime: Number(asyncExchangeProperties.responseTime),
+              resourceAvailableTime: Number(asyncExchangeProperties.resourceAvailableTime),
+              maxResultSet: Number(asyncExchangeProperties.maxResultSet),
+              confirmation: asyncExchangeProperties.confirmation,
+              bulk: isSoap ? false : asyncExchangeProperties.bulk,
+            },
           }
         : {}),
     }
@@ -101,6 +119,9 @@ export const EServiceTemplateCreateStepTechnicalSpecs: React.FC<ActiveStepProps>
             />
           </Stack>
         </SectionContainer>
+        {eserviceTemplateVersion?.eserviceTemplate.asyncExchange && (
+          <EServiceTemplateAsyncExchangeSection />
+        )}
         <StepActions
           back={{
             label: t('create.backWithoutSaveBtn'),

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/UploadTemplateCallbackInterfaceDoc.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/UploadTemplateCallbackInterfaceDoc.tsx
@@ -1,0 +1,82 @@
+import { EServiceTemplateDownloads } from '@/api/eserviceTemplate/eserviceTemplate.downloads'
+import { EServiceTemplateMutations } from '@/api/eserviceTemplate'
+import type { EServiceDoc } from '@/api/api.generatedTypes'
+import { DocumentContainer } from '@/components/layout/containers/DocumentContainer'
+import { UploadDocumentsInterface } from '@/components/shared/UploadDocumentsInterface'
+import { getDownloadDocumentName } from '@/utils/eservice.utils'
+import { type SubmitHandler } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { match, P } from 'ts-pattern'
+import { useEServiceTemplateCreateContext } from '../ProviderEServiceTemplateContext'
+
+type UploadTemplateCallbackInterfaceDocFormValues = {
+  interfaceDoc: File | null
+}
+
+export const UploadTemplateCallbackInterfaceDoc: React.FC = () => {
+  const { t } = useTranslation('eservice', { keyPrefix: 'create.step4.asyncExchangeSection' })
+  const { eserviceTemplateVersion } = useEServiceTemplateCreateContext()
+
+  const downloadDocument = EServiceTemplateDownloads.useDownloadVersionDocument()
+  const { mutate: deleteDocument } = EServiceTemplateMutations.useDeleteVersionDraftDocument()
+  const { mutate: uploadDocument } = EServiceTemplateMutations.usePostVersionDraftDocument()
+
+  const actualInterface: EServiceDoc | null =
+    eserviceTemplateVersion?.asyncExchangeCallbackInterface ?? null
+
+  const onSubmit: SubmitHandler<UploadTemplateCallbackInterfaceDocFormValues> = ({
+    interfaceDoc,
+  }) => {
+    if (!interfaceDoc || !eserviceTemplateVersion) return
+
+    uploadDocument({
+      eServiceTemplateId: eserviceTemplateVersion.eserviceTemplate.id,
+      eServiceTemplateVersionId: eserviceTemplateVersion.id,
+      doc: interfaceDoc,
+      prettyName: t('callbackInterface.prettyName'),
+      kind: 'ASYNC_EXCHANGE_CALLBACK_INTERFACE',
+    })
+  }
+
+  const handleDeleteInterface = () => {
+    if (!actualInterface || !eserviceTemplateVersion) return
+
+    deleteDocument({
+      eServiceTemplateId: eserviceTemplateVersion.eserviceTemplate.id,
+      eServiceTemplateVersionId: eserviceTemplateVersion.id,
+      documentId: actualInterface.id,
+    })
+  }
+
+  const handleDownloadInterface = () => {
+    if (!actualInterface || !eserviceTemplateVersion) return
+
+    downloadDocument(
+      {
+        eServiceTemplateId: eserviceTemplateVersion.eserviceTemplate.id,
+        eServiceTemplateVersionId: eserviceTemplateVersion.id,
+        documentId: actualInterface.id,
+      },
+      getDownloadDocumentName(actualInterface)
+    )
+  }
+
+  return match(actualInterface)
+    .with(null, () => (
+      <UploadDocumentsInterface
+        onSubmit={onSubmit}
+        sxBox={{ py: 2 }}
+        dropzoneLabel={t('callbackInterface.dropzoneLabel')}
+      />
+    ))
+    .with(P.not(null), (actualInterface) => (
+      <DocumentContainer
+        sx={{ mt: 4 }}
+        doc={actualInterface}
+        onDelete={handleDeleteInterface}
+        onDownload={handleDownloadInterface}
+        size="small"
+      />
+    ))
+    .exhaustive()
+}

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/EServiceTemplateCreateStepTechnicalSpecs.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/EServiceTemplateCreateStepTechnicalSpecs.test.tsx
@@ -138,6 +138,36 @@ describe('EServiceTemplateCreateStepTechnicalSpecs', () => {
     expect(screen.queryByText('create.step4.documentation.title')).not.toBeInTheDocument()
   })
 
+  it('renders the async exchange section when the template is async', () => {
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetailsAsync(),
+    })
+    renderWithApplicationContext(<EServiceTemplateCreateStepTechnicalSpecs {...stepProps} />, {
+      withReactQueryContext: true,
+    })
+
+    expect(screen.getByText('title')).toBeInTheDocument()
+    expect(screen.getByText('editableInfoAlert')).toBeInTheDocument()
+    expect(screen.queryByText('callbackInterface.readOnlyLabel')).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('Specifica callback')).toBeInTheDocument()
+    expect(screen.getByText('configSubsection.title')).toBeInTheDocument()
+    expect(screen.getByLabelText(/responseTimeField.label/)).toHaveValue(1000)
+    expect(screen.getByLabelText(/resourceAvailableTimeField.label/)).toHaveValue(2000)
+    expect(screen.getByLabelText(/maxResultSetField.label/)).toHaveValue(100)
+    expect(screen.getByRole('checkbox', { name: /confirmationField.label/ })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /bulkField.label/ })).toBeChecked()
+  })
+
+  it('does not render the async exchange section when the template is synchronous', () => {
+    mockUseEServiceTemplateCreateContext()
+    renderWithApplicationContext(<EServiceTemplateCreateStepTechnicalSpecs {...stepProps} />, {
+      withReactQueryContext: true,
+    })
+
+    expect(screen.queryByText('title')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/responseTimeField.label/)).not.toBeInTheDocument()
+  })
+
   it('includes default asyncExchangeProperties in payload when async template properties are missing', async () => {
     mockUseEServiceTemplateCreateContext({
       eserviceTemplateVersion: createMockEServiceTemplateVersionDetailsAsync({
@@ -159,6 +189,74 @@ describe('EServiceTemplateCreateStepTechnicalSpecs', () => {
           confirmation: false,
           bulk: true,
         },
+      }),
+      expect.any(Object)
+    )
+  })
+
+  it('includes form asyncExchangeProperties in payload when the async template is submitted', async () => {
+    const user = userEvent.setup()
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetailsAsync(),
+    })
+    renderWithApplicationContext(<EServiceTemplateCreateStepTechnicalSpecs {...stepProps} />, {
+      withReactQueryContext: true,
+    })
+
+    await user.clear(screen.getByLabelText(/responseTimeField.label/))
+    await user.type(screen.getByLabelText(/responseTimeField.label/), '123')
+    await user.clear(screen.getByLabelText(/resourceAvailableTimeField.label/))
+    await user.type(screen.getByLabelText(/resourceAvailableTimeField.label/), '456')
+    await user.clear(screen.getByLabelText(/maxResultSetField.label/))
+    await user.type(screen.getByLabelText(/maxResultSetField.label/), '7')
+    await user.click(screen.getByRole('checkbox', { name: /confirmationField.label/ }))
+    await user.click(screen.getByRole('checkbox', { name: /bulkField.label/ }))
+
+    await user.click(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ }))
+
+    expect(mockUpdateVersionDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        asyncExchangeProperties: {
+          responseTime: 123,
+          resourceAvailableTime: 456,
+          maxResultSet: 7,
+          confirmation: false,
+          bulk: false,
+        },
+      }),
+      expect.any(Object)
+    )
+  })
+
+  it('forces bulk to false when the async template technology is SOAP', async () => {
+    const user = userEvent.setup()
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetailsAsync({
+        eserviceTemplate: {
+          ...createMockEServiceTemplateVersionDetailsAsync().eserviceTemplate,
+          technology: 'SOAP',
+        },
+        asyncExchangeProperties: {
+          responseTime: 1,
+          resourceAvailableTime: 1,
+          maxResultSet: 1,
+          confirmation: false,
+          bulk: true,
+        },
+      }),
+    })
+    renderWithApplicationContext(<EServiceTemplateCreateStepTechnicalSpecs {...stepProps} />, {
+      withReactQueryContext: true,
+    })
+
+    const bulkCheckbox = screen.getByRole('checkbox', { name: /bulkField.label/ })
+    expect(bulkCheckbox).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ }))
+
+    expect(mockUpdateVersionDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        asyncExchangeProperties: expect.objectContaining({ bulk: false }),
       }),
       expect.any(Object)
     )

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/UploadTemplateCallbackInterfaceDoc.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/UploadTemplateCallbackInterfaceDoc.test.tsx
@@ -1,0 +1,88 @@
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import {
+  createMockEServiceTemplateVersionDetailsAsync,
+  mockUseEServiceTemplateCreateContext,
+} from '@/../__mocks__/data/eserviceTemplate.mocks'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import { UploadTemplateCallbackInterfaceDoc } from '../UploadTemplateCallbackInterfaceDoc'
+
+const uploadDocument = vi.fn()
+const deleteDocument = vi.fn()
+
+vi.mock('@/api/eserviceTemplate', () => ({
+  EServiceTemplateMutations: {
+    usePostVersionDraftDocument: () => ({ mutate: uploadDocument }),
+    useDeleteVersionDraftDocument: () => ({ mutate: deleteDocument }),
+  },
+}))
+
+vi.mock('@/api/eserviceTemplate/eserviceTemplate.downloads', () => ({
+  EServiceTemplateDownloads: {
+    useDownloadVersionDocument: () => vi.fn(),
+  },
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('UploadTemplateCallbackInterfaceDoc', () => {
+  it('shows the DocumentContainer when a callback interface is already uploaded', () => {
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetailsAsync(),
+    })
+    renderWithApplicationContext(<UploadTemplateCallbackInterfaceDoc />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByDisplayValue('Specifica callback')).toBeInTheDocument()
+  })
+
+  it('shows the upload dropzone when no callback interface is present', () => {
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetailsAsync({
+        asyncExchangeCallbackInterface: undefined,
+      }),
+    })
+    renderWithApplicationContext(<UploadTemplateCallbackInterfaceDoc />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByTestId('fileInput')).toBeInTheDocument()
+  })
+
+  it('calls uploadDocument with kind ASYNC_EXCHANGE_CALLBACK_INTERFACE on submit', async () => {
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetailsAsync({
+        asyncExchangeCallbackInterface: undefined,
+      }),
+    })
+    renderWithApplicationContext(<UploadTemplateCallbackInterfaceDoc />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    const file = new File(['hello'], 'callback.yaml', { type: 'application/yaml' })
+    const input = screen
+      .getByTestId('fileInput')
+      .querySelector('input[type="file"]') as HTMLInputElement
+    await userEvent.upload(input, file)
+
+    await userEvent.click(screen.getByTestId('submitButton'))
+
+    await waitFor(() => {
+      expect(uploadDocument).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eServiceTemplateId: 'template-id-001',
+          eServiceTemplateVersionId: 'version-id-001',
+          kind: 'ASYNC_EXCHANGE_CALLBACK_INTERFACE',
+          doc: file,
+        })
+      )
+    })
+  })
+})


### PR DESCRIPTION
## 🔗 Issue

[PIN-10183](https://pagopa.atlassian.net/browse/PIN-10183)

## 📝 Description / Context

Adds the “Massive asynchronous exchange” card to the e-service template technical specifications step when the template is configured for asynchronous exchange.

## 🛠 List of changes

- Extracted a shared async exchange section base used by both e-service and template flows.
- Added the async exchange card to `EServiceTemplateCreateStepTechnicalSpecs`.
- Added callback interface upload/download/delete support for template descriptors using `ASYNC_EXCHANGE_CALLBACK_INTERFACE`.
- Persisted async exchange configuration values from the template technical specs form.
- Applied default async exchange values when existing template properties are missing.
- Forced bulk download to `false` for SOAP templates.
- Added focused tests for conditional rendering, form payloads, SOAP bulk handling, and callback interface upload.

## 🧪 How to test

- Open the e-service template creation/edit flow for an asynchronous template and go to “Specifiche tecniche”: the “Scambi asincroni e massivi” card should be visible.
- Verify that the callback interface can be uploaded from the card and existing callback documents are shown with download/delete actions.
- Edit the async configuration fields and save the step: the values should be persisted.
- Open the same step for a synchronous template: the async card should not be shown.
- For a SOAP async template, verify that the bulk option is disabled and saved as `false`.

[PIN-10183]: https://pagopa.atlassian.net/browse/PIN-10183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ