### PR TITLE
fix/PIN-10182 minor fix

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
@@ -270,7 +270,7 @@ const EServiceCreateStepTechSpecForm: React.FC<EServiceCreateStepTechSpecFormPro
         <EServiceVoucherSection isEServiceCreatedFromTemplate={isEServiceCreatedFromTemplate} />
         {isAsyncExchange && (
           <EServiceAsyncExchangeSection
-            areEServiceGeneralInfoEditable={areEServiceGeneralInfoEditable}
+            areEServiceGeneralInfoEditable={true}
             isEServiceCreatedFromTemplate={isEServiceCreatedFromTemplate}
           />
         )}

--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -234,11 +234,7 @@ const ProviderEServiceSummaryPage: React.FC = () => {
 
   const areAsyncExchangeFieldsSet =
     !descriptor?.eservice.asyncExchange ||
-    Boolean(
-      descriptor.asyncExchangeCallbackInterface &&
-      descriptor.asyncExchangeProperties &&
-      (associatedKeychains?.pagination.totalCount ?? 0) > 0
-    )
+    Boolean(descriptor.asyncExchangeCallbackInterface && descriptor.asyncExchangeProperties)
 
   const canBePublished = () => {
     return (

--- a/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceDocumentationSummarySection.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceDocumentationSummarySection.tsx
@@ -97,9 +97,9 @@ export const ProviderEServiceDocumentationSummarySection: React.FC<
           count: voucherLifespan,
         })}`}
       />
-      <Divider></Divider>
       {isAsyncExchange && (
         <>
+          <Divider></Divider>
           <SummaryInformationContainer
             label={t('callbackInterface.label')}
             content={

--- a/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceDocumentationSummarySection.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceDocumentationSummarySection.tsx
@@ -99,7 +99,7 @@ export const ProviderEServiceDocumentationSummarySection: React.FC<
       />
       {isAsyncExchange && (
         <>
-          <Divider></Divider>
+          <Divider />
           <SummaryInformationContainer
             label={t('callbackInterface.label')}
             content={
@@ -137,7 +137,7 @@ export const ProviderEServiceDocumentationSummarySection: React.FC<
             label={t('asyncExchange.maxResultSet.label')}
             content={formatAsyncNumber(asyncExchangeProperties?.maxResultSet)}
           />
-          <Divider></Divider>
+          <Divider />
           <SummaryInformationContainer
             label={t('producerKeychains.label')}
             content={keychainsContent}

--- a/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceDocumentationSummarySection.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceDocumentationSummarySection.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { CompactProducerKeychains, EServiceDoc } from '@/api/api.generatedTypes'
-import { Stack, Typography } from '@mui/material'
+import { Divider, Stack, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { IconLink } from '@/components/shared/IconLink'
 import AttachFileIcon from '@mui/icons-material/AttachFile'
@@ -97,6 +97,7 @@ export const ProviderEServiceDocumentationSummarySection: React.FC<
           count: voucherLifespan,
         })}`}
       />
+      <Divider></Divider>
       {isAsyncExchange && (
         <>
           <SummaryInformationContainer
@@ -136,6 +137,7 @@ export const ProviderEServiceDocumentationSummarySection: React.FC<
             label={t('asyncExchange.maxResultSet.label')}
             content={formatAsyncNumber(asyncExchangeProperties?.maxResultSet)}
           />
+          <Divider></Divider>
           <SummaryInformationContainer
             label={t('producerKeychains.label')}
             content={keychainsContent}

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -445,7 +445,7 @@
         "label": "Tecnologia API"
       },
       "exchangeType": {
-        "label": "Tipologia scambio",
+        "label": "Scambio dati",
         "value": {
           "sync": "Sincrono",
           "async": "Asincrono"
@@ -695,7 +695,7 @@
         "technology": "Tecnologia",
         "audience": "Audience",
         "exchangeType": {
-          "label": "Tipologia scambio",
+          "label": "Scambio dati",
           "value": {
             "sync": "Sincrono",
             "async": "Asincrono"


### PR DESCRIPTION
## 🔗 Issue

[PIN-10182](https://pagopa.atlassian.net/browse/PIN-10182)

## 📝 Description / Context

Minor fixes to the async exchange ("scambi async") flow in the e-service creation and summary pages.
These address visual and logic regressions.

## 🛠 List of changes

- **`EServiceCreateStepTechSpec`**: always pass `areEServiceGeneralInfoEditable={true}` to `EServiceAsyncExchangeSection` so async fields remain editable regardless of the e-service version state
- **`ProviderEServiceSummary`**: removed the keychain count check from `areAsyncExchangeFieldsSet` — publish readiness now only requires the callback interface and async exchange properties to be set
- **`ProviderEServiceDocumentationSummarySection`**: added `<Divider />` separators to visually isolate the async exchange block and the producer keychains section; dividers are rendered only when `isAsyncExchange` is true
- **`it/eservice.json`**: renamed label `"Tipologia scambio"` → `"Scambio dati"` in both the tech spec and summary sections

## 🧪 How to test

1. Create an e-service with **async exchange** enabled
2. In step 3 (Tech Spec), verify that the async exchange fields are editable (not read-only)
3. Proceed to the summary page and confirm:
   - The async exchange block is visually separated by dividers
   - The label reads **"Scambio dati"** (not "Tipologia scambio")
   - The publish button is enabled once the callback interface and async exchange properties are filled in — a missing producer keychain should no longer block publishing


[PIN-10182]: https://pagopa.atlassian.net/browse/PIN-10182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ