### PR TITLE
fix: move async agreement confirmation to request action (PIN-9232)

### DIFF
--- a/src/api/agreement/__tests__/agreement.mutations.test.tsx
+++ b/src/api/agreement/__tests__/agreement.mutations.test.tsx
@@ -8,6 +8,7 @@ vi.mock('../agreement.services', () => ({
   AgreementServices: {
     createDraft: vi.fn(),
     submitDraft: vi.fn(),
+    submitToOwnEService: vi.fn(),
   },
 }))
 
@@ -51,6 +52,28 @@ const getConfirmationDialogDescription = (confirmationDialog: unknown) => {
 
 describe('AgreementMutations', () => {
   describe('useCreateDraft', () => {
+    it('should replace the create draft confirmation with the async exchange confirmation for async e-services', () => {
+      const { WrapperComponent, queryClient } = createWrapper()
+      const { result } = renderHook(() => AgreementMutations.useCreateDraft(true, true), {
+        wrapper: WrapperComponent,
+      })
+
+      result.current.mutate({
+        eserviceId: 'eservice-id',
+        descriptorId: 'descriptor-id',
+        eserviceName: 'E-Service name',
+        eserviceVersion: '1',
+      })
+
+      expect(queryClient.getMutationCache().getAll()[0]?.meta?.confirmationDialog).toEqual(
+        expect.objectContaining({
+          title: 'confirmDialog.asyncExchange.title',
+          description: 'confirmDialog.asyncExchange.description',
+          checkbox: 'confirmDialog.asyncExchange.checkbox',
+        })
+      )
+    })
+
     it('should resolve the confirmation description with the e-service name and version', () => {
       const { WrapperComponent, queryClient } = createWrapper()
       const { result } = renderHook(() => AgreementMutations.useCreateDraft(), {
@@ -104,9 +127,9 @@ describe('AgreementMutations', () => {
   })
 
   describe('useSubmitDraft', () => {
-    it('should show the delegation confirmation before the async exchange confirmation', () => {
+    it('should show the delegation confirmation for delegated e-services', () => {
       const { WrapperComponent, queryClient } = createWrapper()
-      const { result } = renderHook(() => AgreementMutations.useSubmitDraft(true, true), {
+      const { result } = renderHook(() => AgreementMutations.useSubmitDraft(true), {
         wrapper: WrapperComponent,
       })
 
@@ -117,34 +140,23 @@ describe('AgreementMutations', () => {
           title: 'confirmDialog.title',
           description: expect.any(Function),
         }),
-        expect.objectContaining({
-          title: 'confirmDialog.asyncExchange.title',
-          description: 'confirmDialog.asyncExchange.description',
-          checkbox: 'confirmDialog.asyncExchange.checkbox',
-        }),
       ])
     })
 
-    it('should show only the async exchange confirmation when there is no delegation', () => {
+    it('should not show a confirmation for non-delegated e-services', () => {
       const { WrapperComponent, queryClient } = createWrapper()
-      const { result } = renderHook(() => AgreementMutations.useSubmitDraft(false, true), {
+      const { result } = renderHook(() => AgreementMutations.useSubmitDraft(false), {
         wrapper: WrapperComponent,
       })
 
       result.current.mutate({ agreementId: 'agreement-id', delegatorName: undefined })
 
-      expect(queryClient.getMutationCache().getAll()[0]?.meta?.confirmationDialog).toEqual([
-        expect.objectContaining({
-          title: 'confirmDialog.asyncExchange.title',
-          description: 'confirmDialog.asyncExchange.description',
-          checkbox: 'confirmDialog.asyncExchange.checkbox',
-        }),
-      ])
+      expect(queryClient.getMutationCache().getAll()[0]?.meta?.confirmationDialog).toBeUndefined()
     })
 
     it('should show only the delegation confirmation for sync delegated e-services', () => {
       const { WrapperComponent, queryClient } = createWrapper()
-      const { result } = renderHook(() => AgreementMutations.useSubmitDraft(true, false), {
+      const { result } = renderHook(() => AgreementMutations.useSubmitDraft(true), {
         wrapper: WrapperComponent,
       })
 
@@ -160,7 +172,7 @@ describe('AgreementMutations', () => {
 
     it('should not show a confirmation for sync non-delegated e-services', () => {
       const { WrapperComponent, queryClient } = createWrapper()
-      const { result } = renderHook(() => AgreementMutations.useSubmitDraft(false, false), {
+      const { result } = renderHook(() => AgreementMutations.useSubmitDraft(false), {
         wrapper: WrapperComponent,
       })
 
@@ -171,7 +183,7 @@ describe('AgreementMutations', () => {
 
     it('should resolve the delegated confirmation description with the delegator name', () => {
       const { WrapperComponent, queryClient } = createWrapper()
-      const { result } = renderHook(() => AgreementMutations.useSubmitDraft(true, false), {
+      const { result } = renderHook(() => AgreementMutations.useSubmitDraft(true), {
         wrapper: WrapperComponent,
       })
 
@@ -184,6 +196,24 @@ describe('AgreementMutations', () => {
         Array.isArray(confirmationDialog) &&
           confirmationDialog[0]?.description?.({ delegatorName: 'Delegator' })
       ).toBe('confirmDialog.description.isDelegated')
+    })
+  })
+
+  describe('useSubmitToOwnEService', () => {
+    it('should show the activation confirmation', () => {
+      const { WrapperComponent, queryClient } = createWrapper()
+      const { result } = renderHook(() => AgreementMutations.useSubmitToOwnEService(), {
+        wrapper: WrapperComponent,
+      })
+
+      result.current.mutate({ eserviceId: 'eservice-id', descriptorId: 'descriptor-id' })
+
+      expect(queryClient.getMutationCache().getAll()[0]?.meta?.confirmationDialog).toEqual(
+        expect.objectContaining({
+          title: 'confirmDialog.title',
+          description: 'confirmDialog.description',
+        })
+      )
     })
   })
 })

--- a/src/api/agreement/__tests__/agreement.mutations.test.tsx
+++ b/src/api/agreement/__tests__/agreement.mutations.test.tsx
@@ -3,6 +3,7 @@ import { renderHook } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ConfirmationDialogMeta } from '@tanstack/react-query'
 import { AgreementMutations } from '../agreement.mutations'
+import { apiGuideLink } from '@/config/constants'
 
 vi.mock('../agreement.services', () => ({
   AgreementServices: {
@@ -69,6 +70,9 @@ describe('AgreementMutations', () => {
         expect.objectContaining({
           title: 'confirmDialog.asyncExchange.title',
           description: 'confirmDialog.asyncExchange.description',
+          descriptionLink: {
+            href: apiGuideLink,
+          },
           checkbox: 'confirmDialog.asyncExchange.checkbox',
         })
       )
@@ -123,6 +127,22 @@ describe('AgreementMutations', () => {
       expect(getConfirmationDialogDescription(confirmationDialog)?.('unexpected')).toBe(
         'confirmDialog.description'
       )
+    })
+
+    it('should not show a confirmation when confirmation dialog is disabled for sync e-services', () => {
+      const { WrapperComponent, queryClient } = createWrapper()
+      const { result } = renderHook(() => AgreementMutations.useCreateDraft(false), {
+        wrapper: WrapperComponent,
+      })
+
+      result.current.mutate({
+        eserviceId: 'eservice-id',
+        descriptorId: 'descriptor-id',
+        eserviceName: 'E-Service name',
+        eserviceVersion: '1',
+      })
+
+      expect(queryClient.getMutationCache().getAll()[0]?.meta?.confirmationDialog).toBeUndefined()
     })
   })
 

--- a/src/api/agreement/agreement.mutations.ts
+++ b/src/api/agreement/agreement.mutations.ts
@@ -3,9 +3,52 @@ import { useTranslation } from 'react-i18next'
 import { AgreementServices } from './agreement.services'
 import type { AgreementPayload, AgreementSubmissionPayload } from '../api.generatedTypes'
 import { apiGuideLink } from '@/config/constants'
+import type { ConfirmationDialogMeta } from '@tanstack/react-query'
+import type { TFunction } from 'i18next'
 
-function useCreateDraft(hasConfirmationDialog = true) {
+const getAsyncExchangeConfirmationDialog = (
+  t: TFunction<'mutations-feedback', 'agreement.submitDraft'>
+): ConfirmationDialogMeta => ({
+  title: t('confirmDialog.asyncExchange.title'),
+  description: t('confirmDialog.asyncExchange.description'),
+  descriptionLink: {
+    href: apiGuideLink,
+  },
+  checkbox: t('confirmDialog.asyncExchange.checkbox'),
+})
+
+function useCreateDraft(hasConfirmationDialog = true, isAsyncExchange = false) {
   const { t } = useTranslation('mutations-feedback', { keyPrefix: 'agreement.createDraft' })
+  const { t: tSubmitDraft } = useTranslation('mutations-feedback', {
+    keyPrefix: 'agreement.submitDraft',
+  })
+
+  const createDraftConfirmationDialog: ConfirmationDialogMeta = {
+    title: t('confirmDialog.title'),
+    description: (variables: unknown) => {
+      const eserviceName =
+        typeof variables === 'object' &&
+        variables !== null &&
+        'eserviceName' in variables &&
+        typeof variables.eserviceName === 'string'
+          ? variables.eserviceName
+          : undefined
+      const eserviceVersion =
+        typeof variables === 'object' &&
+        variables !== null &&
+        'eserviceVersion' in variables &&
+        typeof variables.eserviceVersion === 'string'
+          ? variables.eserviceVersion
+          : undefined
+
+      return t('confirmDialog.description', {
+        name: eserviceName,
+        version: eserviceVersion,
+      })
+    },
+    proceedLabel: t('confirmDialog.proceedLabel'),
+  }
+
   return useMutation({
     mutationFn: ({
       eserviceId,
@@ -19,38 +62,16 @@ function useCreateDraft(hasConfirmationDialog = true) {
     meta: {
       errorToastLabel: t('outcome.error'),
       loadingLabel: t('loading'),
-      confirmationDialog: hasConfirmationDialog
-        ? {
-            title: t('confirmDialog.title'),
-            description: (variables: unknown) => {
-              const eserviceName =
-                typeof variables === 'object' &&
-                variables !== null &&
-                'eserviceName' in variables &&
-                typeof variables.eserviceName === 'string'
-                  ? variables.eserviceName
-                  : undefined
-              const eserviceVersion =
-                typeof variables === 'object' &&
-                variables !== null &&
-                'eserviceVersion' in variables &&
-                typeof variables.eserviceVersion === 'string'
-                  ? variables.eserviceVersion
-                  : undefined
-
-              return t('confirmDialog.description', {
-                name: eserviceName,
-                version: eserviceVersion,
-              })
-            },
-            proceedLabel: t('confirmDialog.proceedLabel'),
-          }
-        : undefined,
+      confirmationDialog: isAsyncExchange
+        ? getAsyncExchangeConfirmationDialog(tSubmitDraft)
+        : hasConfirmationDialog
+          ? createDraftConfirmationDialog
+          : undefined,
     },
   })
 }
 
-function useSubmitDraft(isDelegated = false, isAsyncExchange = false) {
+function useSubmitDraft(isDelegated = false) {
   const { t } = useTranslation('mutations-feedback', { keyPrefix: 'agreement.submitDraft' })
   const submitConfirmationDialog = {
     title: t('confirmDialog.title'),
@@ -71,19 +92,7 @@ function useSubmitDraft(isDelegated = false, isAsyncExchange = false) {
     },
   }
 
-  const asyncExchangeConfirmationDialog = {
-    title: t('confirmDialog.asyncExchange.title'),
-    description: t('confirmDialog.asyncExchange.description'),
-    descriptionLink: {
-      href: apiGuideLink,
-    },
-    checkbox: t('confirmDialog.asyncExchange.checkbox'),
-  }
-
-  const confirmationDialog = [
-    ...(isDelegated ? [submitConfirmationDialog] : []),
-    ...(isAsyncExchange ? [asyncExchangeConfirmationDialog] : []),
-  ]
+  const confirmationDialog = [...(isDelegated ? [submitConfirmationDialog] : [])]
 
   return useMutation({
     mutationFn: ({
@@ -108,6 +117,7 @@ function useSubmitToOwnEService() {
   const { t } = useTranslation('mutations-feedback', {
     keyPrefix: 'agreement.submitToOwnEService',
   })
+
   return useMutation({
     mutationFn: AgreementServices.submitToOwnEService,
     meta: {

--- a/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
+++ b/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
@@ -445,6 +445,26 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     })
   })
 
+  it('should return the create agreement draft action for delegators when jwt is not available', async () => {
+    mockUseJwt({ jwt: undefined, isAdmin: true })
+
+    const eserviceMock = createMockCatalogDescriptorEService({
+      agreements: [],
+      isMine: false,
+      isSubscribed: false,
+      hasCertifiedAttributes: true,
+    })
+
+    const { result } = renderUseGetEServiceConsumerActionsHook(
+      createMockEServiceDescriptorCatalog({ eservice: eserviceMock }),
+      [{ id: 'delegator-id', name: 'Delegator Name' }],
+      false
+    )
+
+    expect(result.current.actions).toHaveLength(1)
+    expect(result.current.actions[0]?.label).toBe('tableEServiceCatalog.subscribe')
+  })
+
   it("should return the create agreement draft action if the user doesn't have an active agreement and the subscriber is the e-service provider", async () => {
     mockUseJwt({ isAdmin: true })
 

--- a/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
+++ b/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
@@ -11,7 +11,17 @@ import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
 import { act, fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 
 vi.mock('@/components/dialogs/DialogSelectAgreementConsumer/DialogSelectAgreementConsumer', () => ({
-  DialogSelectAgreementConsumer: () => <div>DialogSelectAgreementConsumer</div>,
+  DialogSelectAgreementConsumer: ({
+    onSubmitCreate,
+  }: {
+    onSubmitCreate?: (values: { isOwnEService: boolean; delegationId?: string }) => void
+  }) => (
+    <button
+      onClick={() => onSubmitCreate?.({ isOwnEService: false, delegationId: 'delegation-id' })}
+    >
+      DialogSelectAgreementConsumer
+    </button>
+  ),
 }))
 
 const server = setupServer(
@@ -246,6 +256,87 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     })
   })
 
+  it('should replace the create agreement draft confirmation with the async exchange confirmation for async e-services', async () => {
+    mockUseJwt({ isAdmin: true })
+
+    const eserviceMock = createMockCatalogDescriptorEService({
+      agreements: [],
+      isMine: false,
+      hasCertifiedAttributes: true,
+      asyncExchange: true,
+    })
+
+    const { result, history } = renderUseGetEServiceConsumerActionsHook(
+      createMockEServiceDescriptorCatalog({ eservice: eserviceMock })
+    )
+    expect(result.current.actions).toHaveLength(1)
+    const createAgreementDraftAction = result.current.actions[0]!
+
+    act(() => {
+      createAgreementDraftAction.action()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('confirmDialog.asyncExchange.title')).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole('button', { name: 'confirmDialog.proceedLabel' })
+    ).not.toBeInTheDocument()
+
+    act(() => {
+      fireEvent.click(
+        screen.getByRole('checkbox', { name: 'confirmDialog.asyncExchange.checkbox' })
+      )
+    })
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'confirm' }))
+    })
+
+    await waitFor(() => {
+      expect(history.location.pathname).toBe(`/it/fruizione/richieste/test-id/modifica`)
+    })
+  })
+
+  it('should show the async exchange confirmation after selecting the delegated consumer for async e-services', async () => {
+    mockUseJwt({ isAdmin: true })
+
+    const eserviceMock = createMockCatalogDescriptorEService({
+      agreements: [],
+      isMine: false,
+      isSubscribed: false,
+      hasCertifiedAttributes: true,
+      asyncExchange: true,
+    })
+
+    const { result } = renderUseGetEServiceConsumerActionsHook(
+      createMockEServiceDescriptorCatalog({ eservice: eserviceMock }),
+      [{ id: 'delegator-id', name: 'Delegator Name' }],
+      false
+    )
+    expect(result.current.actions).toHaveLength(1)
+    const createAgreementDraftAction = result.current.actions[0]!
+
+    act(() => {
+      createAgreementDraftAction.action()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('DialogSelectAgreementConsumer')).toBeInTheDocument()
+    })
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'DialogSelectAgreementConsumer' }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('confirmDialog.asyncExchange.title')).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole('button', { name: 'confirmDialog.proceedLabel' })
+    ).not.toBeInTheDocument()
+  })
+
   it('should return the create agreement draft action if the user have only agreements with state ARCHIVED', async () => {
     mockUseJwt({ isAdmin: true })
 
@@ -372,6 +463,45 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     act(() => {
       createAgreementDraftAction.action()
     })
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'confirm' }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('progressbar', { hidden: true })).toBeInTheDocument()
+    })
+
+    await waitForElementToBeRemoved(screen.getByRole('progressbar', { hidden: true }), {
+      timeout: 3 * 1000,
+    })
+
+    expect(history.location.pathname).toBe(`/it/fruizione/richieste/test-id`)
+  })
+
+  it('should show the activation confirmation when the subscriber is the async e-service provider', async () => {
+    mockUseJwt({ isAdmin: true })
+
+    const eserviceMock = createMockCatalogDescriptorEService({
+      agreements: [],
+      isMine: true,
+      asyncExchange: true,
+    })
+
+    const { result, history } = renderUseGetEServiceConsumerActionsHook(
+      createMockEServiceDescriptorCatalog({ eservice: eserviceMock })
+    )
+    expect(result.current.actions).toHaveLength(1)
+    const createAgreementDraftAction = result.current.actions[0]!
+
+    act(() => {
+      createAgreementDraftAction.action()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('confirmDialog.title')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('confirmDialog.asyncExchange.title')).not.toBeInTheDocument()
 
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: 'confirm' }))

--- a/src/hooks/useGetEServiceConsumerActions.ts
+++ b/src/hooks/useGetEServiceConsumerActions.ts
@@ -31,7 +31,9 @@ function useGetEServiceConsumerActions(
 
   const { openDialog } = useDialog()
 
-  const { mutate: createAgreementDraft } = AgreementMutations.useCreateDraft()
+  const isAsyncExchange = descriptor?.eservice.asyncExchange === true
+
+  const { mutate: createAgreementDraft } = AgreementMutations.useCreateDraft(true, isAsyncExchange)
   const { mutate: submitToOwnEService } = AgreementMutations.useSubmitToOwnEService()
 
   const actions: Array<ActionItemButton> = []
@@ -202,7 +204,7 @@ function useGetEServiceConsumerActions(
 
   const tenants: DelegationTenant[] = jwt
     ? [{ id: jwt.organizationId as string, name: jwt.organization.name }, ...(delegators ?? [])]
-    : delegators ?? []
+    : (delegators ?? [])
 
   const tenantsWithoutAgreement = tenants.filter(
     (tenant) => !existingAgreements.some((agreement) => agreement.consumerId === tenant.id)

--- a/src/pages/ConsumerAgreementCreatePage/ConsumerAgreementCreate.page.tsx
+++ b/src/pages/ConsumerAgreementCreatePage/ConsumerAgreementCreate.page.tsx
@@ -27,14 +27,10 @@ const ConsumerAgreementCreatePage: React.FC = () => {
   const { data: agreement } = useQuery(AgreementQueries.getSingle(agreementId))
 
   const isDelegated = Boolean(agreement && agreement.delegation)
-  const isAsyncExchange = Boolean(agreement?.eservice.asyncExchange)
 
   const [consumerNotes, setConsumerNotes] = React.useState(agreement?.consumerNotes ?? '')
 
-  const { mutate: submitAgreementDraft } = AgreementMutations.useSubmitDraft(
-    isDelegated,
-    isAsyncExchange
-  )
+  const { mutate: submitAgreementDraft } = AgreementMutations.useSubmitDraft(isDelegated)
   const { mutate: updateAgreementDraft } = AgreementMutations.useUpdateDraft()
   const { mutate: deleteAgreementDraft } = AgreementMutations.useDeleteDraft()
 

--- a/src/pages/ConsumerAgreementCreatePage/__tests__/ConsumerAgreementCreate.page.test.tsx
+++ b/src/pages/ConsumerAgreementCreatePage/__tests__/ConsumerAgreementCreate.page.test.tsx
@@ -29,8 +29,7 @@ vi.mock('@/api/agreement', () => ({
     }),
   },
   AgreementMutations: {
-    useSubmitDraft: (isDelegated: boolean, isAsyncExchange: boolean) =>
-      useSubmitDraftMock(isDelegated, isAsyncExchange),
+    useSubmitDraft: (isDelegated: boolean) => useSubmitDraftMock(isDelegated),
     useUpdateDraft: () => ({ mutate: vi.fn() }),
     useDeleteDraft: () => ({ mutate: vi.fn() }),
   },
@@ -112,13 +111,13 @@ describe('ConsumerAgreementCreatePage', () => {
     })
   })
 
-  it('should submit the draft with the async exchange confirmation enabled', async () => {
+  it('should submit the draft with delegation confirmation enabled', async () => {
     const user = userEvent.setup()
     const { default: ConsumerAgreementCreatePage } = await import('../ConsumerAgreementCreate.page')
 
     render(<ConsumerAgreementCreatePage />)
 
-    expect(useSubmitDraftMock).toHaveBeenCalledWith(true, true)
+    expect(useSubmitDraftMock).toHaveBeenCalledWith(true)
 
     await user.click(screen.getByRole('button', { name: 'edit.submitBtn' }))
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,7 +63,6 @@ export default defineConfig(({ mode }) => {
           '**/__tests__/**',
           '**/__test__/**',
           '**/__mocks__/**',
-          '**/api/agreement/**',
           '**/api/attribute/**',
           '**/api/auth/**',
           '**/api/client/**',


### PR DESCRIPTION
## 🔗 Issue

[PIN-9232](https://pagopa.atlassian.net/browse/PIN-9232)

## 📝 Description / Context

This change moves the async exchange confirmation to the initial e-service consumption request flow. For async e-services, the async confirmation replaces the generic agreement draft creation confirmation from the consumer e-service details page.

The own e-service flow keeps the existing activation confirmation, since that dialog explains that the agreement is created and activated directly without provider approval.

## 🛠 List of changes

- Show the async exchange confirmation when requesting consumption for async e-services from the descriptor page.
- Replace the generic create draft confirmation with the async confirmation for async e-services.
- Keep the own e-service activation confirmation unchanged, including for async e-services.
- Remove the async confirmation from the agreement draft submit flow, leaving only the delegation confirmation there when needed.
- Update mutation, hook, and agreement draft page tests for the new confirmation behavior.

## 🧪 How to test

- Open an async e-service as a consumer from the catalog details page and click “Richiedi fruizione”: the async exchange confirmation should be shown instead of the generic create draft confirmation.
- If consumer delegation selection is available, click “Richiedi fruizione”, select the delegated consumer, and verify the async exchange confirmation is shown after that selection.
- Open an async e-service where the subscriber is also the provider and click “Richiedi fruizione”: the activation confirmation should still be shown, not the async exchange confirmation.
- Submit an existing delegated agreement draft and verify only the delegation confirmation is shown.

[PIN-9232]: https://pagopa.atlassian.net/browse/PIN-9232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ