### PR TITLE
feat: show descriptor exchange type (PIN-9232)

### DIFF
--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
@@ -105,6 +105,12 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
             content={t(`personalDataField.value.${descriptor.eservice.personalData}`)}
           />
           <InformationContainer
+            label={t('exchangeType.label')}
+            content={t(
+              `exchangeType.value.${descriptor.eservice.asyncExchange ? 'async' : 'sync'}`
+            )}
+          />
+          <InformationContainer
             label={t('eserviceDescription.label')}
             content={descriptor.eservice.description}
             direction="column"

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/__tests__/ConsumerEServiceGeneralInfoSection.test.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/__tests__/ConsumerEServiceGeneralInfoSection.test.tsx
@@ -81,6 +81,24 @@ describe('ConsumerEServiceGeneralInfoSection', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders exchange type for synchronous eservices', () => {
+    useSuspenseQueryMock.mockReturnValue({ data: createMockEServiceDescriptorCatalog() })
+
+    renderComponent()
+
+    expect(screen.getByText('exchangeType.label')).toBeInTheDocument()
+    expect(screen.getByText('exchangeType.value.sync')).toBeInTheDocument()
+  })
+
+  it('renders exchange type for asynchronous eservices', () => {
+    useSuspenseQueryMock.mockReturnValue({ data: createMockEServiceDescriptorCatalogAsync() })
+
+    renderComponent()
+
+    expect(screen.getByText('exchangeType.label')).toBeInTheDocument()
+    expect(screen.getByText('exchangeType.value.async')).toBeInTheDocument()
+  })
+
   it('opens async exchange details drawer from the async action', async () => {
     const user = userEvent.setup()
     useSuspenseQueryMock.mockReturnValue({ data: createMockEServiceDescriptorCatalogAsync() })

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
@@ -226,6 +226,12 @@ export const ProviderEServiceGeneralInfoSection: React.FC = () => {
             label={t(`personalDataField.${descriptor.eservice.mode}.label`)}
             content={t(`personalDataField.value.${descriptor.eservice.personalData}`)}
           />
+          <InformationContainer
+            label={t('exchangeType.label')}
+            content={t(
+              `exchangeType.value.${descriptor.eservice.asyncExchange ? 'async' : 'sync'}`
+            )}
+          />
           {(isAdmin || isOperatorAPI) && !arePersonalDataSet && !isEserviceFromTemplate && (
             <Alert severity="warning" sx={{ alignItems: 'center' }} variant="outlined">
               <Stack spacing={25} direction="row" alignItems="center">

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/__tests__/ProviderEServiceGeneralInfoSection.instanceLabel.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/__tests__/ProviderEServiceGeneralInfoSection.instanceLabel.test.tsx
@@ -3,10 +3,14 @@ import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import { ProviderEServiceGeneralInfoSection } from '../ProviderEServiceGeneralInfoSection'
 import { renderWithApplicationContext, mockUseJwt } from '@/utils/testing.utils'
-import { createMockEServiceDescriptorProvider } from '@/../__mocks__/data/eservice.mocks'
+import {
+  createMockEServiceDescriptorProvider,
+  createMockEServiceDescriptorProviderAsync,
+} from '@/../__mocks__/data/eservice.mocks'
 import * as EServiceModule from '@/api/eservice'
 import * as EServiceTemplateMutationsModule from '@/api/eserviceTemplate/eserviceTemplate.mutations'
 import type { ProducerEServiceDescriptor } from '@/api/api.generatedTypes'
+import type * as TanStackReactQuery from '@tanstack/react-query'
 
 const mockUpdateInstanceLabel = vi.fn()
 const mockUpdateDescription = vi.fn()
@@ -51,7 +55,7 @@ vi.mock('@/api/eserviceTemplate/eserviceTemplate.mutations', () => ({
 }))
 
 vi.mock('@tanstack/react-query', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
+  ...(await importOriginal<typeof TanStackReactQuery>()),
   useSuspenseQuery: () => ({ data: mockDescriptorData }),
   useQuery: () => ({ data: [] }),
 }))
@@ -107,6 +111,26 @@ afterEach(() => {
 })
 
 describe('ProviderEServiceGeneralInfoSection - instanceLabel (published e-service from template)', () => {
+  it('renders exchange type for synchronous e-services', () => {
+    mockDescriptorData = createMockEServiceDescriptorProvider()
+    renderWithApplicationContext(<ProviderEServiceGeneralInfoSection />, {
+      withReactQueryContext: true,
+    })
+
+    expect(screen.getByText('exchangeType.label')).toBeInTheDocument()
+    expect(screen.getByText('exchangeType.value.sync')).toBeInTheDocument()
+  })
+
+  it('renders exchange type for asynchronous e-services', () => {
+    mockDescriptorData = createMockEServiceDescriptorProviderAsync()
+    renderWithApplicationContext(<ProviderEServiceGeneralInfoSection />, {
+      withReactQueryContext: true,
+    })
+
+    expect(screen.getByText('exchangeType.label')).toBeInTheDocument()
+    expect(screen.getByText('exchangeType.value.async')).toBeInTheDocument()
+  })
+
   it('shows the instanceLabel value when defined', () => {
     mockDescriptorData = baseTemplateDescriptor
     renderWithApplicationContext(<ProviderEServiceGeneralInfoSection />, {

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -678,6 +678,13 @@
             "label": "Specify whether this e-service processes personal data."
           }
         },
+        "exchangeType": {
+          "label": "Exchange type",
+          "value": {
+            "sync": "Synchronous",
+            "async": "Asynchronous"
+          }
+        },
         "consumerListFileName": "{{timestamp}}-consumers-list-{{eserviceName}}.csv",
         "bottomActions": {
           "navigateVersions": "Navigate to another e-service version",

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -678,6 +678,13 @@
             "label": "Specificare se questo e-service tratta dati personali."
           }
         },
+        "exchangeType": {
+          "label": "Scambio dati",
+          "value": {
+            "sync": "Sincrono",
+            "async": "Asincrono"
+          }
+        },
         "consumerListFileName": "{{timestamp}}-lista-fruitori-{{eserviceName}}.csv",
         "bottomActions": {
           "navigateVersions": "Naviga a un’altra versione dell’e-service",


### PR DESCRIPTION
## 🔗 Issue

[PIN-9232](https://pagopa.atlassian.net/browse/PIN-9232)

## 📝 Description / Context

This PR adds the data exchange type to the descriptor show page

## 🛠 List of changes

- Show the descriptor exchange type in the consumer e-service general information section.
- Show the descriptor exchange type in the provider e-service general information section.
- Add focused tests for synchronous and asynchronous e-services in both views.

## 🧪 How to test

- Open an e-service descriptor detail page as a consumer and verify that the general information section shows the exchange type as synchronous or asynchronous.
- Open an e-service descriptor detail page as a provider and verify that the same exchange type field is shown with the expected value.

[PIN-9232]: https://pagopa.atlassian.net/browse/PIN-9232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ