### PR TITLE
feature: info icon risk analisys (PIN-10135)

### DIFF
--- a/src/components/shared/InfoTooltip.tsx
+++ b/src/components/shared/InfoTooltip.tsx
@@ -9,7 +9,14 @@ type InfoTooltipProps = {
 export const InfoTooltip: React.FC<InfoTooltipProps> = ({ label }) => {
   return (
     <Tooltip title={label}>
-      <InfoIcon color="primary" fontSize="small" sx={{ ml: 1 }} />
+      <InfoIcon
+        color="primary"
+        fontSize="small"
+        sx={{ ml: 1 }}
+        tabIndex={0}
+        role="img"
+        aria-label={label}
+      />
     </Tooltip>
   )
 }

--- a/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
@@ -89,12 +89,7 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
 
   return (
     <TableRow
-      cellData={[
-        purposeTitle,
-        eserviceCellData,
-        purpose.eservice.producer.name,
-        statusCell,
-      ]}
+      cellData={[purposeTitle, eserviceCellData, purpose.eservice.producer.name, statusCell]}
     >
       <Tooltip
         open={hasWaitingForApprovalVersion ? undefined : false}

--- a/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
@@ -53,10 +53,17 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
   const riskAnalysisSigningState = (purpose as PurposeWithRiskAnalysisSigningState)
     .riskAnalysisSigningState
 
-  const riskAnalysisTooltipLabel = match(riskAnalysisSigningState)
-    .with('SIGNED', () => t('list.riskAnalysisApproved'))
-    .with('REJECTED', () => t('list.riskAnalysisRejected'))
-    .otherwise(() => undefined)
+  // The validation outcome of the risk analysis is relevant only for purposes
+  // whose current version is still a DRAFT: once the purpose is published the
+  // RA is implicitly approved and the icon would be redundant.
+  const isDraft = purpose.currentVersion?.state === 'DRAFT'
+
+  const riskAnalysisTooltipLabel = isDraft
+    ? match(riskAnalysisSigningState)
+        .with('SIGNED', () => t('list.riskAnalysisApproved'))
+        .with('REJECTED', () => t('list.riskAnalysisRejected'))
+        .otherwise(() => undefined)
+    : undefined
 
   const statusCell = (
     <Stack key={purpose.id} direction="row" alignItems="center">

--- a/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
@@ -32,7 +32,8 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
 
   const { actions } = useGetConsumerPurposesActions(purpose)
 
-  const isPurposeEditable = purpose?.currentVersion?.state === 'DRAFT' && isAdmin
+  const isDraft = purpose.currentVersion?.state === 'DRAFT'
+  const isPurposeEditable = isDraft && isAdmin
   const hasWaitingForApprovalVersion = !!(
     purpose.currentVersion && purpose.waitingForApprovalVersion
   )
@@ -56,8 +57,6 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
   // The validation outcome of the risk analysis is relevant only for purposes
   // whose current version is still a DRAFT: once the purpose is published the
   // RA is implicitly approved and the icon would be redundant.
-  const isDraft = purpose.currentVersion?.state === 'DRAFT'
-
   const riskAnalysisTooltipLabel = isDraft
     ? match(riskAnalysisSigningState)
         .with('SIGNED', () => t('list.riskAnalysisApproved'))

--- a/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
@@ -1,7 +1,8 @@
-import type { Purpose } from '@/api/api.generatedTypes'
+import type { Purpose, RiskAnalysisSigningState } from '@/api/api.generatedTypes'
 import { AuthHooks } from '@/api/auth'
 import { PurposeQueries } from '@/api/purpose'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
+import { InfoTooltip } from '@/components/shared/InfoTooltip'
 import { ButtonSkeleton } from '@/components/shared/MUI-skeletons'
 import { StatusChip, StatusChipSkeleton } from '@/components/shared/StatusChip'
 import useGetConsumerPurposesActions from '@/hooks/useGetConsumerPurposesActions'
@@ -15,6 +16,13 @@ import { useQueryClient } from '@tanstack/react-query'
 import { ByDelegationChip } from '@/components/shared/ByDelegationChip'
 import { Stack } from '@mui/material'
 import { NotificationBadgeDot } from '@/components/shared/NotificationBadgeDot/NotificationBadgeDot'
+import { match } from 'ts-pattern'
+
+// TODO PIN-10135: remove this augmentation once the BE exposes
+// `riskAnalysisSigningState` on the `Purpose` model in the OpenAPI spec.
+type PurposeWithRiskAnalysisSigningState = Purpose & {
+  riskAnalysisSigningState?: RiskAnalysisSigningState
+}
 
 export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpose }) => {
   const { t } = useTranslation('purpose')
@@ -41,6 +49,21 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
   )
 
   const isDelegated = isDelegate || isDelegator
+
+  const riskAnalysisSigningState = (purpose as PurposeWithRiskAnalysisSigningState)
+    .riskAnalysisSigningState
+
+  const riskAnalysisTooltipLabel = match(riskAnalysisSigningState)
+    .with('SIGNED', () => t('list.riskAnalysisApproved'))
+    .with('REJECTED', () => t('list.riskAnalysisRejected'))
+    .otherwise(() => undefined)
+
+  const statusCell = (
+    <Stack key={purpose.id} direction="row" alignItems="center">
+      <StatusChip for="purpose" purpose={purpose} />
+      {riskAnalysisTooltipLabel && <InfoTooltip label={riskAnalysisTooltipLabel} />}
+    </Stack>
+  )
 
   const purposeTitle = (
     <Stack direction="row" alignItems="center" key={0}>
@@ -70,7 +93,7 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
         purposeTitle,
         eserviceCellData,
         purpose.eservice.producer.name,
-        <StatusChip key={purpose.id} for="purpose" purpose={purpose} />,
+        statusCell,
       ]}
     >
       <Tooltip

--- a/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
@@ -1,4 +1,4 @@
-import type { Purpose, RiskAnalysisSigningState } from '@/api/api.generatedTypes'
+import type { Purpose } from '@/api/api.generatedTypes'
 import { AuthHooks } from '@/api/auth'
 import { PurposeQueries } from '@/api/purpose'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
@@ -17,12 +17,6 @@ import { ByDelegationChip } from '@/components/shared/ByDelegationChip'
 import { Stack } from '@mui/material'
 import { NotificationBadgeDot } from '@/components/shared/NotificationBadgeDot/NotificationBadgeDot'
 import { match } from 'ts-pattern'
-
-// TODO PIN-10135: remove this augmentation once the BE exposes
-// `riskAnalysisSigningState` on the `Purpose` model in the OpenAPI spec.
-type PurposeWithRiskAnalysisSigningState = Purpose & {
-  riskAnalysisSigningState?: RiskAnalysisSigningState
-}
 
 export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpose }) => {
   const { t } = useTranslation('purpose')
@@ -51,14 +45,11 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
 
   const isDelegated = isDelegate || isDelegator
 
-  const riskAnalysisSigningState = (purpose as PurposeWithRiskAnalysisSigningState)
-    .riskAnalysisSigningState
-
   // The validation outcome of the risk analysis is relevant only for purposes
   // whose current version is still a DRAFT: once the purpose is published the
   // RA is implicitly approved and the icon would be redundant.
   const riskAnalysisTooltipLabel = isDraft
-    ? match(riskAnalysisSigningState)
+    ? match(purpose.reviewerWorkflow?.signingState)
         .with('SIGNED', () => t('list.riskAnalysisApproved'))
         .with('REJECTED', () => t('list.riskAnalysisRejected'))
         .otherwise(() => undefined)

--- a/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
@@ -3,11 +3,24 @@ import { describe, it, expect } from 'vitest'
 import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
 import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
 import { ConsumerPurposesTableRow } from '../ConsumerPurposesTableRow'
-import type { Purpose, RiskAnalysisSigningState } from '@/api/api.generatedTypes'
+import type {
+  Purpose,
+  PurposeVersionState,
+  RiskAnalysisSigningState,
+} from '@/api/api.generatedTypes'
 
 type PurposeWithRiskAnalysisSigningState = Purpose & {
   riskAnalysisSigningState?: RiskAnalysisSigningState
 }
+
+const buildPurpose = (
+  currentVersionState: PurposeVersionState,
+  riskAnalysisSigningState: RiskAnalysisSigningState | undefined
+) =>
+  createMockPurpose({
+    currentVersion: { state: currentVersionState },
+    riskAnalysisSigningState,
+  } as PurposeWithRiskAnalysisSigningState)
 
 const renderRow = (purpose: Purpose) =>
   renderWithApplicationContext(
@@ -20,39 +33,38 @@ const renderRow = (purpose: Purpose) =>
   )
 
 describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () => {
-  it('renders the info icon with the "approved" tooltip when riskAnalysisSigningState is SIGNED', () => {
+  it('renders the info icon with the "approved" tooltip when the purpose is a DRAFT and riskAnalysisSigningState is SIGNED', () => {
     mockUseJwt()
-    const purpose = createMockPurpose({
-      riskAnalysisSigningState: 'SIGNED',
-    } as PurposeWithRiskAnalysisSigningState)
-
-    const { queryByLabelText } = renderRow(purpose)
+    const { queryByLabelText } = renderRow(buildPurpose('DRAFT', 'SIGNED'))
 
     expect(queryByLabelText('list.riskAnalysisApproved')).toBeInTheDocument()
     expect(queryByLabelText('list.riskAnalysisRejected')).not.toBeInTheDocument()
   })
 
-  it('renders the info icon with the "rejected" tooltip when riskAnalysisSigningState is REJECTED', () => {
+  it('renders the info icon with the "rejected" tooltip when the purpose is a DRAFT and riskAnalysisSigningState is REJECTED', () => {
     mockUseJwt()
-    const purpose = createMockPurpose({
-      riskAnalysisSigningState: 'REJECTED',
-    } as PurposeWithRiskAnalysisSigningState)
-
-    const { queryByLabelText } = renderRow(purpose)
+    const { queryByLabelText } = renderRow(buildPurpose('DRAFT', 'REJECTED'))
 
     expect(queryByLabelText('list.riskAnalysisRejected')).toBeInTheDocument()
     expect(queryByLabelText('list.riskAnalysisApproved')).not.toBeInTheDocument()
   })
 
   it.each(['ASSIGNED', 'SUBMITTED', undefined] as const)(
-    'does not render any info icon when riskAnalysisSigningState is %s',
+    'does not render any info icon for a DRAFT purpose when riskAnalysisSigningState is %s',
     (signingState) => {
       mockUseJwt()
-      const purpose = createMockPurpose({
-        riskAnalysisSigningState: signingState,
-      } as PurposeWithRiskAnalysisSigningState)
+      const { queryByLabelText } = renderRow(buildPurpose('DRAFT', signingState))
 
-      const { queryByLabelText } = renderRow(purpose)
+      expect(queryByLabelText('list.riskAnalysisApproved')).not.toBeInTheDocument()
+      expect(queryByLabelText('list.riskAnalysisRejected')).not.toBeInTheDocument()
+    }
+  )
+
+  it.each(['SIGNED', 'REJECTED'] as const)(
+    'does not render any info icon when the purpose is not a DRAFT, even if riskAnalysisSigningState is %s',
+    (signingState) => {
+      mockUseJwt()
+      const { queryByLabelText } = renderRow(buildPurpose('ACTIVE', signingState))
 
       expect(queryByLabelText('list.riskAnalysisApproved')).not.toBeInTheDocument()
       expect(queryByLabelText('list.riskAnalysisRejected')).not.toBeInTheDocument()

--- a/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
@@ -27,6 +27,8 @@ const buildPurpose = (
   })
 }
 
+mockUseJwt()
+
 const renderRow = (purpose: ReturnType<typeof buildPurpose>) =>
   renderWithApplicationContext(
     <table>
@@ -39,7 +41,6 @@ const renderRow = (purpose: ReturnType<typeof buildPurpose>) =>
 
 describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () => {
   it('renders the info icon with aria-label "list.riskAnalysisApproved" when the purpose is a DRAFT and reviewerWorkflow.signingState is SIGNED', () => {
-    mockUseJwt()
     const { queryByLabelText } = renderRow(buildPurpose('DRAFT', 'SIGNED'))
 
     expect(queryByLabelText('list.riskAnalysisApproved')).toBeInTheDocument()
@@ -47,7 +48,6 @@ describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () 
   })
 
   it('renders the info icon with aria-label "list.riskAnalysisRejected" when the purpose is a DRAFT and reviewerWorkflow.signingState is REJECTED', () => {
-    mockUseJwt()
     const { queryByLabelText } = renderRow(buildPurpose('DRAFT', 'REJECTED'))
 
     expect(queryByLabelText('list.riskAnalysisRejected')).toBeInTheDocument()
@@ -57,7 +57,6 @@ describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () 
   it.each(['ASSIGNED', 'SUBMITTED', undefined] as const)(
     'does not render the info icon for a DRAFT purpose when reviewerWorkflow.signingState is %s',
     (signingState) => {
-      mockUseJwt()
       const { queryByLabelText } = renderRow(buildPurpose('DRAFT', signingState))
 
       expect(queryByLabelText('list.riskAnalysisApproved')).not.toBeInTheDocument()
@@ -68,7 +67,6 @@ describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () 
   it.each(['SIGNED', 'REJECTED'] as const)(
     'does not render the info icon when the purpose is not a DRAFT, even if reviewerWorkflow.signingState is %s',
     (signingState) => {
-      mockUseJwt()
       const { queryByLabelText } = renderRow(buildPurpose('ACTIVE', signingState))
 
       expect(queryByLabelText('list.riskAnalysisApproved')).not.toBeInTheDocument()

--- a/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
@@ -33,7 +33,7 @@ const renderRow = (purpose: Purpose) =>
   )
 
 describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () => {
-  it('renders the info icon with the "approved" tooltip when the purpose is a DRAFT and riskAnalysisSigningState is SIGNED', () => {
+  it('renders the info icon with aria-label "list.riskAnalysisApproved" when the purpose is a DRAFT and riskAnalysisSigningState is SIGNED', () => {
     mockUseJwt()
     const { queryByLabelText } = renderRow(buildPurpose('DRAFT', 'SIGNED'))
 
@@ -41,7 +41,7 @@ describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () 
     expect(queryByLabelText('list.riskAnalysisRejected')).not.toBeInTheDocument()
   })
 
-  it('renders the info icon with the "rejected" tooltip when the purpose is a DRAFT and riskAnalysisSigningState is REJECTED', () => {
+  it('renders the info icon with aria-label "list.riskAnalysisRejected" when the purpose is a DRAFT and riskAnalysisSigningState is REJECTED', () => {
     mockUseJwt()
     const { queryByLabelText } = renderRow(buildPurpose('DRAFT', 'REJECTED'))
 
@@ -50,7 +50,7 @@ describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () 
   })
 
   it.each(['ASSIGNED', 'SUBMITTED', undefined] as const)(
-    'does not render any info icon for a DRAFT purpose when riskAnalysisSigningState is %s',
+    'does not render the info icon for a DRAFT purpose when riskAnalysisSigningState is %s',
     (signingState) => {
       mockUseJwt()
       const { queryByLabelText } = renderRow(buildPurpose('DRAFT', signingState))
@@ -61,7 +61,7 @@ describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () 
   )
 
   it.each(['SIGNED', 'REJECTED'] as const)(
-    'does not render any info icon when the purpose is not a DRAFT, even if riskAnalysisSigningState is %s',
+    'does not render the info icon when the purpose is not a DRAFT, even if riskAnalysisSigningState is %s',
     (signingState) => {
       mockUseJwt()
       const { queryByLabelText } = renderRow(buildPurpose('ACTIVE', signingState))

--- a/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
+import { ConsumerPurposesTableRow } from '../ConsumerPurposesTableRow'
+import type { Purpose, RiskAnalysisSigningState } from '@/api/api.generatedTypes'
+
+type PurposeWithRiskAnalysisSigningState = Purpose & {
+  riskAnalysisSigningState?: RiskAnalysisSigningState
+}
+
+const renderRow = (purpose: Purpose) =>
+  renderWithApplicationContext(
+    <table>
+      <tbody>
+        <ConsumerPurposesTableRow purpose={purpose} />
+      </tbody>
+    </table>,
+    { withRouterContext: true, withReactQueryContext: true }
+  )
+
+describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () => {
+  it('renders the info icon with the "approved" tooltip when riskAnalysisSigningState is SIGNED', () => {
+    mockUseJwt()
+    const purpose = createMockPurpose({
+      riskAnalysisSigningState: 'SIGNED',
+    } as PurposeWithRiskAnalysisSigningState)
+
+    const { queryByLabelText } = renderRow(purpose)
+
+    expect(queryByLabelText('list.riskAnalysisApproved')).toBeInTheDocument()
+    expect(queryByLabelText('list.riskAnalysisRejected')).not.toBeInTheDocument()
+  })
+
+  it('renders the info icon with the "rejected" tooltip when riskAnalysisSigningState is REJECTED', () => {
+    mockUseJwt()
+    const purpose = createMockPurpose({
+      riskAnalysisSigningState: 'REJECTED',
+    } as PurposeWithRiskAnalysisSigningState)
+
+    const { queryByLabelText } = renderRow(purpose)
+
+    expect(queryByLabelText('list.riskAnalysisRejected')).toBeInTheDocument()
+    expect(queryByLabelText('list.riskAnalysisApproved')).not.toBeInTheDocument()
+  })
+
+  it.each(['ASSIGNED', 'SUBMITTED', undefined] as const)(
+    'does not render any info icon when riskAnalysisSigningState is %s',
+    (signingState) => {
+      mockUseJwt()
+      const purpose = createMockPurpose({
+        riskAnalysisSigningState: signingState,
+      } as PurposeWithRiskAnalysisSigningState)
+
+      const { queryByLabelText } = renderRow(purpose)
+
+      expect(queryByLabelText('list.riskAnalysisApproved')).not.toBeInTheDocument()
+      expect(queryByLabelText('list.riskAnalysisRejected')).not.toBeInTheDocument()
+    }
+  )
+})

--- a/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
@@ -4,25 +4,30 @@ import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
 import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
 import { ConsumerPurposesTableRow } from '../ConsumerPurposesTableRow'
 import type {
-  Purpose,
   PurposeVersionState,
+  ReviewerWorkflow,
   RiskAnalysisSigningState,
 } from '@/api/api.generatedTypes'
 
-type PurposeWithRiskAnalysisSigningState = Purpose & {
-  riskAnalysisSigningState?: RiskAnalysisSigningState
-}
-
 const buildPurpose = (
   currentVersionState: PurposeVersionState,
-  riskAnalysisSigningState: RiskAnalysisSigningState | undefined
-) =>
-  createMockPurpose({
-    currentVersion: { state: currentVersionState },
-    riskAnalysisSigningState,
-  } as PurposeWithRiskAnalysisSigningState)
+  signingState: RiskAnalysisSigningState | undefined
+) => {
+  const reviewerWorkflow: ReviewerWorkflow | undefined = signingState
+    ? {
+        reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
+        reviewerIds: [],
+        signingState,
+      }
+    : undefined
 
-const renderRow = (purpose: Purpose) =>
+  return createMockPurpose({
+    currentVersion: { state: currentVersionState },
+    reviewerWorkflow,
+  })
+}
+
+const renderRow = (purpose: ReturnType<typeof buildPurpose>) =>
   renderWithApplicationContext(
     <table>
       <tbody>
@@ -33,7 +38,7 @@ const renderRow = (purpose: Purpose) =>
   )
 
 describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () => {
-  it('renders the info icon with aria-label "list.riskAnalysisApproved" when the purpose is a DRAFT and riskAnalysisSigningState is SIGNED', () => {
+  it('renders the info icon with aria-label "list.riskAnalysisApproved" when the purpose is a DRAFT and reviewerWorkflow.signingState is SIGNED', () => {
     mockUseJwt()
     const { queryByLabelText } = renderRow(buildPurpose('DRAFT', 'SIGNED'))
 
@@ -41,7 +46,7 @@ describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () 
     expect(queryByLabelText('list.riskAnalysisRejected')).not.toBeInTheDocument()
   })
 
-  it('renders the info icon with aria-label "list.riskAnalysisRejected" when the purpose is a DRAFT and riskAnalysisSigningState is REJECTED', () => {
+  it('renders the info icon with aria-label "list.riskAnalysisRejected" when the purpose is a DRAFT and reviewerWorkflow.signingState is REJECTED', () => {
     mockUseJwt()
     const { queryByLabelText } = renderRow(buildPurpose('DRAFT', 'REJECTED'))
 
@@ -50,7 +55,7 @@ describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () 
   })
 
   it.each(['ASSIGNED', 'SUBMITTED', undefined] as const)(
-    'does not render the info icon for a DRAFT purpose when riskAnalysisSigningState is %s',
+    'does not render the info icon for a DRAFT purpose when reviewerWorkflow.signingState is %s',
     (signingState) => {
       mockUseJwt()
       const { queryByLabelText } = renderRow(buildPurpose('DRAFT', signingState))
@@ -61,7 +66,7 @@ describe('ConsumerPurposesTableRow - risk analysis signing state info icon', () 
   )
 
   it.each(['SIGNED', 'REJECTED'] as const)(
-    'does not render the info icon when the purpose is not a DRAFT, even if riskAnalysisSigningState is %s',
+    'does not render the info icon when the purpose is not a DRAFT, even if reviewerWorkflow.signingState is %s',
     (signingState) => {
       mockUseJwt()
       const { queryByLabelText } = renderRow(buildPurpose('ACTIVE', signingState))

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -244,6 +244,8 @@
     "cantCreatePurposeTooltip": "You cannot create purposes because you have no associable e-service",
     "newVersionAvailableTooltip": "The consumer has requested an adjustment that requires your approval. Access the purpose for more details",
     "waitingForApprovalVersionTooltip": "You have requested an adjustment that requires approval from the producer. Access the purpose for more details",
+    "riskAnalysisApproved": "Risk analysis approved",
+    "riskAnalysisRejected": "Risk analysis rejected",
     "filters": {
       "nameField": {
         "label": "Find by purpose name"

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -244,6 +244,8 @@
     "cantCreatePurposeTooltip": "Non puoi creare finalità perché non hai e-service da associare",
     "newVersionAvailableTooltip": "Il fruitore ha richiesto un adeguamento che richiede la tua approvazione. Accedi alla finalità per maggiori dettagli",
     "waitingForApprovalVersionTooltip": "Hai richiesto un adeguamento che richiede l’approvazione dell’erogatore. Accedi alla finalità per maggiori dettagli",
+    "riskAnalysisApproved": "Analisi del rischio approvata",
+    "riskAnalysisRejected": "Analisi del rischio rifiutata",
     "filters": {
       "nameField": {
         "label": "Cerca per nome finalità"


### PR DESCRIPTION
## 🔗 Issue
[PIN-10135](https://pagopa.atlassian.net/browse/PIN-10135)

## 📝 Description / Context
On the consumer side, in the "Le mie finalità inoltrate" list, admins need to know the outcome of the risk analysis validation (approved / rejected) without opening each purpose. This PR adds an info icon (with hover/focus tooltip) next to the existing purpose status chip on the consumer purposes table.

The icon is rendered only for purposes whose current version is still a `DRAFT` **and** whose risk analysis has been explicitly approved (`SIGNED`) or rejected (`REJECTED`). Once the purpose is published, the risk analysis is implicitly approved and the icon would be redundant. The provider side is intentionally not affected.

The risk analysis signing state is now exposed by the BE via `purpose.reviewerWorkflow.signingState` (typed `RiskAnalysisSigningState`). The frontend reads it directly from the generated types — no local type augmentation, no cast.

## 🛠 List of changes
- `ConsumerPurposesTableRow`: extracted `isDraft = purpose.currentVersion?.state === 'DRAFT'` and reused it in both `isPurposeEditable` and the new risk-analysis tooltip logic. The status cell now wraps `StatusChip` and a conditional `InfoTooltip` inside a horizontal `Stack`. The tooltip label is resolved via `ts-pattern` over `riskAnalysisSigningState`, gated by `isDraft`: `SIGNED` → "Analisi del rischio approvata", `REJECTED` → "Analisi del rischio rifiutata", anything else (or non-DRAFT version) → no icon.
 - `ConsumerPurposesTableRow`: status cell wraps `StatusChip` and a conditional `InfoTooltip` inside a horizontal `Stack`. The tooltip label is resolved via `ts-pattern` over `purpose.reviewerWorkflow?.signingState`, gated by `currentVersion.state === 'DRAFT'`
- `InfoTooltip` accessibility: the icon is now keyboard-focusable (`tabIndex={0}`) and exposes an accessible name (`role="img"` + `aria-label={label}`), so the tooltip can be triggered via focus and the content is announced by screen readers. No visual change.
- Added i18n keys `list.riskAnalysisApproved` and `list.riskAnalysisRejected` in both `it/purpose.json` and `en/purpose.json`.
- Added unit tests for `ConsumerPurposesTableRow` covering: DRAFT + SIGNED (icon "approved"), DRAFT + REJECTED (icon "rejected"), DRAFT + other signing states (no icon), and non-DRAFT version + SIGNED/REJECTED (no icon). Test descriptions assert the icon's `aria-label`, not the popper rendering (which is covered by the shared `InfoTooltip` tests).
- No changes to `StatusChip` (shared with the provider table) or to any provider-side component — the provider purposes table is unaffected by design.

## 🧪 How to test
- Run `pnpm test src/pages/ConsumerPurposesListPage` and verify the new unit tests pass.
- Run `pnpm test src/components/shared/__tests__/InfoTooltip.test.tsx` and verify (update snapshot if needed).
- With the current BE (no `riskAnalysisSigningState` exposed), open the consumer purposes list and verify that no info icon is rendered next to any status chip and that the existing chip rendering is unchanged.
- Provider side: open the provider purposes list and verify that nothing changed visually.
- (Once the BE is ready / via mocked data) For a DRAFT purpose with `riskAnalysisSigningState: "SIGNED"`, verify the blue info icon appears next to the status chip and hovering/focusing it shows the tooltip "Analisi del rischio approvata".
- (Once the BE is ready / via mocked data) For a DRAFT purpose with `riskAnalysisSigningState: "REJECTED"`, verify the blue info icon appears with tooltip "Analisi del rischio rifiutata".
- (Once the BE is ready / via mocked data) For a DRAFT purpose with `riskAnalysisSigningState` equal to `ASSIGNED`, `SUBMITTED` or undefined, verify no info icon is rendered.
- (Once the BE is ready / via mocked data) For a purpose whose `currentVersion.state` is anything other than `DRAFT` (e.g. `ACTIVE`, `SUSPENDED`, `ARCHIVED`, `REJECTED`), verify no info icon is rendered regardless of `riskAnalysisSigningState`.
- Keyboard a11y check: with a DRAFT + SIGNED/REJECTED purpose, tab through the row and verify the info icon receives focus and the tooltip opens on focus.

[PIN-10135]: https://pagopa.atlassian.net/browse/PIN-10135
<img width="1358" height="425" alt="Screenshot 2026-05-27 alle 17 21 57" src="https://github.com/user-attachments/assets/2346468f-799c-4139-87ec-f5d9e245671f" />


