### PR TITLE
bugfix: async exchange flow (PIN-10200) 

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
@@ -45,26 +45,24 @@ export type EServiceCreateStepTechSpecFormValues = {
 }
 
 export const EServiceCreateStepTechSpec: React.FC<ActiveStepProps> = () => {
-  const { descriptor, eserviceTemplate } = useEServiceCreateContext()
+  const { descriptor } = useEServiceCreateContext()
 
   const isEServiceCreatedFromTemplate = Boolean(descriptor?.templateRef?.templateVersionId)
   const isEServiceAsync = Boolean(descriptor?.eservice.asyncExchange)
-  const isProducerKeychainSectionVisible = isEServiceAsync && !eserviceTemplate
 
   const { data: initialAssociatedKeychains, isPending } = useQuery({
     ...KeychainQueries.getAllKeychainsList({
       eserviceId: descriptor?.eservice.id ?? '',
     }),
-    enabled: isProducerKeychainSectionVisible && Boolean(descriptor?.eservice.id),
+    enabled: isEServiceAsync && Boolean(descriptor?.eservice.id),
   })
 
-  if (isProducerKeychainSectionVisible && isPending) {
+  if (isEServiceAsync && isPending) {
     return <EServiceCreateStepTechSpecSkeleton />
   }
 
   return (
     <EServiceCreateStepTechSpecForm
-      isProducerKeychainSectionVisible={isProducerKeychainSectionVisible}
       isEServiceCreatedFromTemplate={isEServiceCreatedFromTemplate}
       initialAssociatedKeychains={initialAssociatedKeychains ?? []}
     />
@@ -72,13 +70,11 @@ export const EServiceCreateStepTechSpec: React.FC<ActiveStepProps> = () => {
 }
 
 type EServiceCreateStepTechSpecFormProps = {
-  isProducerKeychainSectionVisible: boolean
   isEServiceCreatedFromTemplate: boolean
   initialAssociatedKeychains: CompactProducerKeychain[]
 }
 
 const EServiceCreateStepTechSpecForm: React.FC<EServiceCreateStepTechSpecFormProps> = ({
-  isProducerKeychainSectionVisible,
   isEServiceCreatedFromTemplate,
   initialAssociatedKeychains,
 }) => {
@@ -131,7 +127,7 @@ const EServiceCreateStepTechSpecForm: React.FC<EServiceCreateStepTechSpecFormPro
           }
         : null
 
-    if (isProducerKeychainSectionVisible && areEServiceGeneralInfoEditable) {
+    if (isAsyncExchange && areEServiceGeneralInfoEditable) {
       const allKeychainsListQuery = KeychainQueries.getAllKeychainsList({
         eserviceId: descriptor.eservice.id,
       })
@@ -273,7 +269,7 @@ const EServiceCreateStepTechSpecForm: React.FC<EServiceCreateStepTechSpecFormPro
             isEServiceCreatedFromTemplate={isEServiceCreatedFromTemplate}
           />
         )}
-        {isProducerKeychainSectionVisible && <EServiceProducerKeychainSection />}
+        {isAsyncExchange && <EServiceProducerKeychainSection />}
         <StepActions
           back={{
             label: t('backWithoutSaveBtn'),

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
@@ -12,6 +12,7 @@ import {
   createMockEServiceDescriptorProviderAsync,
   mockUseEServiceCreateContext,
 } from '@/../__mocks__/data/eservice.mocks'
+import { createMockEServiceTemplateDetailsAsync } from '@/../__mocks__/data/eserviceTemplate.mocks'
 
 const useRemoveKeychainFromEService = vi.hoisted(() => vi.fn())
 
@@ -397,6 +398,7 @@ describe('EServiceCreateStepTechSpec', () => {
         ...createMockEServiceDescriptorProviderAsync(),
         templateRef: createMockEServiceDescriptorProviderWithTemplateRef().templateRef,
       },
+      eserviceTemplate: createMockEServiceTemplateDetailsAsync(),
     })
     renderWithApplicationContext(<EServiceCreateStepTechSpec {...stepProps} />, {
       withReactQueryContext: true,

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
@@ -2,7 +2,7 @@ import type { AsyncExchangeProperties } from '@/api/api.generatedTypes'
 import { SectionContainer } from '@/components/layout/containers'
 import { RHFCheckbox, RHFTextField } from '@/components/shared/react-hook-form-inputs'
 import { asyncExchangeGuideLink } from '@/config/constants'
-import { Alert, Grid, Link, Stack, Typography } from '@mui/material'
+import { Alert, Box, Grid, Link, Stack, Typography } from '@mui/material'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
 import React from 'react'
 import { useFormContext } from 'react-hook-form'
@@ -133,7 +133,7 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
         {t('editableInfoAlert')}
       </Alert>
 
-      {editableCallbackInterfaceContent}
+      <Box sx={{ mt: 2 }}>{editableCallbackInterfaceContent}</Box>
 
       <Typography variant="subtitle1" sx={{ mt: 3 }}>
         {t('configSubsection.title')}

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -26,6 +26,10 @@ const ProviderEServiceDetailsPage: React.FC = () => {
 
   const isEserviceFromTemplate = Boolean(descriptor?.templateRef)
 
+  const handleViewKeychains = () => {
+    updateActiveTab(null, 'keychains')
+  }
+
   descriptor?.delegation
   const { actions } = useGetProviderEServiceActions(
     eserviceId,
@@ -65,7 +69,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
         </TabList>
 
         <TabPanel value="eserviceDetails">
-          <ProviderEserviceDetailsTab />
+          <ProviderEserviceDetailsTab onViewKeychains={handleViewKeychains} />
         </TabPanel>
 
         <TabPanel value="keychains">

--- a/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetailsAlerts.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetailsAlerts.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
 import {
   createMockEServiceDescriptorProvider,
   createMockEServiceDescriptorProviderAsync,
@@ -34,6 +35,25 @@ describe('ProviderEServiceDetailsAlerts', () => {
 
     expect(screen.getByText('providerMissingProducerKeychainKeys')).toBeInTheDocument()
     expect(screen.queryByText('providerMissingProducerKeychain')).not.toBeInTheDocument()
+  })
+
+  it('calls the keychains tab action from producer keychain alerts', async () => {
+    const descriptor = createMockEServiceDescriptorProviderAsync({
+      eservice: {
+        hasProducerKeychain: true,
+        hasProducerKeychainKeys: false,
+      },
+    })
+    const onViewKeychains = vi.fn()
+
+    renderWithApplicationContext(
+      <ProviderEServiceDetailsAlerts descriptor={descriptor} onViewKeychains={onViewKeychains} />,
+      {}
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'viewProducerKeychains' }))
+
+    expect(onViewKeychains).toHaveBeenCalledTimes(1)
   })
 
   it('does not show producer keychain warnings when an async eservice has a keychain with keys', () => {

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
 import type { ProducerEServiceDescriptor } from '@/api/api.generatedTypes'
-import { Alert, Stack } from '@mui/material'
+import { Alert, Button, Stack } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
 type ProviderEServiceDetailsAlertsProps = {
   descriptor: ProducerEServiceDescriptor | undefined
+  onViewKeychains?: VoidFunction
 }
 
 export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAlertsProps> = ({
   descriptor,
+  onViewKeychains,
 }) => {
   const { t } = useTranslation('eservice', { keyPrefix: 'read.alert' })
 
@@ -22,16 +24,25 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
     descriptor.eservice.asyncExchange &&
     descriptor.eservice.hasProducerKeychain &&
     !descriptor.eservice.hasProducerKeychainKeys
+  const viewKeychainsAction = onViewKeychains ? (
+    <Button color="primary" size="small" onClick={onViewKeychains}>
+      {t('viewProducerKeychains')}
+    </Button>
+  ) : undefined
 
   return (
     <Stack spacing={2}>
       {isSuspended && <Alert severity="error">{t('suspended')}</Alert>}
       {isDeprecated && <Alert severity="info">{t('deprecated')}</Alert>}
       {shouldShowMissingKeychainAlert && (
-        <Alert severity="warning">{t('providerMissingProducerKeychain')}</Alert>
+        <Alert severity="warning" action={viewKeychainsAction}>
+          {t('providerMissingProducerKeychain')}
+        </Alert>
       )}
       {shouldShowMissingKeychainKeysAlert && (
-        <Alert severity="warning">{t('providerMissingProducerKeychainKeys')}</Alert>
+        <Alert severity="warning" action={viewKeychainsAction}>
+          {t('providerMissingProducerKeychainKeys')}
+        </Alert>
       )}
     </Stack>
   )

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsTab.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsTab.tsx
@@ -21,7 +21,13 @@ import {
   ProviderEServiceSignalHubSection,
 } from './ProviderEServiceSignalHubSection'
 
-export const ProviderEserviceDetailsTab: React.FC = () => {
+type ProviderEserviceDetailsTabProps = {
+  onViewKeychains?: VoidFunction
+}
+
+export const ProviderEserviceDetailsTab: React.FC<ProviderEserviceDetailsTabProps> = ({
+  onViewKeychains,
+}) => {
   const { eserviceId, descriptorId } = useParams<'PROVIDE_ESERVICE_MANAGE'>()
 
   const { data: descriptor } = useQuery(
@@ -30,7 +36,7 @@ export const ProviderEserviceDetailsTab: React.FC = () => {
 
   return (
     <>
-      <ProviderEServiceDetailsAlerts descriptor={descriptor} />
+      <ProviderEServiceDetailsAlerts descriptor={descriptor} onViewKeychains={onViewKeychains} />
       <Grid container>
         <Grid item xs={8}>
           <React.Suspense fallback={<ProviderEServiceGeneralInfoSectionSkeleton />}>

--- a/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceDocumentationSummarySection.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceDocumentationSummarySection.tsx
@@ -126,16 +126,16 @@ export const ProviderEServiceDocumentationSummarySection: React.FC<
             content={formatAsyncSeconds(asyncExchangeProperties?.resourceAvailableTime)}
           />
           <SummaryInformationContainer
+            label={t('asyncExchange.maxResultSet.label')}
+            content={formatAsyncNumber(asyncExchangeProperties?.maxResultSet)}
+          />
+          <SummaryInformationContainer
             label={t('asyncExchange.confirmation.label')}
             content={formatAsyncBoolean(asyncExchangeProperties?.confirmation)}
           />
           <SummaryInformationContainer
             label={t('asyncExchange.bulk.label')}
             content={formatAsyncBoolean(asyncExchangeProperties?.bulk)}
-          />
-          <SummaryInformationContainer
-            label={t('asyncExchange.maxResultSet.label')}
-            content={formatAsyncNumber(asyncExchangeProperties?.maxResultSet)}
           />
           <Divider />
           <SummaryInformationContainer

--- a/src/pages/ProviderEServiceTemplateSummaryPage/components/ProviderEServiceTemplateTechnicalSpecsSummarySection.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/components/ProviderEServiceTemplateTechnicalSpecsSummarySection.tsx
@@ -109,6 +109,14 @@ export const ProviderEServiceTemplateTechnicalSpecsSummarySection: React.FC = ()
             }
           />
           <InformationContainer
+            label={t('asyncExchange.maxResultSet.label')}
+            content={
+              asyncExchangeProperties
+                ? String(asyncExchangeProperties.maxResultSet)
+                : renderMissingField()
+            }
+          />
+          <InformationContainer
             label={t('asyncExchange.confirmation.label')}
             content={
               asyncExchangeProperties
@@ -121,14 +129,6 @@ export const ProviderEServiceTemplateTechnicalSpecsSummarySection: React.FC = ()
             content={
               asyncExchangeProperties
                 ? t(`asyncExchange.booleanValue.${asyncExchangeProperties.bulk}`)
-                : renderMissingField()
-            }
-          />
-          <InformationContainer
-            label={t('asyncExchange.maxResultSet.label')}
-            content={
-              asyncExchangeProperties
-                ? String(asyncExchangeProperties.maxResultSet)
                 : renderMissingField()
             }
           />

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -626,7 +626,8 @@
       "missingProducerKeychain": "The producer has not linked the keychain to this async e-service yet. Data exchange is currently unavailable.",
       "missingProducerKeychainKeys": "The producer has not linked any keys to this async e-service keychain yet. Data exchange is currently unavailable.",
       "providerMissingProducerKeychain": "Associate a keychain with this e-service to enable data exchange.",
-      "providerMissingProducerKeychainKeys": "Add at least one key to the keychain linked to this e-service to enable data exchange."
+      "providerMissingProducerKeychainKeys": "Add at least one key to the keychain linked to this e-service to enable data exchange.",
+      "viewProducerKeychains": "View keychains"
     },
     "actions": {
       "backToListLabel": "Back to the e-services",

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -626,7 +626,8 @@
       "missingProducerKeychain": "L’erogatore non ha ancora collegato il portachiavi a questo e-service asincrono. Lo scambio dati non è al momento disponibile.",
       "missingProducerKeychainKeys": "L’erogatore non ha ancora collegato le chiavi al portachiavi di questo e-service asincrono. Lo scambio dati non è al momento disponibile.",
       "providerMissingProducerKeychain": "Associa un portachiavi a questo e-service per abilitare lo scambio dati.",
-      "providerMissingProducerKeychainKeys": "Associa almeno una chiave al portachiavi collegato a questo e-service per abilitare lo scambio dati."
+      "providerMissingProducerKeychainKeys": "Associa almeno una chiave al portachiavi collegato a questo e-service per abilitare lo scambio dati.",
+      "viewProducerKeychains": "Vedi portachiavi"
     },
     "actions": {
       "backToListLabel": "Torna agli e-service",


### PR DESCRIPTION
## 🔗 Issue

[PIN-10200](https://pagopa.atlassian.net/browse/PIN-10200)

## 📝 Description / Context

This PR fixes the async e-service keychain flows for template instances and aligns the summary/details UI with the expected behavior. Async e-services created from a template can now associate producer keychains, in the summary asynnc fields are now in the correct order, and keychain warning alerts provide a direct action to open the associated keychains tab.

## 🛠 List of changes

- Show the producer keychain section when creating an async e-service from a template.
- Add the “View keychains” / “Vedi portachiavi” action to producer keychain warning alerts.
- Wire the alert action to switch the e-service detail page to the associated keychains tab.
- Corrected the order of the async fields in template / eservice creation summary
- Update focused tests and locale keys.

## 🧪 How to test

- Create an async e-service starting from a template and open the technical specifications step: the producer keychain association card should be visible.
- Open an async e-service detail page with a linked keychain missing keys: the warning alert should show “Vedi portachiavi”; clicking it should switch to the associated keychains tab.
- Verify that async template creation still does not show the producer keychain card.
-Open an async eservice/ template creation / edit page and in the "Specifiche tecniche" card look at the order of the async fields

[PIN-10200]: https://pagopa.atlassian.net/browse/PIN-10200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ