### PR TITLE
fix: purpose template summary/edit bugfixes (PIN-10201)

### DIFF
--- a/src/components/layout/containers/ResourceContainer.tsx
+++ b/src/components/layout/containers/ResourceContainer.tsx
@@ -3,7 +3,7 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
-  Card,
+  Box,
   IconButton,
   Stack,
   Typography,
@@ -25,10 +25,19 @@ type ResourceContainerProps = {
 
 export const ResourceContainer: React.FC<ResourceContainerProps> = ({ candidate, onRemove }) => {
   const { t } = useTranslation('shared-components', { keyPrefix: 'resourceContainer' })
+  const { t: tPT } = useTranslation('purposeTemplate', { keyPrefix: 'edit.step2' })
   const panelContentId = React.useId()
   const headerId = React.useId()
 
   const name = candidate.value.name
+
+  const publisher = match(candidate)
+    .with({ resourceKind: 'ESERVICE' }, (c) => c.value.producer.name)
+    .with({ resourceKind: 'ESERVICE_TEMPLATE' }, (c) => c.value.creator.name)
+    .exhaustive()
+  const optionLabelKey =
+    candidate.resourceKind === 'ESERVICE' ? 'options.eservice' : 'options.eserviceTemplate'
+  const displayLabel = tPT(optionLabelKey, { name, publisher })
 
   return (
     <Stack direction="row" alignItems="center" spacing={2}>
@@ -37,20 +46,52 @@ export const ResourceContainer: React.FC<ResourceContainerProps> = ({ candidate,
           <RemoveCircleOutlineIcon color="error" />
         </IconButton>
       )}
-      <Card sx={{ borderRadius: 1, border: '1px solid', borderColor: 'divider', flex: 1 }}>
-        <Accordion disableGutters sx={{ '&:before': { display: 'none' } }}>
+      <Box
+        component="fieldset"
+        sx={{
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          m: 0,
+          px: 1,
+          pt: 0,
+          pb: 0,
+          flex: 1,
+          minWidth: 0,
+        }}
+      >
+        <Box
+          component="legend"
+          sx={{
+            px: 0.5,
+            ml: 0.5,
+            fontSize: 12,
+            color: 'text.secondary',
+            lineHeight: 1,
+          }}
+        >
+          {tPT('autocompleteInput.label')}
+        </Box>
+        <Accordion
+          disableGutters
+          sx={{
+            '&:before': { display: 'none' },
+            backgroundColor: 'transparent',
+            boxShadow: 'none',
+          }}
+        >
           <AccordionSummary
             expandIcon={<ExpandMoreIcon />}
             aria-controls={panelContentId}
             id={headerId}
           >
-            <Typography fontWeight={600}>{name}</Typography>
+            <Typography fontWeight={600}>{displayLabel}</Typography>
           </AccordionSummary>
           <AccordionDetails>
             <ResourceDetails candidate={candidate} />
           </AccordionDetails>
         </Accordion>
-      </Card>
+      </Box>
     </Stack>
   )
 }

--- a/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepLinkedResources/ResourceGroup.tsx
+++ b/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepLinkedResources/ResourceGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Alert, Box, Stack } from '@mui/material'
+import { Alert, Box, Stack, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import AddIcon from '@mui/icons-material/Add'
 import { ButtonNaked } from '@pagopa/mui-italia'
@@ -104,11 +104,16 @@ export const ResourceGroup: React.FC<ResourceGroupProps> = ({
         </Stack>
       )}
       {!readOnly && isAutocompleteShown && (
-        <ResourceAutoComplete
-          onAddResource={handleAddResource}
-          alreadySelectedResourceIds={alreadySelectedResourceIds}
-          purposeTemplate={purposeTemplate}
-        />
+        <Stack spacing={1}>
+          <ResourceAutoComplete
+            onAddResource={handleAddResource}
+            alreadySelectedResourceIds={alreadySelectedResourceIds}
+            purposeTemplate={purposeTemplate}
+          />
+          <Typography variant="body2" color="text.secondary" sx={{ pl: 2 }}>
+            {t('eserviceSelectionSubtitle')}
+          </Typography>
+        </Stack>
       )}
       {!readOnly && !isAutocompleteShown && (
         <ButtonNaked

--- a/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepLinkedResources/__tests__/ResourceGroup.test.tsx
+++ b/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepLinkedResources/__tests__/ResourceGroup.test.tsx
@@ -47,7 +47,13 @@ vi.mock('@/stores/toast-notification.store', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, opts?: Record<string, string>) => {
+      if (key === 'options.eservice')
+        return `${opts?.name} - e-service erogato da ${opts?.publisher}`
+      if (key === 'options.eserviceTemplate')
+        return `${opts?.name} - template erogato da ${opts?.publisher}`
+      return key
+    },
     i18n: { language: 'it' },
   }),
 }))

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -2,7 +2,7 @@
   "backToListBtn": "Torna alle finalità",
   "create": {
     "emptyTitle": "Crea finalità",
-    "preliminaryInformationSectionTitle": "Informazioni sulla finalità",
+    "preliminaryInformationSectionTitle": "Informazioni preliminari",
     "isTemplateField": {
       "label": "Usa un template precompilato"
     },
@@ -13,11 +13,11 @@
     },
     "consumerField": {
       "label": "Fruitore",
-      "infoLabel": "Seleziona il tuo ente o l'ente per cui hai una delega attiva come fruitore"
+      "infoLabel": "Tra gli aderenti, puoi selezionare solo il tuo ente o gli aderenti per i quali hai una delega in fruizione attiva"
     },
     "eserviceField": {
       "label": "E-service da associare",
-      "infoLabel": "Qui trovi solo gli e-service per cui il fruitore ha una richiesta attiva",
+      "infoLabel": "Puoi selezionare solo gli e-service per i quali il fruitore selezionato ha una richiesta di fruizione attiva",
       "alert": {
         "label": "Per l’e-service selezionato è possibile utilizzare la funzionalità di compilazione agevolata!"
       }
@@ -44,13 +44,13 @@
     "riskAnalysisPreviewTitle": "Analisi del rischio",
     "purposeTemplateField": {
       "title": "Compilazione agevolata della finalità",
-      "description": "Questa funzionalità ti guida durante l'analisi del rischio con annotazioni, documenti di supporto e alcune risposte precompilate. Il modello agevolato è reso disponibile per il riuso da altri enti e può essere usato senza vincoli.",
+      "description": "La funzionalità di compilazione agevolata mette a disposizione annotazioni, documenti di supporto e alcune risposte precompilate per facilitare la formulazione dell’analisi del rischio. Il modello è reso disponibile per il riuso da altri enti aderenti e può essere utilizzato senza vincoli.",
       "usePurposeTemplateSwitch": {
-        "label": "Usa la compilazione agevolata",
+        "label": "Utilizza la funzionalità di compilazione agevolata",
         "disabledTooltip": "Non è possibile utilizzare la funzionalità per \n l’e-service selezionato in quanto l’erogatore non ha indicato come verranno trattati i dati personali",
         "selectPurposeTemplate": {
           "title": "Scegli il modello di compilazione agevolata della finalità",
-          "showOnlyLinkedPurposeTemplates": "Mostra solo template suggeriti per l’e-service che ho selezionato",
+          "showOnlyLinkedPurposeTemplates": "Mostra solo template suggeriti",
           "autocompleteLabelPurposeTemplate": "Template per la compilazione agevolata della finalità",
           "viewPurposeTemplateBtn": "Visualizza il template selezionato"
         },

--- a/src/static/locales/it/purposeTemplate.json
+++ b/src/static/locales/it/purposeTemplate.json
@@ -264,7 +264,7 @@
     },
     "linkedResourcesTab": {
       "title": "E-service e template e-service suggeriti",
-      "description": "Qui trovi l'elenco degli e-service e template e-service suggeriti per questa finalità agevolata. Il template può essere usato anche per altri e-service non presenti nell'elenco. <1>Link alla documentazione</1>",
+      "description": "L’ente ha definito un elenco di e-service per cui è suggerito usare la finalità agevolata. Il fruitore ha facoltà di utilizzare questo template anche per e-service che non compaiono nella lista. <1>Link alla documentazione</1>",
       "editButtonTooltip": "Non è possibile modificare l'elenco se il template è sospeso o archiviato",
       "linkedResourceName": "E-service o template e-service",
       "linkedResourceKind": "Tipo",

--- a/src/static/locales/it/purposeTemplate.json
+++ b/src/static/locales/it/purposeTemplate.json
@@ -83,7 +83,7 @@
       "editLinkedEservices": "Aggiorna elenco",
       "editLinkedResources": "Aggiorna elenco",
       "saveBtn": "Salva",
-      "eserviceSelectionSubtitle": "Puoi inserire e-service che hanno un trattamento dei dati personali analogo a quanto hai indicato.",
+      "eserviceSelectionSubtitle": "Puoi inserire e-service che hanno un trattamento dei dati personali simile a quello che hai indicato.",
       "removeResourceAriaLabel": "Rimuovi {{name}}",
       "autocompleteInput": {
         "label": "E-service o template e-service suggeriti"

--- a/src/utils/__tests__/purposeTemplate.utils.test.ts
+++ b/src/utils/__tests__/purposeTemplate.utils.test.ts
@@ -82,16 +82,16 @@ describe('mergeLinkableCandidates', () => {
       expected: ['ESERVICE:es-1', 'ESERVICE_TEMPLATE:tpl-1', 'ESERVICE:es-2'],
     },
     {
-      name: 'excludes e-service that is instance of an active template (templateVersionId in set)',
+      name: 'excludes e-service that is a template instance when its template is in the results',
       eservices: [makeEservice('es-1', 'Alpha', 'tplv-1')],
       templates: [makeTemplate('tpl-1', 'Bravo', 'tplv-1')],
       expected: ['ESERVICE_TEMPLATE:tpl-1'],
     },
     {
-      name: 'keeps e-service whose templateVersionId is not in any active template publishedVersion.id',
+      name: 'excludes template-instance e-service even when its template is not in the results',
       eservices: [makeEservice('es-1', 'Alpha', 'tplv-OLD')],
       templates: [makeTemplate('tpl-1', 'Bravo', 'tplv-NEW')],
-      expected: ['ESERVICE:es-1', 'ESERVICE_TEMPLATE:tpl-1'],
+      expected: ['ESERVICE_TEMPLATE:tpl-1'],
     },
     {
       name: 'keeps e-service with no activeDescriptor (undefined)',
@@ -100,7 +100,7 @@ describe('mergeLinkableCandidates', () => {
       expected: ['ESERVICE:es-1', 'ESERVICE_TEMPLATE:tpl-1'],
     },
     {
-      name: 'partial dedupe: removes only the e-service whose templateVersionId matches',
+      name: 'keeps standalone e-services and filters template-instance ones',
       eservices: [makeEservice('es-1', 'Alpha', 'tplv-1'), makeEservice('es-2', 'Charlie')],
       templates: [makeTemplate('tpl-1', 'Bravo', 'tplv-1')],
       expected: ['ESERVICE_TEMPLATE:tpl-1', 'ESERVICE:es-2'],
@@ -112,7 +112,7 @@ describe('mergeLinkableCandidates', () => {
       expected: ['ESERVICE:es-2', 'ESERVICE_TEMPLATE:tpl-1', 'ESERVICE:es-1'],
     },
     {
-      name: 'dedupe matches any active template publishedVersion.id in the set (cross-template)',
+      name: 'filters template-instance e-services regardless of which template they belong to',
       eservices: [makeEservice('es-1', 'Alpha', 'tplv-2')],
       templates: [
         makeTemplate('tpl-1', 'Bravo', 'tplv-1'),

--- a/src/utils/purposeTemplate.utils.ts
+++ b/src/utils/purposeTemplate.utils.ts
@@ -16,16 +16,13 @@ export function mergeLinkableCandidates(
   eservices: CatalogEService[],
   templates: CatalogEServiceTemplate[]
 ): LinkableCandidate[] {
-  const activeTemplateVersionIds = new Set(templates.map((t) => t.publishedVersion.id))
-
-  const filteredEServices = eservices.filter((e) => {
-    const tplVersionId = e.activeDescriptor?.templateVersionId
-    return tplVersionId === undefined || !activeTemplateVersionIds.has(tplVersionId)
-  })
+  const standaloneEServices = eservices.filter(
+    (e) => e.activeDescriptor?.templateVersionId === undefined
+  )
 
   const candidates: LinkableCandidate[] = [
     ...templates.map((t) => ({ resourceKind: 'ESERVICE_TEMPLATE' as const, value: t })),
-    ...filteredEServices.map((e) => ({ resourceKind: 'ESERVICE' as const, value: e })),
+    ...standaloneEServices.map((e) => ({ resourceKind: 'ESERVICE' as const, value: e })),
   ]
 
   return candidates.sort((a, b) =>


### PR DESCRIPTION
## 🔗 Issue
[PIN-10201](https://pagopa.atlassian.net/browse/PIN-10201)

## 📝 Description / Context
Collects small bugfixes on the purpose template summary/edit flow surfaced after the unified linked resources rollout (PIN-10144). New bugfixes will be added to this PR as separate commits.

## 🛠 List of changes
- (PIN-10202) Restore the helper text below the linked resources autocomplete in step 2 of the consumer purpose template edit page, and align its wording with the design.
- (PIN-10203) Show the provider/creator next to the linked resource name and wrap the selected row in an outlined fieldset with the "E-service o template e-service suggeriti" floating label.
- (PIN-10205) Refine the Italian copy of the linked resources tab description on the consumer purpose template details page.
- (PIN-10206) Align the Italian copy of the consumer "Crea finalità" page (preliminary section title, helpers, compilazione agevolata description, toggles) to the Figma design.
- (PIN-10207) Exclude all e-services that are instances of an e-service template from the linked resources autocomplete, even when their template is not in the current results.

## 🧪 How to test
- Open a draft consumer purpose template and navigate to step 2 ("E-service e template e-service suggeriti").
- Verify that the helper text "Puoi inserire e-service che hanno un trattamento dei dati personali simile a quello che hai indicato." appears below the autocomplete dropdown.
- Add an e-service and an e-service template; verify each selected row shows "{{name}} - e-service erogato da {{publisher}}" or "{{name}} - template e-service erogato da {{publisher}}" inside an outlined box with the floating label "E-service o template e-service suggeriti".
- Open the consumer purpose template details page, "E-service e template e-service suggeriti" tab, and verify the new description starts with "L'ente ha definito un elenco di e-service...".
- Open the consumer "Crea finalità" page and verify the section title is "Informazioni preliminari", the Fruitore/E-service helpers and the compilazione agevolata description/toggle labels match the Figma copy.
- In step 2 of the consumer purpose template edit, type a query that matches an e-service which is an instance of an e-service template (e.g. "tpl") and verify the instance e-service is NOT shown in the dropdown — only standalone e-services and e-service templates.

[PIN-10201]: https://pagopa.atlassian.net/browse/PIN-10201