### PR TITLE
feat: purpose creation step 1 (PIN-10137)

### DIFF
--- a/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
@@ -10,7 +10,7 @@ import type {
 } from '@/api/api.generatedTypes'
 import { PurposeMutations, PurposeQueries } from '@/api/purpose'
 import { SectionContainer } from '@/components/layout/containers'
-import { Box, Button, Divider, Stack } from '@mui/material'
+import { Alert, Box, Button, Divider, Stack } from '@mui/material'
 import React from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
@@ -248,17 +248,24 @@ export const PurposeCreateForm: React.FC<PurposeCreateFormProps> = ({ purposeTem
           </SectionContainer>
         )}
         {isPurposeTemplateCreateSectionVisible && (
-          <SectionContainer
-            title={t('create.purposeTemplateField.title')}
-            description={t('create.purposeTemplateField.description')}
-          >
-            <Stack spacing={3}>
-              <PurposeCreatePurposeTemplateSection
-                selectedEService={selectedEServiceDescriptor?.eservice}
-                purposeTemplateId={purposeTemplateId}
-              />
-            </Stack>
-          </SectionContainer>
+          <>
+            <SectionContainer
+              title={t('create.purposeTemplateField.title')}
+              description={t('create.purposeTemplateField.description')}
+            >
+              <Stack spacing={3}>
+                <PurposeCreatePurposeTemplateSection
+                  selectedEService={selectedEServiceDescriptor?.eservice}
+                  purposeTemplateId={purposeTemplateId}
+                />
+              </Stack>
+            </SectionContainer>
+            {usePurposeTemplate && (
+              <Alert sx={{ mt: 2 }} severity="warning">
+                {t('create.purposeTemplateField.usePurposeTemplateSwitch.evaluatorWarningAlert')}
+              </Alert>
+            )}
+          </>
         )}
         <Stack direction="row" sx={{ mt: 4, justifyContent: 'right' }}>
           <Button variant="contained" type="submit" startIcon={<NoteAddIcon />}>

--- a/src/pages/ConsumerPurposeCreatePage/components/__tests__/PurposeCreateForm.test.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/__tests__/PurposeCreateForm.test.tsx
@@ -1,22 +1,10 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { BrowserRouter } from 'react-router-dom'
 import { useFormContext } from 'react-hook-form'
-import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
 import { PurposeCreateForm } from '../PurposeCreateForm'
-
-vi.mock('@/api/auth', () => ({
-  AuthHooks: {
-    useJwt: () => ({
-      jwt: {
-        organizationId: 'org-1',
-        organization: { name: 'Organization 1' },
-      },
-    }),
-  },
-}))
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
 
 vi.mock('@/router', () => ({
   useNavigate: () => vi.fn(),
@@ -96,22 +84,16 @@ vi.mock('../PurposeCreatePurposeTemplateSection/PurposeCreatePurposeTemplateSect
   },
 }))
 
-const renderForm = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+const renderForm = () =>
+  renderWithApplicationContext(<PurposeCreateForm />, {
+    withReactQueryContext: true,
+    withRouterContext: true,
   })
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <PurposeCreateForm />
-      </BrowserRouter>
-    </QueryClientProvider>
-  )
-}
 
 describe('PurposeCreateForm — evaluator warning alert', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseJwt()
   })
 
   it('does not render the evaluator warning alert when usePurposeTemplate is OFF', () => {

--- a/src/pages/ConsumerPurposeCreatePage/components/__tests__/PurposeCreateForm.test.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/__tests__/PurposeCreateForm.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserRouter } from 'react-router-dom'
+import { useFormContext } from 'react-hook-form'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+import { PurposeCreateForm } from '../PurposeCreateForm'
+
+vi.mock('@/api/auth', () => ({
+  AuthHooks: {
+    useJwt: () => ({
+      jwt: {
+        organizationId: 'org-1',
+        organization: { name: 'Organization 1' },
+      },
+    }),
+  },
+}))
+
+vi.mock('@/router', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('@/api/purpose', () => ({
+  PurposeMutations: {
+    useCreateDraft: () => ({ mutate: vi.fn() }),
+    useCreateDraftForReceiveEService: () => ({ mutate: vi.fn() }),
+    useCreateDraftFromPurposeTemplate: () => ({ mutate: vi.fn() }),
+  },
+  PurposeQueries: {
+    getSingle: () => ({ queryKey: ['purpose-single'], queryFn: vi.fn() }),
+  },
+}))
+
+vi.mock('@/api/eservice', () => ({
+  EServiceQueries: {
+    getAllCatalogEServices: () => ({ queryKey: ['eservices'], queryFn: vi.fn() }),
+    getDescriptorCatalog: () => ({ queryKey: ['descriptor'], queryFn: vi.fn() }),
+  },
+}))
+
+vi.mock('@/api/purposeTemplate/purposeTemplate.queries', () => ({
+  PurposeTemplateQueries: {
+    getCatalogPurposeTemplates: () => ({ queryKey: ['purpose-templates'], queryFn: vi.fn() }),
+  },
+}))
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+  return {
+    ...actual,
+    useQuery: vi.fn(({ queryKey }: { queryKey: Array<string> }) => {
+      if (queryKey?.[0] === 'purpose-templates') {
+        return {
+          data: { results: [{ id: 'tpl-1' }], totalCount: 1 },
+          isLoading: false,
+        }
+      }
+      return { data: undefined, isLoading: false }
+    }),
+  }
+})
+
+vi.mock('../PurposeCreateConsumerAutocomplete', () => ({
+  PurposeCreateConsumerAutocomplete: () => <div>ConsumerAutocomplete</div>,
+}))
+
+vi.mock('../PurposeCreateEServiceAutocomplete', () => ({
+  PurposeCreateEServiceAutocomplete: () => <div>EServiceAutocomplete</div>,
+}))
+
+vi.mock('../PurposeCreateProviderRiskAnalysisAutocomplete', () => ({
+  PurposeCreateProviderRiskAnalysisAutocomplete: () => <div>ProviderRiskAnalysisAutocomplete</div>,
+}))
+
+vi.mock('@/components/shared/RiskAnalysisInfoSummary', () => ({
+  EServiceRiskAnalysisInfoSummary: () => <div>RiskAnalysisInfoSummary</div>,
+}))
+
+vi.mock('../PurposeCreatePurposeTemplateSection/PurposeCreatePurposeTemplateSection', () => ({
+  PurposeCreatePurposeTemplateSection: () => {
+    const { watch, setValue } = useFormContext()
+    const usePurposeTemplate = watch('usePurposeTemplate')
+    return (
+      <label>
+        <input
+          type="checkbox"
+          checked={!!usePurposeTemplate}
+          onChange={() => setValue('usePurposeTemplate', !usePurposeTemplate)}
+        />
+        usePurposeTemplateSwitch
+      </label>
+    )
+  },
+}))
+
+const renderForm = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <PurposeCreateForm />
+      </BrowserRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('PurposeCreateForm — evaluator warning alert', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not render the evaluator warning alert when usePurposeTemplate is OFF', () => {
+    renderForm()
+    expect(
+      screen.queryByText(
+        'create.purposeTemplateField.usePurposeTemplateSwitch.evaluatorWarningAlert'
+      )
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the evaluator warning alert when usePurposeTemplate is ON', async () => {
+    renderForm()
+
+    const toggle = screen.getByLabelText('usePurposeTemplateSwitch')
+    await userEvent.click(toggle)
+
+    expect(
+      screen.getByText('create.purposeTemplateField.usePurposeTemplateSwitch.evaluatorWarningAlert')
+    ).toBeInTheDocument()
+  })
+})

--- a/src/pages/ConsumerPurposeEditPage/ConsumerPurposeEdit.page.tsx
+++ b/src/pages/ConsumerPurposeEditPage/ConsumerPurposeEdit.page.tsx
@@ -37,10 +37,10 @@ const ConsumerPurposeEditPage: React.FC = () => {
   const isReceive = purpose?.eservice.mode === 'RECEIVE'
 
   const steps: Array<StepperStep> = isReceive
-    ? [{ label: t('edit.stepper.stepGeneralLabel'), component: PurposeEditStepGeneral }]
+    ? [{ label: t('edit.stepper.stepGeneralInformationLabel'), component: PurposeEditStepGeneral }]
     : [
         {
-          label: t('edit.stepper.stepGeneralLabel'),
+          label: t('edit.stepper.stepGeneralInformationLabel'),
           component: PurposeEditStepGeneral,
         },
         {

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -57,7 +57,8 @@
         "acknowledgeInfoResponsibility": {
           "label": "I acknowledge that, even in the presence of pre-filled suggestions, it is my responsibility to verify and validate all information before publication.",
           "requiredError": "You must accept the conditions to proceed"
-        }
+        },
+        "evaluatorWarningAlert": "If you choose the facilitated compilation, you will not be able to assign the compilation or the approval of the risk analysis to the evaluator."
       }
     }
   },
@@ -65,6 +66,7 @@
     "emptyTitle": "Edit purpose",
     "stepper": {
       "stepGeneralLabel": "General",
+      "stepGeneralInformationLabel": "General information",
       "stepRiskAnalysisLabel": "Risk assessment"
     },
     "backWithoutSaveBtn": "Back",

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -57,7 +57,8 @@
         "acknowledgeInfoResponsibility": {
           "label": "Dichiaro di aver compreso che, anche in presenza di suggerimenti precompilati, è mia responsabilità verificare e validare tutte le informazioni prima della pubblicazione.",
           "requiredError": "Devi accettare le condizioni per proseguire"
-        }
+        },
+        "evaluatorWarningAlert": "Se scegli la compilazione agevolata, non potrai assegnare la compilazione o l’approvazione dell’analisi del rischio al valutatore."
       }
     }
   },
@@ -65,6 +66,7 @@
     "emptyTitle": "Modifica finalità",
     "stepper": {
       "stepGeneralLabel": "Generale",
+      "stepGeneralInformationLabel": "Informazioni generali",
       "stepRiskAnalysisLabel": "Analisi del rischio"
     },
     "backWithoutSaveBtn": "Indietro",


### PR DESCRIPTION
## 🔗 Issue
[PIN-10137](https://pagopa.atlassian.net/browse/PIN-10137)

## 📝 Description / Context
First slice of the new consumer purpose creation wizard. Introduces the evaluator-related warning on the create form and updates the first step label on the purpose edit page. The full multi-step wizard (including the new "Assegnazione" step) will land in follow-up tickets.

## 🛠 List of changes
- Add a warning alert under the "Compilazione agevolata della finalità" card in `PurposeCreateForm`, rendered only when the `usePurposeTemplate` toggle is active. Copy: "Se scegli la compilazione agevolata, non potrai assegnare la compilazione o l'approvazione dell'analisi del rischio al valutatore."
- Add IT/EN translations for the new alert (`create.purposeTemplateField.usePurposeTemplateSwitch.evaluatorWarningAlert`).
- Rename the first step label on `ConsumerPurposeEditPage` (`/modifica`) from "Generale" to "Informazioni generali" via a new i18n key `edit.stepper.stepGeneralInformationLabel`. `ConsumerPurposeFromTemplateEditPage` is intentionally untouched and keeps "Generale".
- Add unit tests in `PurposeCreateForm.test.tsx` covering the alert's presence/absence based on the toggle state.

## 🧪 How to test
- As an admin consumer, open `/fruizione/finalita/crea`, select an eservice that exposes purpose templates, toggle "Usa la compilazione agevolata" → the warning alert appears under the card with the expected copy.
- Toggle it off → the warning alert disappears.
- Open `/fruizione/finalita/:id/modifica` (non-receive eservice) → the first step in the stepper reads "Informazioni generali".
- Open the from-template edit flow → the first step still reads "Generale".
- Run `pnpm test src/pages/ConsumerPurposeCreatePage` → all tests pass.

[PIN-10137]: https://pagopa.atlassian.net/browse/PIN-10137
<img width="800" height="186" alt="Screenshot 2026-05-28 alle 11 55 46" src="https://github.com/user-attachments/assets/50dc9f34-da42-4d65-9d88-22088e005530" />
<img width="952" height="743" alt="Screenshot 2026-05-28 alle 11 56 18" src="https://github.com/user-attachments/assets/0de2d458-310f-410f-85aa-5ed8a96bfab5" />
