### PR TITLE
fix: omit async exchange from template updates (PIN-10209)

### DIFF
--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
@@ -65,15 +65,19 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
   const onSubmit = (formValues: EServiceTemplateCreateStepGeneralFormValues) => {
     // If we are editing an existing e-service eserviceTemplateVersion, we update the draft
     if (eserviceTemplateVersion) {
+      const { asyncExchange: _asyncExchange, ...updateDraftPayload } = formValues
       // If nothing has changed skip the update call
       const isEServiceTemplateTheSame = compareObjects(
-        formValues,
+        updateDraftPayload,
         eserviceTemplateVersion.eserviceTemplate
       )
 
       if (!isEServiceTemplateTheSame)
         updateDraft(
-          { eServiceTemplateId: eserviceTemplateVersion.eserviceTemplate.id, ...formValues },
+          {
+            eServiceTemplateId: eserviceTemplateVersion.eserviceTemplate.id,
+            ...updateDraftPayload,
+          },
           { onSuccess: forward }
         )
       else forward()

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import {
@@ -7,12 +7,18 @@ import {
   EServiceTemplateCreateStepGeneralSkeleton,
 } from '../EServiceTemplateCreateStepGeneral'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
-import { mockUseEServiceTemplateCreateContext } from '@/../__mocks__/data/eserviceTemplate.mocks'
+import {
+  createMockEServiceTemplateVersionDetailsAsync,
+  mockUseEServiceTemplateCreateContext,
+} from '@/../__mocks__/data/eserviceTemplate.mocks'
+
+const updateDraft = vi.fn()
+const createDraft = vi.fn()
 
 vi.mock('@/api/eserviceTemplate', () => ({
   EServiceTemplateMutations: {
-    useUpdateDraft: () => ({ mutate: vi.fn() }),
-    useCreateDraft: () => ({ mutate: vi.fn() }),
+    useUpdateDraft: () => ({ mutate: updateDraft }),
+    useCreateDraft: () => ({ mutate: createDraft }),
   },
 }))
 
@@ -142,6 +148,30 @@ describe('EServiceTemplateCreateStepGeneral', () => {
       withRouterContext: true,
     })
     expect(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ })).toBeInTheDocument()
+  })
+
+  it('does not send asyncExchange when updating an existing e-service template draft', async () => {
+    const user = userEvent.setup()
+    const eserviceTemplateVersion = createMockEServiceTemplateVersionDetailsAsync({
+      eserviceTemplate: {
+        ...createMockEServiceTemplateVersionDetailsAsync().eserviceTemplate,
+        technology: 'SOAP',
+      },
+    })
+    mockUseEServiceTemplateCreateContext({ eserviceTemplateVersion })
+    renderWithApplicationContext(<EServiceTemplateCreateStepGeneral />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.click(screen.getByLabelText('REST'))
+    await user.click(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ }))
+
+    await waitFor(() => expect(updateDraft).toHaveBeenCalled())
+    expect(updateDraft).toHaveBeenCalledWith(
+      expect.not.objectContaining({ asyncExchange: expect.any(Boolean) }),
+      expect.any(Object)
+    )
   })
 })
 


### PR DESCRIPTION
## 🔗 Issue

[PIN-10209](https://pagopa.atlassian.net/browse/PIN-10209)

## 📝 Description / Context

This PR fixes a 400 Bad Request during e-service template draft updates when a user switches the technical configuration from async SOAP back to async REST.

The frontend was sending the `asyncExchange` field in the existing template draft update payload, but that field is only accepted during template creation and is not part of `UpdateEServiceTemplateSeed`.

## 🛠 List of changes

- Omit `asyncExchange` from the update payload for existing e-service template drafts.
- Keep `asyncExchange` unchanged for new e-service template creation.
- Add a regression test covering the async SOAP to REST update scenario.

## 🧪 How to test

- Create or edit an e-service template draft.
- Select asynchronous exchange and SOAP technology, then proceed.
- Go back to the general information step, switch technology to REST, and save/continue.
- Verify that the draft update completes without a 400 Bad Request.

[PIN-10209]: https://pagopa.atlassian.net/browse/PIN-10209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ