### PR TITLE
fix/PIN-10213 fix async exchange (text)

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
@@ -28,6 +28,7 @@ import {
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { EServiceAsyncExchangeSection } from '../sections/EServiceAsyncExchangeSection'
 import { getAsyncExchangePropertiesWithDefaults } from '@/utils/eservice.utils'
+import { AuthHooks } from '@/api/auth/auth.hooks'
 
 type AsyncExchangePropertiesFormValues = {
   responseTime: number | ''
@@ -47,17 +48,19 @@ export type EServiceCreateStepTechSpecFormValues = {
 export const EServiceCreateStepTechSpec: React.FC<ActiveStepProps> = () => {
   const { descriptor } = useEServiceCreateContext()
 
+  const { isOperatorAPI } = AuthHooks.useJwt()
+
   const isEServiceCreatedFromTemplate = Boolean(descriptor?.templateRef?.templateVersionId)
   const isEServiceAsync = Boolean(descriptor?.eservice.asyncExchange)
 
-  const { data: initialAssociatedKeychains, isPending } = useQuery({
+  const { data: initialAssociatedKeychains, isLoading } = useQuery({
     ...KeychainQueries.getAllKeychainsList({
       eserviceId: descriptor?.eservice.id ?? '',
     }),
-    enabled: isEServiceAsync && Boolean(descriptor?.eservice.id),
+    enabled: isEServiceAsync && Boolean(descriptor?.eservice.id) && !isOperatorAPI,
   })
 
-  if (isEServiceAsync && isPending) {
+  if (isEServiceAsync && isLoading) {
     return <EServiceCreateStepTechSpecSkeleton />
   }
 

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
 import { screen, waitFor } from '@testing-library/react'
 import { EServiceCreateStepTechSpec } from '../EServiceCreateStepTechSpec'
 import { useFieldArray, useFormContext } from 'react-hook-form'
@@ -13,6 +13,8 @@ import {
   mockUseEServiceCreateContext,
 } from '@/../__mocks__/data/eservice.mocks'
 import { createMockEServiceTemplateDetailsAsync } from '@/../__mocks__/data/eserviceTemplate.mocks'
+
+mockUseJwt()
 
 const useRemoveKeychainFromEService = vi.hoisted(() => vi.fn())
 
@@ -127,6 +129,8 @@ describe('EServiceCreateStepTechSpec', () => {
       withReactQueryContext: true,
       withRouterContext: true,
     })
+
+    screen.debug()
     expect(screen.getByText('EServiceInterfaceSection')).toBeInTheDocument()
     expect(screen.getByText('EServiceVoucherSection')).toBeInTheDocument()
   })

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
@@ -130,7 +130,6 @@ describe('EServiceCreateStepTechSpec', () => {
       withRouterContext: true,
     })
 
-    screen.debug()
     expect(screen.getByText('EServiceInterfaceSection')).toBeInTheDocument()
     expect(screen.getByText('EServiceVoucherSection')).toBeInTheDocument()
   })

--- a/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceGeneralInfoSummarySection.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceGeneralInfoSummarySection.tsx
@@ -53,12 +53,12 @@ export const ProviderEServiceGeneralInfoSummarySection: React.FC = () => {
         />
       )}
       <SummaryInformationContainer
-        label={t('apiTechnology.label')}
-        content={descriptor.eservice.technology}
-      />
-      <SummaryInformationContainer
         label={t('exchangeType.label')}
         content={t(`exchangeType.value.${descriptor.eservice.asyncExchange ? 'async' : 'sync'}`)}
+      />
+      <SummaryInformationContainer
+        label={t('apiTechnology.label')}
+        content={descriptor.eservice.technology}
       />
       {isEserviceFromTemplate && (
         <SummaryInformationContainer

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -353,7 +353,7 @@
       "asyncExchangeSection": {
         "title": "Scambi asincroni e massivi",
         "description": "Gli scambi asincroni e massivi richiedono un’interfaccia di callback che i fruitori dovranno implementare per ricevere le tue risposte. Carica il file OpenAPI con la descrizione dell’API. <1>Scopri di più sugli scambi asincroni e massivi</1>.",
-        "editableInfoAlert": "Questi campi non saranno più modificabili dopo la pubblicazione della prima versione dell’e-service.",
+        "editableInfoAlert": "Dopo la pubblicazione, questi campi non saranno più modificabili. Per modificarli, dovrai creare una nuova versione dell’e-service.",
         "callbackInterface": {
           "readOnlyLabel": "Interfaccia di callback",
           "prettyName": "Interfaccia callback",

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -625,9 +625,9 @@
       "deprecated": "Questa versione di e-service è obsoleta ma ancora attiva. Verrà dismessa automaticamente da PDND Interoperabilità quando l’ultima richiesta di fruizione presente su questa versione sarà archiviata.",
       "missingProducerKeychain": "L’erogatore non ha ancora collegato il portachiavi a questo e-service asincrono. Lo scambio dati non è al momento disponibile.",
       "missingProducerKeychainKeys": "L’erogatore non ha ancora collegato le chiavi al portachiavi di questo e-service asincrono. Lo scambio dati non è al momento disponibile.",
-      "providerMissingProducerKeychain": "Associa un portachiavi a questo e-service per abilitare lo scambio dati.",
-      "providerMissingProducerKeychainKeys": "Associa almeno una chiave al portachiavi collegato a questo e-service per abilitare lo scambio dati.",
-      "viewProducerKeychains": "Vedi portachiavi"
+      "providerMissingProducerKeychain": "Collega un portachiavi a questo e-service asincrono per abilitare lo scambio dati.",
+      "providerMissingProducerKeychainKeys": "Associa almeno una chiave al portachiavi collegato a questo e-service asincrono per abilitare lo scambio dati.",
+      "viewProducerKeychains": "Collega portachiavi"
     },
     "actions": {
       "backToListLabel": "Torna agli e-service",


### PR DESCRIPTION
## Issue

[PIN-10213](https://pagopa.atlassian.net/browse/PIN-10213)

## Description / Context

Hotfix for several issues related to async e-service (scambi asincroni) flow:

- The keychain query was incorrectly triggered for `operatorAPI` users, causing unexpected behavior in the tech spec step.
- Field order in the e-service summary was wrong (technology shown before exchange type).
- Several Italian UI strings were inaccurate or inconsistent.

## List of changes

- **EServiceCreateStepTechSpec**: disabled the `getAllKeychainsList` query for `operatorAPI` users via `AuthHooks.useJwt()` switched `isPending` → `isLoading` for correct async state handling
- **ProviderEServiceGeneralInfoSummarySection**: swapped order of `exchangeType` and `apiTechnology` fields to match the expected display order
- **i18n (`eservice.json`)**:
  - Updated `editableInfoAlert` to clarify that a new e-service version is required to edit locked fields after publishing
  - Changed `providerMissingProducerKeychain` copy from "Associa" to "Collega" for consistency
  - Added "asincrono" to `providerMissingProducerKeychainKeys` alert for clarity
  - Renamed CTA `viewProducerKeychains` from "Vedi portachiavi" to "Collega portachiavi"

## How to test

1. Log in as an **operatorAPI** user and open an async e-service in creation/edit mode — verify no unexpected keychain fetch occurs in the Tech Spec step.
2. Open the summary page of an async e-service — verify "Tipo di scambio" appears before "Tecnologia API".
3. On the summary page of an async e-service without a linked keychain, verify the updated alert text and CTA label are displayed correctly.
4. In the Tech Spec step of a published async e-service, verify the updated `editableInfoAlert` message is shown.

---

> Note: there is a leftover `screen.debug()` in `EServiceCreateStepTechSpec.test.tsx:132` — worth removing before merging.


[PIN-10213]: https://pagopa.atlassian.net/browse/PIN-10213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ