### PR TITLE
bugfix: agreement consumer validation (PIN-10234)

### DIFF
--- a/src/components/dialogs/DialogSelectAgreementConsumer/DialogSelectAgreementConsumer.tsx
+++ b/src/components/dialogs/DialogSelectAgreementConsumer/DialogSelectAgreementConsumer.tsx
@@ -158,7 +158,7 @@ export const DialogSelectAgreementConsumer: React.FC<DialogSelectAgreementConsum
     .exhaustive()
 
   const isButtonActionDisable = match(action)
-    .with('create', () => !isLoading && !hasTenantCertifiedAttributes)
+    .with('create', () => isQueryEnabled && !isLoading && !hasTenantCertifiedAttributes)
     .with(P.union('edit', 'inspect'), () => !selectedConsumerId)
     .exhaustive()
 
@@ -188,7 +188,7 @@ export const DialogSelectAgreementConsumer: React.FC<DialogSelectAgreementConsum
                 agreements={agreementsOptions}
                 action={action}
               />
-              {!isLoading && !hasTenantCertifiedAttributes && action === 'create' && (
+              {isQueryEnabled && !isLoading && !hasTenantCertifiedAttributes && (
                 <Alert severity="warning" title={t('certifiedAttributesAlert.title')}>
                   {t('certifiedAttributesAlert.description')}
                 </Alert>

--- a/src/components/dialogs/DialogSelectAgreementConsumer/__tests__/DialogSelectAgreementConsumer.test.tsx
+++ b/src/components/dialogs/DialogSelectAgreementConsumer/__tests__/DialogSelectAgreementConsumer.test.tsx
@@ -1,0 +1,67 @@
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import userEvent from '@testing-library/user-event'
+import { screen, waitFor } from '@testing-library/react'
+import { DialogSelectAgreementConsumer } from '../DialogSelectAgreementConsumer'
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
+import { queryClient } from '@/config/query-client'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+
+const server = setupServer(
+  rest.get(`${BACKEND_FOR_FRONTEND_URL}/delegations`, (_, res, ctx) => {
+    return res(ctx.json({ results: [] }))
+  }),
+  rest.get(`${BACKEND_FOR_FRONTEND_URL}/consumers/delegations/delegators`, (_, res, ctx) => {
+    return res(ctx.json({ results: [{ id: 'delegator-id', name: 'Delegator Name' }] }))
+  }),
+  rest.get(
+    `${BACKEND_FOR_FRONTEND_URL}/tenants/:tenantId/eservices/:eserviceId/descriptors/:descriptorId/certifiedAttributes/validate`,
+    (_, res, ctx) => {
+      return res(ctx.json({ hasCertifiedAttributes: false }))
+    }
+  )
+)
+
+beforeAll(() => server.listen())
+
+afterEach(() => {
+  server.resetHandlers()
+  queryClient.clear()
+  vi.clearAllMocks()
+})
+
+afterAll(() => server.close())
+
+describe('DialogSelectAgreementConsumer', () => {
+  it('shows the required field validation instead of the missing attributes alert when the consumer is cleared', async () => {
+    mockUseJwt()
+    const user = userEvent.setup()
+
+    renderWithApplicationContext(
+      <DialogSelectAgreementConsumer
+        action="create"
+        eservice={{
+          id: 'eservice-id',
+          name: 'E-service name',
+          producerId: 'producer-id',
+        }}
+        descriptor={{
+          id: 'descriptor-id',
+          version: '1',
+        }}
+        agreements={[]}
+        onSubmitCreate={vi.fn()}
+      />,
+      { withReactQueryContext: true, withRouterContext: true }
+    )
+
+    const consumerField = await screen.findByRole('combobox', { name: 'consumerField.label' })
+    await waitFor(() => expect(consumerField).toHaveValue('orgName'))
+
+    await user.click(screen.getByTitle('Clear'))
+    await user.click(screen.getByRole('button', { name: 'actions.create' }))
+
+    expect(await screen.findByText('validation.mixed.required')).toBeInTheDocument()
+    expect(screen.queryByText('certifiedAttributesAlert.description')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/dialogs/DialogSelectAgreementConsumer/__tests__/DialogSelectAgreementConsumer.test.tsx
+++ b/src/components/dialogs/DialogSelectAgreementConsumer/__tests__/DialogSelectAgreementConsumer.test.tsx
@@ -39,6 +39,7 @@ describe('DialogSelectAgreementConsumer', () => {
 
     renderWithApplicationContext(
       <DialogSelectAgreementConsumer
+        type="selectAgreementConsumer"
         action="create"
         eservice={{
           id: 'eservice-id',


### PR DESCRIPTION
## 🔗 Issue

[PIN-10234](https://pagopa.atlassian.net/browse/PIN-10234)

## 📝 Description / Context

Fixes the agreement consumer selection dialog shown when requesting e-service consumption via delegation. When the selected party is cleared, the dialog now shows the required field validation instead of the missing certified attributes warning.

## 🛠 List of changes

- Show the missing certified attributes warning only when a consumer is actually selected.
- Keep the create action submittable when the consumer field is empty so form validation can display the required field error.
- Add a regression test for clearing the consumer autocomplete in the create agreement dialog.

## 🧪 How to test

- Open the e-service catalog and request consumption for an e-service with an active consumer delegation.
- In the “Create draft consumption request” dialog, clear the selected party from the dropdown.
- Click “Create draft” and verify that the required field error is shown, without the certified attributes warning.
- Select a party without the required certified attributes and verify that the warning is still shown.


[PIN-10234]: https://pagopa.atlassian.net/browse/PIN-10234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ