### PR TITLE
fix: validate async exchange limits (PIN-10236)

### DIFF
--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -2177,22 +2177,46 @@ export interface EServiceTemplateDetails {
 }
 
 export interface AsyncExchangeProperties {
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 999999
+   */
   responseTime: number;
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 999999
+   */
   resourceAvailableTime: number;
   confirmation: boolean;
   bulk: boolean;
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 99999
+   */
   maxResultSet: number;
 }
 
 export interface AsyncExchangePropertiesInstanceSeed {
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 999999
+   */
   responseTime?: number;
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 999999
+   */
   resourceAvailableTime?: number;
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 99999
+   */
   maxResultSet?: number;
 }
 
@@ -2287,6 +2311,7 @@ export interface UpdateEServiceTemplateSeed {
   mode: EServiceMode;
   isSignalHubEnabled?: boolean;
   personalData?: boolean;
+  asyncExchange?: boolean;
 }
 
 export interface EServiceTemplateSeed {

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
@@ -22,16 +22,22 @@ const asyncExchangeNumericFields = [
   {
     name: 'asyncExchangeProperties.responseTime',
     translationKey: 'responseTimeField',
+    min: 1,
+    max: 999999,
     sx: { flex: 1, my: 0 },
   },
   {
     name: 'asyncExchangeProperties.maxResultSet',
     translationKey: 'maxResultSetField',
+    min: 1,
+    max: 99999,
     sx: { flex: 1, my: 0 },
   },
   {
     name: 'asyncExchangeProperties.resourceAvailableTime',
     translationKey: 'resourceAvailableTimeField',
+    min: 1,
+    max: 999999,
     sx: { my: 0 },
   },
 ] satisfies Array<{
@@ -40,6 +46,8 @@ const asyncExchangeNumericFields = [
     'responseTime' | 'maxResultSet' | 'resourceAvailableTime'
   >}`
   translationKey: 'responseTimeField' | 'maxResultSetField' | 'resourceAvailableTimeField'
+  min: number
+  max: number
   sx: { flex?: number; my: number }
 }>
 
@@ -139,7 +147,7 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
         {t('configSubsection.title')}
       </Typography>
       <Grid container spacing={2} sx={{ mt: 1 }}>
-        {asyncExchangeNumericFields.map(({ name, translationKey, sx }) => (
+        {asyncExchangeNumericFields.map(({ name, translationKey, min, max, sx }) => (
           <Grid item xs={12} sm={6} key={name}>
             <RHFTextField
               size="small"
@@ -147,11 +155,12 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
               label={t(`${translationKey}.label`)}
               infoLabel={t(`${translationKey}.infoLabel`)}
               type="number"
-              inputProps={{ min: 1 }}
+              inputProps={{ min, max }}
               required
               rules={{
                 required: true,
-                min: 1,
+                min,
+                max,
                 validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
               }}
               sx={sx}

--- a/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceAsyncExchangeSection.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceAsyncExchangeSection.test.tsx
@@ -1,10 +1,13 @@
 import { ReactHookFormWrapper, renderWithApplicationContext } from '@/utils/testing.utils'
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { EServiceAsyncExchangeSection } from '../EServiceAsyncExchangeSection'
+import { EServiceAsyncExchangeSectionBase } from '../EServiceAsyncExchangeSectionBase'
 import {
   createMockEServiceDescriptorProviderAsync,
   mockUseEServiceCreateContext,
 } from '@/../__mocks__/data/eservice.mocks'
+import userEvent from '@testing-library/user-event'
+import { FormProvider, useForm } from 'react-hook-form'
 
 vi.mock('../../components/UploadCallbackInterfaceDoc', () => ({
   UploadCallbackInterfaceDoc: ({ readOnly }: { readOnly?: boolean }) => (
@@ -47,6 +50,33 @@ const renderComponent = (
     </ReactHookFormWrapper>,
     { withReactQueryContext: true, withRouterContext: true }
   )
+}
+
+const AsyncExchangeValidationTestForm = ({ onSubmit }: { onSubmit: () => void }) => {
+  const methods = useForm({ defaultValues: defaultFormValues })
+
+  return (
+    <FormProvider {...methods}>
+      <form noValidate onSubmit={methods.handleSubmit(onSubmit)}>
+        <EServiceAsyncExchangeSectionBase
+          areGeneralInfoEditable={true}
+          areAdvancedOptionsEditable={true}
+          editableCallbackInterfaceContent="UploadCallbackInterfaceDoc"
+          readOnlyCallbackInterfaceContent="UploadCallbackInterfaceDoc-readOnly"
+        />
+        <button type="submit">submit</button>
+      </form>
+    </FormProvider>
+  )
+}
+
+const renderValidationTestForm = (onSubmit = vi.fn()) => {
+  renderWithApplicationContext(<AsyncExchangeValidationTestForm onSubmit={onSubmit} />, {
+    withReactQueryContext: true,
+    withRouterContext: true,
+  })
+
+  return onSubmit
 }
 
 describe('EServiceAsyncExchangeSection', () => {
@@ -128,5 +158,34 @@ describe('EServiceAsyncExchangeSection', () => {
 
     expect(screen.getByText('UploadCallbackInterfaceDoc-readOnly')).toBeInTheDocument()
     expect(screen.queryByText('callbackInterface.readOnlyLabel')).not.toBeInTheDocument()
+  })
+
+  it('should prevent submit when async exchange numeric values exceed their limits', async () => {
+    const onSubmit = renderValidationTestForm()
+
+    await userEvent.clear(screen.getByLabelText(/responseTimeField.label/))
+    await userEvent.type(screen.getByLabelText(/responseTimeField.label/), '1000000')
+    await userEvent.clear(screen.getByLabelText(/resourceAvailableTimeField.label/))
+    await userEvent.type(screen.getByLabelText(/resourceAvailableTimeField.label/), '1000000')
+    await userEvent.clear(screen.getByLabelText(/maxResultSetField.label/))
+    await userEvent.type(screen.getByLabelText(/maxResultSetField.label/), '100000')
+    await userEvent.click(screen.getByText('submit'))
+
+    expect(await screen.findAllByText('validation.number.max')).toHaveLength(3)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('should prevent submit when async exchange numeric values are below their minimum', async () => {
+    const onSubmit = renderValidationTestForm()
+
+    fireEvent.change(screen.getByLabelText(/responseTimeField.label/), { target: { value: '0' } })
+    fireEvent.change(screen.getByLabelText(/resourceAvailableTimeField.label/), {
+      target: { value: '0' },
+    })
+    fireEvent.change(screen.getByLabelText(/maxResultSetField.label/), { target: { value: '0' } })
+    await userEvent.click(screen.getByText('submit'))
+
+    expect(await screen.findAllByText('validation.number.min')).toHaveLength(3)
+    expect(onSubmit).not.toHaveBeenCalled()
   })
 })

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -367,15 +367,15 @@
         },
         "responseTimeField": {
           "label": "Maximum response time (in seconds)",
-          "infoLabel": "Indicates how long your e-service takes to return a response after a call from consumers."
+          "infoLabel": "Indicates how long your e-service takes to return a response after a call from consumers. Accepted values: from 1 to 999,999 seconds."
         },
         "maxResultSetField": {
           "label": "Maximum number of results per response",
-          "infoLabel": "Indicates the maximum number of elements that each response can contain."
+          "infoLabel": "Indicates the maximum number of elements that each response can contain. Accepted values: from 1 to 99,999."
         },
         "resourceAvailableTimeField": {
           "label": "Data availability duration (in seconds)",
-          "infoLabel": "Indicates how long the data is downloadable before being deleted."
+          "infoLabel": "Indicates how long the data is downloadable before being deleted. Accepted values: from 1 to 999,999 seconds."
         },
         "confirmationField": {
           "label": "Require receipt confirmation",

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -367,15 +367,15 @@
         },
         "responseTimeField": {
           "label": "Tempo massimo di risposta (in secondi)",
-          "infoLabel": "Indica in quanto tempo il tuo e-service restituisce una risposta dopo la chiamata dei fruitori."
+          "infoLabel": "Indica in quanto tempo il tuo e-service restituisce una risposta dopo la chiamata dei fruitori. Valori accettati: da 1 a 999.999 secondi."
         },
         "maxResultSetField": {
           "label": "Numero massimo di risultati per risposta",
-          "infoLabel": "Indica quanti elementi può contenere al massimo ogni risposta."
+          "infoLabel": "Indica quanti elementi può contenere al massimo ogni risposta. Valori accettati: da 1 a 99.999."
         },
         "resourceAvailableTimeField": {
           "label": "Durata di disponibilità del dato (in secondi)",
-          "infoLabel": "Indica per quanto tempo il dato è scaricabile prima di essere cancellato."
+          "infoLabel": "Indica per quanto tempo il dato è scaricabile prima di essere cancellato. Valori accettati: da 1 a 999.999 secondi."
         },
         "confirmationField": {
           "label": "Richiedi conferma di ricezione",


### PR DESCRIPTION
## 🔗 Issue

[PIN-10236](https://pagopa.atlassian.net/browse/PIN-10236)

## 📝 Description / Context

Adds frontend validation for asynchronous and bulk exchange numeric limits in the e-service technical specifications step, aligned with the regenerated API constraints.

## 🛠 List of changes

- Added explicit min/max validation for `responseTime`, `resourceAvailableTime`, and `maxResultSet`.
- Updated helper text in Italian and English to show the accepted ranges.
- Added tests to prevent submit when values are below minimum or above maximum.
- Included regenerated API type constraints for async exchange properties.

## 🧪 How to test

- Open the e-service creation/edit flow for an asynchronous e-service and go to the “Technical specifications” step.
- In “Asynchronous and bulk exchanges”, enter values below `1` or above the allowed maximums and verify that validation errors block submit.
- Verify accepted ranges: `responseTime` and `resourceAvailableTime` from `1` to `999999`; `maxResultSet` from `1` to `99999`.

[PIN-10236]: https://pagopa.atlassian.net/browse/PIN-10236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ