### PR TITLE
fix: update async exchange alert copy (PIN-10239)

### DIFF
--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -353,7 +353,7 @@
       "asyncExchangeSection": {
         "title": "Asynchronous and bulk exchanges",
         "description": "Asynchronous and bulk exchanges require a callback interface that consumers will have to implement to receive your responses. Upload the OpenAPI file with the API description. <1>Learn more about asynchronous and bulk exchanges</1>.",
-        "editableInfoAlert": "These fields will no longer be editable after the publication of the first version of the e-service.",
+        "editableInfoAlert": "After publication, these fields will no longer be editable. To modify them, you will need to create a new version of the e-service.",
         "callbackInterface": {
           "readOnlyLabel": "Callback interface",
           "prettyName": "Callback interface",

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -353,7 +353,7 @@
       "asyncExchangeSection": {
         "title": "Scambi asincroni e massivi",
         "description": "Gli scambi asincroni e massivi richiedono un’interfaccia di callback che i fruitori dovranno implementare per ricevere le tue risposte. Carica il file OpenAPI con la descrizione dell’API. <1>Scopri di più sugli scambi asincroni e massivi</1>.",
-        "editableInfoAlert": "Questi campi non saranno più modificabili dopo la pubblicazione della prima versione dell’e-service.",
+        "editableInfoAlert": "Dopo la pubblicazione, questi campi non saranno più modificabili. Per modificarli, dovrai creare una nuova versione dell’e-service.",
         "callbackInterface": {
           "readOnlyLabel": "Interfaccia di callback",
           "prettyName": "Interfaccia callback",


### PR DESCRIPTION
## 🔗 Issue

[PIN-10239](https://pagopa.atlassian.net/browse/PIN-10239)

## 📝 Description / Context

Updates the warning message shown in the “Asynchronous and bulk exchanges” section to match the Figma copy.

## 🛠 List of changes

- Updated the Italian async exchange editable-fields alert copy.
- Updated the corresponding English translation.

## 🧪 How to test

- Open the e-service template creation/edit flow and go to the technical specifications step for an asynchronous template.
- Verify that the “Asynchronous and bulk exchanges” warning says that fields cannot be edited after publication and that a new e-service version is required to modify them.

[PIN-10239]: https://pagopa.atlassian.net/browse/PIN-10239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ