### PR TITLE
Feature: (PIN-10172) purpose creation assing section summary

### DIFF
--- a/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../components/shared/SummaryAccordion'
 import { PageContainer } from '@/components/layout/containers'
 import {
+  ConsumerPurposeSummaryAssignmentAccordion,
   ConsumerPurposeSummaryGeneralInformationAccordion,
   ConsumerPurposeSummaryRiskAnalysisAccordion,
 } from './components'
@@ -136,7 +137,12 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
           </SummaryAccordion>
         </React.Suspense>
         <React.Suspense fallback={<SummaryAccordionSkeleton />}>
-          <SummaryAccordion headline="2" title={t('summary.riskAnalysisSection.title')}>
+          <SummaryAccordion headline="2" title={t('summary.assignmentSection.title')}>
+            <ConsumerPurposeSummaryAssignmentAccordion purposeId={purposeId} />
+          </SummaryAccordion>
+        </React.Suspense>
+        <React.Suspense fallback={<SummaryAccordionSkeleton />}>
+          <SummaryAccordion headline="3" title={t('summary.riskAnalysisSection.title')}>
             <ConsumerPurposeSummaryRiskAnalysisAccordion purposeId={purposeId} />
           </SummaryAccordion>
         </React.Suspense>

--- a/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../components', () => ({
   ConsumerPurposeSummaryGeneralInformationAccordion: () => (
     <div data-testid="general-info-accordion" />
   ),
+  ConsumerPurposeSummaryAssignmentAccordion: () => <div data-testid="assignment-accordion" />,
   ConsumerPurposeSummaryRiskAnalysisAccordion: () => <div data-testid="risk-analysis-accordion" />,
 }))
 

--- a/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
@@ -25,6 +25,8 @@ export const ConsumerPurposeSummaryAssignmentAccordion: React.FC<
     .exhaustive()
 
   // BE does not yet expose the reviewer's first/last name: we render the raw UUID as a placeholder.
+  // We surface only the first reviewer: the BE models `reviewerIds` as a list to allow multiple
+  // reviewers in the future, but today at most one reviewer is ever assigned.
   // BE invariant: when `reviewerWorkflow` is defined, `reviewerIds` is non-empty.
   const reviewerId = purpose.reviewerWorkflow?.reviewerIds[0]
 

--- a/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
@@ -24,7 +24,8 @@ export const ConsumerPurposeSummaryAssignmentAccordion: React.FC<
     .with('REVIEWER_WRITES_REVIEWER_SIGNS', () => t('mode.reviewerWritesReviewerSigns'))
     .exhaustive()
 
-  // BE non espone ancora nome+cognome del Valutatore: mostriamo l'UUID raw come placeholder.
+  // BE does not yet expose the reviewer's first/last name: we render the raw UUID as a placeholder.
+  // BE invariant: when `reviewerWorkflow` is defined, `reviewerIds` is non-empty.
   const reviewerId = purpose.reviewerWorkflow?.reviewerIds[0]
 
   return (

--- a/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
@@ -1,0 +1,38 @@
+import { Stack } from '@mui/material'
+import { InformationContainer } from '@pagopa/interop-fe-commons'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { match } from 'ts-pattern'
+import { PurposeQueries } from '@/api/purpose'
+
+type ConsumerPurposeSummaryAssignmentAccordionProps = {
+  purposeId: string
+}
+
+export const ConsumerPurposeSummaryAssignmentAccordion: React.FC<
+  ConsumerPurposeSummaryAssignmentAccordionProps
+> = ({ purposeId }) => {
+  const { data: purpose } = useSuspenseQuery(PurposeQueries.getSingle(purposeId))
+  const { t } = useTranslation('purpose', { keyPrefix: 'summary.assignmentSection' })
+
+  const reviewMode = purpose.reviewerWorkflow?.reviewMode
+
+  const modeLabel = match(reviewMode)
+    .with(undefined, () => t('mode.autonomy'))
+    .with('ADMIN_WRITES_REVIEWER_SIGNS', () => t('mode.adminWritesReviewerSigns'))
+    .with('REVIEWER_WRITES_REVIEWER_SIGNS', () => t('mode.reviewerWritesReviewerSigns'))
+    .exhaustive()
+
+  // BE non espone ancora nome+cognome del Valutatore: mostriamo l'UUID raw come placeholder.
+  const reviewerId = purpose.reviewerWorkflow?.reviewerIds[0]
+
+  return (
+    <Stack spacing={2}>
+      <InformationContainer content={modeLabel} direction="row" label={t('mode.label')} />
+      {reviewerId && (
+        <InformationContainer content={reviewerId} direction="row" label={t('reviewer.label')} />
+      )}
+    </Stack>
+  )
+}

--- a/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryAssignmentAccordion.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryAssignmentAccordion.test.tsx
@@ -36,7 +36,7 @@ describe('ConsumerPurposeSummaryAssignmentAccordion', () => {
     vi.clearAllMocks()
   })
 
-  it('option 1 (autonomy): reviewerWorkflow undefined → renders only "Modalità" row with autonomy copy', () => {
+  it('option 1 (autonomy) and fallback (reviewerWorkflow undefined): renders only "Modalità" row with autonomy copy', () => {
     setPurpose(undefined)
 
     renderWithApplicationContext(
@@ -83,18 +83,5 @@ describe('ConsumerPurposeSummaryAssignmentAccordion', () => {
     expect(screen.getByText('mode.reviewerWritesReviewerSigns')).toBeInTheDocument()
     expect(screen.getByText('reviewer.label')).toBeInTheDocument()
     expect(screen.getByText(REVIEWER_ID)).toBeInTheDocument()
-  })
-
-  it('fallback: reviewerWorkflow missing on payload → same as option 1', () => {
-    setPurpose(undefined)
-
-    renderWithApplicationContext(
-      <ConsumerPurposeSummaryAssignmentAccordion purposeId="test-id" />,
-      { withReactQueryContext: true }
-    )
-
-    expect(screen.getByText('mode.label')).toBeInTheDocument()
-    expect(screen.getByText('mode.autonomy')).toBeInTheDocument()
-    expect(screen.queryByText('reviewer.label')).not.toBeInTheDocument()
   })
 })

--- a/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryAssignmentAccordion.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryAssignmentAccordion.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { ConsumerPurposeSummaryAssignmentAccordion } from '../ConsumerPurposeSummaryAssignmentAccordion'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
+import type { Purpose, ReviewerWorkflow } from '@/api/api.generatedTypes'
+
+const useSuspenseQueryMock = vi.fn()
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useSuspenseQuery: () => useSuspenseQueryMock(),
+  }
+})
+
+vi.mock('@/api/purpose', () => ({
+  PurposeQueries: {
+    getSingle: (id: string) => ['purpose', id],
+  },
+}))
+
+const REVIEWER_ID = '11111111-2222-3333-4444-555555555555'
+
+const setPurpose = (reviewerWorkflow: ReviewerWorkflow | undefined) => {
+  const purpose: Purpose = {
+    ...createMockPurpose(),
+    reviewerWorkflow,
+  }
+  useSuspenseQueryMock.mockReturnValue({ data: purpose })
+}
+
+describe('ConsumerPurposeSummaryAssignmentAccordion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('option 1 (autonomy): reviewerWorkflow undefined → renders only "Modalità" row with autonomy copy', () => {
+    setPurpose(undefined)
+
+    renderWithApplicationContext(
+      <ConsumerPurposeSummaryAssignmentAccordion purposeId="test-id" />,
+      { withReactQueryContext: true }
+    )
+
+    expect(screen.getByText('mode.label')).toBeInTheDocument()
+    expect(screen.getByText('mode.autonomy')).toBeInTheDocument()
+    expect(screen.queryByText('reviewer.label')).not.toBeInTheDocument()
+  })
+
+  it('option 2 (ADMIN_WRITES_REVIEWER_SIGNS): renders "Modalità" + "Valutatore" rows', () => {
+    setPurpose({
+      reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+      reviewerIds: [REVIEWER_ID],
+      signingState: 'ASSIGNED',
+    })
+
+    renderWithApplicationContext(
+      <ConsumerPurposeSummaryAssignmentAccordion purposeId="test-id" />,
+      { withReactQueryContext: true }
+    )
+
+    expect(screen.getByText('mode.label')).toBeInTheDocument()
+    expect(screen.getByText('mode.adminWritesReviewerSigns')).toBeInTheDocument()
+    expect(screen.getByText('reviewer.label')).toBeInTheDocument()
+    expect(screen.getByText(REVIEWER_ID)).toBeInTheDocument()
+  })
+
+  it('option 3 (REVIEWER_WRITES_REVIEWER_SIGNS): renders "Modalità" + "Valutatore" rows', () => {
+    setPurpose({
+      reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
+      reviewerIds: [REVIEWER_ID],
+      signingState: 'ASSIGNED',
+    })
+
+    renderWithApplicationContext(
+      <ConsumerPurposeSummaryAssignmentAccordion purposeId="test-id" />,
+      { withReactQueryContext: true }
+    )
+
+    expect(screen.getByText('mode.label')).toBeInTheDocument()
+    expect(screen.getByText('mode.reviewerWritesReviewerSigns')).toBeInTheDocument()
+    expect(screen.getByText('reviewer.label')).toBeInTheDocument()
+    expect(screen.getByText(REVIEWER_ID)).toBeInTheDocument()
+  })
+
+  it('fallback: reviewerWorkflow missing on payload → same as option 1', () => {
+    setPurpose(undefined)
+
+    renderWithApplicationContext(
+      <ConsumerPurposeSummaryAssignmentAccordion purposeId="test-id" />,
+      { withReactQueryContext: true }
+    )
+
+    expect(screen.getByText('mode.label')).toBeInTheDocument()
+    expect(screen.getByText('mode.autonomy')).toBeInTheDocument()
+    expect(screen.queryByText('reviewer.label')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/ConsumerPurposeSummaryPage/components/index.ts
+++ b/src/pages/ConsumerPurposeSummaryPage/components/index.ts
@@ -1,2 +1,3 @@
+export * from './ConsumerPurposeSummaryAssignmentAccordion'
 export * from './ConsumerPurposeSummaryGeneralInformationAccordion'
 export * from './ConsumerPurposeSummaryRiskAnalysisAccordion'

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -233,6 +233,18 @@
         }
       }
     },
+    "assignmentSection": {
+      "title": "Assignment",
+      "mode": {
+        "label": "Mode",
+        "autonomy": "Self-compilation and self-approval",
+        "adminWritesReviewerSigns": "Self-compilation and reviewer approval",
+        "reviewerWritesReviewerSigns": "Reviewer compilation and approval"
+      },
+      "reviewer": {
+        "label": "Reviewer"
+      }
+    },
     "riskAnalysisSection": {
       "title": "Risk analysis",
       "providerRiskAnalysisAlert": "The e-service selected for this purpose requires data to be sent from the consumer to the producer. The risk analysis was therefore compiled by the producer."

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -237,9 +237,9 @@
       "title": "Assignment",
       "mode": {
         "label": "Mode",
-        "autonomy": "Self-compilation and self-approval",
-        "adminWritesReviewerSigns": "Self-compilation and reviewer approval",
-        "reviewerWritesReviewerSigns": "Reviewer compilation and approval"
+        "autonomy": "Completed and approved autonomously",
+        "adminWritesReviewerSigns": "Completed autonomously, approved by the reviewer",
+        "reviewerWritesReviewerSigns": "Completed and approved by the reviewer"
       },
       "reviewer": {
         "label": "Reviewer"

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -233,6 +233,18 @@
         }
       }
     },
+    "assignmentSection": {
+      "title": "Assegnazione",
+      "mode": {
+        "label": "Modalità",
+        "autonomy": "Compilazione e approvazione in autonomia",
+        "adminWritesReviewerSigns": "Compilazione in autonomia e approvazione del valutatore",
+        "reviewerWritesReviewerSigns": "Compilazione e approvazione del valutatore"
+      },
+      "reviewer": {
+        "label": "Valutatore"
+      }
+    },
     "riskAnalysisSection": {
       "title": "Analisi del rischio",
       "providerRiskAnalysisAlert": "L’e-service scelto per questa finalità prevede che i dati vengano inviati dal fruitore all’erogatore. L’analisi del rischio è statata quindi compilata dall’erogatore."


### PR DESCRIPTION
## 🔗 Issue
[PIN-10172]

## 📝 Description / Context
Adds a new read-only "Assignment" accordion to the Consumer Purpose Summary page, between "General information" and "Risk analysis". The accordion shows the persisted Risk Analysis assignment mode and, when applicable, the assigned Reviewer.

Mapping of the 3 modes from the Jira task onto the existing `Purpose.reviewerWorkflow` model:
- Option 1 — *Self-completion and self-approval* → `reviewerWorkflow === undefined`
- Option 2 — *Self-completion, reviewer approval* → `reviewMode === "ADMIN_WRITES_REVIEWER_SIGNS"`
- Option 3 — *Reviewer completion and approval* → `reviewMode === "REVIEWER_WRITES_REVIEWER_SIGNS"`

When `reviewerWorkflow` is `undefined` we fall back to Option 1 (consistent with the Jira acceptance criteria).

## 🛠 List of changes
- New component `ConsumerPurposeSummaryAssignmentAccordion` rendered as accordion `2` in `ConsumerPurposeSummaryPage`; existing Risk Analysis accordion renumbered to `3`.
- Discriminant on `reviewMode` handled via `ts-pattern` with `.exhaustive()` (covers `undefined` + the two `RiskAnalysisReviewMode` values).
- New i18n keys under `purpose.summary.assignmentSection.*` in both `it` and `en` locales.
- Unit tests for the new component covering: Option 1 + fallback (single test), Option 2, Option 3.
- Existing `ConsumerPurposeSummary.page.test.tsx` mock of `../components` extended with the new accordion (no other page tests affected: nothing asserts on accordion numbering or order).

## 🧪 How to test
- Open a Consumer Purpose summary page (`SUBSCRIBE_PURPOSE_SUMMARY`) on a draft Purpose.
- Verify a new accordion titled **"Assegnazione"** appears in position `2`, between "Informazioni generali" (`1`) and "Analisi del rischio" (`3`).
- Expand the new accordion: a **"Modalità"** row is always rendered with copy matching the persisted `reviewMode` (or the autonomy copy when missing).
- For `reviewMode === "ADMIN_WRITES_REVIEWER_SIGNS"` and `reviewMode === "REVIEWER_WRITES_REVIEWER_SIGNS"`, also check a **"Valutatore"** row is rendered (placeholder shows the reviewer UUID — see Limitations below).
- Verify the accordion is read-only (no edit action) and visible regardless of role.
- Run the new unit tests: `pnpm test ConsumerPurposeSummaryAssignmentAccordion`.

[PIN-10172]: https://pagopa.atlassian.net/browse/PIN-10172
<img width="1018" height="883" alt="Screenshot 2026-06-04 alle 12 16 26" src="https://github.com/user-attachments/assets/2dc01409-c6b8-4d26-847e-1e34208a5839" />
