### PR TITLE
fix: update template async exchange copy (PIN-10245)

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
@@ -16,6 +16,10 @@ type EServiceAsyncExchangeSectionBaseProps = {
   readOnlyCallbackInterfaceContent: string | React.ReactElement
   isSoap?: boolean
   forceBulkFalse?: boolean
+  translationNamespace?: 'eservice' | 'eserviceTemplate'
+  translationKeyPrefix?:
+    | 'create.step4.asyncExchangeSection'
+    | 'create.step3.technicalSpecs.asyncExchangeSection'
 }
 
 const asyncExchangeNumericFields = [
@@ -59,11 +63,19 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
   readOnlyCallbackInterfaceContent,
   isSoap = false,
   forceBulkFalse = false,
+  translationNamespace = 'eservice',
+  translationKeyPrefix = 'create.step4.asyncExchangeSection',
 }) => {
-  const { t } = useTranslation('eservice', {
-    keyPrefix: 'create.step4.asyncExchangeSection',
-  })
+  const shouldUseDefaultTranslationPrefix =
+    translationNamespace === 'eservice' &&
+    translationKeyPrefix === 'create.step4.asyncExchangeSection'
+  const { t } = useTranslation(
+    translationNamespace,
+    shouldUseDefaultTranslationPrefix ? { keyPrefix: translationKeyPrefix } : undefined
+  )
   const { setValue } = useFormContext()
+  const tAsyncExchange = (key: string) =>
+    shouldUseDefaultTranslationPrefix ? t(key) : t(`${translationKeyPrefix}.${key}`)
 
   React.useEffect(() => {
     if (isSoap && forceBulkFalse) {
@@ -84,49 +96,49 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
         ),
       }}
     >
-      {t('description')}
+      {tAsyncExchange('description')}
     </Trans>
   )
 
   if (!areGeneralInfoEditable) {
     return (
-      <SectionContainer title={t('title')} description={description} sx={{ mt: 3 }}>
+      <SectionContainer title={tAsyncExchange('title')} description={description} sx={{ mt: 3 }}>
         <Stack spacing={2} sx={{ mt: 2 }}>
           <InformationContainer
-            label={t('callbackInterface.readOnlyLabel')}
+            label={tAsyncExchange('callbackInterface.readOnlyLabel')}
             content={readOnlyCallbackInterfaceContent}
           />
           <Typography variant="subtitle1" sx={{ mt: 2 }}>
-            {t('configSubsection.title')}
+            {tAsyncExchange('configSubsection.title')}
           </Typography>
           <InformationContainer
-            label={t('responseTimeField.label')}
+            label={tAsyncExchange('responseTimeField.label')}
             content={asyncExchangeProperties?.responseTime?.toString() ?? '-'}
           />
           <InformationContainer
-            label={t('maxResultSetField.label')}
+            label={tAsyncExchange('maxResultSetField.label')}
             content={asyncExchangeProperties?.maxResultSet?.toString() ?? '-'}
           />
           <InformationContainer
-            label={t('resourceAvailableTimeField.label')}
+            label={tAsyncExchange('resourceAvailableTimeField.label')}
             content={asyncExchangeProperties?.resourceAvailableTime?.toString() ?? '-'}
           />
           <Typography variant="subtitle1" sx={{ mt: 2 }}>
-            {t('advancedSubsection.title')}
+            {tAsyncExchange('advancedSubsection.title')}
           </Typography>
           <InformationContainer
-            label={t('confirmationField.label')}
+            label={tAsyncExchange('confirmationField.label')}
             content={
               asyncExchangeProperties
-                ? t(`readOnlyOptions.${Boolean(asyncExchangeProperties.confirmation)}`)
+                ? tAsyncExchange(`readOnlyOptions.${Boolean(asyncExchangeProperties.confirmation)}`)
                 : '-'
             }
           />
           <InformationContainer
-            label={t('bulkField.label')}
+            label={tAsyncExchange('bulkField.label')}
             content={
               asyncExchangeProperties
-                ? t(`readOnlyOptions.${Boolean(asyncExchangeProperties.bulk)}`)
+                ? tAsyncExchange(`readOnlyOptions.${Boolean(asyncExchangeProperties.bulk)}`)
                 : '-'
             }
           />
@@ -136,15 +148,15 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
   }
 
   return (
-    <SectionContainer title={t('title')} description={description} sx={{ mt: 3 }}>
+    <SectionContainer title={tAsyncExchange('title')} description={description} sx={{ mt: 3 }}>
       <Alert severity="warning" sx={{ mt: 2 }}>
-        {t('editableInfoAlert')}
+        {tAsyncExchange('editableInfoAlert')}
       </Alert>
 
       <Box sx={{ mt: 2 }}>{editableCallbackInterfaceContent}</Box>
 
       <Typography variant="subtitle1" sx={{ mt: 3 }}>
-        {t('configSubsection.title')}
+        {tAsyncExchange('configSubsection.title')}
       </Typography>
       <Grid container spacing={2} sx={{ mt: 1 }}>
         {asyncExchangeNumericFields.map(({ name, translationKey, min, max, sx }) => (
@@ -152,8 +164,8 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
             <RHFTextField
               size="small"
               name={name}
-              label={t(`${translationKey}.label`)}
-              infoLabel={t(`${translationKey}.infoLabel`)}
+              label={tAsyncExchange(`${translationKey}.label`)}
+              infoLabel={tAsyncExchange(`${translationKey}.infoLabel`)}
               type="number"
               inputProps={{ min, max }}
               required
@@ -161,7 +173,8 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
                 required: true,
                 min,
                 max,
-                validate: (value) => Number.isInteger(Number(value)) || t('validation.integer'),
+                validate: (value) =>
+                  Number.isInteger(Number(value)) || tAsyncExchange('validation.integer'),
               }}
               sx={sx}
             />
@@ -169,20 +182,20 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
         ))}
       </Grid>
       <Typography variant="subtitle1" sx={{ mt: 3 }}>
-        {t('advancedSubsection.title')}
+        {tAsyncExchange('advancedSubsection.title')}
       </Typography>
       {areAdvancedOptionsEditable ? (
         <Stack spacing={0} sx={{ mt: 1 }}>
           <RHFCheckbox
             name="asyncExchangeProperties.confirmation"
-            label={t('confirmationField.label')}
-            infoLabel={t('confirmationField.infoLabel')}
+            label={tAsyncExchange('confirmationField.label')}
+            infoLabel={tAsyncExchange('confirmationField.infoLabel')}
             sx={{ my: 0 }}
           />
           <RHFCheckbox
             name="asyncExchangeProperties.bulk"
-            label={t('bulkField.label')}
-            infoLabel={t('bulkField.infoLabel')}
+            label={tAsyncExchange('bulkField.label')}
+            infoLabel={tAsyncExchange('bulkField.infoLabel')}
             disabled={isSoap}
             sx={{ mb: 0 }}
           />
@@ -190,18 +203,18 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
       ) : (
         <Stack spacing={2} sx={{ mt: 2 }}>
           <InformationContainer
-            label={t('confirmationField.label')}
+            label={tAsyncExchange('confirmationField.label')}
             content={
               asyncExchangeProperties
-                ? t(`readOnlyOptions.${Boolean(asyncExchangeProperties.confirmation)}`)
+                ? tAsyncExchange(`readOnlyOptions.${Boolean(asyncExchangeProperties.confirmation)}`)
                 : '-'
             }
           />
           <InformationContainer
-            label={t('bulkField.label')}
+            label={tAsyncExchange('bulkField.label')}
             content={
               asyncExchangeProperties
-                ? t(`readOnlyOptions.${Boolean(asyncExchangeProperties.bulk)}`)
+                ? tAsyncExchange(`readOnlyOptions.${Boolean(asyncExchangeProperties.bulk)}`)
                 : '-'
             }
           />

--- a/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceAsyncExchangeSection.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceAsyncExchangeSection.test.tsx
@@ -70,6 +70,23 @@ const AsyncExchangeValidationTestForm = ({ onSubmit }: { onSubmit: () => void })
   )
 }
 
+const AsyncExchangeTemplateTranslationTestForm = () => {
+  const methods = useForm({ defaultValues: defaultFormValues })
+
+  return (
+    <FormProvider {...methods}>
+      <EServiceAsyncExchangeSectionBase
+        areGeneralInfoEditable={true}
+        areAdvancedOptionsEditable={true}
+        editableCallbackInterfaceContent="UploadCallbackInterfaceDoc"
+        readOnlyCallbackInterfaceContent="UploadCallbackInterfaceDoc-readOnly"
+        translationKeyPrefix="create.step3.technicalSpecs.asyncExchangeSection"
+        translationNamespace="eserviceTemplate"
+      />
+    </FormProvider>
+  )
+}
+
 const renderValidationTestForm = (onSubmit = vi.fn()) => {
   renderWithApplicationContext(<AsyncExchangeValidationTestForm onSubmit={onSubmit} />, {
     withReactQueryContext: true,
@@ -77,6 +94,13 @@ const renderValidationTestForm = (onSubmit = vi.fn()) => {
   })
 
   return onSubmit
+}
+
+const renderTemplateTranslationTestForm = () => {
+  renderWithApplicationContext(<AsyncExchangeTemplateTranslationTestForm />, {
+    withReactQueryContext: true,
+    withRouterContext: true,
+  })
 }
 
 describe('EServiceAsyncExchangeSection', () => {
@@ -151,6 +175,26 @@ describe('EServiceAsyncExchangeSection', () => {
     expect(screen.getByText('UploadCallbackInterfaceDoc-readOnly')).toBeInTheDocument()
     expect(screen.queryByLabelText(/responseTimeField.label/)).not.toBeInTheDocument()
     expect(screen.getByText('callbackInterface.readOnlyLabel')).toBeInTheDocument()
+  })
+
+  it('should support template-specific translation keys', () => {
+    renderTemplateTranslationTestForm()
+
+    expect(
+      screen.getByLabelText(
+        /create\.step3\.technicalSpecs\.asyncExchangeSection\.responseTimeField\.label/
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(
+        /create\.step3\.technicalSpecs\.asyncExchangeSection\.maxResultSetField\.label/
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(
+        /create\.step3\.technicalSpecs\.asyncExchangeSection\.resourceAvailableTimeField\.label/
+      )
+    ).toBeInTheDocument()
   })
 
   it('should render the callback interface without an extra label for e-services created from template', () => {

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateAsyncExchangeSection.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateAsyncExchangeSection.tsx
@@ -15,6 +15,8 @@ export const EServiceTemplateAsyncExchangeSection: React.FC = () => {
       readOnlyCallbackInterfaceContent={<UploadTemplateCallbackInterfaceDoc />}
       isSoap={isSoap}
       forceBulkFalse
+      translationNamespace="eserviceTemplate"
+      translationKeyPrefix="create.step3.technicalSpecs.asyncExchangeSection"
     />
   )
 }

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/UploadTemplateCallbackInterfaceDoc.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/UploadTemplateCallbackInterfaceDoc.tsx
@@ -14,7 +14,9 @@ type UploadTemplateCallbackInterfaceDocFormValues = {
 }
 
 export const UploadTemplateCallbackInterfaceDoc: React.FC = () => {
-  const { t } = useTranslation('eservice', { keyPrefix: 'create.step4.asyncExchangeSection' })
+  const { t } = useTranslation('eserviceTemplate', {
+    keyPrefix: 'create.step3.technicalSpecs.asyncExchangeSection',
+  })
   const { eserviceTemplateVersion } = useEServiceTemplateCreateContext()
 
   const downloadDocument = EServiceTemplateDownloads.useDownloadVersionDocument()

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/EServiceTemplateCreateStepTechnicalSpecs.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/EServiceTemplateCreateStepTechnicalSpecs.test.tsx
@@ -146,16 +146,46 @@ describe('EServiceTemplateCreateStepTechnicalSpecs', () => {
       withReactQueryContext: true,
     })
 
-    expect(screen.getByText('title')).toBeInTheDocument()
-    expect(screen.getByText('editableInfoAlert')).toBeInTheDocument()
-    expect(screen.queryByText('callbackInterface.readOnlyLabel')).not.toBeInTheDocument()
+    expect(
+      screen.getByText('create.step3.technicalSpecs.asyncExchangeSection.title')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('create.step3.technicalSpecs.asyncExchangeSection.editableInfoAlert')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'create.step3.technicalSpecs.asyncExchangeSection.callbackInterface.readOnlyLabel'
+      )
+    ).not.toBeInTheDocument()
     expect(screen.getByDisplayValue('Specifica callback')).toBeInTheDocument()
-    expect(screen.getByText('configSubsection.title')).toBeInTheDocument()
-    expect(screen.getByLabelText(/responseTimeField.label/)).toHaveValue(1000)
-    expect(screen.getByLabelText(/resourceAvailableTimeField.label/)).toHaveValue(2000)
-    expect(screen.getByLabelText(/maxResultSetField.label/)).toHaveValue(100)
-    expect(screen.getByRole('checkbox', { name: /confirmationField.label/ })).toBeChecked()
-    expect(screen.getByRole('checkbox', { name: /bulkField.label/ })).toBeChecked()
+    expect(
+      screen.getByText('create.step3.technicalSpecs.asyncExchangeSection.configSubsection.title')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(
+        /create\.step3\.technicalSpecs\.asyncExchangeSection\.responseTimeField\.label/
+      )
+    ).toHaveValue(1000)
+    expect(
+      screen.getByLabelText(
+        /create\.step3\.technicalSpecs\.asyncExchangeSection\.resourceAvailableTimeField\.label/
+      )
+    ).toHaveValue(2000)
+    expect(
+      screen.getByLabelText(
+        /create\.step3\.technicalSpecs\.asyncExchangeSection\.maxResultSetField\.label/
+      )
+    ).toHaveValue(100)
+    expect(
+      screen.getByRole('checkbox', {
+        name: /create\.step3\.technicalSpecs\.asyncExchangeSection\.confirmationField\.label/,
+      })
+    ).toBeChecked()
+    expect(
+      screen.getByRole('checkbox', {
+        name: /create\.step3\.technicalSpecs\.asyncExchangeSection\.bulkField\.label/,
+      })
+    ).toBeChecked()
   })
 
   it('does not render the async exchange section when the template is synchronous', () => {
@@ -164,8 +194,14 @@ describe('EServiceTemplateCreateStepTechnicalSpecs', () => {
       withReactQueryContext: true,
     })
 
-    expect(screen.queryByText('title')).not.toBeInTheDocument()
-    expect(screen.queryByLabelText(/responseTimeField.label/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('create.step3.technicalSpecs.asyncExchangeSection.title')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(
+        /create\.step3\.technicalSpecs\.asyncExchangeSection\.responseTimeField\.label/
+      )
+    ).not.toBeInTheDocument()
   })
 
   it('includes default asyncExchangeProperties in payload when async template properties are missing', async () => {

--- a/src/static/locales/en/eserviceTemplate.json
+++ b/src/static/locales/en/eserviceTemplate.json
@@ -355,6 +355,49 @@
             "infoLabel": "Maximum value: 1440 minutes (24 hours)"
           }
         },
+        "asyncExchangeSection": {
+          "title": "Asynchronous and bulk exchanges",
+          "description": "Asynchronous and bulk exchanges require a callback interface that consumers will have to implement to receive your responses. Upload the OpenAPI file with the API description. <1>Learn more about asynchronous and bulk exchanges</1>.",
+          "editableInfoAlert": "After publication, these fields will no longer be editable. To modify them, you will need to create a new version of the e-service template.",
+          "callbackInterface": {
+            "readOnlyLabel": "Callback interface",
+            "prettyName": "Callback interface",
+            "dropzoneLabel": "Drag the callback interface here or click here to select it from your computer"
+          },
+          "configSubsection": {
+            "title": "Exchange configuration"
+          },
+          "advancedSubsection": {
+            "title": "Advanced options"
+          },
+          "responseTimeField": {
+            "label": "Suggested maximum response time (in seconds)",
+            "infoLabel": "Suggest how long the e-service instances take to return a response after a call from consumers. Accepted values: from 1 to 999,999 seconds."
+          },
+          "maxResultSetField": {
+            "label": "Suggested maximum number of results per response",
+            "infoLabel": "Suggest the maximum number of elements that each response can contain. Accepted values: from 1 to 99,999."
+          },
+          "resourceAvailableTimeField": {
+            "label": "Suggested data availability duration (in seconds)",
+            "infoLabel": "Suggest how long the data is downloadable before being deleted. Accepted values: from 1 to 999,999 seconds."
+          },
+          "confirmationField": {
+            "label": "Require receipt confirmation",
+            "infoLabel": "The consumer will have to send a notification after downloading the file."
+          },
+          "bulkField": {
+            "label": "Allow chunked download",
+            "infoLabel": "The consumer can download large files in separate parts."
+          },
+          "readOnlyOptions": {
+            "true": "Yes",
+            "false": "No"
+          },
+          "validation": {
+            "integer": "The value must be an integer"
+          }
+        },
         "nameField": {
           "label": "Document name",
           "infoLabel": "Min 5 characters, max 60 characters"

--- a/src/static/locales/it/eserviceTemplate.json
+++ b/src/static/locales/it/eserviceTemplate.json
@@ -355,6 +355,49 @@
             "infoLabel": "Valore massimo: 1440 minuti (24 ore)"
           }
         },
+        "asyncExchangeSection": {
+          "title": "Scambi asincroni e massivi",
+          "description": "Gli scambi asincroni e massivi richiedono un’interfaccia di callback che i fruitori dovranno implementare per ricevere le tue risposte. Carica il file OpenAPI con la descrizione dell’API. <1>Scopri di più sugli scambi asincroni e massivi</1>.",
+          "editableInfoAlert": "Dopo la pubblicazione, questi campi non saranno più modificabili. Per modificarli, dovrai creare una nuova versione del template di e-service.",
+          "callbackInterface": {
+            "readOnlyLabel": "Interfaccia di callback",
+            "prettyName": "Interfaccia callback",
+            "dropzoneLabel": "Trascina qui l’interfaccia di callback oppure clicca qui per selezionarla dal computer"
+          },
+          "configSubsection": {
+            "title": "Configurazione dello scambio"
+          },
+          "advancedSubsection": {
+            "title": "Opzioni avanzate"
+          },
+          "responseTimeField": {
+            "label": "Tempo massimo di risposta suggerito (in secondi)",
+            "infoLabel": "Suggerisci in quanto tempo le istanze di e-service restituiscono una risposta dopo la chiamata dei fruitori. Valori accettati: da 1 a 999.999 secondi."
+          },
+          "maxResultSetField": {
+            "label": "Numero massimo di risultati suggerito per risposta",
+            "infoLabel": "Suggerisci quanti elementi può contenere al massimo ogni risposta. Valori accettati: da 1 a 99.999."
+          },
+          "resourceAvailableTimeField": {
+            "label": "Durata suggerita di disponibilità del dato (in secondi)",
+            "infoLabel": "Suggerisci per quanto tempo il dato è scaricabile prima di essere cancellato. Valori accettati: da 1 a 999.999 secondi."
+          },
+          "confirmationField": {
+            "label": "Richiedi conferma di ricezione",
+            "infoLabel": "Il fruitore dovrà inviare una notifica dopo aver scaricato il file."
+          },
+          "bulkField": {
+            "label": "Consenti download a blocchi",
+            "infoLabel": "Il fruitore può scaricare file di grandi dimensioni in parti separate."
+          },
+          "readOnlyOptions": {
+            "true": "Sì",
+            "false": "No"
+          },
+          "validation": {
+            "integer": "Il valore deve essere un numero intero"
+          }
+        },
         "nameField": {
           "label": "Nome documento",
           "infoLabel": "Min 5 caratteri, max 60 caratteri"


### PR DESCRIPTION
## 🔗 Issue

[PIN-10245](https://pagopa.atlassian.net/browse/PIN-10245)

## 📝 Description / Context

This PR fixes the copy used in the e-service template creation flow for asynchronous/bulk exchange configuration. Template creators now see suggestion-oriented labels and helper texts, while the standard e-service creation flow keeps the existing copy.

## 🛠 List of changes

- Added template-specific translations for the async exchange section.
- Updated the e-service template creation flow to use `eserviceTemplate` copy instead of the standard e-service copy.
- Kept the shared async exchange component backward-compatible with the existing e-service creation flow.
- Added/updated tests for template-specific translation keys.

## 🧪 How to test

- Go to `Erogazione > I miei template e-service > Crea Template E-Service` and create/configure an asynchronous or bulk template.
- In the `Specifiche tecniche` step, check the `Configurazione dello scambio` fields: labels and helper texts should use “Suggerisci” / “suggerito”.
- Verify the standard e-service creation flow still shows the existing “Indica” copy.


[PIN-10245]: https://pagopa.atlassian.net/browse/PIN-10245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ