### PR TITLE
fix: update template publish thank you button (PIN-10249)

### DIFF
--- a/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
@@ -82,7 +82,7 @@ const ProviderEServiceTemplateSummaryPage: React.FC = () => {
               description: isFirstVersion
                 ? t('publishThankYou.firstVersion.description')
                 : t('publishThankYou.newVersion.description'),
-              buttonLabel: t('publishThankYou.action'),
+              buttonLabel: t('publishThankYou.goToTemplateAction'),
               closeRouteKey: 'PROVIDE_ESERVICE_TEMPLATE_DETAILS',
               closeRouteParams: { eServiceTemplateId, eServiceTemplateVersionId },
             },

--- a/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateSummary.page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import ProviderEServiceTemplateSummaryPage from '../ProviderEServiceTemplateSummary.page'
 import { mockUseJwt, mockUseParams, renderWithApplicationContext } from '@/utils/testing.utils'
 import * as router from '@/router'
@@ -248,5 +249,36 @@ describe('ProviderEServiceTemplateSummaryPage', () => {
 
     expect(screen.getByRole('button', { name: 'deleteDraft' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'editDraft' })).toBeInTheDocument()
+  })
+
+  it('navigates to the thank you page with go to template button label when publishing', async () => {
+    const user = userEvent.setup()
+
+    useQueryMock.mockReturnValue({
+      data: createMockEServiceTemplateVersionDetailsAsync(),
+      isLoading: false,
+    })
+
+    publishDraftMock.mockImplementationOnce(
+      (_params: unknown, { onSuccess }: { onSuccess: () => void }) => {
+        onSuccess()
+      }
+    )
+
+    renderWithApplicationContext(<ProviderEServiceTemplateSummaryPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.click(screen.getByRole('button', { name: 'publish' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      'PROVIDE_ESERVICE_TEMPLATE_PUBLISH_THANK_YOU',
+      expect.objectContaining({
+        state: expect.objectContaining({
+          buttonLabel: 'publishThankYou.goToTemplateAction',
+        }),
+      })
+    )
   })
 })

--- a/src/static/locales/en/eserviceTemplate.json
+++ b/src/static/locales/en/eserviceTemplate.json
@@ -537,6 +537,7 @@
       "title": "You have published a new version of the e-service template",
       "description": "It is now available in the e-service template catalog. Those using the previous version of the template will receive a notification and will need to update to the new version."
     },
-    "action": "Close"
+    "action": "Close",
+    "goToTemplateAction": "Go to template"
   }
 }

--- a/src/static/locales/it/eserviceTemplate.json
+++ b/src/static/locales/it/eserviceTemplate.json
@@ -537,6 +537,7 @@
       "title": "Hai pubblicato una nuova versione del template e-service",
       "description": "Ora è disponibile nel catalogo template e-service. Chi sta usando la versione precedente del template, riceverà una notifica e dovrà aggiornare alla nuova versione."
     },
-    "action": "Chiudi"
+    "action": "Chiudi",
+    "goToTemplateAction": "Vai al template"
   }
 }


### PR DESCRIPTION
## 🔗 Issue

[PIN-10249](https://pagopa.atlassian.net/browse/PIN-10249)

## 📝 Description / Context

This PR fixes the e-service template publish thank-you page CTA. After publishing an e-service template, the primary button now says “Go to template” instead of “Close”, consistently with the expected template navigation behavior.

## 🛠 List of changes

- Added a dedicated `goToTemplateAction` translation key for the template publish thank-you CTA.
- Updated the e-service template summary publish flow to use the new CTA label.
- Added a focused test covering the thank-you page navigation state after publishing a template.

## 🧪 How to test

- Go to `Erogazione > I miei template e-service`, create or open a publishable e-service template draft, and publish it from the summary step.
- On the thank-you page, verify that the primary button is labelled “Vai al template” and navigates to the published template details.


[PIN-10249]: https://pagopa.atlassian.net/browse/PIN-10249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ