### PR TITLE
fix: disable advanced async template options (PIN-10253)

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSection.tsx
@@ -23,7 +23,8 @@ export const EServiceAsyncExchangeSection: React.FC<EServiceAsyncExchangeSection
   return (
     <EServiceAsyncExchangeSectionBase
       areGeneralInfoEditable={areEServiceGeneralInfoEditable}
-      areAdvancedOptionsEditable={!isEServiceCreatedFromTemplate}
+      areAdvancedOptionsEditable
+      areAdvancedOptionsDisabled={isEServiceCreatedFromTemplate}
       asyncExchangeProperties={descriptor?.asyncExchangeProperties}
       editableCallbackInterfaceContent={editableCallbackInterfaceContent}
       readOnlyCallbackInterfaceContent={readOnlyCallbackInterfaceContent}

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
@@ -16,6 +16,7 @@ type EServiceAsyncExchangeSectionBaseProps = {
   readOnlyCallbackInterfaceContent: string | React.ReactElement
   isSoap?: boolean
   forceBulkFalse?: boolean
+  areAdvancedOptionsDisabled?: boolean
 }
 
 const asyncExchangeNumericFields = [
@@ -59,6 +60,7 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
   readOnlyCallbackInterfaceContent,
   isSoap = false,
   forceBulkFalse = false,
+  areAdvancedOptionsDisabled = false,
 }) => {
   const { t } = useTranslation('eservice', {
     keyPrefix: 'create.step4.asyncExchangeSection',
@@ -177,13 +179,14 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
             name="asyncExchangeProperties.confirmation"
             label={t('confirmationField.label')}
             infoLabel={t('confirmationField.infoLabel')}
+            disabled={areAdvancedOptionsDisabled}
             sx={{ my: 0 }}
           />
           <RHFCheckbox
             name="asyncExchangeProperties.bulk"
             label={t('bulkField.label')}
             infoLabel={t('bulkField.infoLabel')}
-            disabled={isSoap}
+            disabled={areAdvancedOptionsDisabled || isSoap}
             sx={{ mb: 0 }}
           />
         </Stack>

--- a/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceAsyncExchangeSection.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceAsyncExchangeSection.test.tsx
@@ -160,6 +160,13 @@ describe('EServiceAsyncExchangeSection', () => {
     expect(screen.queryByText('callbackInterface.readOnlyLabel')).not.toBeInTheDocument()
   })
 
+  it('should render advanced options as disabled checkboxes for e-services created from template', () => {
+    renderComponent(true, {}, defaultFormValues, true)
+
+    expect(screen.getByRole('checkbox', { name: /confirmationField.label/ })).toBeDisabled()
+    expect(screen.getByRole('checkbox', { name: /bulkField.label/ })).toBeDisabled()
+  })
+
   it('should prevent submit when async exchange numeric values exceed their limits', async () => {
     const onSubmit = renderValidationTestForm()
 


### PR DESCRIPTION
## 🔗 Issue

[PIN-10253](https://pagopa.atlassian.net/browse/PIN-10253)

## 📝 Description / Context

This PR fixes the technical specifications step for async e-services instantiated from a template. Advanced options are inherited from the template and must remain visible as form controls, but they should not be editable during instantiation.

## 🛠 List of changes

- Render async advanced options as checkbox controls for e-services created from a template.
- Disable inherited advanced option checkboxes while preserving the editable layout.
- Add a regression test for the template-instantiated e-service flow.

## 🧪 How to test

- Open an async e-service instantiated from a template in edit mode, for example the technical specifications step under `Erogazione > I miei e-service > Modifica e-service`.
- Verify that the advanced options are shown as checkboxes, not as read-only information rows.
- Verify that both advanced option checkboxes are disabled and cannot be changed.

[PIN-10253]: https://pagopa.atlassian.net/browse/PIN-10253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ