### PR TITLE
fix: standardize template callback download action (PIN-10254)

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/components/UploadCallbackInterfaceDoc.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/components/UploadCallbackInterfaceDoc.tsx
@@ -6,6 +6,8 @@ import { UploadDocumentsInterface } from '@/components/shared/UploadDocumentsInt
 import { type SubmitHandler } from 'react-hook-form'
 import { useEServiceCreateContext } from '../EServiceCreateContext'
 import { useInterfaceDocActions } from './useInterfaceDocActions'
+import { Button } from '@mui/material'
+import DownloadIcon from '@mui/icons-material/Download'
 
 type UploadCallbackInterfaceDocFormValues = {
   interfaceDoc: File | null
@@ -14,11 +16,13 @@ type UploadCallbackInterfaceDocFormValues = {
 type UploadCallbackInterfaceDocProps = {
   error?: string
   readOnly?: boolean
+  showDownloadButton?: boolean
 }
 
 export const UploadCallbackInterfaceDoc: React.FC<UploadCallbackInterfaceDocProps> = ({
   error,
   readOnly = false,
+  showDownloadButton = false,
 }) => {
   const { t } = useTranslation('eservice', { keyPrefix: 'create.step4.asyncExchangeSection' })
   const { descriptor } = useEServiceCreateContext()
@@ -37,9 +41,20 @@ export const UploadCallbackInterfaceDoc: React.FC<UploadCallbackInterfaceDocProp
 
   return match({ readOnly, actualInterface })
     .with({ readOnly: true, actualInterface: null }, () => <>-</>)
-    .with({ readOnly: true, actualInterface: P.not(null) }, ({ actualInterface }) => (
-      <DocumentContainer doc={actualInterface} onDownload={onDownload} size="small" />
-    ))
+    .with({ readOnly: true, actualInterface: P.not(null) }, ({ actualInterface }) =>
+      showDownloadButton ? (
+        <Button
+          variant="naked"
+          sx={{ fontWeight: 600 }}
+          onClick={onDownload}
+          endIcon={<DownloadIcon sx={{ ml: 1 }} fontSize="small" />}
+        >
+          {t('callbackInterface.download')}
+        </Button>
+      ) : (
+        <DocumentContainer doc={actualInterface} onDownload={onDownload} size="small" />
+      )
+    )
     .with({ readOnly: false, actualInterface: null }, () => (
       <UploadDocumentsInterface
         onSubmit={onSubmit}

--- a/src/pages/ProviderEServiceCreatePage/components/components/__tests__/UploadCallbackInterfaceDoc.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/components/__tests__/UploadCallbackInterfaceDoc.test.tsx
@@ -10,6 +10,7 @@ import {
 
 const uploadDocument = vi.fn()
 const deleteDocument = vi.fn()
+const downloadDocument = vi.fn()
 
 vi.mock('@/api/eservice', () => ({
   EServiceMutations: {
@@ -17,7 +18,7 @@ vi.mock('@/api/eservice', () => ({
     useDeleteVersionDraftDocument: () => ({ mutate: deleteDocument }),
   },
   EServiceDownloads: {
-    useDownloadVersionDocument: () => vi.fn(),
+    useDownloadVersionDocument: () => downloadDocument,
   },
 }))
 
@@ -42,6 +43,28 @@ describe('UploadCallbackInterfaceDoc', () => {
     })
 
     expect(screen.getByDisplayValue('Specifica callback')).toBeInTheDocument()
+  })
+
+  it('shows a textual download action in read-only template mode', async () => {
+    mockUseEServiceCreateContext({
+      descriptor: createMockEServiceDescriptorProviderAsync(),
+    })
+    renderWithApplicationContext(<UploadCallbackInterfaceDoc readOnly showDownloadButton />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'callbackInterface.download' }))
+
+    expect(screen.queryByDisplayValue('Specifica callback')).not.toBeInTheDocument()
+    expect(downloadDocument).toHaveBeenCalledWith(
+      {
+        eserviceId: '4edda5fd-2fed-485c-9ab4-bc7d78a67624',
+        descriptorId: '2092c1ef-9127-4dd5-ad81-c9ecf492975a',
+        documentId: 'callback-interface-doc-001',
+      },
+      'Specifica callback.yml'
+    )
   })
 
   it('shows the upload dropzone when no callback interface is present', () => {

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSection.tsx
@@ -15,7 +15,7 @@ export const EServiceAsyncExchangeSection: React.FC<EServiceAsyncExchangeSection
   const isSoap = descriptor?.eservice.technology === 'SOAP'
   const readOnlyCallbackInterfaceContent = <UploadCallbackInterfaceDoc readOnly />
   const editableCallbackInterfaceContent = isEServiceCreatedFromTemplate ? (
-    readOnlyCallbackInterfaceContent
+    <UploadCallbackInterfaceDoc readOnly showDownloadButton />
   ) : (
     <UploadCallbackInterfaceDoc />
   )

--- a/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceAsyncExchangeSection.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceAsyncExchangeSection.test.tsx
@@ -10,8 +10,17 @@ import userEvent from '@testing-library/user-event'
 import { FormProvider, useForm } from 'react-hook-form'
 
 vi.mock('../../components/UploadCallbackInterfaceDoc', () => ({
-  UploadCallbackInterfaceDoc: ({ readOnly }: { readOnly?: boolean }) => (
-    <div>{readOnly ? 'UploadCallbackInterfaceDoc-readOnly' : 'UploadCallbackInterfaceDoc'}</div>
+  UploadCallbackInterfaceDoc: ({
+    readOnly,
+    showDownloadButton,
+  }: {
+    readOnly?: boolean
+    showDownloadButton?: boolean
+  }) => (
+    <div>
+      {readOnly ? 'UploadCallbackInterfaceDoc-readOnly' : 'UploadCallbackInterfaceDoc'}
+      {showDownloadButton ? '-downloadButton' : ''}
+    </div>
   ),
 }))
 
@@ -156,7 +165,9 @@ describe('EServiceAsyncExchangeSection', () => {
   it('should render the callback interface without an extra label for e-services created from template', () => {
     renderComponent(true, {}, defaultFormValues, true)
 
-    expect(screen.getByText('UploadCallbackInterfaceDoc-readOnly')).toBeInTheDocument()
+    expect(
+      screen.getByText('UploadCallbackInterfaceDoc-readOnly-downloadButton')
+    ).toBeInTheDocument()
     expect(screen.queryByText('callbackInterface.readOnlyLabel')).not.toBeInTheDocument()
   })
 

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -357,6 +357,7 @@
         "callbackInterface": {
           "readOnlyLabel": "Callback interface",
           "prettyName": "Callback interface",
+          "download": "Download callback file",
           "dropzoneLabel": "Drag the callback interface here or click here to select it from your computer"
         },
         "configSubsection": {

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -357,6 +357,7 @@
         "callbackInterface": {
           "readOnlyLabel": "Interfaccia di callback",
           "prettyName": "Interfaccia callback",
+          "download": "Scarica il file di callback",
           "dropzoneLabel": "Trascina qui l’interfaccia di callback oppure clicca qui per selezionarla dal computer"
         },
         "configSubsection": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10254](https://pagopa.atlassian.net/browse/PIN-10254)

## 📝 Description / Context

This PR fixes the async massive template instantiation flow in the e-service technical specifications step. The callback interface download action is now displayed consistently with the standard interface download action.

## 🛠 List of changes

- Added a textual download action for the callback interface when editing an e-service created from a template.
- Removed the disabled callback document input from the template instantiation view.
- Added Italian and English labels for the callback file download action.
- Updated focused tests to cover the template callback download behavior.

## 🧪 How to test

- Go to `Erogazione > I miei e-service > Modifica e-service` for an async massive e-service instantiated from a template.
- Open the `Specifiche tecniche` step.
- Verify that the `Interfaccia` section shows `Scarica il file di interfaccia`.
- Verify that the `Scambi asincroni e massivi` section shows `Scarica il file di callback` with the same visual style, and does not show a disabled callback document input.
- Click `Scarica il file di callback` and verify that the callback interface file is downloaded.


[PIN-10254]: https://pagopa.atlassian.net/browse/PIN-10254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ