### PR TITLE
fix: minor manual archiving fixes (PIN-10257, PIN-10273, PIN-10275, PIN-10276)

### DIFF
--- a/src/components/dialogs/DialogArchiveEservice.tsx
+++ b/src/components/dialogs/DialogArchiveEservice.tsx
@@ -104,7 +104,7 @@ const DialogArchiveEservice: React.FC<DialogArchiveEserviceProps> = ({ eserviceI
           <Alert severity="info" sx={{ mt: 4 }}>
             <Trans
               components={{
-                1: <Link underline="hover" href={DOCUMENTATION_URL} target="_blank" />, // TODO documentation link
+                1: <Link underline="hover" href={DOCUMENTATION_URL} target="_blank" />,
               }}
             >
               {t('content.alert')}

--- a/src/components/dialogs/DialogArchiveEservice.tsx
+++ b/src/components/dialogs/DialogArchiveEservice.tsx
@@ -20,7 +20,7 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { Trans, useTranslation } from 'react-i18next'
 import { RHFTextField } from '../shared/react-hook-form-inputs'
 import { RequiredTextLabel } from '../shared/RequiredTextLabel'
-import addDays from 'date-fns/addDays'
+import { calculateArchivableOn } from '@/utils/eservice.utils'
 
 type ArchiveReasonFormValue = {
   reason: string
@@ -57,7 +57,7 @@ const DialogArchiveEservice: React.FC<DialogArchiveEserviceProps> = ({ eserviceI
     scheduleArchive({ eserviceId, archivingReason: reason }, { onSuccess: closeDialog })
   }
 
-  const archiveDate = addDays(new Date(), GRACE_PERIOD_ARCHIVING_ESERVICE)
+  const archiveDate = calculateArchivableOn(new Date(), GRACE_PERIOD_ARCHIVING_ESERVICE)
   const formattedArchiveDate = formatDateStringNumeric(archiveDate)
 
   const formMethods = useForm<ArchiveReasonFormValue>({

--- a/src/components/dialogs/DialogShowEserviceVersionsList/EserviceVersionRow.tsx
+++ b/src/components/dialogs/DialogShowEserviceVersionsList/EserviceVersionRow.tsx
@@ -6,7 +6,7 @@ import type { RouteKey } from '@/router'
 import { Link } from '@/router'
 import { StatusChip } from '@/components/shared/StatusChip'
 import { ArchivingScheduleBadge } from '@/components/shared/ArchivingScheduleBadge'
-import { isDescriptorBeingArchived } from '@/utils/eservice.utils'
+import { isDescriptorPendingArchiving } from '@/utils/eservice.utils'
 
 export const ROW_HEIGHT = 56
 
@@ -57,7 +57,7 @@ export const EserviceVersionRow: React.FC<EserviceVersionRowProps> = ({
           isActiveDescriptor={isActiveDescriptor}
           size="small"
         />
-        {archivableOn && isDescriptorBeingArchived(descriptor.state) && (
+        {archivableOn && isDescriptorPendingArchiving(descriptor.state) && (
           <ArchivingScheduleBadge
             archivableOn={archivableOn}
             scope={isEserviceScope ? 'ESERVICE' : 'DESCRIPTOR'}

--- a/src/components/dialogs/DialogShowEserviceVersionsList/EserviceVersionRow.tsx
+++ b/src/components/dialogs/DialogShowEserviceVersionsList/EserviceVersionRow.tsx
@@ -6,6 +6,7 @@ import type { RouteKey } from '@/router'
 import { Link } from '@/router'
 import { StatusChip } from '@/components/shared/StatusChip'
 import { ArchivingScheduleBadge } from '@/components/shared/ArchivingScheduleBadge'
+import { isDescriptorBeingArchived } from '@/utils/eservice.utils'
 
 export const ROW_HEIGHT = 56
 
@@ -56,7 +57,7 @@ export const EserviceVersionRow: React.FC<EserviceVersionRowProps> = ({
           isActiveDescriptor={isActiveDescriptor}
           size="small"
         />
-        {archivableOn && (
+        {archivableOn && isDescriptorBeingArchived(descriptor.state) && (
           <ArchivingScheduleBadge
             archivableOn={archivableOn}
             scope={isEserviceScope ? 'ESERVICE' : 'DESCRIPTOR'}

--- a/src/components/dialogs/__tests__/DialogShowEserviceVersionsList.test.tsx
+++ b/src/components/dialogs/__tests__/DialogShowEserviceVersionsList.test.tsx
@@ -117,4 +117,19 @@ describe('DialogShowEserviceVersionsList', () => {
 
     expect(screen.queryByTestId('ArchiveIcon')).not.toBeInTheDocument()
   })
+
+  it('does not show the archive icon for ARCHIVED descriptors even if archivableOn is set', () => {
+    renderDialog({
+      descriptors: [
+        makeDescriptor({
+          id: 'd1',
+          version: '1',
+          state: 'ARCHIVED',
+          archivableOn: '2026-12-31',
+        }),
+      ],
+    })
+
+    expect(screen.queryByTestId('ArchiveIcon')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/shared/ArchivingScheduleBadge.tsx
+++ b/src/components/shared/ArchivingScheduleBadge.tsx
@@ -3,7 +3,7 @@ import { Tooltip } from '@mui/material'
 import ArchiveIcon from '@mui/icons-material/Archive'
 import { useTranslation } from 'react-i18next'
 import type { ArchivingScope } from '@/api/api.generatedTypes'
-import { formatDateString } from '@/utils/format.utils'
+import { formatDateStringNumeric } from '@/utils/format.utils'
 
 type ArchivingScheduleBadgeProps = {
   archivableOn: string
@@ -19,7 +19,7 @@ export const ArchivingScheduleBadge: React.FC<ArchivingScheduleBadgeProps> = ({
     <Tooltip
       arrow
       title={t(scope === 'ESERVICE' ? 'eservice' : 'descriptor', {
-        date: formatDateString(archivableOn),
+        date: formatDateStringNumeric(archivableOn),
       })}
     >
       <ArchiveIcon color="primary" fontSize="small" />

--- a/src/components/shared/StatusChip.tsx
+++ b/src/components/shared/StatusChip.tsx
@@ -6,6 +6,7 @@ import omit from 'lodash/omit'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { match } from 'ts-pattern'
+import { isDescriptorBeingArchived } from '@/utils/eservice.utils'
 import type {
   Agreement,
   AgreementListEntry,
@@ -171,8 +172,7 @@ export const StatusChip: React.FC<StatusChipProps> = (props) => {
 
   if (props.for === 'descriptor') {
     const isActiveDescriptorBeingArchived =
-      props.isActiveDescriptor &&
-      (props.state === 'ARCHIVING' || props.state === 'ARCHIVING_SUSPENDED')
+      props.isActiveDescriptor && isDescriptorBeingArchived(props.state)
 
     const remappedState: EServiceDescriptorState = match({
       state: props.state,

--- a/src/components/shared/StatusChip.tsx
+++ b/src/components/shared/StatusChip.tsx
@@ -6,7 +6,7 @@ import omit from 'lodash/omit'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { match } from 'ts-pattern'
-import { isDescriptorBeingArchived } from '@/utils/eservice.utils'
+import { isDescriptorPendingArchiving } from '@/utils/eservice.utils'
 import type {
   Agreement,
   AgreementListEntry,
@@ -172,7 +172,7 @@ export const StatusChip: React.FC<StatusChipProps> = (props) => {
 
   if (props.for === 'descriptor') {
     const isActiveDescriptorBeingArchived =
-      props.isActiveDescriptor && isDescriptorBeingArchived(props.state)
+      props.isActiveDescriptor && isDescriptorPendingArchiving(props.state)
 
     const remappedState: EServiceDescriptorState = match({
       state: props.state,

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -15,7 +15,7 @@ import ConsumerLinkedPurposeTemplatesTab from './components/ConsumerLinkedPurpos
 import { useMarkNotificationsAsRead } from '@/hooks/useMarkNotificationsAsRead'
 import { NewPageContainer } from '@/components/layout/containers/NewPageContainer'
 import { useDialog } from '@/stores'
-import { getViewLatestVersionTargetId } from '@/utils/eservice.utils'
+import { getViewLatestVersionTargetId, isDescriptorBeingArchived } from '@/utils/eservice.utils'
 import { ConsumerEServiceDetailsAlerts } from './components/ConsumerEServiceDetailsTab/ConsumerEServiceDetailsAlerts'
 
 const ConsumerEServiceDetailsPage: React.FC = () => {
@@ -105,7 +105,9 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
                 isActiveDescriptor: descriptor.id === descriptor.eservice.activeDescriptor?.id,
               },
               archivingScheduleInfo:
-                descriptor.archivingSchedule?.archivableOn && descriptor.archivingSchedule?.scope
+                isDescriptorBeingArchived(descriptor.state) &&
+                descriptor.archivingSchedule?.archivableOn &&
+                descriptor.archivingSchedule?.scope
                   ? {
                       archivableOn: descriptor.archivingSchedule.archivableOn,
                       scope: descriptor.archivingSchedule.scope,

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -15,7 +15,7 @@ import ConsumerLinkedPurposeTemplatesTab from './components/ConsumerLinkedPurpos
 import { useMarkNotificationsAsRead } from '@/hooks/useMarkNotificationsAsRead'
 import { NewPageContainer } from '@/components/layout/containers/NewPageContainer'
 import { useDialog } from '@/stores'
-import { getViewLatestVersionTargetId, isDescriptorBeingArchived } from '@/utils/eservice.utils'
+import { getViewLatestVersionTargetId, isDescriptorPendingArchiving } from '@/utils/eservice.utils'
 import { ConsumerEServiceDetailsAlerts } from './components/ConsumerEServiceDetailsTab/ConsumerEServiceDetailsAlerts'
 
 const ConsumerEServiceDetailsPage: React.FC = () => {
@@ -105,7 +105,7 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
                 isActiveDescriptor: descriptor.id === descriptor.eservice.activeDescriptor?.id,
               },
               archivingScheduleInfo:
-                isDescriptorBeingArchived(descriptor.state) &&
+                isDescriptorPendingArchiving(descriptor.state) &&
                 descriptor.archivingSchedule?.archivableOn &&
                 descriptor.archivingSchedule?.scope
                   ? {

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -14,7 +14,11 @@ import { NewPageContainer } from '@/components/layout/containers/NewPageContaine
 import { useDialog } from '@/stores'
 import { useDrawerState } from '@/hooks/useDrawerState'
 import { EServiceVersionSelectorDrawer } from '@/components/shared/EServiceVersionSelectorDrawer'
-import { getActiveDescriptor, getViewLatestVersionTargetId } from '@/utils/eservice.utils'
+import {
+  getActiveDescriptor,
+  getViewLatestVersionTargetId,
+  isDescriptorBeingArchived,
+} from '@/utils/eservice.utils'
 import { ProviderEServiceDetailsAlerts } from './components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts'
 
 const ProviderEServiceDetailsPage: React.FC = () => {
@@ -52,8 +56,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
   )
 
   const isActiveDescriptor = descriptor?.id === activeDescriptor?.id
-  const isEServiceBeingArchived =
-    activeDescriptor?.state === 'ARCHIVING' || activeDescriptor?.state === 'ARCHIVING_SUSPENDED'
+  const isEServiceBeingArchived = isDescriptorBeingArchived(activeDescriptor?.state)
 
   const hasMultipleVersions = (descriptor?.eservice.descriptors?.length ?? 0) > 1
 
@@ -113,7 +116,9 @@ const ProviderEServiceDetailsPage: React.FC = () => {
                 isActiveDescriptor,
               },
               archivingScheduleInfo:
-                descriptor.archivingSchedule?.archivableOn && descriptor.archivingSchedule?.scope
+                isDescriptorBeingArchived(descriptor.state) &&
+                descriptor.archivingSchedule?.archivableOn &&
+                descriptor.archivingSchedule?.scope
                   ? {
                       archivableOn: descriptor.archivingSchedule.archivableOn,
                       scope: descriptor.archivingSchedule.scope,

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -17,7 +17,7 @@ import { EServiceVersionSelectorDrawer } from '@/components/shared/EServiceVersi
 import {
   getActiveDescriptor,
   getViewLatestVersionTargetId,
-  isDescriptorBeingArchived,
+  isDescriptorPendingArchiving,
 } from '@/utils/eservice.utils'
 import { ProviderEServiceDetailsAlerts } from './components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts'
 
@@ -56,7 +56,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
   )
 
   const isActiveDescriptor = descriptor?.id === activeDescriptor?.id
-  const isEServiceBeingArchived = isDescriptorBeingArchived(activeDescriptor?.state)
+  const isEServiceBeingArchived = isDescriptorPendingArchiving(activeDescriptor?.state)
 
   const hasMultipleVersions = (descriptor?.eservice.descriptors?.length ?? 0) > 1
 
@@ -116,7 +116,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
                 isActiveDescriptor,
               },
               archivingScheduleInfo:
-                isDescriptorBeingArchived(descriptor.state) &&
+                isDescriptorPendingArchiving(descriptor.state) &&
                 descriptor.archivingSchedule?.archivableOn &&
                 descriptor.archivingSchedule?.scope
                   ? {

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -370,7 +370,7 @@
       },
       "confirmDialog": {
         "title": "Fruition Request Draft Creation",
-        "description": "Do you want to create a fruition request draft for the e-service **{{name}}**, version **{{version}}**",
+        "description": "Do you want to create a fruition request draft for the e-service <strong>{{name}}</strong>, version <strong>{{version}}</strong>",
         "proceedLabel": "Create draft"
       }
     },

--- a/src/utils/__tests__/eservice.utils.test.ts
+++ b/src/utils/__tests__/eservice.utils.test.ts
@@ -7,7 +7,7 @@ import {
   getEServiceDescriptorAlertSpec,
   getLastDescriptor,
   getViewLatestVersionTargetId,
-  isDescriptorBeingArchived,
+  isDescriptorPendingArchiving,
 } from '../eservice.utils'
 
 describe('getDownloadDocumentName utility function testing', () => {
@@ -148,10 +148,10 @@ describe('calculateArchivableOn utility function testing', () => {
   })
 })
 
-describe('isDescriptorBeingArchived utility function testing', () => {
+describe('isDescriptorPendingArchiving utility function testing', () => {
   it('returns true for ARCHIVING and ARCHIVING_SUSPENDED', () => {
-    expect(isDescriptorBeingArchived('ARCHIVING')).toBe(true)
-    expect(isDescriptorBeingArchived('ARCHIVING_SUSPENDED')).toBe(true)
+    expect(isDescriptorPendingArchiving('ARCHIVING')).toBe(true)
+    expect(isDescriptorPendingArchiving('ARCHIVING_SUSPENDED')).toBe(true)
   })
 
   it.each<EServiceDescriptorState | undefined>([
@@ -162,7 +162,7 @@ describe('isDescriptorBeingArchived utility function testing', () => {
     'DRAFT',
     undefined,
   ])('returns false for state %s', (state) => {
-    expect(isDescriptorBeingArchived(state)).toBe(false)
+    expect(isDescriptorPendingArchiving(state)).toBe(false)
   })
 })
 

--- a/src/utils/__tests__/eservice.utils.test.ts
+++ b/src/utils/__tests__/eservice.utils.test.ts
@@ -6,6 +6,7 @@ import {
   getEServiceDescriptorAlertSpec,
   getLastDescriptor,
   getViewLatestVersionTargetId,
+  isDescriptorBeingArchived,
 } from '../eservice.utils'
 
 describe('getDownloadDocumentName utility function testing', () => {
@@ -143,6 +144,22 @@ describe('calculateArchivableOn utility function testing', () => {
     const result = calculateArchivableOn(now, 30)
 
     expect(result.toISOString()).toEqual('2026-07-16T00:00:00.000Z')
+  })
+})
+
+describe('isDescriptorBeingArchived utility function testing', () => {
+  it('returns true for ARCHIVING and ARCHIVING_SUSPENDED', () => {
+    expect(isDescriptorBeingArchived('ARCHIVING')).toBe(true)
+    expect(isDescriptorBeingArchived('ARCHIVING_SUSPENDED')).toBe(true)
+  })
+
+  it('returns false for other states and undefined', () => {
+    expect(isDescriptorBeingArchived('PUBLISHED')).toBe(false)
+    expect(isDescriptorBeingArchived('ARCHIVED')).toBe(false)
+    expect(isDescriptorBeingArchived('SUSPENDED')).toBe(false)
+    expect(isDescriptorBeingArchived('DEPRECATED')).toBe(false)
+    expect(isDescriptorBeingArchived('DRAFT')).toBe(false)
+    expect(isDescriptorBeingArchived(undefined)).toBe(false)
   })
 })
 

--- a/src/utils/__tests__/eservice.utils.test.ts
+++ b/src/utils/__tests__/eservice.utils.test.ts
@@ -1,4 +1,5 @@
 import type { TFunction } from 'i18next'
+import type { EServiceDescriptorState } from '@/api/api.generatedTypes'
 import {
   calculateArchivableOn,
   getAsyncExchangePropertiesWithDefaults,
@@ -153,13 +154,15 @@ describe('isDescriptorBeingArchived utility function testing', () => {
     expect(isDescriptorBeingArchived('ARCHIVING_SUSPENDED')).toBe(true)
   })
 
-  it('returns false for other states and undefined', () => {
-    expect(isDescriptorBeingArchived('PUBLISHED')).toBe(false)
-    expect(isDescriptorBeingArchived('ARCHIVED')).toBe(false)
-    expect(isDescriptorBeingArchived('SUSPENDED')).toBe(false)
-    expect(isDescriptorBeingArchived('DEPRECATED')).toBe(false)
-    expect(isDescriptorBeingArchived('DRAFT')).toBe(false)
-    expect(isDescriptorBeingArchived(undefined)).toBe(false)
+  it.each<EServiceDescriptorState | undefined>([
+    'PUBLISHED',
+    'ARCHIVED',
+    'SUSPENDED',
+    'DEPRECATED',
+    'DRAFT',
+    undefined,
+  ])('returns false for state %s', (state) => {
+    expect(isDescriptorBeingArchived(state)).toBe(false)
   })
 })
 

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -9,7 +9,7 @@ import type {
 import type { AlertColor } from '@mui/material'
 import type { TFunction } from 'i18next'
 import { match } from 'ts-pattern'
-import { formatDateString } from './format.utils'
+import { formatDateStringNumeric } from './format.utils'
 
 export const defaultAsyncExchangeProperties: AsyncExchangeProperties = {
   responseTime: 60,
@@ -78,8 +78,8 @@ export function getEServiceDescriptorAlertSpec(args: {
   t: TFunction<'eservice', 'read.alert'>
 }): { severity: AlertColor; content: string } | undefined {
   const { state, scope, archivableOn, archivedAt, t } = args
-  const scheduledDate = archivableOn ? formatDateString(archivableOn) : ''
-  const archivedDate = archivedAt ? formatDateString(archivedAt) : ''
+  const scheduledDate = archivableOn ? formatDateStringNumeric(archivableOn) : ''
+  const archivedDate = archivedAt ? formatDateStringNumeric(archivedAt) : ''
 
   return match({ state, scope })
     .returnType<{ severity: AlertColor; content: string } | undefined>()

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -114,3 +114,7 @@ export function calculateArchivableOn(now: Date, gracePeriodDays: number): Date 
   d.setUTCHours(0, 0, 0, 0)
   return d
 }
+
+export function isDescriptorBeingArchived(state: EServiceDescriptorState | undefined): boolean {
+  return state === 'ARCHIVING' || state === 'ARCHIVING_SUSPENDED'
+}

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -115,6 +115,6 @@ export function calculateArchivableOn(now: Date, gracePeriodDays: number): Date 
   return d
 }
 
-export function isDescriptorBeingArchived(state: EServiceDescriptorState | undefined): boolean {
+export function isDescriptorPendingArchiving(state: EServiceDescriptorState | undefined): boolean {
   return state === 'ARCHIVING' || state === 'ARCHIVING_SUSPENDED'
 }


### PR DESCRIPTION
## 🔗 Issue

- [PIN-10257](https://pagopa.atlassian.net/browse/PIN-10257)
- [PIN-10273](https://pagopa.atlassian.net/browse/PIN-10273)
- [PIN-10275](https://pagopa.atlassian.net/browse/PIN-10275)
- [PIN-10276](https://pagopa.atlassian.net/browse/PIN-10276)

## 📝 Description / Context

Collection of minor, independent fixes that emerged from the manual archiving QA (children of PIN-9936). Small, low-risk changes, kept separate from the heavier header/menu action-logic changes (which go in a dedicated PR).

## 🛠 List of changes

- **PIN-10257** — Archiving date format unified to numeric (dd/mm/yyyy): badge tooltip (`ArchivingScheduleBadge`) and all status banners (`getEServiceDescriptorAlertSpec`), aligned with the dialogs that already used the numeric format.
- **PIN-10273** — Date in the "Archivia e-service" dialog aligned with the server value: uses `calculateArchivableOn` (like the "Archivia versione" dialog) instead of `addDays`, which produced a date off by one day.
- **PIN-10275** — The scheduled-archiving badge now disappears when the version is `ARCHIVED`: gated on the `ARCHIVING`/`ARCHIVING_SUSPENDED` states in the e-service detail pages (provider and consumer) and in the "Stato versioni" drawer. Introduced the shared helper `isDescriptorPendingArchiving` (also reused in `StatusChip` and the provider detail page to remove duplicated conditions).
- **PIN-10276** — EN copy of the "Fruition Request Draft Creation" dialog: replaced the (non-rendered) markdown bold `**...**` with `<strong>...</strong>`, consistent with the Italian.
- Tests: unit tests for the archiving-state helper and a test that the badge is not shown for `ARCHIVED` versions in the drawer.

## 🧪 How to test

- **Numeric dates**: with a version/e-service being archived, check that the badge tooltip and banners show the date as `dd/mm/yyyy`.
- **Archivia e-service dialog**: the notice end date matches the `archivableOn` returned by the server (same day as the "Archivia versione" dialog).
- **Post-archiving badge**: once a version is `ARCHIVED`, the "scheduled archiving" badge is no longer visible (page header + "Stato versioni" drawer); only the "archived on …" banner remains.
- **EN copy**: open the fruition request creation dialog in EN and check the e-service name/version in bold, without `**`.

[PIN-10257]: https://pagopa.atlassian.net/browse/PIN-10257
[PIN-10273]: https://pagopa.atlassian.net/browse/PIN-10273
[PIN-10275]: https://pagopa.atlassian.net/browse/PIN-10275
[PIN-10276]: https://pagopa.atlassian.net/browse/PIN-10276
