### PR TITLE
fix: archived version menu and draft-present actions on provider e-service details (PIN-10256, PIN-10258)

### DIFF
--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -1287,6 +1287,68 @@ describe('useGetProviderEServiceActions slot split (where=detailsPage, admin hap
   })
 })
 
+describe('useGetProviderEServiceActions slot split with an existing version draft (where=detailsPage, admin happy path)', () => {
+  beforeEach(() => {
+    mockUseJwt({ isAdmin: true })
+  })
+
+  it('PUBLISHED + draft: stays in happy path, manageDraft replaces createNewVersion in header, menu unchanged', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      draftDescriptor: { id: 'draft-1', state: 'DRAFT', version: '2' },
+      delegation: undefined,
+    })
+    const { result } = renderDetailsPageHook(descriptorMock)
+    expect(result.current.primaryAction).toBeUndefined()
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual([
+      'suspendVersion',
+      'manageDraft',
+    ])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'cloneEservice',
+      'archiveEservice',
+      'viewAllVersions',
+    ])
+  })
+
+  it('DEPRECATED + draft: header keeps suspend+archiveVersion, manageDraft replaces createNewVersion in menu (4 items, no deleteDraft)', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
+      draftDescriptor: { id: 'draft-1', state: 'DRAFT', version: '2' },
+      delegation: undefined,
+    })
+    const { result } = renderDetailsPageHook(descriptorMock)
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual([
+      'suspendVersion',
+      'archiveVersion',
+    ])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'manageDraft',
+      'cloneEservice',
+      'archiveEservice',
+      'viewAllVersions',
+    ])
+  })
+
+  it('SUSPENDED on the active descriptor + draft: manageDraft replaces createNewVersion in header', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+      draftDescriptor: { id: 'draft-1', state: 'DRAFT', version: '2' },
+      delegation: undefined,
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, { isActiveDescriptor: true })
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual([
+      'reactivateVersion',
+      'manageDraft',
+    ])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'cloneEservice',
+      'archiveEservice',
+      'viewAllVersions',
+    ])
+  })
+})
+
 describe('useGetProviderEServiceActions slot split bypass (preserve legacy behavior)', () => {
   beforeEach(() => {
     mockUseJwt({ isAdmin: true })
@@ -1303,24 +1365,6 @@ describe('useGetProviderEServiceActions slot split bypass (preserve legacy behav
     expect(result.current.primaryAction).toBeUndefined()
     expect(result.current.headerInfoActions).toHaveLength(0)
     expect(result.current.menuActions.map((a) => a.label)).toEqual(['viewAllVersions'])
-  })
-
-  it('PUBLISHED + hasVersionDraft: no slot split, legacy menu preserved + viewAllVersions appended', () => {
-    const descriptorMock = createMockEServiceProvider({
-      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
-      draftDescriptor: { id: 'draft-1', state: 'DRAFT', version: '2' },
-      delegation: undefined,
-    })
-    const { result } = renderDetailsPageHook(descriptorMock)
-    expect(result.current.primaryAction).toBeUndefined()
-    expect(result.current.headerInfoActions).toHaveLength(0)
-    expect(result.current.menuActions.map((a) => a.label)).toEqual([
-      'cloneEservice',
-      'manageDraft',
-      'deleteDraft',
-      'suspendVersion',
-      'viewAllVersions',
-    ])
   })
 
   it('PUBLISHED + template instance: no slot split, template menu preserved', () => {

--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -1068,24 +1068,32 @@ describe('useGetProviderEServiceActions slot split (where=detailsPage, admin hap
     ])
   })
 
-  it('ARCHIVED with a newer descriptor: viewLatestVersion in header, only clone in menu', () => {
+  it('ARCHIVED with a newer descriptor (e-service still active): viewLatestVersion in header, full menu with createNewVersion+archiveEservice', () => {
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: '1' },
       delegation: undefined,
     })
     const { result } = renderDetailsPageHook(descriptorMock, { latestDescriptorId: 'newer-id' })
     expect(result.current.headerInfoActions.map((a) => a.label)).toEqual(['viewLatestVersion'])
-    expect(result.current.menuActions.map((a) => a.label)).toEqual(['cloneEservice'])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'createNewVersion',
+      'cloneEservice',
+      'archiveEservice',
+      'viewAllVersions',
+    ])
   })
 
-  it('ARCHIVED with no newer descriptor: no header actions, only clone in menu', () => {
+  it('ARCHIVED with no newer descriptor (whole e-service archived): no header actions, clone+viewAllVersions in menu', () => {
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: '1' },
       delegation: undefined,
     })
     const { result } = renderDetailsPageHook(descriptorMock)
     expect(result.current.headerInfoActions).toHaveLength(0)
-    expect(result.current.menuActions.map((a) => a.label)).toEqual(['cloneEservice'])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'cloneEservice',
+      'viewAllVersions',
+    ])
   })
 
   it('ARCHIVING with DESCRIPTOR scope: suspend and cancelArchivingVersion in header, no primary', () => {
@@ -1342,6 +1350,22 @@ describe('useGetProviderEServiceActions slot split with an existing version draf
       'manageDraft',
     ])
     expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'cloneEservice',
+      'archiveEservice',
+      'viewAllVersions',
+    ])
+  })
+
+  it('ARCHIVED with a newer descriptor (e-service still active) + draft: manageDraft replaces createNewVersion in the menu', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: '1' },
+      draftDescriptor: { id: 'draft-1', state: 'DRAFT', version: '2' },
+      delegation: undefined,
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, { latestDescriptorId: 'newer-id' })
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual(['viewLatestVersion'])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'manageDraft',
       'cloneEservice',
       'archiveEservice',
       'viewAllVersions',

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -1157,7 +1157,13 @@ export function useGetProviderEServiceActions(
     ? [cloneAction, ...viewAllVersionsItems]
     : [newVersionAction, cloneAction, archiveEserviceAction, ...viewAllVersionsItems]
   const menuEserviceArchiving = [cloneAction, ...viewAllVersionsItems]
-  const menuArchived = [cloneAction]
+  const menuArchivedEserviceActive = [
+    newVersionAction,
+    cloneAction,
+    archiveEserviceAction,
+    ...viewAllVersionsItems,
+  ]
+  const menuArchivedEserviceArchived = [cloneAction, ...viewAllVersionsItems]
 
   const slots: Slots = match({ state, archivingScope, isActiveDescriptor, isEServiceBeingArchived })
     .with({ state: 'PUBLISHED' }, () => ({
@@ -1183,7 +1189,7 @@ export function useGetProviderEServiceActions(
     .with({ state: 'ARCHIVED' }, () => ({
       primary: undefined,
       header: latestDescriptorId ? [viewLatestVersionAction] : [],
-      menu: menuArchived,
+      menu: latestDescriptorId ? menuArchivedEserviceActive : menuArchivedEserviceArchived,
     }))
     .with({ state: 'ARCHIVING', archivingScope: 'ESERVICE' }, () => ({
       primary: cancelArchivingEserviceAction,

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -1128,7 +1128,6 @@ export function useGetProviderEServiceActions(
     (isAdmin || isOperatorAPI) &&
     !isDelegator &&
     !isDelegate &&
-    !hasVersionDraft &&
     !isTemplateInstance
 
   if (!isHappyPathDetailsPage) {
@@ -1151,17 +1150,19 @@ export function useGetProviderEServiceActions(
 
   const emptySlots = (): Slots => ({ primary: undefined, header: [], menu: [] })
 
+  const newVersionAction = hasVersionDraft ? editDraftAction : createNewDraftAction
+
   const menuClassic = [cloneAction, archiveEserviceAction, ...viewAllVersionsItems]
   const menuWithNewVersion = isEServiceBeingArchived
     ? [cloneAction, ...viewAllVersionsItems]
-    : [createNewDraftAction, cloneAction, archiveEserviceAction, ...viewAllVersionsItems]
+    : [newVersionAction, cloneAction, archiveEserviceAction, ...viewAllVersionsItems]
   const menuEserviceArchiving = [cloneAction, ...viewAllVersionsItems]
   const menuArchived = [cloneAction]
 
   const slots: Slots = match({ state, archivingScope, isActiveDescriptor, isEServiceBeingArchived })
     .with({ state: 'PUBLISHED' }, () => ({
       primary: undefined,
-      header: [suspendAction, createNewDraftAction],
+      header: [suspendAction, newVersionAction],
       menu: menuClassic,
     }))
     .with({ state: 'DEPRECATED' }, () => ({
@@ -1171,7 +1172,7 @@ export function useGetProviderEServiceActions(
     }))
     .with({ state: 'SUSPENDED', isActiveDescriptor: true }, () => ({
       primary: undefined,
-      header: [reactivateAction, createNewDraftAction],
+      header: [reactivateAction, newVersionAction],
       menu: menuClassic,
     }))
     .with({ state: 'SUSPENDED' }, () => ({


### PR DESCRIPTION
## 🔗 Issue

- [PIN-10256](https://pagopa.atlassian.net/browse/PIN-10256)
- [PIN-10258](https://pagopa.atlassian.net/browse/PIN-10258)

## 📝 Description / Context

Two fixes to the provider-side e-service detail that emerged from the manual archiving QA (children of PIN-9936), both in the `useGetProviderEServiceActions` hook. These are the heavier changes to the header/menu action logic, kept separate from the minor fixes in the previous PR.

## 🛠 List of changes

- **PIN-10256** — Archived-version menu: distinguishes the two Figma scenarios via `latestDescriptorId`. E-service still active ([Figma E08](https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW/Interop-%E2%80%94-Delivery-FE---QA?node-id=5975-22757&t=Gi6VDZ7jEDpd4IOX-4)) → full menu (Create new version, Clone, Archive e-service, View all versions); fully archived e-service ([Figma E17](https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW/Interop-%E2%80%94-Delivery-FE---QA?node-id=8211-70150&t=Gi6VDZ7jEDpd4IOX-4)) → Clone + View all versions. Previously it always showed only "Clone e-service".
- **PIN-10258** — With an existing version draft the page no longer falls back to the legacy layout: removed `!hasVersionDraft` from the happy-path gate. Where "Create new version" would appear, "Manage draft" now appears (`newVersionAction`), and "Archive version" (header) and "Archive e-service" (menu) become available again, which previously disappeared when a draft was present.
- Tests: updated the ARCHIVED cases, added the happy-path cases with a draft (PUBLISHED, DEPRECATED, active SUSPENDED, ARCHIVED + draft).

## 🧪 How to test

- **Archived version, active e-service**: open an archived version of an e-service that has a more recent active version → ⋮ menu with 4 items.
- **Fully archived e-service**: open the archived version → ⋮ menu with Clone + View all versions.
- **Draft present**: with a new-version draft, on the active/deprecated version check that the header is no longer empty, that "Manage draft" replaces "Create new version", and that "Archive version"/"Archive e-service" are available again.

[PIN-10256]: https://pagopa.atlassian.net/browse/PIN-10256
[PIN-10258]: https://pagopa.atlassian.net/browse/PIN-10258
