### PR TITLE
fix: mask archiving states as active/suspended in provider e-service list chip (PIN-10296)

### DIFF
--- a/src/components/shared/StatusChip.tsx
+++ b/src/components/shared/StatusChip.tsx
@@ -164,10 +164,15 @@ export const StatusChip: React.FC<StatusChipProps> = (props) => {
   let label = ''
 
   if (props.for === 'eservice') {
-    color = props.isDraftToCorrect ? 'warning' : chipColors['eservice'][props.state]
+    const remappedState: EServiceDescriptorState = match(props.state)
+      .with('ARCHIVING', () => 'PUBLISHED' as const)
+      .with('ARCHIVING_SUSPENDED', () => 'SUSPENDED' as const)
+      .otherwise((state) => state)
+
+    color = props.isDraftToCorrect ? 'warning' : chipColors['eservice'][remappedState]
     label = props.isDraftToCorrect
       ? t('status.eservice.DRAFT_TO_CORRECT')
-      : t(`status.eservice.${props.state}`)
+      : t(`status.eservice.${remappedState}`)
   }
 
   if (props.for === 'descriptor') {

--- a/src/components/shared/__tests__/StatusChip.test.tsx
+++ b/src/components/shared/__tests__/StatusChip.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { StatusChip } from '@/components/shared/StatusChip'
+
+describe('StatusChip for="eservice" archiving masking', () => {
+  it('masks ARCHIVING as the active (PUBLISHED) status', () => {
+    const { baseElement } = render(<StatusChip for="eservice" state="ARCHIVING" />)
+    expect(baseElement).toHaveTextContent('status.eservice.PUBLISHED')
+  })
+
+  it('masks ARCHIVING_SUSPENDED as the suspended status', () => {
+    const { baseElement } = render(<StatusChip for="eservice" state="ARCHIVING_SUSPENDED" />)
+    expect(baseElement).toHaveTextContent('status.eservice.SUSPENDED')
+  })
+
+  it('leaves non-archiving states unchanged', () => {
+    const { baseElement } = render(<StatusChip for="eservice" state="DEPRECATED" />)
+    expect(baseElement).toHaveTextContent('status.eservice.DEPRECATED')
+  })
+})


### PR DESCRIPTION
## 🔗 Issue

[PIN-10296](https://pagopa.atlassian.net/browse/PIN-10296)

## 📝 Description / Context

In the provider "My e-services" list, an e-service whose active version is being archived (`ARCHIVING` / `ARCHIVING_SUSPENDED`, e-service scope) showed "deprecated" in the status chip, indistinguishable from a genuinely deprecated e-service. The `for="eservice"` branch of `StatusChip` did not mask the archiving states, unlike the `for="descriptor"` branch (used in the detail page and the versions drawer). Expected: "active" (and "suspended" for `ARCHIVING_SUSPENDED`).

## 🛠 List of changes

- `StatusChip.tsx` (`for="eservice"` branch): remaps `ARCHIVING → PUBLISHED` and `ARCHIVING_SUSPENDED → SUSPENDED` (unconditionally — the e-service chip always represents the active version), aligning it with the `for="descriptor"` branch. No icon/badge added.
- New `StatusChip.test.tsx`: covers the masking of the archiving states.

## 🧪 How to test

- Put an e-service into archiving (e-service scope) and go to _Producing → My e-services_.
- Check that the chip shows "active" (no longer "deprecated"); with the version suspended while archiving, "suspended".
- Applies both to single-version and multi-version e-services.

[PIN-10296]: https://pagopa.atlassian.net/browse/PIN-10296
