### PR TITLE
fix: add success toasts for schedule archive e-service and archiving suspend/reactivate (PIN-10298)

### DIFF
--- a/src/api/eservice/eservice.mutations.ts
+++ b/src/api/eservice/eservice.mutations.ts
@@ -8,6 +8,7 @@ import type {
 import { EServiceServices } from './eservice.services'
 import { EServiceQueries } from './eservice.queries'
 import type { AttributeKey } from '@/types/attribute.types'
+import { GRACE_PERIOD_ARCHIVING_ESERVICE } from '@/config/env'
 
 function useCreateDraft() {
   const { t } = useTranslation('mutations-feedback', { keyPrefix: 'eservice.createDraft' })
@@ -158,12 +159,14 @@ function usePublishVersionDraft({ isByDelegation }: { isByDelegation?: boolean }
   })
 }
 
-function useSuspendVersion(options?: { skipConfirmation?: boolean }) {
+function useSuspendVersion(options?: { skipConfirmation?: boolean; isArchivingContext?: boolean }) {
   const { t } = useTranslation('mutations-feedback', { keyPrefix: 'eservice.suspendVersion' })
   return useMutation({
     mutationFn: EServiceServices.suspendVersion,
     meta: {
-      successToastLabel: t('outcome.success'),
+      successToastLabel: t(
+        options?.isArchivingContext ? 'outcome.successArchiving' : 'outcome.success'
+      ),
       errorToastLabel: t('outcome.error'),
       loadingLabel: t('loading'),
       confirmationDialog: options?.skipConfirmation
@@ -176,12 +179,17 @@ function useSuspendVersion(options?: { skipConfirmation?: boolean }) {
   })
 }
 
-function useReactivateVersion(options?: { skipConfirmation?: boolean }) {
+function useReactivateVersion(options?: {
+  skipConfirmation?: boolean
+  isArchivingContext?: boolean
+}) {
   const { t } = useTranslation('mutations-feedback', { keyPrefix: 'eservice.reactivateVersion' })
   return useMutation({
     mutationFn: EServiceServices.reactivateVersion,
     meta: {
-      successToastLabel: t('outcome.success'),
+      successToastLabel: t(
+        options?.isArchivingContext ? 'outcome.successArchiving' : 'outcome.success'
+      ),
       errorToastLabel: t('outcome.error'),
       loadingLabel: t('loading'),
       confirmationDialog: options?.skipConfirmation
@@ -207,8 +215,14 @@ function useCancelDescriptorArchiving() {
 }
 
 function useScheduleArchiveEservice() {
+  const { t } = useTranslation('mutations-feedback', {
+    keyPrefix: 'eservice.scheduleArchiveEservice',
+  })
   return useMutation({
     mutationFn: EServiceServices.scheduleArchiveEservice,
+    meta: {
+      successToastLabel: t('outcome.success', { days: GRACE_PERIOD_ARCHIVING_ESERVICE }),
+    },
   })
 }
 

--- a/src/components/dialogs/DialogReactivateArchivingDescriptor.tsx
+++ b/src/components/dialogs/DialogReactivateArchivingDescriptor.tsx
@@ -13,7 +13,10 @@ export const DialogReactivateArchivingDescriptor: React.FC<
     keyPrefix: 'read.dialogReactivateArchivingDescriptor',
   })
   const { closeDialog } = useDialog()
-  const { mutate: reactivate } = EServiceMutations.useReactivateVersion({ skipConfirmation: true })
+  const { mutate: reactivate } = EServiceMutations.useReactivateVersion({
+    skipConfirmation: true,
+    isArchivingContext: true,
+  })
 
   return (
     <DialogConfirmArchivingAction

--- a/src/components/dialogs/DialogReactivateArchivingEservice.tsx
+++ b/src/components/dialogs/DialogReactivateArchivingEservice.tsx
@@ -11,7 +11,10 @@ export const DialogReactivateArchivingEservice: React.FC<
 > = ({ eserviceId, descriptorId }) => {
   const { t } = useTranslation('eservice', { keyPrefix: 'read.dialogReactivateArchivingEservice' })
   const { closeDialog } = useDialog()
-  const { mutate: reactivate } = EServiceMutations.useReactivateVersion({ skipConfirmation: true })
+  const { mutate: reactivate } = EServiceMutations.useReactivateVersion({
+    skipConfirmation: true,
+    isArchivingContext: true,
+  })
 
   return (
     <DialogConfirmArchivingAction

--- a/src/components/dialogs/DialogSuspendArchivingDescriptor.tsx
+++ b/src/components/dialogs/DialogSuspendArchivingDescriptor.tsx
@@ -13,7 +13,10 @@ export const DialogSuspendArchivingDescriptor: React.FC<DialogSuspendArchivingDe
   const { t } = useTranslation('eservice', { keyPrefix: 'read.dialogSuspendArchivingDescriptor' })
   const { t: tCommon } = useTranslation('common', { keyPrefix: 'actions' })
   const { closeDialog } = useDialog()
-  const { mutate: suspend } = EServiceMutations.useSuspendVersion({ skipConfirmation: true })
+  const { mutate: suspend } = EServiceMutations.useSuspendVersion({
+    skipConfirmation: true,
+    isArchivingContext: true,
+  })
 
   return (
     <DialogConfirmArchivingAction

--- a/src/components/dialogs/DialogSuspendArchivingEservice.tsx
+++ b/src/components/dialogs/DialogSuspendArchivingEservice.tsx
@@ -13,7 +13,10 @@ export const DialogSuspendArchivingEservice: React.FC<DialogSuspendArchivingEser
   const { t } = useTranslation('eservice', { keyPrefix: 'read.dialogSuspendArchivingEservice' })
   const { t: tCommon } = useTranslation('common', { keyPrefix: 'actions' })
   const { closeDialog } = useDialog()
-  const { mutate: suspend } = EServiceMutations.useSuspendVersion({ skipConfirmation: true })
+  const { mutate: suspend } = EServiceMutations.useSuspendVersion({
+    skipConfirmation: true,
+    isArchivingContext: true,
+  })
 
   return (
     <DialogConfirmArchivingAction

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -135,10 +135,16 @@
         "description": "The risk analysis will be deleted from this e-service."
       }
     },
+    "scheduleArchiveEservice": {
+      "outcome": {
+        "success": "This e-service will be archived in {{days}} days"
+      }
+    },
     "suspendVersion": {
       "loading": "E-service version is being suspended",
       "outcome": {
         "success": "E-service version suspended successfully",
+        "successArchiving": "You have suspended this e-service version",
         "error": "The e-service version could not be suspended. Please try again!"
       },
       "confirmDialog": {
@@ -150,6 +156,7 @@
       "loading": "E-service version is being reactivated",
       "outcome": {
         "success": "E-service version reactivated successfully",
+        "successArchiving": "You have reactivated this e-service version",
         "error": "The e-service version could not be reactivated. Please try again!"
       },
       "confirmDialog": {

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -135,10 +135,16 @@
         "description": "Cliccando \"conferma\" la finalità sarà eliminata da questo e-service."
       }
     },
+    "scheduleArchiveEservice": {
+      "outcome": {
+        "success": "Questo e-service sarà archiviato tra {{days}} giorni"
+      }
+    },
     "suspendVersion": {
       "loading": "Stiamo sospendendo la versione",
       "outcome": {
         "success": "La versione dell'e-service è stata sospesa",
+        "successArchiving": "Hai sospeso questa versione dell'e-service",
         "error": "Non è stato possibile sospendere questa versione dell'e-service. Per favore, riprova!"
       },
       "confirmDialog": {
@@ -150,6 +156,7 @@
       "loading": "Stiamo riattivando la versione",
       "outcome": {
         "success": "La versione dell'e-service è stata riattivata",
+        "successArchiving": "Hai riattivato questa versione dell'e-service",
         "error": "Non è stato possibile riattivare questa versione dell'e-service. Per favore, riprova!"
       },
       "confirmDialog": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10298](https://pagopa.atlassian.net/browse/PIN-10298)

## 📝 Description / Context

Follow-up of PIN-10294. Adds the success toasts (copy provided by Design) for the remaining archiving-family actions that were missing them. The `useSuspendVersion`/`useReactivateVersion` mutations are shared with the normal (non-archiving) flows, so the new copy is applied only in the archiving context via a new `isArchivingContext` option; the normal flows are left unchanged.

## 🛠 List of changes

- `useScheduleArchiveEservice`: added `meta.successToastLabel` = "Questo e-service sarà archiviato tra {{days}} giorni", with `days = GRACE_PERIOD_ARCHIVING_ESERVICE` (FE env var).
- `useSuspendVersion` / `useReactivateVersion`: new `isArchivingContext` option that selects a dedicated success key (`outcome.successArchiving`). The 4 archiving dialogs (`DialogSuspendArchivingEservice`, `DialogSuspendArchivingDescriptor`, `DialogReactivateArchivingEservice`, `DialogReactivateArchivingDescriptor`) pass it. Normal suspend/reactivate is unchanged.
- New i18n keys (IT + EN) in `mutations-feedback.json`: `scheduleArchiveEservice.outcome.success`, `suspendVersion.outcome.successArchiving`, `reactivateVersion.outcome.successArchiving`.

## 🧪 How to test

- **Archive e-service**: from the provider e-service detail, archive the whole e-service → success toast "Questo e-service sarà archiviato tra 90 giorni" (90 = configured grace period).
- **Suspend while archiving**: on a version being archived, "Sospendi versione" → toast "Hai sospeso questa versione dell'e-service".
- **Reactivate while archiving**: on a suspended version being archived, "Riattiva versione" → toast "Hai riattivato questa versione dell'e-service".
- **Regression**: suspend/reactivate a version that is NOT being archived → toasts unchanged ("La versione dell'e-service è stata sospesa/riattivata").

[PIN-10298]: https://pagopa.atlassian.net/browse/PIN-10298
