### PR TITLE
feature: PIN-10281 viewer role disable cta

### DIFF
--- a/src/components/sidebar/__test__/useGetSidebarItems.test.tsx
+++ b/src/components/sidebar/__test__/useGetSidebarItems.test.tsx
@@ -37,6 +37,17 @@ describe('useGetSidebarItems', () => {
     expect(result.current.length).toBe(7)
   })
 
+  it('should include the "Il mio ente" (PARTY_REGISTRY) item for a viewer', () => {
+    mockUseJwt({ currentRoles: ['viewer'], isViewer: true, isAdmin: false })
+    mockUseGetActiveUserParty()
+
+    const { result } = renderHook(() => useGetSidebarItems())
+    const tenantItem = result.current.find((item) => item.rootRouteKey === 'PARTY_REGISTRY')
+
+    expect(tenantItem).toBeDefined()
+    expect(tenantItem?.children?.some((child) => child.to === 'PARTY_REGISTRY')).toBe(true)
+  })
+
   describe('Delegations visibility', () => {
     it('should NOT hide the delegations route when allowed and not loading', () => {
       mockUseJwt({ currentRoles: ['admin'] })

--- a/src/pages/ConsumerPurposeTemplateListPage/components/ConsumerPurposeTemplateTableRow.tsx
+++ b/src/pages/ConsumerPurposeTemplateListPage/components/ConsumerPurposeTemplateTableRow.tsx
@@ -9,6 +9,8 @@ import { useTranslation } from 'react-i18next'
 import type { CreatorPurposeTemplate } from '@/api/api.generatedTypes'
 import useGetConsumerPurposeTemplateTemplatesActions from '@/hooks/useGetConsumerPurposeTemplatesActions'
 import { TenantHooks } from '@/api/tenant'
+import { AuthHooks } from '@/api/auth'
+import { match } from 'ts-pattern'
 
 export const ConsumerPurposeTemplateTableRow: React.FC<{
   purposeTemplate: CreatorPurposeTemplate
@@ -20,7 +22,16 @@ export const ConsumerPurposeTemplateTableRow: React.FC<{
     keyPrefix: 'list.filters.targetTenantKindField.values',
   })
 
+  const { isViewer } = AuthHooks.useJwt()
+
   const isPA = Boolean(purposeTemplate.targetTenantKind === 'PA')
+  const isDraft = purposeTemplate.state === 'DRAFT'
+
+  // A viewer cannot reach the draft edit route: route them to the read-only summary instead.
+  const linkTo = match({ isDraft, isViewer })
+    .with({ isDraft: true, isViewer: false }, () => 'SUBSCRIBE_PURPOSE_TEMPLATE_EDIT' as const)
+    .with({ isDraft: true, isViewer: true }, () => 'SUBSCRIBE_PURPOSE_TEMPLATE_SUMMARY' as const)
+    .otherwise(() => 'SUBSCRIBE_PURPOSE_TEMPLATE_DETAILS' as const)
 
   return (
     <TableRow
@@ -36,14 +47,10 @@ export const ConsumerPurposeTemplateTableRow: React.FC<{
         onFocusVisible={() => {}}
         variant="outlined"
         size="small"
-        to={
-          purposeTemplate.state === 'DRAFT'
-            ? 'SUBSCRIBE_PURPOSE_TEMPLATE_EDIT'
-            : 'SUBSCRIBE_PURPOSE_TEMPLATE_DETAILS'
-        }
+        to={linkTo}
         params={{ purposeTemplateId: purposeTemplate.id }}
       >
-        {tCommon(`actions.${purposeTemplate.state === 'DRAFT' ? 'manageDraft' : 'inspect'}`)}
+        {tCommon(`actions.${isDraft && !isViewer ? 'manageDraft' : 'inspect'}`)}
       </Link>
       <Box component="span" sx={{ ml: 2, display: 'inline-block' }}>
         <ActionMenu actions={actions} />

--- a/src/pages/ConsumerPurposeTemplateListPage/components/__tests__/ConsumerPurposeTemplateTableRow.test.tsx
+++ b/src/pages/ConsumerPurposeTemplateListPage/components/__tests__/ConsumerPurposeTemplateTableRow.test.tsx
@@ -13,6 +13,8 @@ vi.mock('@/hooks/useGetConsumerPurposeTemplatesActions', () => ({
   default: () => ({ actions: [] }),
 }))
 
+mockUseJwt()
+
 const draftTemplate = {
   id: 'pt-1',
   purposeTitle: 'My draft template',

--- a/src/pages/ConsumerPurposeTemplateListPage/components/__tests__/ConsumerPurposeTemplateTableRow.test.tsx
+++ b/src/pages/ConsumerPurposeTemplateListPage/components/__tests__/ConsumerPurposeTemplateTableRow.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import {
+  mockUseGetActiveUserParty,
+  mockUseJwt,
+  renderWithApplicationContext,
+} from '@/utils/testing.utils'
+import { ConsumerPurposeTemplateTableRow } from '../ConsumerPurposeTemplateTableRow'
+import type { CreatorPurposeTemplate } from '@/api/api.generatedTypes'
+
+vi.mock('@/hooks/useGetConsumerPurposeTemplatesActions', () => ({
+  default: () => ({ actions: [] }),
+}))
+
+const draftTemplate = {
+  id: 'pt-1',
+  purposeTitle: 'My draft template',
+  state: 'DRAFT',
+  targetTenantKind: 'PA',
+} as CreatorPurposeTemplate
+
+function renderRow(purposeTemplate: CreatorPurposeTemplate = draftTemplate) {
+  return renderWithApplicationContext(
+    <table>
+      <tbody>
+        <ConsumerPurposeTemplateTableRow purposeTemplate={purposeTemplate} />
+      </tbody>
+    </table>,
+    { withRouterContext: true, withReactQueryContext: true }
+  )
+}
+
+describe('ConsumerPurposeTemplateTableRow', () => {
+  beforeEach(() => {
+    mockUseGetActiveUserParty()
+  })
+
+  it('navigates a viewer to the read-only summary for a draft template', async () => {
+    mockUseJwt({ isAdmin: false, isViewer: true })
+
+    const { getByRole, history } = renderRow()
+    await userEvent.setup().click(getByRole('link'))
+
+    expect(history.location.pathname).toBe(
+      '/it/fruizione/template-finalita/pt-1/modifica/riepilogo'
+    )
+  })
+
+  it('navigates a non-viewer to the draft edit page for a draft template', async () => {
+    mockUseJwt()
+
+    const { getByRole, history } = renderRow()
+    await userEvent.setup().click(getByRole('link'))
+
+    expect(history.location.pathname).toBe('/it/fruizione/template-finalita/pt-1/modifica')
+  })
+})

--- a/src/pages/ConsumerPurposeTemplateSummaryPage/ConsumerPurposeTemplateSummary.page.tsx
+++ b/src/pages/ConsumerPurposeTemplateSummaryPage/ConsumerPurposeTemplateSummary.page.tsx
@@ -13,6 +13,7 @@ import { PageContainer } from '@/components/layout/containers'
 import { PurposeTemplateQueries } from '@/api/purposeTemplate/purposeTemplate.queries'
 import { useQuery } from '@tanstack/react-query'
 import { PurposeTemplateMutations } from '@/api/purposeTemplate/purposeTemplate.mutations'
+import { AuthHooks } from '@/api/auth'
 import { PurposeTemplateTemplateSummaryGeneralInformationAccordion } from './components'
 import { PurposeTemplateSummaryLinkedResourceAccordion } from './components/PurposeTemplateSummaryLinkedResourceAccordion'
 import { PurposeTemplateSummaryRiskAnalysisAccordion } from './components/PurposeTemplateSummaryRiskAnalysisAccordion'
@@ -22,6 +23,8 @@ const ConsumerPurposeTemplateTemplateSummaryPage: React.FC = () => {
   const { t: tCommon } = useTranslation('common', { keyPrefix: 'actions' })
 
   const { purposeTemplateId } = useParams<'SUBSCRIBE_PURPOSE_TEMPLATE_SUMMARY'>()
+
+  const { isAdmin } = AuthHooks.useJwt()
 
   const navigate = useNavigate()
 
@@ -102,22 +105,24 @@ const ConsumerPurposeTemplateTemplateSummaryPage: React.FC = () => {
         </React.Suspense>
       </Stack>
 
-      <Stack spacing={1} sx={{ mt: 4 }} direction="row" justifyContent="end">
-        <Button
-          startIcon={<DeleteOutlineIcon />}
-          variant="text"
-          color="error"
-          onClick={handleDeleteDraft}
-        >
-          {tCommon('deleteDraft')}
-        </Button>
-        <Button startIcon={<CreateIcon />} variant="text" onClick={handleEditDraft}>
-          {tCommon('editDraft')}
-        </Button>
-        <Button startIcon={<PublishIcon />} variant="contained" onClick={handlePublishDraft}>
-          {tCommon('publish')}
-        </Button>
-      </Stack>
+      {isAdmin && (
+        <Stack spacing={1} sx={{ mt: 4 }} direction="row" justifyContent="end">
+          <Button
+            startIcon={<DeleteOutlineIcon />}
+            variant="text"
+            color="error"
+            onClick={handleDeleteDraft}
+          >
+            {tCommon('deleteDraft')}
+          </Button>
+          <Button startIcon={<CreateIcon />} variant="text" onClick={handleEditDraft}>
+            {tCommon('editDraft')}
+          </Button>
+          <Button startIcon={<PublishIcon />} variant="contained" onClick={handlePublishDraft}>
+            {tCommon('publish')}
+          </Button>
+        </Stack>
+      )}
     </PageContainer>
   )
 }

--- a/src/pages/ConsumerPurposeTemplateSummaryPage/ConsumerPurposeTemplateSummary.page.tsx
+++ b/src/pages/ConsumerPurposeTemplateSummaryPage/ConsumerPurposeTemplateSummary.page.tsx
@@ -24,7 +24,7 @@ const ConsumerPurposeTemplateTemplateSummaryPage: React.FC = () => {
 
   const { purposeTemplateId } = useParams<'SUBSCRIBE_PURPOSE_TEMPLATE_SUMMARY'>()
 
-  const { isAdmin } = AuthHooks.useJwt()
+  const { isViewer } = AuthHooks.useJwt()
 
   const navigate = useNavigate()
 
@@ -105,7 +105,7 @@ const ConsumerPurposeTemplateTemplateSummaryPage: React.FC = () => {
         </React.Suspense>
       </Stack>
 
-      {isAdmin && (
+      {!isViewer && (
         <Stack spacing={1} sx={{ mt: 4 }} direction="row" justifyContent="end">
           <Button
             startIcon={<DeleteOutlineIcon />}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
@@ -36,7 +36,7 @@ export const ProviderEServiceGeneralInfoSection: React.FC = () => {
   const { t: tDrawer } = useTranslation('eservice', {
     keyPrefix: 'read.drawers',
   })
-  const { jwt, isOperatorAPI, isAdmin } = AuthHooks.useJwt()
+  const { jwt, isOperatorAPI, isAdmin, isViewer } = AuthHooks.useJwt()
 
   const { eserviceId, descriptorId } = useParams<'PROVIDE_ESERVICE_MANAGE'>()
   const { data: descriptor } = useSuspenseQuery(
@@ -254,7 +254,7 @@ export const ProviderEServiceGeneralInfoSection: React.FC = () => {
                 title={t('instanceLabel.label')}
                 titleTypographyProps={{ variant: 'body1', fontWeight: 600 }}
                 topSideActions={
-                  isDelegator
+                  isDelegator || isViewer
                     ? []
                     : [
                         {
@@ -281,7 +281,7 @@ export const ProviderEServiceGeneralInfoSection: React.FC = () => {
                 title={t('eserviceName.label')}
                 titleTypographyProps={{ variant: 'body1', fontWeight: 600 }}
                 topSideActions={
-                  isDelegator
+                  isDelegator || isViewer
                     ? []
                     : [
                         {
@@ -302,7 +302,7 @@ export const ProviderEServiceGeneralInfoSection: React.FC = () => {
             title={t('eserviceDescription.label')}
             titleTypographyProps={{ variant: 'body1', fontWeight: 600 }}
             topSideActions={
-              isDelegator || isEserviceFromTemplate
+              isDelegator || isEserviceFromTemplate || isViewer
                 ? []
                 : [
                     {

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/__tests__/ProviderEServiceGeneralInfoSection.instanceLabel.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/__tests__/ProviderEServiceGeneralInfoSection.instanceLabel.test.tsx
@@ -171,6 +171,17 @@ describe('ProviderEServiceGeneralInfoSection - instanceLabel (published e-servic
     expect(screen.getByText('actions.edit')).toBeInTheDocument()
   })
 
+  it('does NOT show the edit button for instanceLabel for a viewer', () => {
+    mockUseJwt({ isAdmin: false, isViewer: true })
+    mockDescriptorData = baseTemplateDescriptor
+    renderWithApplicationContext(<ProviderEServiceGeneralInfoSection />, {
+      withReactQueryContext: true,
+    })
+
+    expect(screen.getByText('instanceLabel.label')).toBeInTheDocument()
+    expect(screen.queryByText('actions.edit')).not.toBeInTheDocument()
+  })
+
   it('opens the update instanceLabel drawer when clicking the edit button', async () => {
     const user = userEvent.setup()
     mockDescriptorData = baseTemplateDescriptor

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceSignalHubSection/ProviderEServiceSignalHubSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceSignalHubSection/ProviderEServiceSignalHubSection.tsx
@@ -32,7 +32,8 @@ export const ProviderEServiceSignalHubSection: React.FC = () => {
 
   const isSignalHubEnabled = descriptor.eservice.isSignalHubEnabled ?? false
 
-  const organizationId = AuthHooks.useJwt().jwt?.organizationId
+  const { jwt, isViewer } = AuthHooks.useJwt()
+  const organizationId = jwt?.organizationId
   const { isDelegator } = useGetProducerDelegationUserRole({
     eserviceId,
     organizationId: organizationId,
@@ -80,7 +81,7 @@ export const ProviderEServiceSignalHubSection: React.FC = () => {
               innerSection
               title={t('innerSection.title')}
               topSideActions={
-                isDelegator
+                isDelegator || isViewer
                   ? []
                   : [
                       {

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDelegationsSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDelegationsSection.tsx
@@ -24,7 +24,7 @@ export const ProviderEServiceDelegationsSection: React.FC<
 
   const { isOpen, openDrawer, closeDrawer } = useDrawerState()
 
-  const { jwt } = AuthHooks.useJwt()
+  const { jwt, isViewer } = AuthHooks.useJwt()
 
   const isConsumerDelegable = descriptor.eservice.isConsumerDelegable
   const isClientAccessDelegable = descriptor.eservice.isClientAccessDelegable
@@ -40,7 +40,7 @@ export const ProviderEServiceDelegationsSection: React.FC<
         innerSection
         title={t('title')}
         topSideActions={
-          isDelegator
+          isDelegator || isViewer
             ? []
             : [
                 {

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDocumentationSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDocumentationSection.tsx
@@ -26,7 +26,7 @@ export const ProviderEServiceDocumentationSection: React.FC<
   })
   const { t: tCommon } = useTranslation('common')
 
-  const { jwt } = AuthHooks.useJwt()
+  const { jwt, isViewer } = AuthHooks.useJwt()
 
   const { isDelegator } = useGetProducerDelegationUserRole({
     eserviceId: descriptor.eservice.id,
@@ -62,7 +62,7 @@ export const ProviderEServiceDocumentationSection: React.FC<
         innerSection
         title={t('documentation.title')}
         topSideActions={
-          isDelegator || isEserviceFromTemplate
+          isDelegator || isEserviceFromTemplate || isViewer
             ? []
             : [
                 {

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceVoucherLifespanSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceVoucherLifespanSection.tsx
@@ -27,7 +27,7 @@ export const ProviderEServiceVoucherLifespanSection: React.FC<
     keyPrefix: 'read.drawers.updateVoucherDrawer',
   })
 
-  const { jwt } = AuthHooks.useJwt()
+  const { jwt, isViewer } = AuthHooks.useJwt()
 
   const { isDelegator } = useGetProducerDelegationUserRole({
     eserviceId: descriptor.eservice.id,
@@ -78,7 +78,7 @@ export const ProviderEServiceVoucherLifespanSection: React.FC<
         innerSection
         title={t('thresholds.title')}
         topSideActions={
-          !isDelegator && !isEserviceFromTemplate
+          !isDelegator && !isEserviceFromTemplate && !isViewer
             ? [
                 {
                   action: onEdit,

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceVersionInfoSection/ProviderEServiceVersionInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceVersionInfoSection/ProviderEServiceVersionInfoSection.tsx
@@ -12,12 +12,15 @@ import { formatDateString } from '@/utils/format.utils'
 import { getLastDescriptor } from '@/utils/eservice.utils'
 import { FEATURE_FLAG_AGREEMENT_APPROVAL_POLICY_UPDATE } from '@/config/env'
 import { ProviderEServiceUpdateAgreementApprovalPolicyDrawer } from './ProviderEServiceUpdateAgreementApprovalPolicyDrawer'
+import { AuthHooks } from '@/api/auth'
 
 export const ProviderEServiceVersionInfoSection: React.FC = () => {
   const { t } = useTranslation('eservice', {
     keyPrefix: 'read.sections.versionInformations',
   })
   const { t: tCommon } = useTranslation('common')
+
+  const { isViewer } = AuthHooks.useJwt()
 
   const { eserviceId, descriptorId } = useParams<'PROVIDE_ESERVICE_MANAGE'>()
   const { data: descriptor } = useSuspenseQuery(
@@ -68,13 +71,17 @@ export const ProviderEServiceVersionInfoSection: React.FC = () => {
                 innerSection
                 title={t('agreementApprovalPolicy.title')}
                 titleTypographyProps={{ variant: 'body1', fontWeight: 600 }}
-                topSideActions={[
-                  {
-                    action: openApprovalPolicyDrawer,
-                    label: tCommon('actions.edit'),
-                    icon: EditIcon,
-                  },
-                ]}
+                topSideActions={
+                  isViewer
+                    ? []
+                    : [
+                        {
+                          action: openApprovalPolicyDrawer,
+                          label: tCommon('actions.edit'),
+                          icon: EditIcon,
+                        },
+                      ]
+                }
               >
                 <InformationContainer
                   label={t('agreementApprovalPolicy.label')}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceVersionInfoSection/__tests__/ProviderEServiceVersionInfoSection.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceVersionInfoSection/__tests__/ProviderEServiceVersionInfoSection.test.tsx
@@ -116,6 +116,20 @@ describe('ProviderEServiceVersionInfoSection', () => {
         expect(screen.getByRole('heading', { level: 6, name: 'title' })).toBeInTheDocument()
       })
     })
+
+    it('does NOT render the edit button for a viewer', () => {
+      mockUseJwt({ isAdmin: false, isViewer: true })
+      mockDescriptorData = createMockEServiceDescriptorProvider({
+        agreementApprovalPolicy: 'AUTOMATIC',
+      })
+
+      renderWithApplicationContext(<ProviderEServiceVersionInfoSection />, {
+        withReactQueryContext: true,
+      })
+
+      expect(screen.getByText('agreementApprovalPolicy.title')).toBeInTheDocument()
+      expect(screen.queryByText('actions.edit')).not.toBeInTheDocument()
+    })
   })
 
   describe('Ciclo di vita', () => {

--- a/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
@@ -9,6 +9,7 @@ import PublishIcon from '@mui/icons-material/Publish'
 import { SummaryAccordion, SummaryAccordionSkeleton } from '@/components/shared/SummaryAccordion'
 import { useQuery } from '@tanstack/react-query'
 import { EServiceTemplateMutations, EServiceTemplateQueries } from '@/api/eserviceTemplate'
+import { AuthHooks } from '@/api/auth'
 import {
   ProviderEServiceTemplateGeneralInfoSummarySection,
   ProviderEServiceTemplateThresholdsAndAttributesSummarySection,
@@ -27,6 +28,8 @@ const ProviderEServiceTemplateSummaryPage: React.FC = () => {
   const { eServiceTemplateId, eServiceTemplateVersionId } =
     useParams<'PROVIDE_ESERVICE_TEMPLATE_SUMMARY'>()
   const navigate = useNavigate()
+
+  const { isAdmin } = AuthHooks.useJwt()
 
   const { mutate: deleteVersion } = EServiceTemplateMutations.useDeleteVersionDraft()
   const { mutate: publishVersion } = EServiceTemplateMutations.usePublishVersionDraft()
@@ -197,7 +200,7 @@ const ProviderEServiceTemplateSummaryPage: React.FC = () => {
             </SummaryAccordion>
           </React.Suspense>
         </Stack>
-        {!arePersonalDataSet && !isLoading && (
+        {isAdmin && !arePersonalDataSet && !isLoading && (
           <Alert severity="warning" sx={{ alignItems: 'center', mt: 3 }} variant="outlined">
             <Stack spacing={30} direction="row" alignItems="center">
               {' '}
@@ -219,25 +222,27 @@ const ProviderEServiceTemplateSummaryPage: React.FC = () => {
             {t('summary.missingFieldsBanner')}
           </Alert>
         )}
-        <Stack spacing={1} sx={{ mt: 4 }} direction="row" justifyContent="end">
-          <Button
-            startIcon={<DeleteOutlineIcon />}
-            variant="text"
-            color="error"
-            onClick={handleDeleteDraft}
-          >
-            {tCommon('deleteDraft')}
-          </Button>
-          <Button startIcon={<CreateIcon />} variant="text" onClick={handleEditDraft}>
-            {tCommon('editDraft')}
-          </Button>
-          <PublishButton
-            onClick={handlePublishDraft}
-            disabled={!canBePublished()}
-            arePersonalDataSet={arePersonalDataSet}
-            hasMissingFields={hasMissingFields}
-          />
-        </Stack>
+        {isAdmin && (
+          <Stack spacing={1} sx={{ mt: 4 }} direction="row" justifyContent="end">
+            <Button
+              startIcon={<DeleteOutlineIcon />}
+              variant="text"
+              color="error"
+              onClick={handleDeleteDraft}
+            >
+              {tCommon('deleteDraft')}
+            </Button>
+            <Button startIcon={<CreateIcon />} variant="text" onClick={handleEditDraft}>
+              {tCommon('editDraft')}
+            </Button>
+            <PublishButton
+              onClick={handlePublishDraft}
+              disabled={!canBePublished()}
+              arePersonalDataSet={arePersonalDataSet}
+              hasMissingFields={hasMissingFields}
+            />
+          </Stack>
+        )}
       </PageContainer>
       <UpdatePersonalDataDrawer
         isOpen={isEServiceTemplateUpdatePersonalDataDrawerOpen}

--- a/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
@@ -29,7 +29,7 @@ const ProviderEServiceTemplateSummaryPage: React.FC = () => {
     useParams<'PROVIDE_ESERVICE_TEMPLATE_SUMMARY'>()
   const navigate = useNavigate()
 
-  const { isAdmin } = AuthHooks.useJwt()
+  const { isViewer } = AuthHooks.useJwt()
 
   const { mutate: deleteVersion } = EServiceTemplateMutations.useDeleteVersionDraft()
   const { mutate: publishVersion } = EServiceTemplateMutations.usePublishVersionDraft()
@@ -200,7 +200,7 @@ const ProviderEServiceTemplateSummaryPage: React.FC = () => {
             </SummaryAccordion>
           </React.Suspense>
         </Stack>
-        {isAdmin && !arePersonalDataSet && !isLoading && (
+        {!isViewer && !arePersonalDataSet && !isLoading && (
           <Alert severity="warning" sx={{ alignItems: 'center', mt: 3 }} variant="outlined">
             <Stack spacing={30} direction="row" alignItems="center">
               {' '}
@@ -222,7 +222,7 @@ const ProviderEServiceTemplateSummaryPage: React.FC = () => {
             {t('summary.missingFieldsBanner')}
           </Alert>
         )}
-        {isAdmin && (
+        {!isViewer && (
           <Stack spacing={1} sx={{ mt: 4 }} direction="row" justifyContent="end">
             <Button
               startIcon={<DeleteOutlineIcon />}

--- a/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateSummary.page.test.tsx
@@ -249,4 +249,21 @@ describe('ProviderEServiceTemplateSummaryPage', () => {
     expect(screen.getByRole('button', { name: 'deleteDraft' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'editDraft' })).toBeInTheDocument()
   })
+
+  it('does NOT render draft actions (publish/edit/delete) for a viewer', () => {
+    mockUseJwt({ isAdmin: false, isViewer: true })
+    useQueryMock.mockReturnValue({
+      data: createMockEServiceTemplateVersionDetails(),
+      isLoading: false,
+    })
+
+    renderWithApplicationContext(<ProviderEServiceTemplateSummaryPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.queryByRole('button', { name: 'publish' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'deleteDraft' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'editDraft' })).not.toBeInTheDocument()
+  })
 })

--- a/src/pages/ProviderEServiceTemplatesListPage/components/EServiceTemplateTableRow.tsx
+++ b/src/pages/ProviderEServiceTemplatesListPage/components/EServiceTemplateTableRow.tsx
@@ -11,6 +11,7 @@ import { EServiceTemplateQueries } from '@/api/eserviceTemplate'
 import type { ProducerEServiceTemplate } from '@/api/api.generatedTypes'
 import { useGetProviderEServiceTemplateActions } from '@/hooks/useGetProviderEServiceTemplateActions'
 import { NotificationBadgeDot } from '@/components/shared/NotificationBadgeDot/NotificationBadgeDot'
+import { AuthHooks } from '@/api/auth'
 
 type EServiceTemplateTableRow = {
   eserviceTemplate: ProducerEServiceTemplate
@@ -20,6 +21,7 @@ export const EServiceTemplateTableRow: React.FC<EServiceTemplateTableRow> = ({
   eserviceTemplate,
 }) => {
   const { t } = useTranslation('common', { keyPrefix: 'actions' })
+  const { isViewer } = AuthHooks.useJwt()
 
   const queryClient = useQueryClient()
 
@@ -87,7 +89,7 @@ export const EServiceTemplateTableRow: React.FC<EServiceTemplateTableRow> = ({
           eServiceTemplateVersionId: versionId ?? '',
         }}
       >
-        {hasNotActiveVersionTemplate ? t('manageDraft') : t('inspect')}
+        {hasNotActiveVersionTemplate && !isViewer ? t('manageDraft') : t('inspect')}
       </Link>
 
       <Box component="span" sx={{ ml: 2, display: 'inline-block' }}>

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -367,7 +367,7 @@ export const { routes, reactRouterDOMRoutes, hooks, components, utils } = new In
     redirect: 'SUBSCRIBE_AGREEMENT_LIST',
     public: false,
     hideSideNav: false,
-    authLevels: ['admin', 'support', 'security', 'api'],
+    authLevels: ['admin', 'support', 'security', 'api', 'viewer'],
   })
   .addRoute({
     key: 'PARTY_REGISTRY',
@@ -439,7 +439,7 @@ export const { routes, reactRouterDOMRoutes, hooks, components, utils } = new In
     redirect: 'PARTY_REGISTRY',
     public: false,
     hideSideNav: false,
-    authLevels: ['admin', 'support', 'api', 'security'],
+    authLevels: ['admin', 'support', 'api', 'security', 'viewer'],
   })
   .addRoute({
     key: 'TENANT_CERTIFIER',

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -375,7 +375,7 @@ export const { routes, reactRouterDOMRoutes, hooks, components, utils } = new In
     element: <PartyRegistryPage />,
     public: false,
     hideSideNav: false,
-    authLevels: ['admin', 'support', 'api', 'security', 'reviewer'],
+    authLevels: ['admin', 'support', 'api', 'security', 'reviewer', 'viewer'],
   })
   .addRoute({
     key: 'ASSISTENCE_PARTY_SELECTION',
@@ -591,7 +591,7 @@ export const { routes, reactRouterDOMRoutes, hooks, components, utils } = new In
     element: <ProviderEServiceTemplateSummaryPage />,
     public: false,
     hideSideNav: true,
-    authLevels: ['admin', 'api', 'support'],
+    authLevels: ['admin', 'api', 'support', 'viewer'],
   })
   .addRoute({
     key: 'PROVIDE_ESERVICE_FROM_TEMPLATE_CREATE',
@@ -688,7 +688,7 @@ export const { routes, reactRouterDOMRoutes, hooks, components, utils } = new In
     element: <ConsumerPurposeTemplateSummaryPage />,
     public: false,
     hideSideNav: true,
-    authLevels: ['admin', 'api', 'support'],
+    authLevels: ['admin', 'api', 'support', 'viewer'],
   })
   .addRoute({
     key: 'SUBSCRIBE_PURPOSE_TEMPLATE_EDIT',


### PR DESCRIPTION
## 🔗 Issue
[PIN-10281](https://pagopa.atlassian.net/browse/PIN-10281)

## 📝 Description / Context
The `viewer` is a read-only role (introduced in PIN-10263). Most mutating CTAs were already hidden because action hooks gate on `isAdmin`, but several inline CTAs and navigation paths were still reachable by a viewer. This PR audits every section the viewer can access and hides the remaining mutating CTAs, while keeping read-only/consultation actions (downloads, "show details"). It also makes draft template elements open a read-only summary, and restores the missing "Il mio ente" entry for the viewer.

## 🛠 List of changes
- **Routes**: added `viewer` to `authLevels` of `PROVIDE_ESERVICE_TEMPLATE_SUMMARY`, `SUBSCRIBE_PURPOSE_TEMPLATE_SUMMARY` (so drafts open a reachable read-only summary) and `PARTY_REGISTRY` (so "Il mio ente" / Anagrafica e attributi is visible to the viewer — was missing).
- **Template summary pages** (`ProviderEServiceTemplateSummary`, `ConsumerPurposeTemplateSummary`): publish/edit/delete actions (and the provider personal-data alert action) gated on `!isViewer` — kept available for admin/api/support, hidden for the viewer.
- **Table rows**:
  - `ConsumerPurposeTemplateTableRow`: a viewer opening a draft is routed to the read-only summary instead of the edit page (label "Ispeziona").
  - `EServiceTemplateTableRow`: label switched to "Ispeziona" for the viewer on draft-only templates.
- **Provider e-service detail page**: hidden the inline "Modifica" CTAs for the viewer (`!isViewer`) in: version info (agreement approval policy), delegations, voucher lifespan, signal hub, dogeneral info (name/description/instance label). Otherroles are unaffected.
- **Tests**: added/extended viewer coverage for the pr version info section, instance label section, theconsumer purpose template row navigation, and `useGetSidebarItems` (viewer sees "Il mio ente").

## 🧪 How to test
- Log in as a `viewer` (read-only role).
- **Catalogo**: open an e-service detail → no "Richiedi fruizione" CTA.
- **Il mio ente**: the sidebar entry is visible; the pi (read-only, no edit) and Attributi, with no actions.
- **Fruizione / Erogazione**: lists and details open in read-only; no create/edit/delete/publish/suspend CTAs; downloads still available.
- **Drafts**: open a draft e-service template / purposmmary is shown with no publish/edit/delete buttons.
- Regression check: log in as `admin`, `api` and `support` → the template summary publish/edit/delete actions and the e-service edit CTAs
are still present.

[PIN-10281]: https://pagopa.atlassian.net/browse/PIN-10281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ