### PR TITLE
feat: add missing feedback toasts for e-service archiving actions (PIN-10306)

### DIFF
--- a/src/api/eservice/eservice.mutations.ts
+++ b/src/api/eservice/eservice.mutations.ts
@@ -167,7 +167,7 @@ function useSuspendVersion(options?: { skipConfirmation?: boolean; isArchivingCo
       successToastLabel: t(
         options?.isArchivingContext ? 'outcome.successArchiving' : 'outcome.success'
       ),
-      errorToastLabel: t('outcome.error'),
+      errorToastLabel: t(options?.isArchivingContext ? 'outcome.errorArchiving' : 'outcome.error'),
       loadingLabel: t('loading'),
       confirmationDialog: options?.skipConfirmation
         ? undefined
@@ -190,7 +190,7 @@ function useReactivateVersion(options?: {
       successToastLabel: t(
         options?.isArchivingContext ? 'outcome.successArchiving' : 'outcome.success'
       ),
-      errorToastLabel: t('outcome.error'),
+      errorToastLabel: t(options?.isArchivingContext ? 'outcome.errorArchiving' : 'outcome.error'),
       loadingLabel: t('loading'),
       confirmationDialog: options?.skipConfirmation
         ? undefined
@@ -203,14 +203,28 @@ function useReactivateVersion(options?: {
 }
 
 function useScheduleArchiveDescriptor() {
+  const { t } = useTranslation('mutations-feedback', {
+    keyPrefix: 'eservice.scheduleArchiveDescriptor',
+  })
   return useMutation({
     mutationFn: EServiceServices.scheduleArchiveDescriptor,
+    meta: {
+      successToastLabel: t('outcome.success', { days: GRACE_PERIOD_ARCHIVING_ESERVICE }),
+      errorToastLabel: t('outcome.error'),
+    },
   })
 }
 
 function useCancelDescriptorArchiving() {
+  const { t } = useTranslation('mutations-feedback', {
+    keyPrefix: 'eservice.cancelDescriptorArchiving',
+  })
   return useMutation({
     mutationFn: EServiceServices.cancelDescriptorArchiving,
+    meta: {
+      successToastLabel: t('outcome.success'),
+      errorToastLabel: t('outcome.error'),
+    },
   })
 }
 
@@ -222,6 +236,7 @@ function useScheduleArchiveEservice() {
     mutationFn: EServiceServices.scheduleArchiveEservice,
     meta: {
       successToastLabel: t('outcome.success', { days: GRACE_PERIOD_ARCHIVING_ESERVICE }),
+      errorToastLabel: t('outcome.error'),
     },
   })
 }
@@ -234,6 +249,7 @@ function useCancelEserviceArchiving() {
     mutationFn: EServiceServices.cancelEserviceArchiving,
     meta: {
       successToastLabel: t('outcome.success'),
+      errorToastLabel: t('outcome.error'),
     },
   })
 }

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -135,14 +135,28 @@
         "description": "The risk analysis will be deleted from this e-service."
       }
     },
+    "scheduleArchiveDescriptor": {
+      "outcome": {
+        "success": "This e-service version will be archived in {{days}} days",
+        "error": "This e-service version could not be archived. Please try again later."
+      }
+    },
+    "cancelDescriptorArchiving": {
+      "outcome": {
+        "success": "This version is no longer being archived",
+        "error": "The archiving of this e-service version could not be canceled. Please try again later."
+      }
+    },
     "cancelEserviceArchiving": {
       "outcome": {
-        "success": "The e-service is no longer being archived"
+        "success": "The e-service is no longer being archived",
+        "error": "The archiving of this e-service could not be canceled. Please try again later."
       }
     },
     "scheduleArchiveEservice": {
       "outcome": {
-        "success": "This e-service will be archived in {{days}} days"
+        "success": "This e-service will be archived in {{days}} days",
+        "error": "This e-service could not be archived. Please try again later."
       }
     },
     "suspendVersion": {
@@ -150,7 +164,8 @@
       "outcome": {
         "success": "E-service version suspended successfully",
         "successArchiving": "You have suspended this e-service version",
-        "error": "The e-service version could not be suspended. Please try again!"
+        "error": "The e-service version could not be suspended. Please try again!",
+        "errorArchiving": "The e-service version could not be suspended. Please try again later."
       },
       "confirmDialog": {
         "title": "Confirm Version Suspension",
@@ -162,7 +177,8 @@
       "outcome": {
         "success": "E-service version reactivated successfully",
         "successArchiving": "You have reactivated this e-service version",
-        "error": "The e-service version could not be reactivated. Please try again!"
+        "error": "The e-service version could not be reactivated. Please try again!",
+        "errorArchiving": "The e-service version could not be reactivated. Please try again later."
       },
       "confirmDialog": {
         "title": "Confirm Version Reactivation",

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -135,14 +135,28 @@
         "description": "Cliccando \"conferma\" la finalità sarà eliminata da questo e-service."
       }
     },
+    "scheduleArchiveDescriptor": {
+      "outcome": {
+        "success": "Questa versione dell'e-service sarà archiviata tra {{days}} giorni",
+        "error": "Non è stato possibile procedere con l'archiviazione di questa versione dell'e-service. Riprova più tardi."
+      }
+    },
+    "cancelDescriptorArchiving": {
+      "outcome": {
+        "success": "Questa versione non è più in fase di archiviazione",
+        "error": "Non è stato possibile annullare l'archiviazione di questa versione dell'e-service. Riprova più tardi."
+      }
+    },
     "cancelEserviceArchiving": {
       "outcome": {
-        "success": "L'e-service non è più in fase di archiviazione"
+        "success": "L'e-service non è più in fase di archiviazione",
+        "error": "Non è stato possibile annullare l'archiviazione di questo e-service. Riprova più tardi."
       }
     },
     "scheduleArchiveEservice": {
       "outcome": {
-        "success": "Questo e-service sarà archiviato tra {{days}} giorni"
+        "success": "Questo e-service sarà archiviato tra {{days}} giorni",
+        "error": "Non è stato possibile procedere con l'archiviazione di questo e-service. Riprova più tardi."
       }
     },
     "suspendVersion": {
@@ -150,7 +164,8 @@
       "outcome": {
         "success": "La versione dell'e-service è stata sospesa",
         "successArchiving": "Hai sospeso questa versione dell'e-service",
-        "error": "Non è stato possibile sospendere questa versione dell'e-service. Per favore, riprova!"
+        "error": "Non è stato possibile sospendere questa versione dell'e-service. Per favore, riprova!",
+        "errorArchiving": "Non è stato possibile sospendere questa versione dell'e-service. Riprova più tardi."
       },
       "confirmDialog": {
         "title": "Conferma sospensione versione",
@@ -162,7 +177,8 @@
       "outcome": {
         "success": "La versione dell'e-service è stata riattivata",
         "successArchiving": "Hai riattivato questa versione dell'e-service",
-        "error": "Non è stato possibile riattivare questa versione dell'e-service. Per favore, riprova!"
+        "error": "Non è stato possibile riattivare questa versione dell'e-service. Per favore, riprova!",
+        "errorArchiving": "Non è stato possibile riattivare questa versione dell'e-service. Riprova più tardi."
       },
       "confirmDialog": {
         "title": "Conferma riattivazione versione",


### PR DESCRIPTION
## 🔗 Issue
[PIN-10306](https://pagopa.atlassian.net/browse/PIN-10306)

## 📝 Description / Context
Follow-up of the review comment on #1983 (PIN-10294): several e-service archiving actions showed no toast on error (with `throwOnError: false` and no `errorToastLabel`, the error is silent). While checking Figma, two success toasts were also missing at the version level. The Design team provided all the copy. This PR completes the feedback toasts for the whole archiving action family.

## 🛠 List of changes
- `eservice.mutations.ts`:
  - `useSuspendVersion` / `useReactivateVersion`: `errorToastLabel` is now conditional on `isArchivingContext` (`outcome.errorArchiving` in the archiving flow, `outcome.error` otherwise), mirroring the existing success pattern.
  - `useScheduleArchiveEservice` / `useCancelEserviceArchiving`: added `errorToastLabel`.
  - `useScheduleArchiveDescriptor` / `useCancelDescriptorArchiving`: previously had no `meta`; added both `successToastLabel` and `errorToastLabel` (the schedule one interpolates `{{days}}` with `GRACE_PERIOD_ARCHIVING_ESERVICE`, the same grace period used by `DialogArchiveVersion`).
- i18n (`mutations-feedback.json`, IT + EN): added the `error` / `errorArchiving` / `success` keys for the actions above.

Resulting matrix (success / error) for the 6 archiving actions: all covered.

## 🧪 How to test
- Force an error (e.g. backend unreachable) on each of the 6 actions from their archiving dialogs, and check the error toast matches the Figma copy.
- Successfully run archive-version and cancel-version-archiving, and check the new success toasts appear.
- Outside the archiving context, suspend/reactivate version still show the generic error text.

[PIN-10306]: https://pagopa.atlassian.net/browse/PIN-10306
