### PR TITLE
feat: add schema editor link to REST interface descriptions (PIN-10303)

### DIFF
--- a/src/components/shared/RestInterfaceDescription.tsx
+++ b/src/components/shared/RestInterfaceDescription.tsx
@@ -1,0 +1,70 @@
+import { openApiCheckerLink, schemaEditorLink } from '@/config/constants'
+import { IconLink } from './IconLink'
+import LaunchIcon from '@mui/icons-material/Launch'
+import { Box, Typography } from '@mui/material'
+
+type RestInterfaceDescriptionProps = {
+  description: string
+  beforePublishing: string
+  technicalCompliance: string
+  technicalComplianceDescription: string
+  semanticCompliance: string
+  semanticComplianceDescription: string
+  openApiCheckerLabel: string
+  schemaEditorLabel: string
+  onOpenApiCheckerClick?: () => void
+}
+
+export const RestInterfaceDescription: React.FC<RestInterfaceDescriptionProps> = ({
+  description,
+  beforePublishing,
+  technicalCompliance,
+  technicalComplianceDescription,
+  semanticCompliance,
+  semanticComplianceDescription,
+  openApiCheckerLabel,
+  schemaEditorLabel,
+  onOpenApiCheckerClick,
+}) => {
+  return (
+    <Box sx={{ color: 'text.primary' }}>
+      <Typography component="span" variant="body2">
+        {description}
+      </Typography>{' '}
+      <Typography component="span" variant="body2">
+        {beforePublishing}
+      </Typography>
+      <Box component="ul" sx={{ m: 0, mt: 1, pl: 3 }}>
+        <Box component="li">
+          <Typography component="span" variant="body2" fontWeight={600}>
+            {technicalCompliance}
+          </Typography>{' '}
+          {technicalComplianceDescription}{' '}
+          <IconLink
+            href={openApiCheckerLink}
+            target="_blank"
+            endIcon={<LaunchIcon fontSize="small" />}
+            onClick={onOpenApiCheckerClick}
+          >
+            {openApiCheckerLabel}
+          </IconLink>
+          .
+        </Box>
+        <Box component="li">
+          <Typography component="span" variant="body2" fontWeight={600}>
+            {semanticCompliance}
+          </Typography>{' '}
+          {semanticComplianceDescription}{' '}
+          <IconLink
+            href={schemaEditorLink}
+            target="_blank"
+            endIcon={<LaunchIcon fontSize="small" />}
+          >
+            {schemaEditorLabel}
+          </IconLink>
+          .
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/shared/__tests__/RestInterfaceDescription.test.tsx
+++ b/src/components/shared/__tests__/RestInterfaceDescription.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RestInterfaceDescription } from '../RestInterfaceDescription'
+
+const restInterfaceDescriptionProps = {
+  description: 'Upload the OpenAPI file.',
+  beforePublishing: 'Before publishing, check:',
+  technicalCompliance: 'technical compliance',
+  technicalComplianceDescription: 'with ModI guidelines through',
+  semanticCompliance: 'semantic compliance',
+  semanticComplianceDescription: 'with National Data Catalog annotations through',
+  openApiCheckerLabel: 'OpenAPI Checker',
+  schemaEditorLabel: 'Schema Editor',
+}
+
+describe('RestInterfaceDescription', () => {
+  it('renders the introductory copy and the compliance list', () => {
+    render(<RestInterfaceDescription {...restInterfaceDescriptionProps} />)
+
+    expect(screen.getByText(restInterfaceDescriptionProps.description)).toBeInTheDocument()
+    expect(screen.getByText(restInterfaceDescriptionProps.beforePublishing)).toBeInTheDocument()
+
+    const complianceItems = screen.getAllByRole('listitem')
+    expect(complianceItems).toHaveLength(2)
+    expect(complianceItems[0]).toHaveTextContent('technical compliance')
+    expect(complianceItems[0]).toHaveTextContent('with ModI guidelines through')
+    expect(complianceItems[1]).toHaveTextContent('semantic compliance')
+    expect(complianceItems[1]).toHaveTextContent('with National Data Catalog annotations through')
+  })
+
+  it('renders the OpenAPI Checker and Schema Editor external links', () => {
+    render(<RestInterfaceDescription {...restInterfaceDescriptionProps} />)
+
+    expect(screen.getByRole('link', { name: /OpenAPI Checker/ })).toHaveAttribute(
+      'href',
+      'https://italia.github.io/api-oas-checker/'
+    )
+    expect(screen.getByRole('link', { name: /Schema Editor/ })).toHaveAttribute(
+      'href',
+      'https://schema.gov.it/schema-editor'
+    )
+  })
+
+  it('calls the OpenAPI Checker tracking callback when the link is clicked', async () => {
+    const user = userEvent.setup()
+    const onOpenApiCheckerClick = vi.fn()
+
+    render(
+      <RestInterfaceDescription
+        {...restInterfaceDescriptionProps}
+        onOpenApiCheckerClick={onOpenApiCheckerClick}
+      />
+    )
+
+    await user.click(screen.getByRole('link', { name: /OpenAPI Checker/ }))
+
+    expect(onOpenApiCheckerClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -34,6 +34,7 @@ export const apiGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/api-espost
 export const delegationGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/deleghe`
 export const delegationEServiceGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/deleghe/delega-per-la-fruizione`
 export const openApiCheckerLink = 'https://italia.github.io/api-oas-checker/'
+export const schemaEditorLink = 'https://schema.gov.it/schema-editor'
 // TODO: aggiornare con il link reale alla guida sugli scambi asincroni
 export const asyncExchangeGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/scambi-asincroni`
 export const eserviceNamingBestPracticeLink =

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/EServiceCreateStepTechSpec.tsx
@@ -14,9 +14,6 @@ import { compareObjects } from '@/utils/common.utils'
 import SaveIcon from '@mui/icons-material/Save'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { remapDescriptorAttributesToDescriptorAttributesSeed } from '@/utils/attribute.utils'
-import { IconLink } from '@/components/shared/IconLink'
-import LaunchIcon from '@mui/icons-material/Launch'
-import { openApiCheckerLink } from '@/config/constants'
 import { trackEvent } from '@/config/tracking'
 import { match } from 'ts-pattern'
 import { EServiceInterfaceSection } from '../sections/EServiceInterfaceSection'
@@ -28,6 +25,7 @@ import {
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { EServiceAsyncExchangeSection } from '../sections/EServiceAsyncExchangeSection'
 import { getAsyncExchangePropertiesWithDefaults } from '@/utils/eservice.utils'
+import { RestInterfaceDescription } from '@/components/shared/RestInterfaceDescription'
 
 type AsyncExchangePropertiesFormValues = {
   responseTime: number | ''
@@ -242,23 +240,35 @@ const EServiceCreateStepTechSpecForm: React.FC<EServiceCreateStepTechSpecFormPro
     ) : isEServiceCreatedFromTemplate ? (
       t('step4.interface.description.restForm')
     ) : (
-      <>
-        {t(`step4.interface.description.rest`)}{' '}
-        <IconLink
-          href={openApiCheckerLink}
-          target="_blank"
-          endIcon={<LaunchIcon fontSize="small" />}
-          onClick={() => trackEvent('INTEROP_EXT_LINK_DTD_API_CHECKER', { src: 'CREATE_ESERVICE' })}
-        >
-          {t('step4.interface.description.restLinkLabel')}
-        </IconLink>
-      </>
+      <RestInterfaceDescription
+        description={t('step4.interface.description.rest')}
+        beforePublishing={t('step4.interface.description.beforePublishing')}
+        technicalCompliance={t('step4.interface.description.technicalCompliance')}
+        technicalComplianceDescription={t(
+          'step4.interface.description.technicalComplianceDescription'
+        )}
+        semanticCompliance={t('step4.interface.description.semanticCompliance')}
+        semanticComplianceDescription={t(
+          'step4.interface.description.semanticComplianceDescription'
+        )}
+        openApiCheckerLabel={t('step4.interface.description.restLinkLabel')}
+        schemaEditorLabel={t('step4.interface.description.schemaEditorLinkLabel')}
+        onOpenApiCheckerClick={() =>
+          trackEvent('INTEROP_EXT_LINK_DTD_API_CHECKER', { src: 'CREATE_ESERVICE' })
+        }
+      />
     )
 
   return (
     <FormProvider {...formMethods}>
       <EServiceInterfaceSection
         description={sectionDescription}
+        descriptionTypographyProps={{
+          component:
+            descriptor?.eservice.technology === 'REST' && !isEServiceCreatedFromTemplate
+              ? 'div'
+              : undefined,
+        }}
         isEServiceCreatedFromTemplate={isEServiceCreatedFromTemplate}
       />
       <Box component="form" noValidate onSubmit={formMethods.handleSubmit(onSubmit)}>

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
@@ -4,6 +4,7 @@ import { EServiceCreateStepTechSpec } from '../EServiceCreateStepTechSpec'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 import userEvent from '@testing-library/user-event'
 import type { Mock } from 'vitest'
+import type { ReactNode } from 'react'
 import { KeychainQueries } from '@/api/keychain'
 import { queryClient } from '@/config/query-client'
 import {
@@ -17,8 +18,13 @@ import { createMockEServiceTemplateDetailsAsync } from '@/../__mocks__/data/eser
 const useRemoveKeychainFromEService = vi.hoisted(() => vi.fn())
 
 vi.mock('../../sections/EServiceInterfaceSection', () => ({
-  EServiceInterfaceSection: () => {
-    return <div>EServiceInterfaceSection</div>
+  EServiceInterfaceSection: ({ description }: { description?: ReactNode }) => {
+    return (
+      <div>
+        <div>EServiceInterfaceSection</div>
+        {description}
+      </div>
+    )
   },
 }))
 
@@ -129,6 +135,45 @@ describe('EServiceCreateStepTechSpec', () => {
     })
     expect(screen.getByText('EServiceInterfaceSection')).toBeInTheDocument()
     expect(screen.getByText('EServiceVoucherSection')).toBeInTheDocument()
+  })
+
+  it('should render OpenAPI Checker and Schema Editor links in the REST interface description', () => {
+    mockUseEServiceCreateContext({ descriptor: createMockEServiceDescriptorProvider() })
+    renderWithApplicationContext(<EServiceCreateStepTechSpec {...stepProps} />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('step4.interface.description.rest')).toBeInTheDocument()
+    expect(screen.getByText('step4.interface.description.technicalCompliance')).toBeInTheDocument()
+    expect(screen.getByText('step4.interface.description.semanticCompliance')).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('link', { name: /step4.interface.description.restLinkLabel/ })
+    ).toHaveAttribute('href', 'https://italia.github.io/api-oas-checker/')
+    expect(
+      screen.getByRole('link', { name: /step4.interface.description.schemaEditorLinkLabel/ })
+    ).toHaveAttribute('href', 'https://schema.gov.it/schema-editor')
+  })
+
+  it('should not render the Schema Editor link in the SOAP interface description', () => {
+    const descriptor = createMockEServiceDescriptorProvider()
+
+    mockUseEServiceCreateContext({
+      descriptor: {
+        ...descriptor,
+        eservice: { ...descriptor.eservice, technology: 'SOAP' },
+      },
+    })
+    renderWithApplicationContext(<EServiceCreateStepTechSpec {...stepProps} />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('step4.interface.description.soap')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: /step4.interface.description.schemaEditorLinkLabel/ })
+    ).not.toBeInTheDocument()
   })
 
   it('should render step actions', () => {

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepTechSpec/__tests__/EServiceCreateStepTechSpec.test.tsx
@@ -172,6 +172,39 @@ describe('EServiceCreateStepTechSpec', () => {
 
     expect(screen.getByText('step4.interface.description.soap')).toBeInTheDocument()
     expect(
+      screen.queryByText('step4.interface.description.technicalCompliance')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('step4.interface.description.semanticCompliance')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: /step4.interface.description.restLinkLabel/ })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: /step4.interface.description.schemaEditorLinkLabel/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not render compliance links when creating an e-service from a template', () => {
+    mockUseEServiceCreateContext({
+      descriptor: createMockEServiceDescriptorProviderWithTemplateRef(),
+    })
+    renderWithApplicationContext(<EServiceCreateStepTechSpec {...stepProps} />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('step4.interface.description.restForm')).toBeInTheDocument()
+    expect(
+      screen.queryByText('step4.interface.description.technicalCompliance')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('step4.interface.description.semanticCompliance')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: /step4.interface.description.restLinkLabel/ })
+    ).not.toBeInTheDocument()
+    expect(
       screen.queryByRole('link', { name: /step4.interface.description.schemaEditorLinkLabel/ })
     ).not.toBeInTheDocument()
   })

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceInterfaceSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceInterfaceSection.tsx
@@ -6,18 +6,26 @@ import { GenerateInterfaceForm } from '../components/GenerateInterfaceForm'
 type EServiceInterfaceSectionProps = {
   isEServiceCreatedFromTemplate: boolean
   description: string | JSX.Element
+  descriptionTypographyProps?: React.ComponentProps<
+    typeof SectionContainer
+  >['descriptionTypographyProps']
   error?: string
 }
 
 export const EServiceInterfaceSection: React.FC<EServiceInterfaceSectionProps> = ({
   description,
+  descriptionTypographyProps,
   isEServiceCreatedFromTemplate,
   error,
 }) => {
   const { t } = useTranslation('eservice', { keyPrefix: 'create.step4.interface' })
 
   return (
-    <SectionContainer title={t('title')} description={description}>
+    <SectionContainer
+      title={t('title')}
+      description={description}
+      descriptionTypographyProps={descriptionTypographyProps}
+    >
       {isEServiceCreatedFromTemplate ? (
         <GenerateInterfaceForm />
       ) : (

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateCreateStepTechnicalSpecs.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateCreateStepTechnicalSpecs.tsx
@@ -16,6 +16,7 @@ import { remapDescriptorAttributesToDescriptorAttributesSeed } from '@/utils/att
 import type { UpdateEServiceTemplateVersionSeed } from '@/api/api.generatedTypes'
 import { getAsyncExchangePropertiesWithDefaults } from '@/utils/eservice.utils'
 import { EServiceTemplateAsyncExchangeSection } from './EServiceTemplateAsyncExchangeSection'
+import { RestInterfaceDescription } from '@/components/shared/RestInterfaceDescription'
 
 type EServiceTemplateCreateStepTechnicalSpecsFormValues = {
   voucherLifespan: number
@@ -90,7 +91,26 @@ export const EServiceTemplateCreateStepTechnicalSpecs: React.FC<ActiveStepProps>
     eserviceTemplateVersion?.eserviceTemplate.technology === 'SOAP' ? (
       t(`create.step3.technicalSpecs.interface.description.soap`)
     ) : (
-      <>{t(`create.step3.technicalSpecs.interface.description.rest`)} </>
+      <RestInterfaceDescription
+        description={t('create.step3.technicalSpecs.interface.description.rest')}
+        beforePublishing={t('create.step3.technicalSpecs.interface.description.beforePublishing')}
+        technicalCompliance={t(
+          'create.step3.technicalSpecs.interface.description.technicalCompliance'
+        )}
+        technicalComplianceDescription={t(
+          'create.step3.technicalSpecs.interface.description.technicalComplianceDescription'
+        )}
+        semanticCompliance={t(
+          'create.step3.technicalSpecs.interface.description.semanticCompliance'
+        )}
+        semanticComplianceDescription={t(
+          'create.step3.technicalSpecs.interface.description.semanticComplianceDescription'
+        )}
+        openApiCheckerLabel={t('create.step3.technicalSpecs.interface.description.restLinkLabel')}
+        schemaEditorLabel={t(
+          'create.step3.technicalSpecs.interface.description.schemaEditorLinkLabel'
+        )}
+      />
     )
 
   return (
@@ -98,6 +118,10 @@ export const EServiceTemplateCreateStepTechnicalSpecs: React.FC<ActiveStepProps>
       <SectionContainer
         title={t('create.step3.technicalSpecs.interface.title')}
         description={sectionDescription}
+        descriptionTypographyProps={{
+          component:
+            eserviceTemplateVersion?.eserviceTemplate.technology !== 'SOAP' ? 'div' : undefined,
+        }}
       >
         <Stack spacing={3}>
           <Alert severity="info"> {t('create.step3.technicalSpecs.interface.alert')}</Alert>

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateCreateStepTechnicalSpecs.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateCreateStepTechnicalSpecs.tsx
@@ -120,7 +120,7 @@ export const EServiceTemplateCreateStepTechnicalSpecs: React.FC<ActiveStepProps>
         description={sectionDescription}
         descriptionTypographyProps={{
           component:
-            eserviceTemplateVersion?.eserviceTemplate.technology !== 'SOAP' ? 'div' : undefined,
+            eserviceTemplateVersion?.eserviceTemplate.technology === 'REST' ? 'div' : undefined,
         }}
       >
         <Stack spacing={3}>

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/EServiceTemplateCreateStepTechnicalSpecs.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/EServiceTemplateCreateStepTechnicalSpecs.test.tsx
@@ -157,6 +157,17 @@ describe('EServiceTemplateCreateStepTechnicalSpecs', () => {
       screen.getByText('create.step3.technicalSpecs.interface.description.soap')
     ).toBeInTheDocument()
     expect(
+      screen.queryByText('create.step3.technicalSpecs.interface.description.technicalCompliance')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('create.step3.technicalSpecs.interface.description.semanticCompliance')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', {
+        name: /create.step3.technicalSpecs.interface.description.restLinkLabel/,
+      })
+    ).not.toBeInTheDocument()
+    expect(
       screen.queryByRole('link', {
         name: /create.step3.technicalSpecs.interface.description.schemaEditorLinkLabel/,
       })

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/EServiceTemplateCreateStepTechnicalSpecs.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/__tests__/EServiceTemplateCreateStepTechnicalSpecs.test.tsx
@@ -7,6 +7,7 @@ import {
 } from '../EServiceTemplateCreateStepTechnicalSpecs'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import {
+  createMockEServiceTemplateVersionDetails,
   createMockEServiceTemplateVersionDetailsAsync,
   mockUseEServiceTemplateCreateContext,
 } from '@/../__mocks__/data/eserviceTemplate.mocks'
@@ -96,6 +97,33 @@ describe('EServiceTemplateCreateStepTechnicalSpecs', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders OpenAPI Checker and Schema Editor links for REST templates', () => {
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetails(),
+    })
+    renderWithApplicationContext(<EServiceTemplateCreateStepTechnicalSpecs {...stepProps} />, {
+      withReactQueryContext: true,
+    })
+
+    expect(
+      screen.getByText('create.step3.technicalSpecs.interface.description.technicalCompliance')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('create.step3.technicalSpecs.interface.description.semanticCompliance')
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('link', {
+        name: /create.step3.technicalSpecs.interface.description.restLinkLabel/,
+      })
+    ).toHaveAttribute('href', 'https://italia.github.io/api-oas-checker/')
+    expect(
+      screen.getByRole('link', {
+        name: /create.step3.technicalSpecs.interface.description.schemaEditorLinkLabel/,
+      })
+    ).toHaveAttribute('href', 'https://schema.gov.it/schema-editor')
+  })
+
   it('renders SOAP description when technology is SOAP', () => {
     mockUseEServiceTemplateCreateContext({
       eserviceTemplateVersion: {
@@ -128,6 +156,11 @@ describe('EServiceTemplateCreateStepTechnicalSpecs', () => {
     expect(
       screen.getByText('create.step3.technicalSpecs.interface.description.soap')
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', {
+        name: /create.step3.technicalSpecs.interface.description.schemaEditorLinkLabel/,
+      })
+    ).not.toBeInTheDocument()
   })
 
   it('does not render the Documentation section', () => {

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -299,8 +299,14 @@
       "interface": {
         "title": "Interface",
         "description": {
-          "rest": "Upload the OpenAPI file that describes the API. Before uploading, verify that it meets the ModI requirements with",
-          "restLinkLabel": "the OpenAPI Checker",
+          "rest": "Upload the OpenAPI file that describes the API.",
+          "beforePublishing": "Before publishing, you can use these tools to check:",
+          "technicalCompliance": "technical compliance",
+          "technicalComplianceDescription": "with the ModI guidelines through",
+          "semanticCompliance": "semantic compliance",
+          "semanticComplianceDescription": "with the National Data Catalog annotations through",
+          "restLinkLabel": "OpenAPI Checker",
+          "schemaEditorLinkLabel": "Schema Editor",
           "restForm": "Fill in these fields to automatically generate the OpenAPI file.",
           "soap": "Upload the WSDL file that describes the API"
         },

--- a/src/static/locales/en/eserviceTemplate.json
+++ b/src/static/locales/en/eserviceTemplate.json
@@ -343,6 +343,13 @@
           "alert": "You can upload a file without contact data, terms and conditions, and server URLs, as these will be filled in by the implementer in the next phase.",
           "description": {
             "rest": "Upload a draft of the OpenAPI specification that describes the API.",
+            "beforePublishing": "Before publishing, you can use these tools to check:",
+            "technicalCompliance": "technical compliance",
+            "technicalComplianceDescription": "with the ModI guidelines through",
+            "semanticCompliance": "semantic compliance",
+            "semanticComplianceDescription": "with the National Data Catalog annotations through",
+            "restLinkLabel": "OpenAPI Checker",
+            "schemaEditorLinkLabel": "Schema Editor",
             "soap": "Upload a draft of the WSDL specification that describes the API"
           },
           "prettyName": "API specification"

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -299,8 +299,14 @@
       "interface": {
         "title": "Interfaccia",
         "description": {
-          "rest": "Carica il file OpenAPI che descrive l'API. Prima di caricarlo, verifica che rispetti i requisiti del ModI con",
-          "restLinkLabel": "l'OpenAPI Checker",
+          "rest": "Carica il file OpenAPI che descrive l'API.",
+          "beforePublishing": "Prima della pubblicazione, puoi usare questi strumenti per controllare:",
+          "technicalCompliance": "la conformità tecnica",
+          "technicalComplianceDescription": "secondo le linee guida ModI con",
+          "semanticCompliance": "la conformità semantica",
+          "semanticComplianceDescription": "tramite le annotazioni del Catalogo Nazionale Dati con",
+          "restLinkLabel": "OpenAPI Checker",
+          "schemaEditorLinkLabel": "Schema Editor",
           "restForm": "Compila questi campi per generare automaticamente il file OpenAPI.",
           "soap": "Carica il file WSDL che descrive l'API"
         },

--- a/src/static/locales/it/eserviceTemplate.json
+++ b/src/static/locales/it/eserviceTemplate.json
@@ -343,6 +343,13 @@
           "alert": "Puoi caricare un file senza dati di contatto, Termini e Condizioni e indirizzi dei server: queste informazioni saranno inserite in una fase successiva da chi userà il template.",
           "description": {
             "rest": "Carica una bozza del file OpenAPI che descrive l'API.",
+            "beforePublishing": "Prima della pubblicazione, puoi usare questi strumenti per controllare:",
+            "technicalCompliance": "la conformità tecnica",
+            "technicalComplianceDescription": "secondo le linee guida ModI con",
+            "semanticCompliance": "la conformità semantica",
+            "semanticComplianceDescription": "tramite le annotazioni del Catalogo Nazionale Dati con",
+            "restLinkLabel": "OpenAPI Checker",
+            "schemaEditorLinkLabel": "Schema Editor",
             "soap": "Carica una bozza del file WSDL che descrive l'API"
           },
           "prettyName": "Specifica API"


### PR DESCRIPTION
## 🔗 Issue

[PIN-10303](https://pagopa.atlassian.net/browse/PIN-10303)

## 📝 Description / Context

This PR updates the REST API interface description in the e-service technical specification step to include a reference to Schema Editor, as required for checking semantic compliance before publication.

## 🛠 List of changes

- Added a shared REST interface description component with OpenAPI Checker and Schema Editor external links.
- Updated producer e-service creation/new version technical specs descriptions.
- Updated e-service template creation/update technical specs descriptions.
- Added the Schema Editor URL constant.
- Updated Italian and English translations.
- Added focused tests for REST and SOAP behavior in producer and template flows.

## 🧪 How to test

- Create or edit a REST producer e-service and open the technical specifications step: the Interface section should show OpenAPI Checker and Schema Editor links.
- Create or edit a REST e-service template and open the technical specifications step: the Interface section should show OpenAPI Checker and Schema Editor links.
- Create or edit a SOAP e-service/template: the Interface section should keep the SOAP description and not show the Schema Editor link.
- Creating an e-service from a template should not show the Schema Editor link, as this flow is excluded by the Jira scope.

[PIN-10303]: https://pagopa.atlassian.net/browse/PIN-10303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ