### PR TITLE
fix: add missing archiving banner for e-service being archived (PIN-10312)

### DIFF
--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -633,6 +633,7 @@
       "suspended": "This e-service version is discontinued. Until its reactivation, no consumer will be able to access the data provided through the API.",
       "deprecated": "This e-service version is obsolete but still active. It will be automatically archived when it has no more agreements.",
       "archivingDescriptor": "This e-service version is being archived but is still active. It will be automatically archived on {{date}}.",
+      "archivingEService": "This e-service is being archived but is still active. It will be automatically archived on {{date}}.",
       "archivingSuspendedDescriptor": "This e-service version is being archived and is currently suspended. It will be automatically archived on {{date}}.",
       "archivedDescriptor": "This e-service version was archived on {{date}}.",
       "archivingSuspendedEService": "This version is currently suspended. The e-service is being archived and will be automatically archived on {{date}}.",
@@ -642,44 +643,6 @@
       "providerMissingProducerKeychain": "Associate a keychain with this e-service to enable data exchange.",
       "providerMissingProducerKeychainKeys": "Add at least one key to the keychain linked to this e-service to enable data exchange.",
       "viewProducerKeychains": "View keychains"
-    },
-    "dialogSuspendArchivingEservice": {
-      "title": "Suspend version of e-service being archived",
-      "intro": "What happens with the suspension:",
-      "bullets": {
-        "suspended": "the version will not be usable and will remain inactive until any reactivation;",
-        "archivingNotAffected": "the suspension <strong>does not modify</strong> the archiving already started for the e-service and <strong>does not interrupt</strong> the notice period;",
-        "archivedAfterNotice": "after the notice period, the e-service and all its versions will be permanently archived."
-      }
-    },
-    "dialogReactivateArchivingEservice": {
-      "title": "Reactivate version of e-service being archived",
-      "intro": "What happens with the reactivation:",
-      "bullets": {
-        "usableAgain": "the version becomes usable again, but the e-service remains in the archiving phase;",
-        "archivingNotAffected": "the reactivation <strong>does not modify</strong> the archiving already started for the e-service and <strong>does not interrupt</strong> the notice period;",
-        "archivedAfterNotice": "after the notice period, the e-service and all its versions will be permanently archived."
-      },
-      "proceedLabel": "Reactivate"
-    },
-    "dialogSuspendArchivingDescriptor": {
-      "title": "Suspend version under archival",
-      "intro": "What suspension does:",
-      "bullets": {
-        "suspended": "the version cannot be used and will remain suspended until reactivated;",
-        "archivingNotAffected": "suspension <strong>does not change</strong> the ongoing archival of this version and <strong>does not interrupt</strong> the notice period;",
-        "archivedAfterNotice": "once the notice period elapses, the version will be permanently archived."
-      }
-    },
-    "dialogReactivateArchivingDescriptor": {
-      "title": "Reactivate version under archival",
-      "intro": "What reactivation does:",
-      "bullets": {
-        "usableAgain": "the version becomes usable again, while remaining under archival;",
-        "archivingNotAffected": "reactivation <strong>does not change</strong> the ongoing archival of this version and <strong>does not interrupt</strong> the notice period;",
-        "archivedAfterNotice": "once the notice period elapses, the version will be permanently archived."
-      },
-      "proceedLabel": "Reactivate"
     },
     "dialogSuspendArchivingEservice": {
       "title": "Suspend version of e-service being archived",

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -633,6 +633,7 @@
       "suspended": "Questa versione di e-service è sospesa. Fino alla sua riattivazione nessun fruitore potrà accedere ai dati erogati attraverso l’API.",
       "deprecated": "Questa versione di e-service è obsoleta ma è ancora attiva. Sarà archiviata automaticamente quando non avrà più richieste di fruizione.",
       "archivingDescriptor": "Questa versione dell’e-service è in fase di archiviazione, ma è ancora attiva. Sarà archiviata automaticamente il giorno {{date}}.",
+      "archivingEService": "Questo e-service è in fase di archiviazione, ma è ancora attivo. Sarà archiviato automaticamente il giorno {{date}}.",
       "archivingSuspendedDescriptor": "Questa versione dell’e-service è in fase di archiviazione ed è al momento sospesa. Sarà archiviata automaticamente il giorno {{date}}.",
       "archivedDescriptor": "Questa versione dell’e-service è stata archiviata il giorno {{date}}.",
       "archivingSuspendedEService": "Questa versione è al momento sospesa. L’e-service è in fase di archiviazione e sarà archiviato automaticamente il giorno {{date}}.",
@@ -642,44 +643,6 @@
       "providerMissingProducerKeychain": "Associa un portachiavi a questo e-service per abilitare lo scambio dati.",
       "providerMissingProducerKeychainKeys": "Associa almeno una chiave al portachiavi collegato a questo e-service per abilitare lo scambio dati.",
       "viewProducerKeychains": "Vedi portachiavi"
-    },
-    "dialogSuspendArchivingEservice": {
-      "title": "Sospendi versione di e-service in fase di archiviazione",
-      "intro": "Cosa succede con la sospensione:",
-      "bullets": {
-        "suspended": "la versione non potrà essere utilizzata e resterà disattiva fino a un’eventuale riattivazione;",
-        "archivingNotAffected": "la sospensione <strong>non modifica</strong> l’archiviazione già avviata per l’e-service e <strong>non interrompe</strong> il periodo di preavviso;",
-        "archivedAfterNotice": "dopo il periodo di preavviso, l’e-service e tutte le sue versioni saranno archiviate definitivamente."
-      }
-    },
-    "dialogReactivateArchivingEservice": {
-      "title": "Riattiva versione di e-service in fase di archiviazione",
-      "intro": "Cosa succede con la riattivazione:",
-      "bullets": {
-        "usableAgain": "la versione torna a essere utilizzabile, ma l’e-service resta in fase di archiviazione;",
-        "archivingNotAffected": "la riattivazione <strong>non modifica</strong> l’archiviazione già avviata per l’e-service e <strong>non interrompe</strong> il periodo di preavviso;",
-        "archivedAfterNotice": "dopo il periodo di preavviso, l’e-service e tutte le sue versioni saranno archiviate definitivamente."
-      },
-      "proceedLabel": "Riattiva"
-    },
-    "dialogSuspendArchivingDescriptor": {
-      "title": "Sospendi versione in fase di archiviazione",
-      "intro": "Cosa succede con la sospensione:",
-      "bullets": {
-        "suspended": "la versione non potrà essere utilizzata e resterà sospesa fino a un’eventuale riattivazione;",
-        "archivingNotAffected": "la sospensione <strong>non modifica</strong> l’archiviazione già avviata per questa versione e <strong>non interrompe</strong> il periodo di preavviso;",
-        "archivedAfterNotice": "dopo il periodo di preavviso, la versione sarà archiviata definitivamente."
-      }
-    },
-    "dialogReactivateArchivingDescriptor": {
-      "title": "Riattiva versione in fase di archiviazione",
-      "intro": "Cosa succede con la riattivazione:",
-      "bullets": {
-        "usableAgain": "la versione torna a essere utilizzabile, pur restando in fase di archiviazione;",
-        "archivingNotAffected": "la riattivazione <strong>non modifica</strong> l’archiviazione già avviata per questa versione e <strong>non interrompe</strong> il periodo di preavviso;",
-        "archivedAfterNotice": "dopo il periodo di preavviso, la versione sarà archiviata definitivamente."
-      },
-      "proceedLabel": "Riattiva"
     },
     "dialogSuspendArchivingEservice": {
       "title": "Sospendi versione di e-service in fase di archiviazione",

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -89,6 +89,10 @@ export function getEServiceDescriptorAlertSpec(args: {
       severity: 'info',
       content: t('archivingDescriptor', { date: scheduledDate }),
     }))
+    .with({ state: 'ARCHIVING', scope: 'ESERVICE' }, () => ({
+      severity: 'info',
+      content: t('archivingEService', { date: scheduledDate }),
+    }))
     .with({ state: 'ARCHIVING_SUSPENDED', scope: 'DESCRIPTOR' }, () => ({
       severity: 'error',
       content: t('archivingSuspendedDescriptor', { date: scheduledDate }),


### PR DESCRIPTION
## 🔗 Issue

[PIN-10312](https://pagopa.atlassian.net/browse/PIN-10312)

## 📝 Description / Context

During a production check of the manual archiving feature, the e-service detail page did not show the informative banner for an e-service that is being archived while still active (state `ARCHIVING` with scope `ESERVICE`). All the other archiving banners (version being archived, version suspended while archiving, archived version, e-service suspended while archiving, e-service permanently archived) were already present and correct: only the active e-service case was missing.

Root cause is purely frontend: `getEServiceDescriptorAlertSpec` had no match arm for `{ state: 'ARCHIVING', scope: 'ESERVICE' }`, so it fell through to `otherwise` and rendered nothing, and the related i18n key `read.alert.archivingEService` did not exist. The required data (`archivingSchedule` with `archivableOn` and `scope`) is already exposed on `ProducerEServiceDescriptor`, so no backend change is needed.

While editing the file, I also removed a pre-existing duplication: the four `dialog*Archiving` i18n blocks (`dialogSuspendArchivingEservice`, `dialogReactivateArchivingEservice`, `dialogSuspendArchivingDescriptor`, `dialogReactivateArchivingDescriptor`) were present twice, verbatim, in both `it` and `en` (introduced in #1870). With duplicate JSON keys the last one wins, so the second identical copy was dead and has been dropped.

## 🛠 List of changes

- Add the `ARCHIVING + ESERVICE` arm to `getEServiceDescriptorAlertSpec` (`src/utils/eservice.utils.ts`), rendering an `info` banner with the new `archivingEService` content.
- Add the `read.alert.archivingEService` key to `it` and `en` `eservice.json` (EN mirrored from the existing `archivingDescriptor` sibling, adapted to the e-service level).
- Remove the duplicated `dialog*Archiving` i18n blocks in both `it` and `en` `eservice.json`.

## 🧪 How to test

- Open the detail page of an e-service in state `ARCHIVING` with scope `ESERVICE` (e.g. right after the "Archivia e-service" action).
- Verify the info banner appears: "Questo e-service è in fase di archiviazione, ma è ancora attivo. Sarà archiviato automaticamente il giorno gg/mm/aaaa." with the correct date in numeric format.
- Verify the other archiving banners (version-level archiving/suspended/archived, e-service suspended/archived) are unchanged.

[PIN-10312]: https://pagopa.atlassian.net/browse/PIN-10312
