### PR TITLE
fix: hide create-version and archive-eservice actions on archived version when e-service is already being archived (PIN-10317)

### DIFF
--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -1189,7 +1189,10 @@ export function useGetProviderEServiceActions(
     .with({ state: 'ARCHIVED' }, () => ({
       primary: undefined,
       header: latestDescriptorId ? [viewLatestVersionAction] : [],
-      menu: latestDescriptorId ? menuArchivedEserviceActive : menuArchivedEserviceArchived,
+      menu:
+        latestDescriptorId && !isEServiceBeingArchived
+          ? menuArchivedEserviceActive
+          : menuArchivedEserviceArchived,
     }))
     .with({ state: 'ARCHIVING', archivingScope: 'ESERVICE' }, () => ({
       primary: cancelArchivingEserviceAction,


### PR DESCRIPTION
## 🔗 Issue

[PIN-10317](https://pagopa.atlassian.net/browse/PIN-10317)

## 📝 Description / Context

On the detail page of an archived version (`ARCHIVED`) of an e-service that is already being archived (active descriptor in `ARCHIVING` or `ARCHIVING_SUSPENDED`), the "more options" (⋮) menu offered "Crea nuova versione" and "Archivia e-service". Those should not be there: the e-service is already being archived, so it cannot be re-archived nor get new versions. Confirmed by the Design team.

Root cause is frontend only: the `{ state: 'ARCHIVED' }` arm in `useGetProviderEServiceActions` did not consider `isEServiceBeingArchived` and always used `menuArchivedEserviceActive`, which hardcodes the create-version and archive-e-service actions. The other menus (`menuWithNewVersion`) already drop both actions when `isEServiceBeingArchived` is true; the flag is already computed and passed by `ProviderEServiceDetails.page.tsx`.

## 🛠 List of changes

- In the `ARCHIVED` arm of `useGetProviderEServiceActions`, use the full `menuArchivedEserviceActive` only when a `latestDescriptorId` exists and the e-service is not being archived; otherwise fall back to the reduced menu (`Duplica e-service` + `Vedi tutte le versioni`). The `Vedi ultima versione` header action is unchanged.

## 🧪 How to test

- Create an e-service, publish v1, then create and publish v2 (v1 becomes archived if there are no consumers).
- Put the whole e-service into archiving via "Archivia e-service".
- Open the archived v1 detail page and open the ⋮ menu: only "Duplica e-service" and "Vedi tutte le versioni" should appear, not "Crea nuova versione" nor "Archivia e-service".
- Regression: on an archived version of an e-service that is NOT being archived, the menu still shows the full set (create version, duplicate, archive e-service, view all versions).

[PIN-10317]: https://pagopa.atlassian.net/browse/PIN-10317
