### PR TITLE
fix: show combined archived-version and e-service-archiving banner on provider detail (PIN-10319)

### DIFF
--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import type { ProducerEServiceDescriptor } from '@/api/api.generatedTypes'
 import { Alert, Button, Stack } from '@mui/material'
 import { useTranslation } from 'react-i18next'
-import { getEServiceDescriptorAlertSpec } from '@/utils/eservice.utils'
+import {
+  getActiveDescriptor,
+  getEServiceDescriptorAlertSpec,
+  isDescriptorPendingArchiving,
+} from '@/utils/eservice.utils'
 
 type ProviderEServiceDetailsAlertsProps = {
   descriptor: ProducerEServiceDescriptor | undefined
@@ -17,11 +21,16 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
 
   if (!descriptor) return null
 
+  const activeDescriptor = getActiveDescriptor(descriptor.eservice.descriptors)
+  const isEServiceBeingArchived = isDescriptorPendingArchiving(activeDescriptor?.state)
+
   const alert = getEServiceDescriptorAlertSpec({
     state: descriptor.state,
     scope: descriptor.archivingSchedule?.scope,
     archivableOn: descriptor.archivingSchedule?.archivableOn,
     archivedAt: descriptor.archivedAt,
+    isEServiceBeingArchived,
+    eserviceArchivableOn: activeDescriptor?.archivableOn,
     t,
   })
 

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -633,6 +633,7 @@
       "suspended": "This e-service version is discontinued. Until its reactivation, no consumer will be able to access the data provided through the API.",
       "deprecated": "This e-service version is obsolete but still active. It will be automatically archived when it has no more agreements.",
       "archivingDescriptor": "This e-service version is being archived but is still active. It will be automatically archived on {{date}}.",
+      "archivingEService": "This e-service is being archived but is still active. It will be automatically archived on {{date}}.",
       "archivingSuspendedDescriptor": "This e-service version is being archived and is currently suspended. It will be automatically archived on {{date}}.",
       "archivedDescriptor": "This e-service version was archived on {{date}}.",
       "archivingSuspendedEService": "This version is currently suspended. The e-service is being archived and will be automatically archived on {{date}}.",
@@ -642,44 +643,6 @@
       "providerMissingProducerKeychain": "Associate a keychain with this e-service to enable data exchange.",
       "providerMissingProducerKeychainKeys": "Add at least one key to the keychain linked to this e-service to enable data exchange.",
       "viewProducerKeychains": "View keychains"
-    },
-    "dialogSuspendArchivingEservice": {
-      "title": "Suspend version of e-service being archived",
-      "intro": "What happens with the suspension:",
-      "bullets": {
-        "suspended": "the version will not be usable and will remain inactive until any reactivation;",
-        "archivingNotAffected": "the suspension <strong>does not modify</strong> the archiving already started for the e-service and <strong>does not interrupt</strong> the notice period;",
-        "archivedAfterNotice": "after the notice period, the e-service and all its versions will be permanently archived."
-      }
-    },
-    "dialogReactivateArchivingEservice": {
-      "title": "Reactivate version of e-service being archived",
-      "intro": "What happens with the reactivation:",
-      "bullets": {
-        "usableAgain": "the version becomes usable again, but the e-service remains in the archiving phase;",
-        "archivingNotAffected": "the reactivation <strong>does not modify</strong> the archiving already started for the e-service and <strong>does not interrupt</strong> the notice period;",
-        "archivedAfterNotice": "after the notice period, the e-service and all its versions will be permanently archived."
-      },
-      "proceedLabel": "Reactivate"
-    },
-    "dialogSuspendArchivingDescriptor": {
-      "title": "Suspend version under archival",
-      "intro": "What suspension does:",
-      "bullets": {
-        "suspended": "the version cannot be used and will remain suspended until reactivated;",
-        "archivingNotAffected": "suspension <strong>does not change</strong> the ongoing archival of this version and <strong>does not interrupt</strong> the notice period;",
-        "archivedAfterNotice": "once the notice period elapses, the version will be permanently archived."
-      }
-    },
-    "dialogReactivateArchivingDescriptor": {
-      "title": "Reactivate version under archival",
-      "intro": "What reactivation does:",
-      "bullets": {
-        "usableAgain": "the version becomes usable again, while remaining under archival;",
-        "archivingNotAffected": "reactivation <strong>does not change</strong> the ongoing archival of this version and <strong>does not interrupt</strong> the notice period;",
-        "archivedAfterNotice": "once the notice period elapses, the version will be permanently archived."
-      },
-      "proceedLabel": "Reactivate"
     },
     "dialogSuspendArchivingEservice": {
       "title": "Suspend version of e-service being archived",

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -633,6 +633,7 @@
       "suspended": "Questa versione di e-service è sospesa. Fino alla sua riattivazione nessun fruitore potrà accedere ai dati erogati attraverso l’API.",
       "deprecated": "Questa versione di e-service è obsoleta ma è ancora attiva. Sarà archiviata automaticamente quando non avrà più richieste di fruizione.",
       "archivingDescriptor": "Questa versione dell’e-service è in fase di archiviazione, ma è ancora attiva. Sarà archiviata automaticamente il giorno {{date}}.",
+      "archivingEService": "Questo e-service è in fase di archiviazione, ma è ancora attivo. Sarà archiviato automaticamente il giorno {{date}}.",
       "archivingSuspendedDescriptor": "Questa versione dell’e-service è in fase di archiviazione ed è al momento sospesa. Sarà archiviata automaticamente il giorno {{date}}.",
       "archivedDescriptor": "Questa versione dell’e-service è stata archiviata il giorno {{date}}.",
       "archivingSuspendedEService": "Questa versione è al momento sospesa. L’e-service è in fase di archiviazione e sarà archiviato automaticamente il giorno {{date}}.",
@@ -642,44 +643,6 @@
       "providerMissingProducerKeychain": "Associa un portachiavi a questo e-service per abilitare lo scambio dati.",
       "providerMissingProducerKeychainKeys": "Associa almeno una chiave al portachiavi collegato a questo e-service per abilitare lo scambio dati.",
       "viewProducerKeychains": "Vedi portachiavi"
-    },
-    "dialogSuspendArchivingEservice": {
-      "title": "Sospendi versione di e-service in fase di archiviazione",
-      "intro": "Cosa succede con la sospensione:",
-      "bullets": {
-        "suspended": "la versione non potrà essere utilizzata e resterà disattiva fino a un’eventuale riattivazione;",
-        "archivingNotAffected": "la sospensione <strong>non modifica</strong> l’archiviazione già avviata per l’e-service e <strong>non interrompe</strong> il periodo di preavviso;",
-        "archivedAfterNotice": "dopo il periodo di preavviso, l’e-service e tutte le sue versioni saranno archiviate definitivamente."
-      }
-    },
-    "dialogReactivateArchivingEservice": {
-      "title": "Riattiva versione di e-service in fase di archiviazione",
-      "intro": "Cosa succede con la riattivazione:",
-      "bullets": {
-        "usableAgain": "la versione torna a essere utilizzabile, ma l’e-service resta in fase di archiviazione;",
-        "archivingNotAffected": "la riattivazione <strong>non modifica</strong> l’archiviazione già avviata per l’e-service e <strong>non interrompe</strong> il periodo di preavviso;",
-        "archivedAfterNotice": "dopo il periodo di preavviso, l’e-service e tutte le sue versioni saranno archiviate definitivamente."
-      },
-      "proceedLabel": "Riattiva"
-    },
-    "dialogSuspendArchivingDescriptor": {
-      "title": "Sospendi versione in fase di archiviazione",
-      "intro": "Cosa succede con la sospensione:",
-      "bullets": {
-        "suspended": "la versione non potrà essere utilizzata e resterà sospesa fino a un’eventuale riattivazione;",
-        "archivingNotAffected": "la sospensione <strong>non modifica</strong> l’archiviazione già avviata per questa versione e <strong>non interrompe</strong> il periodo di preavviso;",
-        "archivedAfterNotice": "dopo il periodo di preavviso, la versione sarà archiviata definitivamente."
-      }
-    },
-    "dialogReactivateArchivingDescriptor": {
-      "title": "Riattiva versione in fase di archiviazione",
-      "intro": "Cosa succede con la riattivazione:",
-      "bullets": {
-        "usableAgain": "la versione torna a essere utilizzabile, pur restando in fase di archiviazione;",
-        "archivingNotAffected": "la riattivazione <strong>non modifica</strong> l’archiviazione già avviata per questa versione e <strong>non interrompe</strong> il periodo di preavviso;",
-        "archivedAfterNotice": "dopo il periodo di preavviso, la versione sarà archiviata definitivamente."
-      },
-      "proceedLabel": "Riattiva"
     },
     "dialogSuspendArchivingEservice": {
       "title": "Sospendi versione di e-service in fase di archiviazione",

--- a/src/utils/__tests__/eservice.utils.test.ts
+++ b/src/utils/__tests__/eservice.utils.test.ts
@@ -277,6 +277,21 @@ describe('getEServiceDescriptorAlertSpec utility function testing', () => {
     })
   })
 
+  it('returns combined archivedDescriptor + archivingEService when ARCHIVED and the e-service is being archived', () => {
+    expect(
+      getEServiceDescriptorAlertSpec({
+        ...baseArgs,
+        state: 'ARCHIVED',
+        archivedAt: '2026-12-01T00:00:00.000Z',
+        isEServiceBeingArchived: true,
+        eserviceArchivableOn: '2027-01-15T00:00:00.000Z',
+      })
+    ).toEqual({
+      severity: 'info',
+      content: expect.stringMatching(/^archivedDescriptor:.+ archivingEService:.+$/),
+    })
+  })
+
   it('returns undefined for states not handled by any branch (PUBLISHED)', () => {
     expect(getEServiceDescriptorAlertSpec({ ...baseArgs, state: 'PUBLISHED' })).toBeUndefined()
   })

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -89,6 +89,10 @@ export function getEServiceDescriptorAlertSpec(args: {
       severity: 'info',
       content: t('archivingDescriptor', { date: scheduledDate }),
     }))
+    .with({ state: 'ARCHIVING', scope: 'ESERVICE' }, () => ({
+      severity: 'info',
+      content: t('archivingEService', { date: scheduledDate }),
+    }))
     .with({ state: 'ARCHIVING_SUSPENDED', scope: 'DESCRIPTOR' }, () => ({
       severity: 'error',
       content: t('archivingSuspendedDescriptor', { date: scheduledDate }),

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -75,13 +75,26 @@ export function getEServiceDescriptorAlertSpec(args: {
   scope: ArchivingScope | undefined
   archivableOn: string | undefined
   archivedAt: string | undefined
+  isEServiceBeingArchived?: boolean
+  eserviceArchivableOn?: string
   t: TFunction<'eservice', 'read.alert'>
 }): { severity: AlertColor; content: string } | undefined {
-  const { state, scope, archivableOn, archivedAt, t } = args
+  const {
+    state,
+    scope,
+    archivableOn,
+    archivedAt,
+    isEServiceBeingArchived,
+    eserviceArchivableOn,
+    t,
+  } = args
   const scheduledDate = archivableOn ? formatDateStringNumeric(archivableOn) : ''
   const archivedDate = archivedAt ? formatDateStringNumeric(archivedAt) : ''
+  const eserviceScheduledDate = eserviceArchivableOn
+    ? formatDateStringNumeric(eserviceArchivableOn)
+    : ''
 
-  return match({ state, scope })
+  return match({ state, scope, isEServiceBeingArchived })
     .returnType<{ severity: AlertColor; content: string } | undefined>()
     .with({ state: 'SUSPENDED' }, () => ({ severity: 'error', content: t('suspended') }))
     .with({ state: 'DEPRECATED' }, () => ({ severity: 'info', content: t('deprecated') }))
@@ -100,6 +113,12 @@ export function getEServiceDescriptorAlertSpec(args: {
     .with({ state: 'ARCHIVING_SUSPENDED', scope: 'ESERVICE' }, () => ({
       severity: 'error',
       content: t('archivingSuspendedEService', { date: scheduledDate }),
+    }))
+    .with({ state: 'ARCHIVED', isEServiceBeingArchived: true }, () => ({
+      severity: 'info',
+      content: `${t('archivedDescriptor', { date: archivedDate })} ${t('archivingEService', {
+        date: eserviceScheduledDate,
+      })}`,
     }))
     .with({ state: 'ARCHIVED', scope: 'ESERVICE' }, () => ({
       severity: 'info',


### PR DESCRIPTION
## 🔗 Issue

[PIN-10319](https://pagopa.atlassian.net/browse/PIN-10319)

## 📝 Description / Context

On the provider detail page of an archived version (`ARCHIVED`) of an e-service that is still being archived (active descriptor in `ARCHIVING` / `ARCHIVING_SUSPENDED`, not yet fully archived), the alert must combine two pieces of information, as provided by the Design team: "Questa versione dell'e-service è stata archiviata il giorno {{versionDate}}. Questo e-service è in fase di archiviazione, ma è ancora attivo. Sarà archiviato automaticamente il giorno {{eserviceDate}}."

Previously only the first sentence was shown (`archivedDescriptor` banner), because `getEServiceDescriptorAlertSpec` had no awareness that the overall e-service was still being archived. The two sentences are exactly the existing banners `read.alert.archivedDescriptor` and `read.alert.archivingEService`, so concatenating them reproduces the Design text without introducing new copy.

This is stacked on PIN-10312 (#1995), which introduces the `archivingEService` key; it must be rebased onto `dev` after #1995 is merged. No backend change.

## 🛠 List of changes

- Extend `getEServiceDescriptorAlertSpec` (`src/utils/eservice.utils.ts`) with the e-service archiving context (`isEServiceBeingArchived` + `eserviceArchivableOn`, both optional) and add a `{ state: 'ARCHIVED', isEServiceBeingArchived: true }` arm before the generic `ARCHIVED` arms, returning an `info` alert that concatenates `archivedDescriptor` (date from `descriptor.archivedAt`) and `archivingEService` (date from the active descriptor's `archivableOn`).
- Compute and pass the new context from `ProviderEServiceDetailsAlerts` (`activeDescriptor` from `descriptor.eservice.descriptors`, `isEServiceBeingArchived` via `isDescriptorPendingArchiving`).
- Add a unit test for the combined banner case.

## 🧪 How to test

- Open the provider detail of an archived version (`ARCHIVED`) of an e-service whose active descriptor is in `ARCHIVING` (scope `ESERVICE`).
- Verify the alert shows both sentences: "Questa versione dell'e-service è stata archiviata il giorno gg/mm/aaaa. Questo e-service è in fase di archiviazione, ma è ancora attivo. Sarà archiviato automaticamente il giorno gg/mm/aaaa."
- Regression: a fully archived e-service (active descriptor `ARCHIVED`) keeps the single "archiviato definitivamente" banner; an archived version of a non-archiving e-service keeps the single "Questa versione ... è stata archiviata il giorno ..." banner.

## 🖼 Screenshot

<img width="1200" height="886" alt="PIN-10319-detail-viewport" src="https://github.com/user-attachments/assets/0c1eabf4-c9e2-43cf-b5e2-0dc55b96666f" />


[PIN-10319]: https://pagopa.atlassian.net/browse/PIN-10319
