### PR TITLE
feat: show reviewer full name in purpose approval dialog

### DIFF
--- a/src/components/dialogs/DialogRequestPurposeApproval.tsx
+++ b/src/components/dialogs/DialogRequestPurposeApproval.tsx
@@ -12,7 +12,7 @@ import { useDialog } from '@/stores'
 import type { DialogRequestPurposeApprovalProps } from '@/types/dialog.types'
 
 export const DialogRequestPurposeApproval: React.FC<DialogRequestPurposeApprovalProps> = ({
-  reviewerId,
+  reviewer,
   onConfirm,
 }) => {
   const ariaLabelId = React.useId()
@@ -23,6 +23,8 @@ export const DialogRequestPurposeApproval: React.FC<DialogRequestPurposeApproval
     keyPrefix: 'edit.stepRiskAnalysis.requestApprovalDialog',
   })
   const { t: tCommon } = useTranslation('common', { keyPrefix: 'actions' })
+
+  const reviewerName = `${reviewer.name} ${reviewer.familyName}`.trim()
 
   const handleConfirm = () => {
     onConfirm()
@@ -46,7 +48,7 @@ export const DialogRequestPurposeApproval: React.FC<DialogRequestPurposeApproval
               strong: <Typography component="span" variant="inherit" fontWeight={600} />,
             }}
           >
-            {t('description', { reviewerId })}
+            {t('description', { reviewerName })}
           </Trans>
         </Typography>
       </DialogContent>

--- a/src/components/dialogs/__tests__/DialogRequestPurposeApproval.test.tsx
+++ b/src/components/dialogs/__tests__/DialogRequestPurposeApproval.test.tsx
@@ -43,7 +43,7 @@ vi.mock('react-i18next', () => ({
 
 const defaultProps = {
   type: 'requestPurposeApproval' as const,
-  reviewerId: 'reviewer-abc',
+  reviewer: { userId: 'reviewer-1', name: 'Mario', familyName: 'Rossi' },
   onConfirm: vi.fn(),
 }
 
@@ -52,16 +52,16 @@ describe('DialogRequestPurposeApproval', () => {
     vi.clearAllMocks()
   })
 
-  it('renders the title, the description with the reviewerId interpolated, a strong wrapper, and both CTAs', () => {
+  it('renders the title, the description with the reviewerName interpolated, a strong wrapper, and both CTAs', () => {
     render(<DialogRequestPurposeApproval {...defaultProps} />)
 
     expect(
       screen.getByText('edit.stepRiskAnalysis.requestApprovalDialog.title')
     ).toBeInTheDocument()
-    // The description string from t() is resolved with reviewerId interpolated.
+    // The description string from t() is resolved with reviewerName interpolated.
     expect(
       screen.getByText(
-        'edit.stepRiskAnalysis.requestApprovalDialog.description(reviewerId=reviewer-abc)'
+        'edit.stepRiskAnalysis.requestApprovalDialog.description(reviewerName=Mario Rossi)'
       )
     ).toBeInTheDocument()
     // <Trans> receives a `components.strong` to wrap the bold portion.

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
@@ -137,21 +137,20 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
   }
 
   const handleRequestApproval = (answers: Record<string, string[]>) => {
-    const reviewerId = purpose.reviewerWorkflow?.reviewerIds?.[0]
-    if (!reviewerId) {
-      // BE contract: option 2 always assigns at least one reviewer
-      // (RiskAnalysisAssignmentSeed.reviewerIds has @minItems 1). If we land
-      // here the purpose is malformed; log loudly and no-op rather than
-      // crashing the route — this is a UI action handler, not a place to
-      // throw to the ErrorBoundary.
+    const reviewer = purpose.reviewerWorkflow?.reviewers?.[0]
+    if (!reviewer) {
+      // BE contract: option 2 always assigns at least one reviewer.
+      // If we land here the purpose is malformed;
+      // log loudly and no-op rather than crashing the route —
+      // this is a UI action handler, not a place to throw to the ErrorBoundary.
       console.error(
-        'PurposeEditStepRiskAnalysis: reviewerIds is missing on a purpose in ADMIN_WRITES_REVIEWER_SIGNS mode'
+        'PurposeEditStepRiskAnalysis: reviewers is missing on a purpose in ADMIN_WRITES_REVIEWER_SIGNS mode'
       )
       return
     }
     openDialog({
       type: 'requestPurposeApproval',
-      reviewerId,
+      reviewer,
       // Chain must live in the parent: putting it in the dialog would race
       // closeDialog(), and the second mutate() would silently no-op against a
       // destroyed observer.

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
@@ -304,6 +304,7 @@ describe('PurposeEditStepRiskAnalysis', () => {
     const purpose = buildPurpose({
       reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
       reviewerIds: ['reviewer-1'],
+      reviewers: [{ userId: 'reviewer-1', name: 'Mario', familyName: 'Rossi' }],
       signingState: 'DRAFT',
     })
     const riskAnalysis = createMockRiskAnalysisFormConfig()
@@ -323,7 +324,7 @@ describe('PurposeEditStepRiskAnalysis', () => {
     const dialogPayload = openDialogMock.mock.calls[0][0]
     expect(dialogPayload).toMatchObject({
       type: 'requestPurposeApproval',
-      reviewerId: 'reviewer-1',
+      reviewer: { userId: 'reviewer-1', name: 'Mario', familyName: 'Rossi' },
     })
     expect(typeof dialogPayload.onConfirm).toBe('function')
 
@@ -355,11 +356,12 @@ describe('PurposeEditStepRiskAnalysis', () => {
     })
   })
 
-  it('in option 2 logs and no-ops when reviewerIds is missing (BE contract violation) instead of opening a malformed dialog', () => {
+  it('in option 2 logs and no-ops when reviewers is missing (BE contract violation) instead of opening a malformed dialog', () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const purpose = buildPurpose({
       reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-      reviewerIds: [],
+      reviewerIds: ['reviewer-1'],
+      // reviewers intentionally omitted: the BE did not expose the reviewer info.
       signingState: 'DRAFT',
     })
     mockQueries(purpose, createMockRiskAnalysisFormConfig())
@@ -368,7 +370,7 @@ describe('PurposeEditStepRiskAnalysis', () => {
 
     getLastFormProps().onSubmit({ purpose: ['OTHER'] })
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/reviewerIds/))
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/reviewers/))
     expect(openDialogMock).not.toHaveBeenCalled()
 
     consoleErrorSpy.mockRestore()

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -198,7 +198,7 @@
       "requiredFieldErrorReviewer": "Fill in to continue",
       "requestApprovalDialog": {
         "title": "Request approval",
-        "description": "By confirming, you will assign the approval of the risk analysis to the reviewer <strong>{{reviewerId}}</strong> and you will no longer be able to make changes.",
+        "description": "By confirming, you will assign the approval of the risk analysis to the reviewer <strong>{{reviewerName}}</strong> and you will no longer be able to make changes.",
         "proceedLabel": "Confirm"
       }
     },

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -198,7 +198,7 @@
       "requiredFieldErrorReviewer": "Compila per proseguire",
       "requestApprovalDialog": {
         "title": "Richiedi approvazione",
-        "description": "Se confermi, assegnerai l’approvazione dell’analisi del rischio al valutatore <strong>{{reviewerId}}</strong> e non potrai più fare modifiche.",
+        "description": "Se confermi, assegnerai l’approvazione dell’analisi del rischio al valutatore <strong>{{reviewerName}}</strong> e non potrai più fare modifiche.",
         "proceedLabel": "Conferma"
       }
     },

--- a/src/types/dialog.types.ts
+++ b/src/types/dialog.types.ts
@@ -7,6 +7,7 @@ import type {
   TenantKind,
   TargetTenantKind,
   CompactAgreement,
+  CompactUser,
 } from '@/api/api.generatedTypes'
 import type { RouteKey } from '@/router'
 import type { DialogProps as MUIDialogProps } from '@mui/material'
@@ -202,7 +203,7 @@ export type DialogTenantKindPurposeTemplateProps = {
 
 export type DialogRequestPurposeApprovalProps = {
   type: 'requestPurposeApproval'
-  reviewerId: string
+  reviewer: CompactUser
   onConfirm: VoidFunction
 }
 


### PR DESCRIPTION
## 🔗 Issue
[PIN-10301](https://pagopa.atlassian.net/browse/PIN-10301)

## 📝 Description / Context
The "Request approval" dialog (Step 3, option 2 — `ADMIN_WRITES_REVIEWER_SIGNS`) was showing the raw reviewer id instead of the reviewer's full name. The BE now exposes the reviewer info inline on the reviewer workflow (`ReviewerWorkflow.reviewers: CompactUser[]`), so we can display the reviewer's name and surname, aligning this dialog with the rest of the purpose create/edit flow (assignment step, options, compilation dialog), which already used name + surname.

## 🛠 List of changes
- `DialogRequestPurposeApproval` now receives the `reviewer` (`CompactUser`) instead of `reviewerId`, and builds the full name internally.
- `DialogRequestPurposeApprovalProps`: `reviewerId: string` → `reviewer: CompactUser`.
- `PurposeEditStepRiskAnalysis` reads the reviewer directly from `reviewerWorkflow.reviewers[0]`, dropping the `reviewerIds[0]` lookup; logs and no-ops if the reviewer info is missing (BE contract violation).
- i18n (`it`/`en`): approval dialog description placeholder `{{reviewerId}}` → `{{reviewerName}}`.
- Updated unit tests for the dialog and the risk-analysis step accordingly.

## 🧪 How to test
- Create/edit a purpose as admin and, in Step 2, choose option 2 ("Compilazione in autonomia e approvazione del valutatore"), selecting a reviewer.
- Go to Step 3, fill in the risk analysis, and click "Richiedi approvazione".
- Verify the dialog body shows the reviewer's **name and surname** (not the id).
- Confirm the action and verify the save + submit + redirect to the purpose summary still works.

[PIN-10301]: https://pagopa.atlassian.net/browse/PIN-10301