### PR TITLE
fix: fix check on possibility to config discreteConfig (PIN-10332)

### DIFF
--- a/src/components/shared/AddAttributesToForm/AttributeGroup.tsx
+++ b/src/components/shared/AddAttributesToForm/AttributeGroup.tsx
@@ -153,7 +153,7 @@ export const AttributeGroup: React.FC<AttributeGroupProps> = ({
                         : undefined
                     }
                     onOpenConfigDrawer={
-                      FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE
+                      FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE && !readOnly
                         ? () => openConfigureDiscreteAttributeDrawer(attribute, groupIndex)
                         : undefined
                     }


### PR DESCRIPTION
## 🔗 Issue

[PIN-10332](https://pagopa.atlassian.net/browse/PIN-10332)

## 📝 Description / Context

This PR include the fix that remove the possibility to change the configuration of attribute certified discrete `discreteConfig` using the readOnly prop.

## 🛠 List of changes

- Add `!readOnly` when pass the config function inside `AttributeContainer`

## 🧪 How to test

Create a new e-service from template and when in the threshold step go to the attribute section. The aspected behavior is that the discreteConfig is not changable


[PIN-10332]: https://pagopa.atlassian.net/browse/PIN-10332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ