### PR TITLE
performance: add lazy loading for attribute details drawer (PIN-10336)

### DIFF
--- a/src/components/layout/containers/AttributeContainer.tsx
+++ b/src/components/layout/containers/AttributeContainer.tsx
@@ -13,9 +13,9 @@ import { ButtonNaked } from '@pagopa/mui-italia'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline'
 import { AttributeQueries } from '@/api/attribute'
-import { InformationContainer } from '@pagopa/interop-fe-commons'
+import { InformationContainer, InformationContainerSkeleton } from '@pagopa/interop-fe-commons'
 import { useTranslation } from 'react-i18next'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE } from '@/config/env'
 import { ActionMenu } from '@/components/shared/ActionMenu'
 import type { ActionItemButton } from '@/types/common.types'
@@ -73,9 +73,16 @@ export const AttributeContainer = <
   const { t } = useTranslation('shared-components', { keyPrefix: 'attributeContainer' })
   const { t: tCommon } = useTranslation('common', { keyPrefix: 'comparators' })
   const [isDetailsDrawerOpen, setIsDetailsDrawerOpen] = React.useState<boolean>(false)
-  const { data: completeAttribute, isLoading: isLoadingCompleteAttribute } = useQuery(
-    AttributeQueries.getSingle(attribute.id)
-  )
+
+  const alreadyPrefetched = React.useRef(false)
+
+  const queryClient = useQueryClient()
+
+  const handlePrefetchAttribute = () => {
+    if (alreadyPrefetched.current) return
+    alreadyPrefetched.current = true
+    queryClient.prefetchQuery(AttributeQueries.getSingle(attribute.id))
+  }
 
   const isAttributeCertifiedDiscrete =
     FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE && attribute.kind === 'CERTIFIED_DISCRETE'
@@ -169,7 +176,11 @@ export const AttributeContainer = <
                 </Stack>
               )}
             </Stack>
-            <Box alignSelf="center">
+            <Box
+              alignSelf="center"
+              onPointerEnter={handlePrefetchAttribute}
+              onFocus={handlePrefetchAttribute}
+            >
               <ActionMenu actions={menuActions} iconColor="action" />
             </Box>
           </Stack>
@@ -199,11 +210,11 @@ export const AttributeContainer = <
           )}
         </Card>
       </Stack>
-      {!isLoadingCompleteAttribute && completeAttribute && (
+      {alreadyPrefetched.current && (
         <AttributeDetailsDrawer
           isOpen={isDetailsDrawerOpen}
           onClose={() => setIsDetailsDrawerOpen(false)}
-          attribute={completeAttribute}
+          attributeId={attribute.id}
         />
       )}
     </>
@@ -213,35 +224,67 @@ export const AttributeContainer = <
 const AttributeDetailsDrawer: React.FC<{
   isOpen: boolean
   onClose: VoidFunction
-  attribute: Attribute
-}> = ({ isOpen, onClose, attribute }) => {
+  attributeId: string
+}> = ({ isOpen, onClose, attributeId }) => {
   const { t } = useTranslation('shared-components', { keyPrefix: 'attributeContainer' })
 
+  const { data: attribute, isLoading } = useQuery({
+    ...AttributeQueries.getSingle(attributeId),
+    enabled: isOpen,
+  })
+
   return (
-    <Drawer isOpen={isOpen} onClose={onClose} title={attribute.name}>
-      <Stack sx={{ mt: 1 }} spacing={2}>
-        <InformationContainer
-          direction="column"
-          label={t('descriptionLabel')}
-          content={attribute.description}
-        />
-        <InformationContainer
-          direction="column"
-          label={t('attributeIdLabel')}
-          content={attribute.id}
-          copyToClipboard={{
-            value: attribute.id,
-            tooltipTitle: t('idCopytooltipLabel'),
-          }}
-        />
-        {attribute.origin && attribute.origin !== 'SELFCARE' && (
+    <Drawer
+      isOpen={isOpen}
+      onClose={onClose}
+      title={
+        attribute?.name ?? (
+          <Typography variant="h6">
+            <Skeleton width={'50%'} />
+          </Typography>
+        )
+      }
+    >
+      {!attribute || isLoading ? (
+        <Stack sx={{ mt: 1 }} spacing={2}>
+          <Stack spacing={0}>
+            <Skeleton width={'50%'} />
+            <Skeleton width={'70%'} />
+          </Stack>
+          <Stack spacing={0}>
+            <Skeleton width={'50%'} />
+            <Skeleton width={'70%'} />
+          </Stack>
+          <Stack spacing={0}>
+            <Skeleton width={'50%'} />
+            <Skeleton width={'70%'} />
+          </Stack>
+        </Stack>
+      ) : (
+        <Stack sx={{ mt: 1 }} spacing={2}>
           <InformationContainer
             direction="column"
-            label={t('tenantCertifierLabel')}
-            content={attribute.origin}
+            label={t('descriptionLabel')}
+            content={attribute.description}
           />
-        )}
-      </Stack>
+          <InformationContainer
+            direction="column"
+            label={t('attributeIdLabel')}
+            content={attribute.id}
+            copyToClipboard={{
+              value: attribute.id,
+              tooltipTitle: t('idCopytooltipLabel'),
+            }}
+          />
+          {attribute.origin && attribute.origin !== 'SELFCARE' && (
+            <InformationContainer
+              direction="column"
+              label={t('tenantCertifierLabel')}
+              content={attribute.origin}
+            />
+          )}
+        </Stack>
+      )}
     </Drawer>
   )
 }

--- a/src/components/layout/containers/AttributeContainer.tsx
+++ b/src/components/layout/containers/AttributeContainer.tsx
@@ -13,14 +13,13 @@ import { ButtonNaked } from '@pagopa/mui-italia'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline'
 import { AttributeQueries } from '@/api/attribute'
-import { InformationContainer, InformationContainerSkeleton } from '@pagopa/interop-fe-commons'
+import { InformationContainer } from '@pagopa/interop-fe-commons'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE } from '@/config/env'
 import { ActionMenu } from '@/components/shared/ActionMenu'
 import type { ActionItemButton } from '@/types/common.types'
 import type {
-  Attribute,
   AttributeKind,
   EServiceAttributeCertifiedDiscreteConfig,
 } from '@/api/api.generatedTypes'

--- a/src/components/layout/containers/__tests__/AttributeContainer.test.tsx
+++ b/src/components/layout/containers/__tests__/AttributeContainer.test.tsx
@@ -13,6 +13,16 @@ import { AttributeQueries } from '@/api/attribute'
 
 const baseAttribute = createMockAttribute({ id: 'attr-1', name: 'Test Attribute' })
 
+vi.mock('@tanstack/react-query', async () => {
+  const actual = (await vi.importActual('@tanstack/react-query')) as Record<string, unknown>
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      prefetchQuery: vi.fn(),
+    }),
+  }
+})
+
 vi.mock('@/api/attribute', () => ({
   AttributeQueries: {
     getSingle: vi.fn((id: string) => ({
@@ -262,7 +272,7 @@ describe('AttributeContainer', () => {
     expect(discreteConfig).toBeInTheDocument()
   })
 
-  it('should open AttributeDetailsDrawer with the attributes details when "inspectAttributeDetails" is clicked', async () => {
+  it('should open AttributeDetailsDrawer with the attribute details when "inspectAttributeDetails" is clicked', async () => {
     const user = userEvent.setup()
     renderWithApplicationContext(<AttributeContainer attribute={{ ...baseAttribute }} />, {
       withReactQueryContext: true,
@@ -285,10 +295,10 @@ describe('AttributeContainer', () => {
     expect(attributeDetailsDrawerOrigin).not.toBeInTheDocument()
   })
 
-  it('AttributeDetailsDrawer should contain origin if the attrubte has it', async () => {
+  it('AttributeDetailsDrawer should contain origin if the attribute has it', async () => {
     const mockedAttributeWithOrigin: Attribute = { ...baseAttribute, origin: 'test origin' }
 
-    vi.mocked(AttributeQueries.getSingle).mockImplementationOnce(
+    vi.mocked(AttributeQueries.getSingle).mockImplementation(
       (id: string) =>
         ({
           queryKey: ['attribute', id],
@@ -298,9 +308,12 @@ describe('AttributeContainer', () => {
 
     const user = userEvent.setup()
 
-    renderWithApplicationContext(<AttributeContainer attribute={{ ...baseAttribute }} />, {
-      withReactQueryContext: true,
-    })
+    renderWithApplicationContext(
+      <AttributeContainer attribute={{ ...mockedAttributeWithOrigin }} />,
+      {
+        withReactQueryContext: true,
+      }
+    )
 
     const menuActionsIconButton = screen.getByLabelText('iconButtonAriaLabel')
     await user.click(menuActionsIconButton)
@@ -310,7 +323,7 @@ describe('AttributeContainer', () => {
     })
     await user.click(inspectAttributeDetailsMenuItem)
 
-    const attributeDetailsDrawerOrigin = screen.getByText(mockedAttributeWithOrigin.origin!)
+    const attributeDetailsDrawerOrigin = screen.queryByText(mockedAttributeWithOrigin.origin!)
 
     expect(attributeDetailsDrawerOrigin).toBeInTheDocument()
   })

--- a/src/components/shared/Drawer.tsx
+++ b/src/components/shared/Drawer.tsx
@@ -16,7 +16,7 @@ import type { ActionItem } from '@/types/common.types'
 export type DrawerProps = {
   isOpen: boolean
   onClose: VoidFunction
-  title: string
+  title: React.ReactNode
   subtitle?: React.ReactNode
   buttonAction?: ActionItem & {
     disabled?: boolean
@@ -89,9 +89,13 @@ export const Drawer: React.FC<DrawerProps> = ({
         }}
       >
         <Stack spacing={1} pb={5}>
-          <Typography variant="h6" fontWeight={600}>
-            {title}
-          </Typography>
+          {typeof title === 'string' ? (
+            <Typography variant="h6" fontWeight={600}>
+              {title}
+            </Typography>
+          ) : (
+            title
+          )}
           {typeof subtitle === 'string' ? (
             <Typography variant="body2">{subtitle}</Typography>
           ) : (


### PR DESCRIPTION
## 🔗 Issue

[PIN-10336](https://pagopa.atlassian.net/browse/PIN-10336)

## 📝 Description / Context

This PR include the lazy loading of attribute for AttributeDetailsDrawer. The prefetch query starts on menu actions icon hover, then the query is inside the drawer. It is implemented a skeleton inside the drawer to show if the data are not ready to display.

## 🛠 List of changes

- Add prefetch query on menu icon hover
- Add skeleton in AttributeDetailsDrawer


[PIN-10336]: https://pagopa.atlassian.net/browse/PIN-10336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ