### PR TITLE
fix: remove save draft call (PIN-10342)

### DIFF
--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
@@ -156,17 +156,13 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
       // closeDialog(), and the second mutate() would silently no-op against a
       // destroyed observer.
       onConfirm: () => {
-        saveDraft(answers, {
-          onSuccess: () => {
-            submitRiskAnalysis(
-              {
-                purposeId: purpose.id,
-                riskAnalysisForm: { version: riskAnalysis.version, answers },
-              },
-              { onSuccess: goToSummary }
-            )
+        submitRiskAnalysis(
+          {
+            purposeId: purpose.id,
+            riskAnalysisForm: { version: riskAnalysis.version, answers },
           },
-        })
+          { onSuccess: goToSummary }
+        )
       },
     })
   }

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
@@ -300,7 +300,7 @@ describe('PurposeEditStepRiskAnalysis', () => {
     })
   })
 
-  it('in option 2 opens the requestPurposeApproval dialog and the dialog onConfirm runs the save+submit+navigate chain', () => {
+  it('in option 2 opens the requestPurposeApproval dialog and the dialog onConfirm runs the submit+navigate chain', () => {
     const purpose = buildPurpose({
       reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
       reviewerIds: ['reviewer-1'],
@@ -328,18 +328,11 @@ describe('PurposeEditStepRiskAnalysis', () => {
     expect(typeof dialogPayload.onConfirm).toBe('function')
 
     // Step 2: dialog onConfirm fires the chain. The chain lives in the parent
-    // so the MutationObservers stay mounted across closeDialog.
+    // so the MutationObservers stay mounted across closeDialog. The BE unified
+    // the save into the submit call, so no save-draft request is made.
     dialogPayload.onConfirm()
 
-    expect(updateDraftMock).toHaveBeenCalledTimes(1)
-    const [savePayload, saveOptions] = updateDraftMock.mock.calls[0]
-    expect(savePayload).toMatchObject({
-      purposeId: purpose.id,
-      riskAnalysisForm: { version: riskAnalysis.version, answers },
-    })
-    expect(submitRiskAnalysisMock).not.toHaveBeenCalled()
-
-    saveOptions.onSuccess!()
+    expect(updateDraftMock).not.toHaveBeenCalled()
 
     expect(submitRiskAnalysisMock).toHaveBeenCalledTimes(1)
     const [submitPayload, submitOptions] = submitRiskAnalysisMock.mock.calls[0]


### PR DESCRIPTION
## 🔗 Issue
[PIN-10342](https://pagopa.atlassian.net/browse/PIN-10342)

## 📝 Description / Context
In the purpose creation form, "Compilazione in autonomia e approvazione da valutatore" flow, sending the purpose for approval used to fire two requests: a save-draft (`updatePurpose`) followed by the submit-for-approval (`submitRiskAnalysis`). The backend has unified both into the second call, so the save-draft request is now redundant and is removed.

## 🛠 List of changes
- Removed the superfluous `saveDraft`/`updatePurpose` call from the "Richiedi approvazione" handler in `PurposeEditStepRiskAnalysis`; `submitRiskAnalysis` is now invoked directly with `onSuccess: goToSummary`.

## 🧪 How to test
- Open a purpose in the "Compilazione in autonomia e approvazione da valutatore" (reviewer-approval) draft flow and reach the risk analysis step.
- Click "Richiedi approvazione" and confirm in the dialog.
- In the network tab, verify a single request is fired (only the risk-analysis submit, no preceding save-draft) and that on success you are redirected to the summary page.

[PIN-10342]: https://pagopa.atlassian.net/browse/PIN-10342