### PR TITLE
fix: grey out disabled Signal Hub label and align async advanced-option checkboxes (PIN-10341)

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAsyncExchangeSectionBase.tsx
@@ -55,6 +55,18 @@ const asyncExchangeNumericFields = [
   sx: { flex?: number; my: number }
 }>
 
+const AdvancedOptionLabel: React.FC<{ label: string; infoLabel: string }> = ({
+  label,
+  infoLabel,
+}) => (
+  <Stack>
+    <Typography variant="body1">{label}</Typography>
+    <Typography variant="body2" color="text.secondary">
+      {infoLabel}
+    </Typography>
+  </Stack>
+)
+
 export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSectionBaseProps> = ({
   areGeneralInfoEditable,
   areAdvancedOptionsEditable,
@@ -188,14 +200,22 @@ export const EServiceAsyncExchangeSectionBase: React.FC<EServiceAsyncExchangeSec
         <Stack spacing={0} sx={{ mt: 1 }}>
           <RHFCheckbox
             name="asyncExchangeProperties.confirmation"
-            label={tAsyncExchange('confirmationField.label')}
-            infoLabel={tAsyncExchange('confirmationField.infoLabel')}
+            label={
+              <AdvancedOptionLabel
+                label={tAsyncExchange('confirmationField.label')}
+                infoLabel={tAsyncExchange('confirmationField.infoLabel')}
+              />
+            }
             sx={{ my: 0 }}
           />
           <RHFCheckbox
             name="asyncExchangeProperties.bulk"
-            label={tAsyncExchange('bulkField.label')}
-            infoLabel={tAsyncExchange('bulkField.infoLabel')}
+            label={
+              <AdvancedOptionLabel
+                label={tAsyncExchange('bulkField.label')}
+                infoLabel={tAsyncExchange('bulkField.infoLabel')}
+              />
+            }
             disabled={isSoap}
             sx={{ mb: 0 }}
           />

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
@@ -94,19 +94,29 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
     })
   }
 
-  const signalHubLabel = (
-    <>
-      {' '}
-      <span> {t('create.step1.eserviceTemplateModeField.isSignalHubEnabled.label')} </span>
-      <Typography variant="body2" color="textSecondary" sx={{ marginTop: 0.5 }}>
-        {t('create.step1.eserviceTemplateModeField.isSignalHubEnabled.infoLabel.before')}{' '}
-        <IconLink href={SIGNALHUB_GUIDE_URL} target="_blank">
-          {t('create.step1.eserviceTemplateModeField.isSignalHubEnabled.infoLabel.linkLabel')}
-        </IconLink>{' '}
-        {t('create.step1.eserviceTemplateModeField.isSignalHubEnabled.infoLabel.after')}
-      </Typography>
-    </>
-  ) as unknown as string
+  const signalHubLabel = (disabled: boolean) =>
+    (
+      <>
+        {' '}
+        <span> {t('create.step1.eserviceTemplateModeField.isSignalHubEnabled.label')} </span>
+        <Typography
+          variant="body2"
+          color={disabled ? 'text.disabled' : 'text.secondary'}
+          sx={{ marginTop: 0.5 }}
+        >
+          {t('create.step1.eserviceTemplateModeField.isSignalHubEnabled.infoLabel.before')}{' '}
+          <IconLink
+            href={SIGNALHUB_GUIDE_URL}
+            target="_blank"
+            aria-disabled={disabled}
+            tabIndex={disabled ? -1 : undefined}
+          >
+            {t('create.step1.eserviceTemplateModeField.isSignalHubEnabled.infoLabel.linkLabel')}
+          </IconLink>{' '}
+          {t('create.step1.eserviceTemplateModeField.isSignalHubEnabled.infoLabel.after')}
+        </Typography>
+      </>
+    ) as unknown as string
 
   if (!areEServiceTemplateGeneralInfoEditable && eserviceTemplateVersion) {
     return (
@@ -143,7 +153,7 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
           <SectionContainer title={t('create.step1.signalHubTitle')} component="div">
             <RHFSwitch
               name="isSignalHubEnabled"
-              label={signalHubLabel}
+              label={signalHubLabel(!areEServiceTemplateGeneralInfoEditable)}
               disabled={!areEServiceTemplateGeneralInfoEditable}
             />
           </SectionContainer>
@@ -211,7 +221,7 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
         />
 
         <SectionContainer title={t('create.step1.signalHubTitle')} component="div">
-          <RHFSwitch name="isSignalHubEnabled" label={signalHubLabel} />
+          <RHFSwitch name="isSignalHubEnabled" label={signalHubLabel(false)} />
         </SectionContainer>
 
         <StepActions


### PR DESCRIPTION
## 🔗 Issue

[PIN-10341](https://pagopa.atlassian.net/browse/PIN-10341)

## 📝 Description / Context

Two UI alignment fixes in the e-service / e-service-template flow, both from a [reported inconsistency on Slack](https://pagopaspa.slack.com/archives/C06QH79HJTD/p1781282674695559). (1) When editing a non-editable template version the Signal Hub toggle is correctly disabled (introduced in [PR #1850](https://github.com/pagopa/pdnd-interop-frontend/pull/1850), PIN-9784), but only the title was greyed out while the description and the "notifiche push" link stayed active; now the whole label block (title, description, link) reflects the disabled state and the link is no longer clickable. (2) In the async "Opzioni avanzate" options the checkbox was vertically centered only against the title, with the description rendered as a separate helper text below; per the [Figma](https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW/Interop-%E2%80%94-Delivery-FE---QA?node-id=4155-45483) the checkbox must be centered against the whole title + description block.

## 🛠 List of changes

- `EServiceTemplateCreateStepGeneral.tsx`: `signalHubLabel` is now a function of `disabled`; when disabled the description uses `text.disabled` and the `IconLink` gets `aria-disabled` + `tabIndex={-1}` (greyed, not clickable).
- `EServiceAsyncExchangeSectionBase.tsx`: each advanced-option description is moved from the `RHFCheckbox` `infoLabel` into the `label` as a title + description block (`AdvancedOptionLabel`), so `FormControlLabel` vertically centers the checkbox against the whole block (same pattern already used by the Signal Hub switch).

## 🧪 How to test

- Signal Hub disabled: open a published e-service template, use "Crea bozza da template" to create a new draft version, then on step 1 ("Informazioni generali", read-only) verify the Signal Hub section: toggle, title, description and "notifiche push" link are all greyed and the link is not clickable.
- Async advanced options: create a new e-service with "Asincrono / massivo" data exchange, go to step 3 ("Specifiche tecniche") → "Opzioni avanzate": the checkbox is vertically centered against the title + description block (see [Figma](https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW/Interop-%E2%80%94-Delivery-FE---QA?node-id=4155-45483)).

## 📸 Screenshots

<img width="920" height="178" alt="signalhub-disabled" src="https://github.com/user-attachments/assets/9f1bc63e-c2d9-455b-98b5-b18790be4d84" />


<img width="872" height="116" alt="checkbox-spacing-v2" src="https://github.com/user-attachments/assets/e6136e0d-fd33-4dd5-a4c3-f54265d1b8a0" />

[PIN-10341]: https://pagopa.atlassian.net/browse/PIN-10341
