### PR TITLE
bugfix: fix typography bugs inside drawers (PIN-10346)

### DIFF
--- a/src/components/shared/CustomizeThresholdDrawer.tsx
+++ b/src/components/shared/CustomizeThresholdDrawer.tsx
@@ -118,9 +118,7 @@ export const CustomizeThresholdDrawer: React.FC<CustomizeThresholdDrawerProps> =
             />
             <GreyAlert>
               <Stack spacing={0.5}>
-                <Typography variant="overline" sx={{ whiteSpace: 'nowrap' }}>
-                  {t('limitAlert.title')}
-                </Typography>
+                <Typography variant="overline">{t('limitAlert.title')}</Typography>
                 <Stack
                   direction={'row'}
                   alignItems={'center'}

--- a/src/components/shared/ProviderThresholdsInfoAlert.tsx
+++ b/src/components/shared/ProviderThresholdsInfoAlert.tsx
@@ -22,7 +22,12 @@ export function ProviderThresholdsInfoAlert({
   return (
     <GreyAlert>
       <AlertTitle sx={{ textTransform: 'uppercase', fontWeight: 700 }}>{t('label')}</AlertTitle>
-      <Stack direction="row" spacing={6} sx={{ mt: 0.5, mb: 1, whiteSpace: 'nowrap' }}>
+      <Stack
+        direction={{ xs: 'column', lg: 'row' }}
+        spacing={{ xs: 1, lg: 6 }}
+        sx={{ mt: 0.5, mb: 1, flexWrap: 'wrap' }}
+        alignItems={{ xs: 'flex-start', lg: 'center' }}
+      >
         <Stack direction="row" spacing={2} alignItems="center">
           <Typography>{t('dailyCallsPerConsumer.label')}</Typography>
           <Typography fontWeight={600}>

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
@@ -170,12 +170,15 @@ export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
   }
 
   const customizeThresholdDrawerSubtitle = (
-    <Trans
-      ns="eservice"
-      i18nKey="read.drawers.customizeThresholdDrawer.subtitle"
-      values={{ name: attribute?.name }}
-      components={{ 1: <strong /> }}
-    />
+    <Typography variant="body2">
+      <Trans
+        components={{
+          strong: <Typography component="span" variant="inherit" fontWeight={600} />,
+        }}
+      >
+        {tCustomizeThresholdDrawer('subtitle', { name: attribute?.name })}
+      </Trans>
+    </Typography>
   )
 
   const currentConsumerThreshold = (


### PR DESCRIPTION
## 🔗 Issue

[PIN-10346](https://pagopa.atlassian.net/browse/PIN-10346)

## 📝 Description / Context

This PR include the fix for some bugs inside drawers:

- bug on the subtitle of the `CustomizeThresholdDrawer`
- bug on the limit alert of the `CustomizeThresholdDrawer`
- bug that show threhsold values in consumer pages components and drawer
- bug that made threshold info in `ProviderThresholdsInfoAlert` to overflow the alert dimension

## 🛠 List of changes

- fix the subtitle to be inline
- fix the alert removing `sx={{ whiteSpace: 'nowrap' }}` that cause the text to overflow the space
- hiding threshold in drawers and sections in consumers pages
- refactor the behaviour of the stack inside the `ProviderThresholdsInfoAlert`


[PIN-10346]: https://pagopa.atlassian.net/browse/PIN-10346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ