### PR TITLE
fix: fix attribute autocomplete options (PIN-10352)

### DIFF
--- a/src/components/shared/AddAttributesToForm/AttributeGroup.tsx
+++ b/src/components/shared/AddAttributesToForm/AttributeGroup.tsx
@@ -53,6 +53,7 @@ export const AttributeGroup: React.FC<AttributeGroupProps> = ({
     close: closeConfigureDiscreteAttributeDrawer,
     attribute,
     groupIndex: attributeGroupIndex,
+    attributeIndex,
   } = useConfigureCertifiedDiscreteAttributeDrawer()
 
   const handleDeleteAttributesGroup = () => {
@@ -91,9 +92,11 @@ export const AttributeGroup: React.FC<AttributeGroupProps> = ({
       threshold: threshold,
     }
 
-    if (groups[attributeGroupIndex].some((att) => att.id === attribute.id)) {
-      groups[attributeGroupIndex] = group.map((att) =>
-        att.id === attribute.id ? { ...att, discreteConfig: discreteConfig } : att
+    if (attributeIndex && groups[attributeGroupIndex][attributeIndex].id === attribute.id) {
+      groups[attributeGroupIndex] = group.map((att, index) =>
+        att.id === attribute.id && index === attributeIndex
+          ? { ...att, discreteConfig: discreteConfig }
+          : att
       )
     } else {
       groups[attributeGroupIndex].push({ ...attribute, discreteConfig: discreteConfig })
@@ -154,7 +157,7 @@ export const AttributeGroup: React.FC<AttributeGroupProps> = ({
                     }
                     onOpenConfigDrawer={
                       FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE && !readOnly
-                        ? () => openConfigureDiscreteAttributeDrawer(attribute, groupIndex)
+                        ? () => openConfigureDiscreteAttributeDrawer(attribute, groupIndex, index)
                         : undefined
                     }
                   />

--- a/src/components/shared/AddAttributesToForm/ConfigureCertifiedDiscreteAttributeDrawer.tsx
+++ b/src/components/shared/AddAttributesToForm/ConfigureCertifiedDiscreteAttributeDrawer.tsx
@@ -19,10 +19,15 @@ type ConfigureCertifiedDiscreteAttributeDrawerProps = {
 
 type ConfigureCertifiedDiscreteAttributeDrawerStore = {
   isOpen: boolean
-  open: (attribute: DescriptorAttribute | FormDescriptorAttribute, groupIndex: number) => void
+  open: (
+    attribute: DescriptorAttribute | FormDescriptorAttribute,
+    groupIndex: number,
+    attributeIndex?: number
+  ) => void
   close: VoidFunction
   attribute?: DescriptorAttribute | FormDescriptorAttribute
   groupIndex?: number
+  attributeIndex?: number
 }
 
 // TODO check if is more simple to add this in autocomplete directly and in attributeContainer directly
@@ -31,8 +36,15 @@ type ConfigureCertifiedDiscreteAttributeDrawerStore = {
 export const useConfigureCertifiedDiscreteAttributeDrawer =
   create<ConfigureCertifiedDiscreteAttributeDrawerStore>((set) => ({
     isOpen: false,
-    open: (attribute, groupIndex) => set({ attribute, groupIndex, isOpen: true }),
-    close: () => set({ isOpen: false, attribute: undefined, groupIndex: undefined }),
+    open: (attribute, groupIndex, attributeIndex = undefined) =>
+      set({ attribute, groupIndex, attributeIndex, isOpen: true }),
+    close: () =>
+      set({
+        isOpen: false,
+        attribute: undefined,
+        groupIndex: undefined,
+        attributeIndex: undefined,
+      }),
   }))
 
 type ConfigureCertifiedDiscreteAttributeFormValues = {

--- a/src/components/shared/AttributeAutocomplete.tsx
+++ b/src/components/shared/AttributeAutocomplete.tsx
@@ -86,7 +86,11 @@ export const AttributeAutocomplete: React.FC<AttributeAutocompleteProps> = ({
   const options: { label: string; value: CompactAttribute }[] = React.useMemo(() => {
     const attributes = data?.results ?? []
     return attributes
-      .filter((att) => !alreadySelectedAttributeIds.includes(att.id))
+      .filter(
+        (att) =>
+          (att.kind === 'CERTIFIED' && !alreadySelectedAttributeIds.includes(att.id)) ||
+          att.kind === 'CERTIFIED_DISCRETE'
+      )
       .map((att) => ({
         label: att.name,
         value: att,

--- a/src/components/shared/AttributeAutocomplete.tsx
+++ b/src/components/shared/AttributeAutocomplete.tsx
@@ -17,7 +17,11 @@ export type AttributeAutocompleteProps = {
   alreadySelectedAttributeIds: string[]
   groupIndex: number
   direction?: 'column' | 'row'
-  onOpenConfigDrawer?: (attribute: CompactAttribute, groupIndex: number) => void
+  onOpenConfigDrawer?: (
+    attribute: CompactAttribute,
+    groupIndex: number,
+    attributeIndex?: number
+  ) => void
   areCertifiedDiscreteOptionsIncluded?: boolean
 }
 


### PR DESCRIPTION
## 🔗 Issue

[PIN-10352](https://pagopa.atlassian.net/browse/PIN-10352)

## 📝 Description / Context

This PR incluse the fix that allow a `CERTIFIED_DISCRETE` attribute to be added more than one time in a descriptor

## 🛠 List of changes

- Change the options on AttributeAutocomplete


[PIN-10352]: https://pagopa.atlassian.net/browse/PIN-10352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ