### PR TITLE
fix: fix state problem in UpdateAttributesDrawer (PIN-10353)

### DIFF
--- a/src/components/shared/UpdateAttributesDrawer.tsx
+++ b/src/components/shared/UpdateAttributesDrawer.tsx
@@ -46,7 +46,10 @@ export const UpdateAttributesDrawer: React.FC<UpdateAttributesDrawerProps> = ({
   const { eServiceTemplateId, eServiceTemplateVersionId } =
     useParams<'PROVIDE_ESERVICE_TEMPLATE_DETAILS'>()
 
-  const formModelAttributes = mapDescriptorAttributesToFormDescriptorAttributes(attributes)
+  const formModelAttributes = React.useMemo(
+    () => mapDescriptorAttributesToFormDescriptorAttributes(attributes),
+    [attributes]
+  )
 
   const [selectedAttributes, setSelectedAttributes] = React.useState<FormDescriptorAttributes>(() =>
     cloneDeep(formModelAttributes)
@@ -127,7 +130,7 @@ export const UpdateAttributesDrawer: React.FC<UpdateAttributesDrawerProps> = ({
     if (isOpen) {
       setSelectedAttributes(cloneDeep(formModelAttributes))
     }
-  }, [isOpen])
+  }, [formModelAttributes, isOpen])
 
   return (
     <Drawer

--- a/src/components/shared/UpdateAttributesDrawer.tsx
+++ b/src/components/shared/UpdateAttributesDrawer.tsx
@@ -14,7 +14,10 @@ import AddIcon from '@mui/icons-material/Add'
 import { AttributeAutocomplete } from '@/components/shared/AttributeAutocomplete'
 import cloneDeep from 'lodash/cloneDeep'
 import { EServiceMutations } from '@/api/eservice'
-import { mapFormDescriptorAttributesToDescriptorAttributesSeed } from '@/utils/attribute.utils'
+import {
+  mapDescriptorAttributesToFormDescriptorAttributes,
+  mapFormDescriptorAttributesToDescriptorAttributesSeed,
+} from '@/utils/attribute.utils'
 import { useParams } from '@/router'
 import { EServiceTemplateMutations } from '@/api/eserviceTemplate'
 
@@ -43,8 +46,10 @@ export const UpdateAttributesDrawer: React.FC<UpdateAttributesDrawerProps> = ({
   const { eServiceTemplateId, eServiceTemplateVersionId } =
     useParams<'PROVIDE_ESERVICE_TEMPLATE_DETAILS'>()
 
+  const formModelAttributes = mapDescriptorAttributesToFormDescriptorAttributes(attributes)
+
   const [selectedAttributes, setSelectedAttributes] = React.useState<FormDescriptorAttributes>(() =>
-    cloneDeep(attributes)
+    cloneDeep(formModelAttributes)
   )
 
   const { mutate: updateEserviceAttributes } = EServiceMutations.useUpdateDescriptorAttributes()
@@ -118,11 +123,17 @@ export const UpdateAttributesDrawer: React.FC<UpdateAttributesDrawerProps> = ({
     }
   }
 
+  React.useEffect(() => {
+    if (isOpen) {
+      setSelectedAttributes(cloneDeep(formModelAttributes))
+    }
+  }, [isOpen])
+
   return (
     <Drawer
       isOpen={isOpen}
       onClose={onClose}
-      onTransitionExited={() => setSelectedAttributes(cloneDeep(attributes))}
+      onTransitionExited={() => setSelectedAttributes(cloneDeep(formModelAttributes))}
       title={t('title', { attributeKind: tAttribute(`type.${attributeKey}_other`) })}
       subtitle={t('subtitle')}
       buttonAction={{

--- a/src/components/shared/__tests__/UpdateAttributesDrawer.test.tsx
+++ b/src/components/shared/__tests__/UpdateAttributesDrawer.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { UpdateAttributesDrawer } from '../UpdateAttributesDrawer'
 import type { FormDescriptorAttributes } from '@/types/attribute.types'
+import { DescriptorAttributes } from '@/api/api.generatedTypes'
 
 vi.mock('@/components/layout/containers', () => {
   type Attribute = { id: string; name: string }
@@ -62,10 +63,6 @@ vi.mock('@/router', () => ({
     eServiceTemplateId: 't1',
     eServiceTemplateVersionId: 'v1',
   }),
-}))
-
-vi.mock('@/utils/attribute.utils', () => ({
-  mapFormDescriptorAttributesToDescriptorAttributesSeed: (attrs: FormDescriptorAttributes) => attrs,
 }))
 
 vi.mock('react-i18next', () => ({

--- a/src/components/shared/__tests__/UpdateAttributesDrawer.test.tsx
+++ b/src/components/shared/__tests__/UpdateAttributesDrawer.test.tsx
@@ -2,8 +2,6 @@ import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { UpdateAttributesDrawer } from '../UpdateAttributesDrawer'
-import type { FormDescriptorAttributes } from '@/types/attribute.types'
-import { DescriptorAttributes } from '@/api/api.generatedTypes'
 
 vi.mock('@/components/layout/containers', () => {
   type Attribute = { id: string; name: string }


### PR DESCRIPTION
## 🔗 Issue

[PIN-10353](https://pagopa.atlassian.net/browse/PIN-10353)

## 📝 Description / Context

This PR fix a type inconsistency in UpdateAttributesDrawer and most important fix the problem that the state of the drawer miss a data update and show an old instance of data

## 🛠 List of changes

- Use map function
- Add useEffect at the open to update the data


[PIN-10353]: https://pagopa.atlassian.net/browse/PIN-10353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ