### PR TITLE
fix: fix AttributeGroup color and subtitle and AttributeContainer threshold presence (PIN-10356)

### DIFF
--- a/src/components/layout/containers/AttributeContainer.tsx
+++ b/src/components/layout/containers/AttributeContainer.tsx
@@ -152,7 +152,7 @@ export const AttributeContainer = <
               {(attribute.dailyCallsPerConsumer !== undefined || onCustomizeThreshold) &&
                 !hideThreshold && (
                   <Stack direction={'row'} spacing={2} alignItems={'center'}>
-                    {attribute.dailyCallsPerConsumer !== undefined && !hideThreshold && (
+                    {attribute.dailyCallsPerConsumer !== undefined && (
                       <Stack direction={'row'} spacing={1}>
                         <Typography variant="body2">{t('thresholdLabel')}</Typography>
                         <Typography variant="body2" fontWeight={700}>

--- a/src/components/layout/containers/AttributeContainer.tsx
+++ b/src/components/layout/containers/AttributeContainer.tsx
@@ -149,31 +149,32 @@ export const AttributeContainer = <
                   {formatThousands(attribute.discreteValue)}
                 </Typography>
               )}
-              {(attribute.dailyCallsPerConsumer !== undefined || onCustomizeThreshold) && (
-                <Stack direction={'row'} spacing={2} alignItems={'center'}>
-                  {attribute.dailyCallsPerConsumer !== undefined && !hideThreshold && (
-                    <Stack direction={'row'} spacing={1}>
-                      <Typography variant="body2">{t('thresholdLabel')}</Typography>
-                      <Typography variant="body2" fontWeight={700}>
-                        {attribute.dailyCallsPerConsumer}
-                      </Typography>
-                    </Stack>
-                  )}
-                  {onCustomizeThreshold && !attribute.dailyCallsPerConsumer && (
-                    <ButtonNaked
-                      color="primary"
-                      type="button"
-                      sx={{ fontWeight: 700 }}
-                      onClick={(e: React.MouseEvent) => {
-                        e.stopPropagation()
-                        onCustomizeThreshold()
-                      }}
-                    >
-                      {t('actions.customizeThreshold')}
-                    </ButtonNaked>
-                  )}
-                </Stack>
-              )}
+              {(attribute.dailyCallsPerConsumer !== undefined || onCustomizeThreshold) &&
+                !hideThreshold && (
+                  <Stack direction={'row'} spacing={2} alignItems={'center'}>
+                    {attribute.dailyCallsPerConsumer !== undefined && !hideThreshold && (
+                      <Stack direction={'row'} spacing={1}>
+                        <Typography variant="body2">{t('thresholdLabel')}</Typography>
+                        <Typography variant="body2" fontWeight={700}>
+                          {attribute.dailyCallsPerConsumer}
+                        </Typography>
+                      </Stack>
+                    )}
+                    {onCustomizeThreshold && !attribute.dailyCallsPerConsumer && (
+                      <ButtonNaked
+                        color="primary"
+                        type="button"
+                        sx={{ fontWeight: 700 }}
+                        onClick={(e: React.MouseEvent) => {
+                          e.stopPropagation()
+                          onCustomizeThreshold()
+                        }}
+                      >
+                        {t('actions.customizeThreshold')}
+                      </ButtonNaked>
+                    )}
+                  </Stack>
+                )}
             </Stack>
             <Box
               alignSelf="center"

--- a/src/components/layout/containers/AttributeGroupContainer.tsx
+++ b/src/components/layout/containers/AttributeGroupContainer.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, IconButton, alpha } from '@mui/material'
 import { theme } from '@pagopa/interop-fe-commons'
 import { useTranslation } from 'react-i18next'
 
-type AttributeGroupContainerProps = Omit<CardProps, 'title'> & {
+export type AttributeGroupContainerProps = Omit<CardProps, 'title'> & {
   title: React.ReactNode
   onRemove?: () => void
   subheader?: React.ReactNode

--- a/src/components/layout/containers/__tests__/AttributeContainer.test.tsx
+++ b/src/components/layout/containers/__tests__/AttributeContainer.test.tsx
@@ -93,6 +93,38 @@ describe('AttributeContainer', () => {
     expect(screen.getByRole('menuitem', { name: 'actions.changeThreshold' })).toBeInTheDocument()
   })
 
+  it('should show threshold value when hideThreshold is false', async () => {
+    renderWithApplicationContext(
+      <AttributeContainer
+        attribute={{ ...baseAttribute, dailyCallsPerConsumer: 100 }}
+        hideThreshold={false}
+      />,
+      { withReactQueryContext: true }
+    )
+
+    const thresholdLabel = screen.queryByText('thresholdLabel')
+    const thresholdValue = screen.queryByText(100)
+
+    expect(thresholdLabel).toBeInTheDocument()
+    expect(thresholdValue).toBeInTheDocument()
+  })
+
+  it('should not show threshold value when hideThreshold is true', async () => {
+    renderWithApplicationContext(
+      <AttributeContainer
+        attribute={{ ...baseAttribute, dailyCallsPerConsumer: 100 }}
+        hideThreshold
+      />,
+      { withReactQueryContext: true }
+    )
+
+    const thresholdLabel = screen.queryByText('thresholdLabel')
+    const thresholdValue = screen.queryByText(100)
+
+    expect(thresholdLabel).not.toBeInTheDocument()
+    expect(thresholdValue).not.toBeInTheDocument()
+  })
+
   it('should call onCustomizeThreshold on click with stopPropagation', () => {
     const onCustomizeThreshold = vi.fn()
     renderWithApplicationContext(

--- a/src/components/shared/EserviceTemplate/EServiceTemplateAttributes.tsx
+++ b/src/components/shared/EserviceTemplate/EServiceTemplateAttributes.tsx
@@ -44,6 +44,7 @@ export const EServiceTemplateAttributes: React.FC<EServiceTemplateAttributesProp
         attributeKey="certified"
         descriptorAttributes={attributes}
         topSideActions={readonly ? undefined : getAttributeSectionActions('certified')}
+        hideThreshold
       />
       <Divider sx={{ my: 3 }} />
       <AttributeGroupsListSection

--- a/src/components/shared/ReadOnlyDescriptorAttributes.tsx
+++ b/src/components/shared/ReadOnlyDescriptorAttributes.tsx
@@ -17,11 +17,7 @@ import type { ActionItemButton } from '@/types/common.types'
 import { attributesHelpLink } from '@/config/constants'
 import { Typography } from '@mui/material'
 import { useCustomizeThresholdDrawer } from './CustomizeThresholdDrawer'
-import {
-  hasAllDescriptorAttributes,
-  isAttributeGroupFullfilled,
-  isAttributeOwned,
-} from '@/utils/attribute.utils'
+import { isAttributeGroupFullfilled, isAttributeOwned } from '@/utils/attribute.utils'
 
 export type AttributeOwnershipData = {
   certified: TenantAttributes['certified']
@@ -57,35 +53,24 @@ export const ReadOnlyDescriptorAttributes: React.FC<ReadOnlyDescriptorAttributes
     )
   }
 
-  const hasBlockingAttribute =
-    !!ownershipData &&
-    !hasAllDescriptorAttributes(
-      'certified',
-      ownershipData.certified,
-      descriptorAttributes.certified
-    )
-
   return (
     <>
       <AttributeGroupsListSection
         descriptorAttributes={descriptorAttributes}
         attributeKey="certified"
         ownershipData={ownershipData}
-        hasBlockingAttribute={hasBlockingAttribute}
       />
       <Divider sx={{ my: 3 }} />
       <AttributeGroupsListSection
         descriptorAttributes={descriptorAttributes}
         attributeKey="verified"
         ownershipData={ownershipData}
-        hasBlockingAttribute={hasBlockingAttribute}
       />
       <Divider sx={{ my: 3 }} />
       <AttributeGroupsListSection
         descriptorAttributes={descriptorAttributes}
         attributeKey="declared"
         ownershipData={ownershipData}
-        hasBlockingAttribute={hasBlockingAttribute}
       />
     </>
   )
@@ -97,7 +82,6 @@ type AttributeGroupsListSectionProps = {
   topSideActions?: Array<ActionItemButton>
   withThreshold?: boolean
   ownershipData?: AttributeOwnershipData
-  hasBlockingAttribute?: boolean
 }
 
 export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProps> = ({
@@ -106,7 +90,6 @@ export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProp
   topSideActions,
   withThreshold,
   ownershipData,
-  hasBlockingAttribute = false,
 }) => {
   const { t: tAttribute } = useTranslation('attribute')
 
@@ -135,7 +118,6 @@ export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProp
               attributeKey={attributeKey}
               withThreshold={withThreshold}
               ownershipData={ownershipData}
-              hasBlockingAttribute={hasBlockingAttribute}
             />
           ))}
         </Stack>
@@ -158,7 +140,6 @@ type AttributeGroupProps = {
   attributeKey: AttributeKey
   withThreshold?: boolean
   ownershipData?: AttributeOwnershipData
-  hasBlockingAttribute?: boolean
 }
 
 function getGroupColorAndText(
@@ -229,7 +210,6 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
   attributeKey,
   withThreshold,
   ownershipData,
-  hasBlockingAttribute = false,
 }) => {
   const { open } = useCustomizeThresholdDrawer()
   const { t: tAttribute } = useTranslation('attribute')
@@ -242,10 +222,6 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
   const rawGroupColorAndText = ownershipData
     ? getGroupColorAndText(attributeKey, attributes, ownershipData)
     : undefined
-
-  const shouldHideFulfillmentStatus =
-    hasBlockingAttribute && rawGroupColorAndText?.color !== 'error'
-  const groupColorAndText = shouldHideFulfillmentStatus ? undefined : rawGroupColorAndText
 
   return (
     <AttributeGroupContainer
@@ -262,14 +238,15 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
           text
         )
       })()}
-      color={groupColorAndText?.color ?? 'gray'}
+      color={rawGroupColorAndText?.color ?? 'gray'}
       subheader={
         <Typography variant="body2" color="text.primary" sx={{ px: 2, pt: 1.5 }}>
-          {tAttribute('group.subtitle')}
+          {rawGroupColorAndText
+            ? tAttribute(rawGroupColorAndText.textKey)
+            : tAttribute('group.subtitle')}
         </Typography>
       }
     >
-      {groupColorAndText && <Typography>{tAttribute(groupColorAndText.textKey)}</Typography>}
       <Stack spacing={1.2} sx={{ my: 2, mx: 0, listStyle: 'none', px: 0 }} component="ul">
         {sortedAttributes.map((attribute, _index) => (
           <React.Fragment key={attribute.id}>
@@ -277,7 +254,7 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
               <AttributeContainer
                 attribute={attribute}
                 checked={
-                  ownershipData && !shouldHideFulfillmentStatus
+                  ownershipData
                     ? getAttributeChecked(
                         attributeKey,
                         attribute.id,

--- a/src/components/shared/ReadOnlyDescriptorAttributes.tsx
+++ b/src/components/shared/ReadOnlyDescriptorAttributes.tsx
@@ -72,6 +72,7 @@ export const ReadOnlyDescriptorAttributes: React.FC<ReadOnlyDescriptorAttributes
         attributeKey="certified"
         ownershipData={ownershipData}
         hasBlockingAttribute={hasBlockingAttribute}
+        hideThreshold
       />
       <Divider sx={{ my: 3 }} />
       <AttributeGroupsListSection
@@ -98,6 +99,7 @@ type AttributeGroupsListSectionProps = {
   withThreshold?: boolean
   ownershipData?: AttributeOwnershipData
   hasBlockingAttribute?: boolean
+  hideThreshold?: boolean
 }
 
 export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProps> = ({
@@ -107,6 +109,7 @@ export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProp
   withThreshold,
   ownershipData,
   hasBlockingAttribute = false,
+  hideThreshold = false,
 }) => {
   const { t: tAttribute } = useTranslation('attribute')
 
@@ -136,6 +139,7 @@ export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProp
               withThreshold={withThreshold}
               ownershipData={ownershipData}
               hasBlockingAttribute={hasBlockingAttribute}
+              hideThreshold={hideThreshold}
             />
           ))}
         </Stack>
@@ -159,6 +163,7 @@ type AttributeGroupProps = {
   withThreshold?: boolean
   ownershipData?: AttributeOwnershipData
   hasBlockingAttribute?: boolean
+  hideThreshold?: boolean
 }
 
 function getGroupColorAndText(
@@ -230,6 +235,7 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
   withThreshold,
   ownershipData,
   hasBlockingAttribute = false,
+  hideThreshold = false,
 }) => {
   const { open } = useCustomizeThresholdDrawer()
   const { t: tAttribute } = useTranslation('attribute')
@@ -287,7 +293,7 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
                     : undefined
                 }
                 onCustomizeThreshold={withThreshold ? () => open(attribute, index) : undefined}
-                hideThreshold={!withThreshold}
+                hideThreshold={hideThreshold}
               />
             </Box>
             {sortedAttributes.length > 1 && _index < sortedAttributes.length - 1 && (

--- a/src/components/shared/ReadOnlyDescriptorAttributes.tsx
+++ b/src/components/shared/ReadOnlyDescriptorAttributes.tsx
@@ -247,6 +247,12 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
     hasBlockingAttribute && rawGroupColorAndText?.color !== 'error'
   const groupColorAndText = shouldHideFulfillmentStatus ? undefined : rawGroupColorAndText
 
+  const subtitleText = (() => {
+    if (groupColorAndText) return tAttribute(groupColorAndText.textKey)
+    if (!groupColorAndText && !ownershipData) return tAttribute('group.subtitle')
+    return undefined
+  })()
+
   return (
     <AttributeGroupContainer
       title={(() => {
@@ -264,12 +270,13 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
       })()}
       color={groupColorAndText?.color ?? 'gray'}
       subheader={
-        <Typography variant="body2" color="text.primary" sx={{ px: 2, pt: 1.5 }}>
-          {tAttribute('group.subtitle')}
-        </Typography>
+        subtitleText && (
+          <Typography variant="body2" color="text.primary" sx={{ px: 2, pt: 1.5 }}>
+            {subtitleText}
+          </Typography>
+        )
       }
     >
-      {groupColorAndText && <Typography>{tAttribute(groupColorAndText.textKey)}</Typography>}
       <Stack spacing={1.2} sx={{ my: 2, mx: 0, listStyle: 'none', px: 0 }} component="ul">
         {sortedAttributes.map((attribute, _index) => (
           <React.Fragment key={attribute.id}>

--- a/src/components/shared/ReadOnlyDescriptorAttributes.tsx
+++ b/src/components/shared/ReadOnlyDescriptorAttributes.tsx
@@ -245,13 +245,8 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
 
   const shouldHideFulfillmentStatus =
     hasBlockingAttribute && rawGroupColorAndText?.color !== 'error'
-  const groupColorAndText = shouldHideFulfillmentStatus ? undefined : rawGroupColorAndText
-
-  const subtitleText = (() => {
-    if (groupColorAndText) return tAttribute(groupColorAndText.textKey)
-    if (!groupColorAndText && !ownershipData) return tAttribute('group.subtitle')
-    return undefined
-  })()
+  const groupColor = shouldHideFulfillmentStatus ? undefined : rawGroupColorAndText?.color
+  const groupText = rawGroupColorAndText?.textKey
 
   return (
     <AttributeGroupContainer
@@ -268,13 +263,11 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
           text
         )
       })()}
-      color={groupColorAndText?.color ?? 'gray'}
+      color={groupColor ?? 'gray'}
       subheader={
-        subtitleText && (
-          <Typography variant="body2" color="text.primary" sx={{ px: 2, pt: 1.5 }}>
-            {subtitleText}
-          </Typography>
-        )
+        <Typography variant="body2" color="text.primary" sx={{ px: 2, pt: 1.5 }}>
+          {groupText ? tAttribute(groupText) : tAttribute('group.subtitle')}
+        </Typography>
       }
     >
       <Stack spacing={1.2} sx={{ my: 2, mx: 0, listStyle: 'none', px: 0 }} component="ul">

--- a/src/components/shared/ReadOnlyDescriptorAttributes.tsx
+++ b/src/components/shared/ReadOnlyDescriptorAttributes.tsx
@@ -264,6 +264,7 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
                     : undefined
                 }
                 onCustomizeThreshold={withThreshold ? () => open(attribute, index) : undefined}
+                hideThreshold={!withThreshold}
               />
             </Box>
             {sortedAttributes.length > 1 && _index < sortedAttributes.length - 1 && (

--- a/src/components/shared/ReadOnlyDescriptorAttributes.tsx
+++ b/src/components/shared/ReadOnlyDescriptorAttributes.tsx
@@ -17,7 +17,11 @@ import type { ActionItemButton } from '@/types/common.types'
 import { attributesHelpLink } from '@/config/constants'
 import { Typography } from '@mui/material'
 import { useCustomizeThresholdDrawer } from './CustomizeThresholdDrawer'
-import { isAttributeGroupFullfilled, isAttributeOwned } from '@/utils/attribute.utils'
+import {
+  hasAllDescriptorAttributes,
+  isAttributeGroupFullfilled,
+  isAttributeOwned,
+} from '@/utils/attribute.utils'
 
 export type AttributeOwnershipData = {
   certified: TenantAttributes['certified']
@@ -53,24 +57,35 @@ export const ReadOnlyDescriptorAttributes: React.FC<ReadOnlyDescriptorAttributes
     )
   }
 
+  const hasBlockingAttribute =
+    !!ownershipData &&
+    !hasAllDescriptorAttributes(
+      'certified',
+      ownershipData.certified,
+      descriptorAttributes.certified
+    )
+
   return (
     <>
       <AttributeGroupsListSection
         descriptorAttributes={descriptorAttributes}
         attributeKey="certified"
         ownershipData={ownershipData}
+        hasBlockingAttribute={hasBlockingAttribute}
       />
       <Divider sx={{ my: 3 }} />
       <AttributeGroupsListSection
         descriptorAttributes={descriptorAttributes}
         attributeKey="verified"
         ownershipData={ownershipData}
+        hasBlockingAttribute={hasBlockingAttribute}
       />
       <Divider sx={{ my: 3 }} />
       <AttributeGroupsListSection
         descriptorAttributes={descriptorAttributes}
         attributeKey="declared"
         ownershipData={ownershipData}
+        hasBlockingAttribute={hasBlockingAttribute}
       />
     </>
   )
@@ -82,6 +97,7 @@ type AttributeGroupsListSectionProps = {
   topSideActions?: Array<ActionItemButton>
   withThreshold?: boolean
   ownershipData?: AttributeOwnershipData
+  hasBlockingAttribute?: boolean
 }
 
 export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProps> = ({
@@ -90,6 +106,7 @@ export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProp
   topSideActions,
   withThreshold,
   ownershipData,
+  hasBlockingAttribute = false,
 }) => {
   const { t: tAttribute } = useTranslation('attribute')
 
@@ -118,6 +135,7 @@ export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProp
               attributeKey={attributeKey}
               withThreshold={withThreshold}
               ownershipData={ownershipData}
+              hasBlockingAttribute={hasBlockingAttribute}
             />
           ))}
         </Stack>
@@ -140,6 +158,7 @@ type AttributeGroupProps = {
   attributeKey: AttributeKey
   withThreshold?: boolean
   ownershipData?: AttributeOwnershipData
+  hasBlockingAttribute?: boolean
 }
 
 function getGroupColorAndText(
@@ -210,6 +229,7 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
   attributeKey,
   withThreshold,
   ownershipData,
+  hasBlockingAttribute = false,
 }) => {
   const { open } = useCustomizeThresholdDrawer()
   const { t: tAttribute } = useTranslation('attribute')
@@ -222,6 +242,10 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
   const rawGroupColorAndText = ownershipData
     ? getGroupColorAndText(attributeKey, attributes, ownershipData)
     : undefined
+
+  const shouldHideFulfillmentStatus =
+    hasBlockingAttribute && rawGroupColorAndText?.color !== 'error'
+  const groupColorAndText = shouldHideFulfillmentStatus ? undefined : rawGroupColorAndText
 
   return (
     <AttributeGroupContainer
@@ -238,15 +262,14 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
           text
         )
       })()}
-      color={rawGroupColorAndText?.color ?? 'gray'}
+      color={groupColorAndText?.color ?? 'gray'}
       subheader={
         <Typography variant="body2" color="text.primary" sx={{ px: 2, pt: 1.5 }}>
-          {rawGroupColorAndText
-            ? tAttribute(rawGroupColorAndText.textKey)
-            : tAttribute('group.subtitle')}
+          {tAttribute('group.subtitle')}
         </Typography>
       }
     >
+      {groupColorAndText && <Typography>{tAttribute(groupColorAndText.textKey)}</Typography>}
       <Stack spacing={1.2} sx={{ my: 2, mx: 0, listStyle: 'none', px: 0 }} component="ul">
         {sortedAttributes.map((attribute, _index) => (
           <React.Fragment key={attribute.id}>
@@ -254,7 +277,7 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
               <AttributeContainer
                 attribute={attribute}
                 checked={
-                  ownershipData
+                  ownershipData && !shouldHideFulfillmentStatus
                     ? getAttributeChecked(
                         attributeKey,
                         attribute.id,

--- a/src/components/shared/__tests__/ReadOnlyDescriptorAttributes.test.tsx
+++ b/src/components/shared/__tests__/ReadOnlyDescriptorAttributes.test.tsx
@@ -135,8 +135,8 @@ describe('ReadOnlyDescriptorAttributes', () => {
     })
   })
 
-  describe('fulfillment status hidden when there is a blocking attribute', () => {
-    it('should hide fulfillment status for non-blocking groups when a certified group is unfulfilled', () => {
+  describe('fulfillment status color hidden and text visible when there is a blocking attribute', () => {
+    it('should hide fulfillment status color but not text for non-blocking groups when a certified group is unfulfilled', () => {
       const descriptorAttributes = createDescriptorAttributes({
         certified: [[createMockDescriptorAttribute({ id: 'cert-attr-1' })]],
         verified: [[createMockDescriptorAttribute({ id: 'ver-attr-1', kind: 'VERIFIED' })]],
@@ -160,11 +160,8 @@ describe('ReadOnlyDescriptorAttributes', () => {
       // The certified group should still show the error text
       expect(screen.getByText('group.manage.error.consumer')).toBeInTheDocument()
 
-      // Verified and declared groups should hide fulfillment status (no subtitle shown)
-      expect(screen.queryByText('consumer')).not.toBeInTheDocument()
-
-      // Success text should NOT appear (verified is fulfilled but hidden due to blocking attribute)
-      expect(screen.queryByText('group.manage.success.consumer')).not.toBeInTheDocument()
+      // Success text should appear (verified and declared are fulfilled and only color is hidden due to blocking attribute)
+      expect(screen.queryAllByText('group.manage.success.consumer').length).toBe(2)
     })
 
     it('should show fulfillment status when all certified groups are fulfilled', () => {

--- a/src/components/shared/__tests__/ReadOnlyDescriptorAttributes.test.tsx
+++ b/src/components/shared/__tests__/ReadOnlyDescriptorAttributes.test.tsx
@@ -11,12 +11,40 @@ import {
   createVerifiedTenantAttribute,
   createMockDescriptorAttribute,
 } from '@/../__mocks__/data/attribute.mocks'
+import type { AttributeGroupContainerProps } from '@/components/layout/containers'
 
 mockUseCurrentRoute({ mode: 'consumer' })
 
 vi.mock('../CustomizeThresholdDrawer', () => ({
   useCustomizeThresholdDrawer: () => ({ open: vi.fn() }),
 }))
+
+const { mockContainerBehavior } = vi.hoisted(() => ({
+  mockContainerBehavior: vi.fn(),
+}))
+vi.mock('@/components/layout/containers/AttributeGroupContainer', async () => {
+  const actual = await vi.importActual<
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    typeof import('@/components/layout/containers/AttributeGroupContainer')
+  >('@/components/layout/containers/AttributeGroupContainer')
+  return {
+    ...actual,
+    AttributeGroupContainer: (props: AttributeGroupContainerProps) => {
+      const shouldMock = mockContainerBehavior()
+      if (shouldMock) {
+        const { color, title, subheader, children } = props
+        return (
+          <div data-testid="attribute-group-container" data-color={color}>
+            <div>{title}</div>
+            {subheader}
+            {children}
+          </div>
+        )
+      }
+      return <actual.AttributeGroupContainer {...props} />
+    },
+  }
+})
 
 const PRODUCER_ID = 'producer-id'
 
@@ -136,7 +164,12 @@ describe('ReadOnlyDescriptorAttributes', () => {
   })
 
   describe('fulfillment status color hidden and text visible when there is a blocking attribute', () => {
+    beforeEach(() => {
+      mockContainerBehavior.mockReturnValue(false)
+    })
+
     it('should hide fulfillment status color but not text for non-blocking groups when a certified group is unfulfilled', () => {
+      mockContainerBehavior.mockReturnValue(true)
       const descriptorAttributes = createDescriptorAttributes({
         certified: [[createMockDescriptorAttribute({ id: 'cert-attr-1' })]],
         verified: [[createMockDescriptorAttribute({ id: 'ver-attr-1', kind: 'VERIFIED' })]],
@@ -162,6 +195,15 @@ describe('ReadOnlyDescriptorAttributes', () => {
 
       // Success text should appear (verified and declared are fulfilled and only color is hidden due to blocking attribute)
       expect(screen.queryAllByText('group.manage.success.consumer').length).toBe(2)
+
+      const groups = screen.getAllByTestId('attribute-group-container')
+      expect(groups.length).toBe(3)
+
+      const [certifiedGroup, verifiedGroup, declaredGroup] = groups
+
+      expect(certifiedGroup).toHaveAttribute('data-color', 'error')
+      expect(verifiedGroup).toHaveAttribute('data-color', 'gray')
+      expect(declaredGroup).toHaveAttribute('data-color', 'gray')
     })
 
     it('should show fulfillment status when all certified groups are fulfilled', () => {
@@ -210,7 +252,7 @@ describe('ReadOnlyDescriptorAttributes', () => {
 
       // The verified attribute is owned but its fulfillment status is hidden,
       // so no checkmark should be rendered for it
-      const checkIcons = screen.queryAllByTestId('CheckIcon')
+      const checkIcons = screen.queryAllByTestId('CheckCircleIcon')
       expect(checkIcons.length).toBe(0)
     })
   })

--- a/src/pages/ConsumerAgreementCreatePage/components/ConsumerAgreementCreateCertifiedAttributesDrawer.tsx
+++ b/src/pages/ConsumerAgreementCreatePage/components/ConsumerAgreementCreateCertifiedAttributesDrawer.tsx
@@ -76,6 +76,7 @@ const ConsumerAgreementCreateCertifiedAttributesDrawer: React.FC = () => {
                   checked={isAttributeOwned('certified', attribute.id, ownedCertifiedAttributes, {
                     discreteConfig: attribute.discreteConfig,
                   })}
+                  hideThreshold
                 />
               ))}
             </Stack>

--- a/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsAttributesSectionsList/ConsumerAgreementDetailsCertifiedAttributesSection.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsAttributesSectionsList/ConsumerAgreementDetailsCertifiedAttributesSection.tsx
@@ -64,6 +64,7 @@ export const ConsumerAgreementDetailsCertifiedAttributesSection: React.FC = () =
                   checked={isAttributeOwned('certified', attribute.id, ownedCertifiedAttributes, {
                     discreteConfig: attribute.discreteConfig,
                   })}
+                  hideThreshold
                 />
               ))}
             </Stack>

--- a/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsGeneralInfoSection/ConsumerAgreementDetailsCertifiedAttributesDrawer.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsGeneralInfoSection/ConsumerAgreementDetailsCertifiedAttributesDrawer.tsx
@@ -77,6 +77,7 @@ export const ConsumerAgreementDetailsCertifiedAttributesDrawer: React.FC<
                   checked={isAttributeOwned('certified', attribute.id, ownedCertifiedAttributes, {
                     discreteConfig: attribute.discreteConfig,
                   })}
+                  hideThreshold
                 />
               ))}
             </Stack>


### PR DESCRIPTION
## 🔗 Issue

[PIN-10356](https://pagopa.atlassian.net/browse/PIN-10356)

## 📝 Description / Context

This PR include the fix that remove threshold in AttributeContainer in consumer page. Also include the fix about the subtitle of the AttributeGroup

## 🛠 List of changes

- set hideThreshold prop
- remove the duplicated subtitle


[PIN-10356]: https://pagopa.atlassian.net/browse/PIN-10356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ