### PR TITLE
feat: hide edit actions and restricted tabs for viewer role

### DIFF
--- a/src/pages/ConsumerPurposeDetailsPage/ConsumerPurposeDetails.page.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/ConsumerPurposeDetails.page.tsx
@@ -20,7 +20,7 @@ import { AuthHooks } from '@/api/auth'
 const ConsumerPurposeDetailsPage: React.FC = () => {
   const { purposeId } = useParams<'SUBSCRIBE_PURPOSE_DETAILS'>()
   const { t } = useTranslation('purpose')
-  const { jwt } = AuthHooks.useJwt()
+  const { jwt, isViewer } = AuthHooks.useJwt()
 
   const { data: purpose, isLoading: isPurposeLoading } = useQuery(
     PurposeQueries.getSingle(purposeId)
@@ -45,8 +45,9 @@ const ConsumerPurposeDetailsPage: React.FC = () => {
   const isPurposeArchived = purpose?.currentVersion?.state === 'ARCHIVED'
 
   const canAccessClientTab =
-    descriptor?.eservice.isClientAccessDelegable ||
-    purpose?.delegation?.delegate.id !== jwt?.organizationId
+    (descriptor?.eservice.isClientAccessDelegable ||
+      purpose?.delegation?.delegate.id !== jwt?.organizationId) &&
+    !isViewer
 
   const alertProps = useGetPurposeStateAlertProps(
     purpose,

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsPlanCard.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsPlanCard.tsx
@@ -84,6 +84,7 @@ export const ConsumerPurposeDetailsDailyCallsPlanCard: React.FC<
               <Typography variant="h4">{formatThousands(dailyCalls)}</Typography>
             </Box>
             {!(
+              !isAdmin ||
               isSuspended ||
               isArchived ||
               waitingForApprovalVersion ||
@@ -107,11 +108,13 @@ export const ConsumerPurposeDetailsDailyCallsPlanCard: React.FC<
           </Stack>
         </CardContent>
       </Card>
-      <ConsumerPurposeDetailsDailyCallsUpdateDrawer
-        isOpen={isOpen}
-        onClose={closeDrawer}
-        purpose={purpose}
-      />
+      {isAdmin && (
+        <ConsumerPurposeDetailsDailyCallsUpdateDrawer
+          isOpen={isOpen}
+          onClose={closeDrawer}
+          purpose={purpose}
+        />
+      )}
     </>
   )
 }

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsDailyCallsPlanCard.test.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsDailyCallsPlanCard.test.tsx
@@ -19,7 +19,7 @@ describe('ConsumerPurposeDetailsDailyCallsPlanCard', () => {
     expect(screen.getByText('changePlanRequestLink.label')).toBeInTheDocument()
   })
 
-  it('hides the change plan request link for non-admin (viewer) users', () => {
+  it('hides the change plan request link for non-admin users', () => {
     mockUseJwt({ isAdmin: false })
     renderWithApplicationContext(
       <ConsumerPurposeDetailsDailyCallsPlanCard purpose={createMockPurpose()} />,

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsDailyCallsPlanCard.test.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsDailyCallsPlanCard.test.tsx
@@ -1,0 +1,30 @@
+import { screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ConsumerPurposeDetailsDailyCallsPlanCard } from '../ConsumerPurposeDetailsDailyCallsPlanCard'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
+
+mockUseJwt()
+
+vi.mock('../ConsumerPurposeDetailsDailyCallsUpdateDrawer', () => ({
+  ConsumerPurposeDetailsDailyCallsUpdateDrawer: () => <div data-testid="update-drawer" />,
+}))
+
+describe('ConsumerPurposeDetailsDailyCallsPlanCard', () => {
+  it('shows the change plan request link for admin users', () => {
+    renderWithApplicationContext(
+      <ConsumerPurposeDetailsDailyCallsPlanCard purpose={createMockPurpose()} />,
+      { withReactQueryContext: true }
+    )
+    expect(screen.getByText('changePlanRequestLink.label')).toBeInTheDocument()
+  })
+
+  it('hides the change plan request link for non-admin (viewer) users', () => {
+    mockUseJwt({ isAdmin: false })
+    renderWithApplicationContext(
+      <ConsumerPurposeDetailsDailyCallsPlanCard purpose={createMockPurpose()} />,
+      { withReactQueryContext: true }
+    )
+    expect(screen.queryByText('changePlanRequestLink.label')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -20,10 +20,12 @@ import {
   isDescriptorPendingArchiving,
 } from '@/utils/eservice.utils'
 import { ProviderEServiceDetailsAlerts } from './components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts'
+import { AuthHooks } from '@/api/auth'
 
 const ProviderEServiceDetailsPage: React.FC = () => {
   const { t } = useTranslation('eservice', { keyPrefix: 'read' })
   const { eserviceId, descriptorId } = useParams<'PROVIDE_ESERVICE_MANAGE'>()
+  const { isViewer } = AuthHooks.useJwt()
 
   const { activeTab, updateActiveTab } = useActiveTab('eserviceDetails')
   const { openDialog } = useDialog()
@@ -132,20 +134,24 @@ const ProviderEServiceDetailsPage: React.FC = () => {
         descriptor={descriptor}
         onViewKeychains={handleViewKeychains}
       />
-      <TabContext value={activeTab}>
-        <TabList onChange={updateActiveTab} aria-label={t('tabs.ariaLabel')} variant="fullWidth">
-          <Tab label={t('tabs.eserviceDetails')} value="eserviceDetails" />
-          <Tab label={t('tabs.keychain')} value="keychains" />
-        </TabList>
+      {!isViewer ? (
+        <TabContext value={activeTab}>
+          <TabList onChange={updateActiveTab} aria-label={t('tabs.ariaLabel')} variant="fullWidth">
+            <Tab label={t('tabs.eserviceDetails')} value="eserviceDetails" />
+            <Tab label={t('tabs.keychain')} value="keychains" />
+          </TabList>
 
-        <TabPanel value="eserviceDetails">
-          <ProviderEserviceDetailsTab />
-        </TabPanel>
+          <TabPanel value="eserviceDetails">
+            <ProviderEserviceDetailsTab />
+          </TabPanel>
 
-        <TabPanel value="keychains">
-          <ProviderEserviceKeychainsTab />
-        </TabPanel>
-      </TabContext>
+          <TabPanel value="keychains">
+            <ProviderEserviceKeychainsTab />
+          </TabPanel>
+        </TabContext>
+      ) : (
+        <ProviderEserviceDetailsTab />
+      )}
       {descriptor && (
         <EServiceVersionSelectorDrawer
           isOpen={isVersionSelectorDrawerOpen}

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -132,7 +132,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
     >
       <ProviderEServiceDetailsAlerts
         descriptor={descriptor}
-        onViewKeychains={handleViewKeychains}
+        onViewKeychains={isViewer ? undefined : handleViewKeychains}
       />
       {!isViewer ? (
         <TabContext value={activeTab}>

--- a/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDescriptorAttributesSection.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDescriptorAttributesSection.test.tsx
@@ -90,4 +90,19 @@ describe('ProviderEServiceDescriptorAttributesSection', () => {
     expect(screen.getByText('thresholds.dailyCallsTotal.label')).toBeInTheDocument()
     expect(screen.getByText('1000')).toBeInTheDocument()
   })
+
+  it('shows the threshold edit action for admin users', () => {
+    renderWithApplicationContext(<ProviderEServiceDescriptorAttributesSection />, {
+      withReactQueryContext: true,
+    })
+    expect(screen.getByText('modify')).toBeInTheDocument()
+  })
+
+  it('hides the threshold edit action for viewer users', () => {
+    mockUseJwt({ isAdmin: false, isViewer: true })
+    renderWithApplicationContext(<ProviderEServiceDescriptorAttributesSection />, {
+      withReactQueryContext: true,
+    })
+    expect(screen.queryByText('modify')).not.toBeInTheDocument()
+  })
 })

--- a/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetails.page.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetails.page.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import ProviderEServiceDetailsPage from '../ProviderEServiceDetails.page'
+import type * as ReactQuery from '@tanstack/react-query'
+
+const { mockedGetDescriptorProvider, mockedUseQuery } = vi.hoisted(() => ({
+  mockedGetDescriptorProvider: vi.fn(),
+  mockedUseQuery: vi.fn(),
+}))
+
+mockUseJwt()
+
+vi.mock('@/components/layout/containers/NewPageContainer', () => ({
+  NewPageContainer: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock('@/router', () => ({
+  useParams: () => ({ eserviceId: 'eservice-id', descriptorId: 'descriptor-id' }),
+}))
+
+vi.mock('@/hooks/useActiveTab', () => ({
+  useActiveTab: () => ({ activeTab: 'eserviceDetails', updateActiveTab: vi.fn() }),
+}))
+
+vi.mock('@/hooks/useMarkNotificationsAsRead', () => ({
+  useMarkNotificationsAsRead: vi.fn(),
+}))
+
+vi.mock('@/hooks/useDrawerState', () => ({
+  useDrawerState: () => ({ isOpen: false, openDrawer: vi.fn(), closeDrawer: vi.fn() }),
+}))
+
+vi.mock('@/stores', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/stores')>()),
+  useDialog: () => ({ openDialog: vi.fn() }),
+}))
+
+vi.mock('@/hooks/useGetProviderEServiceActions', () => ({
+  useGetProviderEServiceActions: () => ({
+    primaryAction: undefined,
+    secondaryAction: undefined,
+    menuActions: [],
+    headerInfoActions: [],
+  }),
+}))
+
+vi.mock('@/api/eservice', () => ({
+  EServiceQueries: {
+    getDescriptorProvider: mockedGetDescriptorProvider,
+  },
+}))
+
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactQuery>()),
+  useQuery: mockedUseQuery,
+}))
+
+vi.mock('../components/ProviderEServiceDetailsTab/ProviderEServiceDetailsTab', () => ({
+  ProviderEserviceDetailsTab: () => <div data-testid="eservice-details-tab" />,
+}))
+
+vi.mock('../components/ProviderEServiceKeychainsTab/ProviderEServiceKeychainsTab', () => ({
+  ProviderEserviceKeychainsTab: () => <div data-testid="eservice-keychains-tab" />,
+}))
+
+vi.mock('../components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts', () => ({
+  ProviderEServiceDetailsAlerts: ({ onViewKeychains }: { onViewKeychains?: () => void }) => (
+    <div data-testid="alerts" data-has-view-keychains={String(Boolean(onViewKeychains))} />
+  ),
+}))
+
+vi.mock('@/components/shared/EServiceVersionSelectorDrawer', () => ({
+  EServiceVersionSelectorDrawer: () => <div data-testid="version-selector-drawer" />,
+}))
+
+describe('ProviderEServiceDetailsPage', () => {
+  beforeEach(() => {
+    mockedGetDescriptorProvider.mockReturnValue({ queryKey: ['EServiceGetDescriptorProvider'] })
+    mockedUseQuery.mockReturnValue({
+      data: {
+        id: 'descriptor-id',
+        version: '1',
+        state: 'PUBLISHED',
+        eservice: {
+          name: 'E-Service Name',
+          descriptors: [{ id: 'descriptor-id', state: 'PUBLISHED', version: '1' }],
+        },
+      },
+    })
+  })
+
+  it('shows both tabs and wires the view-keychains action for admin users', () => {
+    renderWithApplicationContext(<ProviderEServiceDetailsPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByRole('tab', { name: 'tabs.eserviceDetails' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'tabs.keychain' })).toBeInTheDocument()
+    expect(screen.getByTestId('alerts')).toHaveAttribute('data-has-view-keychains', 'true')
+  })
+
+  it('hides the tabs and the view-keychains action for viewer users', () => {
+    mockUseJwt({ isAdmin: false, isViewer: true })
+    renderWithApplicationContext(<ProviderEServiceDetailsPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.queryByRole('tab', { name: 'tabs.eserviceDetails' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: 'tabs.keychain' })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('eservice-keychains-tab')).not.toBeInTheDocument()
+    expect(screen.getByTestId('eservice-details-tab')).toBeInTheDocument()
+    expect(screen.getByTestId('alerts')).toHaveAttribute('data-has-view-keychains', 'false')
+  })
+})

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
@@ -86,7 +86,7 @@ export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
   }
 
   const getThresholdSectionActions = (): Array<ActionItemButton> | undefined => {
-    if (isViewer) return []
+    if (isViewer) return
     return [
       {
         action: () => setEditDailyCallsDrawerState({ isOpen: true }),
@@ -217,7 +217,7 @@ export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
           attributeKey="certified"
           descriptorAttributes={descriptorAttributes}
           topSideActions={getAttributeSectionActions('certified')}
-          withThreshold
+          withThreshold={!isViewer}
         />
         <Divider sx={{ my: 3 }} />
         <AttributeGroupsListSection

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
@@ -31,7 +31,7 @@ export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
   const { t: tCustomizeThresholdDrawer } = useTranslation('eservice', {
     keyPrefix: 'read.drawers.customizeThresholdDrawer',
   })
-  const { jwt, isAdmin, isOperatorAPI } = AuthHooks.useJwt()
+  const { jwt, isAdmin, isOperatorAPI, isViewer } = AuthHooks.useJwt()
 
   const { eserviceId, descriptorId } = useParams<'PROVIDE_ESERVICE_MANAGE'>()
 
@@ -86,6 +86,7 @@ export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
   }
 
   const getThresholdSectionActions = (): Array<ActionItemButton> | undefined => {
+    if (isViewer) return []
     return [
       {
         action: () => setEditDailyCallsDrawerState({ isOpen: true }),

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
@@ -199,7 +199,7 @@ export const ProviderEServiceGeneralInfoSection: React.FC = () => {
             ? [watchRiskyAnalysisAssociatedAction]
             : []),
           downloadConsumerListAction,
-          ...(!isEserviceFromTemplate ? [exportVersionListAction] : []),
+          ...(!isEserviceFromTemplate && !isViewer ? [exportVersionListAction] : []),
         ]}
       >
         <Stack spacing={2}>

--- a/src/pages/ProviderEServiceTemplateDetailsPage/ProviderEServiceTemplateDetails.page.tsx
+++ b/src/pages/ProviderEServiceTemplateDetailsPage/ProviderEServiceTemplateDetails.page.tsx
@@ -11,11 +11,14 @@ import { EServiceTemplateQueries } from '@/api/eserviceTemplate'
 import { ProviderEServiceTemplateDetailsTab } from './components/ProviderEServiceTemplateDetailsTab/ProviderEServiceTemplateDetailsTab'
 import { ProviderEServiceTemplateTenantsTab } from './components/ProviderEServiceTemplateTenantsTab/ProviderEServiceTemplateTenantsTab'
 import { useGetProviderEServiceTemplateActions } from '@/hooks/useGetProviderEServiceTemplateActions'
+import { AuthHooks } from '@/api/auth'
 
 const ProviderEServiceTemplateDetailsPage: React.FC = () => {
   const { t } = useTranslation('eserviceTemplate', { keyPrefix: 'read' })
   const { eServiceTemplateId, eServiceTemplateVersionId } =
     useParams<'PROVIDE_ESERVICE_TEMPLATE_DETAILS'>()
+
+  const { isViewer } = AuthHooks.useJwt()
 
   const { activeTab, updateActiveTab } = useActiveTab('eserviceTemplateDetails')
 
@@ -37,7 +40,7 @@ const ProviderEServiceTemplateDetailsPage: React.FC = () => {
   return (
     <PageContainer
       title={eserviceTemplate?.eserviceTemplate.name || ''}
-      topSideActions={actions}
+      topSideActions={isViewer ? [] : actions}
       isLoading={!eserviceTemplate}
       statusChip={
         eserviceTemplate

--- a/src/pages/ProviderEServiceTemplateDetailsPage/__tests__/ProviderEServiceTemplateDetails.page.test.tsx
+++ b/src/pages/ProviderEServiceTemplateDetailsPage/__tests__/ProviderEServiceTemplateDetails.page.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import ProviderEServiceTemplateDetailsPage from '../ProviderEServiceTemplateDetails.page'
+import type * as ReactQuery from '@tanstack/react-query'
+import type { ActionItemButton } from '@/types/common.types'
+
+const { mockedGetSingle, mockedUseQuery } = vi.hoisted(() => ({
+  mockedGetSingle: vi.fn(),
+  mockedUseQuery: vi.fn(),
+}))
+
+mockUseJwt()
+
+vi.mock('@/components/layout/containers', () => ({
+  PageContainer: ({
+    children,
+    title,
+    topSideActions,
+  }: {
+    children: React.ReactNode
+    title: string
+    topSideActions?: Array<ActionItemButton>
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      <div data-testid="top-side-actions">
+        {(topSideActions ?? []).map((action) => (
+          <span key={action.label}>{action.label}</span>
+        ))}
+      </div>
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock('@/router', () => ({
+  useParams: () => ({
+    eServiceTemplateId: 'template-id',
+    eServiceTemplateVersionId: 'version-id',
+  }),
+}))
+
+vi.mock('@/hooks/useActiveTab', () => ({
+  useActiveTab: () => ({
+    activeTab: 'eserviceTemplateDetails',
+    updateActiveTab: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/useMarkNotificationsAsRead', () => ({
+  useMarkNotificationsAsRead: vi.fn(),
+}))
+
+vi.mock('@/api/eserviceTemplate', () => ({
+  EServiceTemplateQueries: {
+    getSingle: mockedGetSingle,
+  },
+}))
+
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactQuery>()),
+  useQuery: mockedUseQuery,
+}))
+
+vi.mock(
+  '../components/ProviderEServiceTemplateDetailsTab/ProviderEServiceTemplateDetailsTab',
+  () => ({
+    ProviderEServiceTemplateDetailsTab: () => <div data-testid="template-details-tab" />,
+  })
+)
+
+vi.mock(
+  '../components/ProviderEServiceTemplateTenantsTab/ProviderEServiceTemplateTenantsTab',
+  () => ({
+    ProviderEServiceTemplateTenantsTab: () => <div data-testid="template-tenants-tab" />,
+  })
+)
+
+vi.mock('@/hooks/useGetProviderEServiceTemplateActions', () => ({
+  useGetProviderEServiceTemplateActions: () => ({
+    actions: [{ action: vi.fn(), label: 'edit-action' }],
+  }),
+}))
+
+describe('ProviderEServiceTemplateDetailsPage', () => {
+  beforeEach(() => {
+    mockedGetSingle.mockReturnValue({ queryKey: ['EServiceTemplateGetSingle'] })
+    mockedUseQuery.mockReturnValue({
+      data: {
+        state: 'PUBLISHED',
+        eserviceTemplate: {
+          name: 'Template Name',
+          draftVersion: undefined,
+          mode: 'DELIVER',
+          versions: [],
+        },
+      },
+    })
+  })
+
+  it('shows the edit actions for admin users', () => {
+    renderWithApplicationContext(<ProviderEServiceTemplateDetailsPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+    expect(screen.getByText('edit-action')).toBeInTheDocument()
+  })
+
+  it('hides the edit actions for viewer users', () => {
+    mockUseJwt({ isAdmin: false, isViewer: true })
+    renderWithApplicationContext(<ProviderEServiceTemplateDetailsPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+    expect(screen.queryByText('edit-action')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/ProviderEServiceTemplateDetailsPage/components/ProviderEServiceTemplateDetailsTab/ProviderEServiceTemplateDetailsTab.tsx
+++ b/src/pages/ProviderEServiceTemplateDetailsPage/components/ProviderEServiceTemplateDetailsTab/ProviderEServiceTemplateDetailsTab.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/components/shared/EserviceTemplate'
 import type { EServiceTemplateVersionState } from '@/api/api.generatedTypes'
 import { EServiceTemplateThresholdsAndAttributesSection } from './EServiceTemplateThresholdsAndAttributesSection'
+import { AuthHooks } from '@/api/auth'
 
 type ProviderEServiceDetailsTabProps = {
   eserviceTemplateVersionState: EServiceTemplateVersionState | undefined
@@ -13,7 +14,8 @@ type ProviderEServiceDetailsTabProps = {
 export const ProviderEServiceTemplateDetailsTab: React.FC<ProviderEServiceDetailsTabProps> = ({
   eserviceTemplateVersionState,
 }) => {
-  const readonly = eserviceTemplateVersionState === 'DEPRECATED'
+  const { isViewer } = AuthHooks.useJwt()
+  const readonly = eserviceTemplateVersionState === 'DEPRECATED' || isViewer
   const routeKey = 'PROVIDE_ESERVICE_TEMPLATE_DETAILS'
   return (
     <>

--- a/src/pages/ProviderEServiceTemplateDetailsPage/components/ProviderEServiceTemplateDetailsTab/__tests__/ProviderEServiceTemplateDetailsTab.test.tsx
+++ b/src/pages/ProviderEServiceTemplateDetailsPage/components/ProviderEServiceTemplateDetailsTab/__tests__/ProviderEServiceTemplateDetailsTab.test.tsx
@@ -4,8 +4,11 @@ import { ProviderEServiceTemplateDetailsTab } from '../ProviderEServiceTemplateD
 import {
   mockUseParams,
   mockUseCurrentRoute,
+  mockUseJwt,
   renderWithApplicationContext,
 } from '@/utils/testing.utils'
+
+mockUseJwt()
 
 mockUseParams({
   eServiceTemplateId: 'template-id-001',

--- a/src/pages/ProviderEServiceTemplateDetailsPage/components/ProviderEServiceTemplateDetailsTab/__tests__/ProviderEServiceTemplateDetailsTab.test.tsx
+++ b/src/pages/ProviderEServiceTemplateDetailsPage/components/ProviderEServiceTemplateDetailsTab/__tests__/ProviderEServiceTemplateDetailsTab.test.tsx
@@ -18,13 +18,17 @@ mockUseParams({
 mockUseCurrentRoute({ mode: 'provider' })
 
 vi.mock('@/components/shared/EserviceTemplate', () => ({
-  EServiceTemplateGeneralInfoSection: () => <div data-testid="general-info-section" />,
-  EServiceTemplateTechnicalInfoSection: () => <div data-testid="technical-info-section" />,
+  EServiceTemplateGeneralInfoSection: ({ readonly }: { readonly: boolean }) => (
+    <div data-testid="general-info-section" data-readonly={String(readonly)} />
+  ),
+  EServiceTemplateTechnicalInfoSection: ({ readonly }: { readonly: boolean }) => (
+    <div data-testid="technical-info-section" data-readonly={String(readonly)} />
+  ),
 }))
 
 vi.mock('../EServiceTemplateThresholdsAndAttributesSection', () => ({
-  EServiceTemplateThresholdsAndAttributesSection: () => (
-    <div data-testid="thresholds-and-attributes-section" />
+  EServiceTemplateThresholdsAndAttributesSection: ({ readonly }: { readonly: boolean }) => (
+    <div data-testid="thresholds-and-attributes-section" data-readonly={String(readonly)} />
   ),
 }))
 
@@ -52,7 +56,45 @@ describe('ProviderEServiceTemplateDetailsTab', () => {
       }
     )
 
-    expect(screen.getByTestId('general-info-section')).toBeInTheDocument()
-    expect(screen.getByTestId('thresholds-and-attributes-section')).toBeInTheDocument()
+    expect(screen.getByTestId('general-info-section')).toHaveAttribute('data-readonly', 'true')
+    expect(screen.getByTestId('thresholds-and-attributes-section')).toHaveAttribute(
+      'data-readonly',
+      'true'
+    )
+  })
+
+  it('sets readonly to false for admin users on a non-deprecated version', () => {
+    renderWithApplicationContext(
+      <ProviderEServiceTemplateDetailsTab eserviceTemplateVersionState="PUBLISHED" />,
+      {
+        withReactQueryContext: true,
+        withRouterContext: true,
+      }
+    )
+
+    expect(screen.getByTestId('general-info-section')).toHaveAttribute('data-readonly', 'false')
+    expect(screen.getByTestId('technical-info-section')).toHaveAttribute('data-readonly', 'false')
+    expect(screen.getByTestId('thresholds-and-attributes-section')).toHaveAttribute(
+      'data-readonly',
+      'false'
+    )
+  })
+
+  it('sets readonly to true for viewer users even on a non-deprecated version', () => {
+    mockUseJwt({ isAdmin: false, isViewer: true })
+    renderWithApplicationContext(
+      <ProviderEServiceTemplateDetailsTab eserviceTemplateVersionState="PUBLISHED" />,
+      {
+        withReactQueryContext: true,
+        withRouterContext: true,
+      }
+    )
+
+    expect(screen.getByTestId('general-info-section')).toHaveAttribute('data-readonly', 'true')
+    expect(screen.getByTestId('technical-info-section')).toHaveAttribute('data-readonly', 'true')
+    expect(screen.getByTestId('thresholds-and-attributes-section')).toHaveAttribute(
+      'data-readonly',
+      'true'
+    )
   })
 })


### PR DESCRIPTION
## 🔗 Issue
[PIN-10281](https://pagopa.atlassian.net/browse/PIN-10363)

## 📝 Description / Context
Extend the viewer-role restrictions to a few pages/components that still exposed edit actions or tabs not meant for the viewer role. The goal is consistency with how CTAs are already hidden/disabled for viewers elsewhere.

## 🛠 List of changes
- `ConsumerPurposeDetailsDailyCallsPlanCard`: hide the "request plan change" link for non-admin users (viewers).
- `ProviderEServiceDetailsPage`: hide the tab navigation for viewers and render only the e-service details content (no keychains tab).
- `ProviderEServiceTemplateDetailsPage`: hide all edit actions (`topSideActions`) for viewers.
- `ProviderEServiceTemplateDetailsTab`: force the general/technical/thresholds-and-attributes sections to `readonly` for viewers, hiding their edit actions.

## 🧪 How to test
- Log in with a viewer-role user.
- Open a consumer purpose detail: the "request plan change" link is not shown.
- Open a provider e-service detail: tabs are hidden and only the details content is visible.
- Open a provider e-service template detail: no edit actions in the header and no edit actions inside the detail sections.
- Repeat with an admin user and verify all actions/tabs are still present.

[PIN-10281]: https://pagopa.atlassian.net/browse/PIN-10281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ