### PR TITLE
fix: risk analysis put service types (PIN-10364)

### DIFF
--- a/src/api/purpose/purpose.services.ts
+++ b/src/api/purpose/purpose.services.ts
@@ -339,11 +339,10 @@ async function updateRiskAnalysis({
   purposeId,
   ...payload
 }: { purposeId: string } & RiskAnalysisFormSeed) {
-  const response = await axiosInstance.put<PurposeVersionResource>(
+  return axiosInstance.put(
     `${BACKEND_FOR_FRONTEND_URL}/purposes/${purposeId}/riskAnalysis/form`,
     payload
   )
-  return response.data
 }
 
 async function getRiskAnalysisAssignments(params: GetRiskAnalysisAssignmentsParams) {

--- a/src/api/purpose/purpose.services.ts
+++ b/src/api/purpose/purpose.services.ts
@@ -28,6 +28,7 @@ import type {
   RiskAnalysisSubmissionSeed,
   RiskAnalysisRejectionSeed,
   SignRiskAnalysisParams,
+  RiskAnalysisFormSeed,
 } from '../api.generatedTypes'
 
 /**
@@ -337,7 +338,7 @@ async function rejectRiskAnalysis({
 async function updateRiskAnalysis({
   purposeId,
   ...payload
-}: { purposeId: string } & PurposeUpdateContent) {
+}: { purposeId: string } & RiskAnalysisFormSeed) {
   const response = await axiosInstance.put<PurposeVersionResource>(
     `${BACKEND_FOR_FRONTEND_URL}/purposes/${purposeId}/riskAnalysis/form`,
     payload

--- a/src/pages/RiskAnalysisCompilePage/RiskAnalysisCompile.page.tsx
+++ b/src/pages/RiskAnalysisCompilePage/RiskAnalysisCompile.page.tsx
@@ -47,13 +47,8 @@ const RiskAnalysisCompilePage: React.FC = () => {
     updateRiskAnalysis(
       {
         purposeId: purpose.id,
-        title: purpose.title,
-        description: purpose.description,
-        riskAnalysisForm: { version: riskAnalysis.version, answers },
-        freeOfChargeReason: purpose.freeOfChargeReason,
-        isFreeOfCharge: purpose.isFreeOfCharge,
-        dailyCalls:
-          purpose.currentVersion?.dailyCalls ?? purpose.waitingForApprovalVersion?.dailyCalls ?? 1,
+        version: riskAnalysis.version,
+        answers,
       },
       { onSuccess: goToSummary }
     )

--- a/src/pages/RiskAnalysisCompilePage/__tests__/RiskAnalysisCompile.page.test.tsx
+++ b/src/pages/RiskAnalysisCompilePage/__tests__/RiskAnalysisCompile.page.test.tsx
@@ -173,17 +173,10 @@ describe('RiskAnalysisCompilePage', () => {
     expect(updateRiskAnalysisMock).toHaveBeenCalledWith(
       {
         purposeId: 'purpose-1',
-        title: 'Purpose title',
-        description: 'Purpose description',
-        riskAnalysisForm: {
-          version: '2',
-          answers: {
-            question1: ['answer1'],
-          },
+        version: '2',
+        answers: {
+          question1: ['answer1'],
         },
-        freeOfChargeReason: 'reason',
-        isFreeOfCharge: false,
-        dailyCalls: 10,
       },
       expect.any(Object)
     )
@@ -233,30 +226,5 @@ describe('RiskAnalysisCompilePage', () => {
         purposeId: 'purpose-1',
       },
     })
-  })
-
-  it('should use 1 as dailyCalls when currentVersion is missing', async () => {
-    const user = userEvent.setup()
-
-    setQueryData({
-      purpose: {
-        ...purpose,
-        currentVersion: undefined,
-      },
-      riskAnalysis,
-    })
-
-    renderWithApplicationContext(<RiskAnalysisCompilePage />, {
-      withRouterContext: true,
-    })
-
-    await user.click(screen.getByRole('button', { name: 'Submit' }))
-
-    expect(updateRiskAnalysisMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dailyCalls: 1,
-      }),
-      expect.any(Object)
-    )
   })
 })


### PR DESCRIPTION
## Issue
- [PIN-10364](https://pagopa.atlassian.net/browse/PIN-10364)
## Description / Context / Why
- Fixed PUT /riskAnalysis/form type and data passed
- Updated tests

[PIN-10364]: https://pagopa.atlassian.net/browse/PIN-10364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ