### PR TITLE
fix: point async exchange guide link to existing dev-portal page (PIN-10250)

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -35,8 +35,7 @@ export const delegationGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/del
 export const delegationEServiceGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/deleghe/delega-per-la-fruizione`
 export const openApiCheckerLink = 'https://italia.github.io/api-oas-checker/'
 export const schemaEditorLink = 'https://schema.gov.it/schema-editor'
-// TODO: aggiornare con il link reale alla guida sugli scambi asincroni
-export const asyncExchangeGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/scambi-asincroni`
+export const asyncExchangeGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/e-service/scambi-di-dati-asincroni`
 export const eserviceNamingBestPracticeLink =
   'https://italia.github.io/pdnd-guida-nomenclatura-eservice/'
 export const keychainGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/utilizzare-i-voucher/garanzia-dellintegrita-della-risposta`


### PR DESCRIPTION
## 🔗 Issue
[PIN-10250](https://pagopa.atlassian.net/browse/PIN-10250)

## 📝 Description / Context
The "Scopri di più sui scambi asincroni e massivi" link in the async exchange section of the e-service creation flow pointed to a dev-portal page that no longer exists: the old `${DOCUMENTATION_URL}/riferimenti-tecnici/scambi-asincroni` returns an error. This repoints it to the current page, which is live and titled "Scambi di dati asincroni".

## 🛠 List of changes
- Update `asyncExchangeGuideLink` in `src/config/constants.ts` to `${DOCUMENTATION_URL}/riferimenti-tecnici/e-service/scambi-di-dati-asincroni`, consistent with the other e-service guide links.
- Remove the now-resolved `TODO` comment above the constant.

## 🧪 How to test
- Open the e-service creation flow and reach the "Scambi asincroni e massivi" section.
- Click "Scopri di più sui scambi asincroni e massivi".
- Verify it opens the live dev-portal page titled "Scambi di dati asincroni" instead of an error page.

[PIN-10250]: https://pagopa.atlassian.net/browse/PIN-10250
