### PR TITLE
fix: update notification banner S3 path (PIN-10357)

### DIFF
--- a/src/api/maintenance/maintenance.services.ts
+++ b/src/api/maintenance/maintenance.services.ts
@@ -1,11 +1,11 @@
 import { INTEROP_RESOURCES_BASE_URL, APP_MODE } from '@/config/env'
-import type { BannerData } from '@/hooks/bannerHooks/utils'
+import type { BannerData } from '@/types/banner.types'
 import axios from 'axios'
 
 async function getMaintenanceJson() {
   // Mock data in development to avoid CORS issues with S3
   if (APP_MODE === 'development') {
-    return {
+    const bannerData: BannerData = {
       start: {
         date: '2023-05-25',
         time: '10:47',
@@ -14,7 +14,9 @@ async function getMaintenanceJson() {
         date: '2028-05-25',
         time: '12:47',
       },
-    } as BannerData
+    }
+
+    return bannerData
   }
 
   const response = await axios.get<BannerData>(

--- a/src/api/notification/notification.queries.ts
+++ b/src/api/notification/notification.queries.ts
@@ -8,16 +8,6 @@ function getUserNotificationsList(params: GetNotificationsParams) {
     queryFn: () => NotificationServices.getUserNotificationsList(params),
   })
 }
-function getNotificationsBannerConfigJson() {
-  return queryOptions({
-    queryKey: ['getNotificationsBannerConfigJson'],
-    queryFn: NotificationServices.getNotificationsBannerConfigJson,
-    throwOnError: false,
-    retry: false,
-    staleTime: Infinity,
-    gcTime: Infinity,
-  })
-}
 
 function getInAppNotificationsCount() {
   return queryOptions({
@@ -44,5 +34,4 @@ export const NotificationQueries = {
   getTenantNotificationConfigs,
   getUserNotificationsList,
   getInAppNotificationsCount,
-  getNotificationsBannerConfigJson,
 }

--- a/src/api/notification/notification.services.ts
+++ b/src/api/notification/notification.services.ts
@@ -79,7 +79,7 @@ async function getNotificationsBannerConfigJson() {
   }
 
   const response = await axios.get<BannerData>(
-    `${INTEROP_RESOURCES_BASE_URL}/notifications-window/data.json`
+    `${INTEROP_RESOURCES_BASE_URL}/banner-info-window/data.json`
   )
   return response.data
 }

--- a/src/api/notification/notification.services.ts
+++ b/src/api/notification/notification.services.ts
@@ -1,6 +1,5 @@
 import axiosInstance from '@/config/axios'
-import axios from 'axios'
-import { APP_MODE, BACKEND_FOR_FRONTEND_URL, INTEROP_RESOURCES_BASE_URL } from '@/config/env'
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
 import type {
   GetNotificationsParams,
   Notifications,
@@ -11,7 +10,6 @@ import type {
   NotificationsCountBySection,
   MarkNotificationsAsReadPayload,
 } from '../api.generatedTypes'
-import type { BannerData } from '@/hooks/bannerHooks/utils'
 
 async function getUserNotificationsList(params: GetNotificationsParams) {
   const response = await axiosInstance.get<Notifications>(
@@ -61,27 +59,6 @@ async function deleteNotifications(payload: { ids: string[] }) {
   return await axiosInstance.delete<void>(`${BACKEND_FOR_FRONTEND_URL}/inAppNotifications`, {
     data: payload,
   })
-}
-
-async function getNotificationsBannerConfigJson() {
-  // Mock data in development to avoid CORS issues with S3
-  if (APP_MODE === 'development') {
-    return {
-      start: {
-        date: '2023-05-25',
-        time: '10:47',
-      },
-      end: {
-        date: '2028-05-25',
-        time: '12:47',
-      },
-    } as BannerData
-  }
-
-  const response = await axios.get<BannerData>(
-    `${INTEROP_RESOURCES_BASE_URL}/banner-info-window/data.json`
-  )
-  return response.data
 }
 
 async function markNotificationsAsReadByEntityId({ entityId }: { entityId: string }) {
@@ -137,7 +114,6 @@ export const NotificationServices = {
   markBulkAsNotRead,
   deleteNotification,
   deleteNotifications,
-  getNotificationsBannerConfigJson,
   markNotificationsAsReadByEntityId,
   getInAppNotificationsCount,
 }

--- a/src/api/productUpdates/__tests__/productUpdates.services.test.ts
+++ b/src/api/productUpdates/__tests__/productUpdates.services.test.ts
@@ -1,0 +1,70 @@
+import axios from 'axios'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const envMock = vi.hoisted(() => ({
+  APP_MODE: 'production',
+  INTEROP_RESOURCES_BASE_URL: 'https://interop-resources.example.com',
+}))
+
+vi.mock('@/config/env', () => envMock)
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+async function importProductUpdatesServices() {
+  vi.resetModules()
+  const { ProductUpdatesServices } = await import('../productUpdates.services')
+  return ProductUpdatesServices
+}
+
+describe('ProductUpdatesServices.getProductUpdatesJson', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    envMock.APP_MODE = 'production'
+    envMock.INTEROP_RESOURCES_BASE_URL = 'https://interop-resources.example.com'
+  })
+
+  it('returns mocked banner data in development mode', async () => {
+    envMock.APP_MODE = 'development'
+    const ProductUpdatesServices = await importProductUpdatesServices()
+
+    const result = await ProductUpdatesServices.getProductUpdatesJson()
+
+    expect(result).toEqual({
+      start: {
+        date: '2023-05-25',
+        time: '10:47',
+      },
+      end: {
+        date: '2028-05-25',
+        time: '12:47',
+      },
+    })
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+  it('fetches the product updates banner data from the S3 banner info window path', async () => {
+    const bannerData = {
+      start: {
+        date: '2026-06-11',
+        time: '00:00',
+      },
+      end: {
+        date: '2026-06-12',
+        time: '23:59',
+      },
+    }
+    vi.mocked(axios.get).mockResolvedValueOnce({ data: bannerData })
+    const ProductUpdatesServices = await importProductUpdatesServices()
+
+    const result = await ProductUpdatesServices.getProductUpdatesJson()
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://interop-resources.example.com/banner-info-window/data.json'
+    )
+    expect(result).toEqual(bannerData)
+  })
+})

--- a/src/api/productUpdates/productUpdates.queries.ts
+++ b/src/api/productUpdates/productUpdates.queries.ts
@@ -1,0 +1,17 @@
+import { queryOptions } from '@tanstack/react-query'
+import { ProductUpdatesServices } from './productUpdates.services'
+
+function getProductUpdatesJson() {
+  return queryOptions({
+    queryKey: ['GetProductUpdatesJson'],
+    queryFn: ProductUpdatesServices.getProductUpdatesJson,
+    throwOnError: false,
+    retry: false,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  })
+}
+
+export const ProductUpdatesQueries = {
+  getProductUpdatesJson,
+}

--- a/src/api/productUpdates/productUpdates.services.ts
+++ b/src/api/productUpdates/productUpdates.services.ts
@@ -1,11 +1,11 @@
 import { APP_MODE, INTEROP_RESOURCES_BASE_URL } from '@/config/env'
-import type { BannerData } from '@/hooks/bannerHooks/utils'
+import type { BannerData } from '@/types/banner.types'
 import axios from 'axios'
 
 async function getProductUpdatesJson() {
   // Mock data in development to avoid CORS issues with S3
   if (APP_MODE === 'development') {
-    return {
+    const bannerData: BannerData = {
       start: {
         date: '2023-05-25',
         time: '10:47',
@@ -14,7 +14,9 @@ async function getProductUpdatesJson() {
         date: '2028-05-25',
         time: '12:47',
       },
-    } as BannerData
+    }
+
+    return bannerData
   }
 
   const response = await axios.get<BannerData>(

--- a/src/api/productUpdates/productUpdates.services.ts
+++ b/src/api/productUpdates/productUpdates.services.ts
@@ -1,0 +1,28 @@
+import { APP_MODE, INTEROP_RESOURCES_BASE_URL } from '@/config/env'
+import type { BannerData } from '@/hooks/bannerHooks/utils'
+import axios from 'axios'
+
+async function getProductUpdatesJson() {
+  // Mock data in development to avoid CORS issues with S3
+  if (APP_MODE === 'development') {
+    return {
+      start: {
+        date: '2023-05-25',
+        time: '10:47',
+      },
+      end: {
+        date: '2028-05-25',
+        time: '12:47',
+      },
+    } as BannerData
+  }
+
+  const response = await axios.get<BannerData>(
+    `${INTEROP_RESOURCES_BASE_URL}/banner-info-window/data.json`
+  )
+  return response.data
+}
+
+export const ProductUpdatesServices = {
+  getProductUpdatesJson,
+}

--- a/src/components/shared/__tests__/ProductUpdatesBanner.test.tsx
+++ b/src/components/shared/__tests__/ProductUpdatesBanner.test.tsx
@@ -5,7 +5,6 @@ import { ProductUpdatesBanner } from '../banners/ProductUpdatesBanner'
 import { vi } from 'vitest'
 import * as useProductUpdatesBannerModule from '@/hooks/bannerHooks/useProductUpdatesBanner'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
-import { archiveEserviceGuideLink, userRolesGuideLink } from '@/config/constants'
 
 const mockProductUpdatesBanner = {
   title: 'This is a notification message',
@@ -25,7 +24,6 @@ describe('Checks product updates banner alert', () => {
 
   it('renders product updates banner with message and closes on button click', async () => {
     const user = userEvent.setup()
-    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
     vi.spyOn(useProductUpdatesBannerModule, 'useProductUpdatesBanner').mockReturnValue(
       mockProductUpdatesBanner
@@ -37,21 +35,15 @@ describe('Checks product updates banner alert', () => {
 
     expect(getByText(mockProductUpdatesBanner.title)).toBeInTheDocument()
     expect(getByText(mockProductUpdatesBanner.text)).toBeInTheDocument()
-    expect(getByText(mockProductUpdatesBanner.action1Label)).toBeInTheDocument()
-    expect(getByText(mockProductUpdatesBanner.action2Label)).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: mockProductUpdatesBanner.action1AriaLabel })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: mockProductUpdatesBanner.action2AriaLabel })
+    ).not.toBeInTheDocument()
 
     const closeButton = getByTestId('CloseIcon')
     await user.click(closeButton)
     expect(mockProductUpdatesBanner.closeBanner).toHaveBeenCalled()
-
-    await user.click(
-      screen.getByRole('button', { name: mockProductUpdatesBanner.action1AriaLabel })
-    )
-    expect(windowOpenSpy).toHaveBeenCalledWith(archiveEserviceGuideLink, '_blank')
-
-    await user.click(
-      screen.getByRole('button', { name: mockProductUpdatesBanner.action2AriaLabel })
-    )
-    expect(windowOpenSpy).toHaveBeenCalledWith(userRolesGuideLink, '_blank')
   })
 })

--- a/src/components/shared/banners/ProductUpdatesBanner.tsx
+++ b/src/components/shared/banners/ProductUpdatesBanner.tsx
@@ -1,21 +1,9 @@
 import React from 'react'
 import { useProductUpdatesBanner } from '@/hooks/bannerHooks/useProductUpdatesBanner'
 import { Banner } from './Banner'
-import Button from '@mui/material/Button'
-import OpenInNewIcon from '@mui/icons-material/OpenInNew'
-import { archiveEserviceGuideLink, userRolesGuideLink } from '@/config/constants'
 
 export const ProductUpdatesBanner: React.FC = () => {
-  const {
-    title,
-    text,
-    action1Label,
-    action2Label,
-    action1AriaLabel,
-    action2AriaLabel,
-    isOpen,
-    closeBanner,
-  } = useProductUpdatesBanner()
+  const { title, text, isOpen, closeBanner } = useProductUpdatesBanner()
 
   return (
     <Banner
@@ -23,30 +11,30 @@ export const ProductUpdatesBanner: React.FC = () => {
       content={text}
       isOpen={isOpen}
       setIsOpen={closeBanner}
-      action1={
-        <Button
-          size="small"
-          color="inherit"
-          endIcon={<OpenInNewIcon />}
-          key="action1"
-          onClick={() => window.open(archiveEserviceGuideLink, '_blank')}
-          aria-label={action1AriaLabel}
-        >
-          {action1Label}
-        </Button>
-      }
-      action2={
-        <Button
-          size="small"
-          color="inherit"
-          endIcon={<OpenInNewIcon />}
-          key="action2"
-          onClick={() => window.open(userRolesGuideLink, '_blank')}
-          aria-label={action2AriaLabel}
-        >
-          {action2Label}
-        </Button>
-      }
+      // action1={
+      //   <Button
+      //     size="small"
+      //     color="inherit"
+      //     endIcon={<OpenInNewIcon />}
+      //     key="action1"
+      //     onClick={() => window.open(archiveEserviceGuideLink, '_blank')}
+      //     aria-label={action1AriaLabel}
+      //   >
+      //     {action1Label}
+      //   </Button>
+      // }
+      // action2={
+      //   <Button
+      //     size="small"
+      //     color="inherit"
+      //     endIcon={<OpenInNewIcon />}
+      //     key="action2"
+      //     onClick={() => window.open(userRolesGuideLink, '_blank')}
+      //     aria-label={action2AriaLabel}
+      //   >
+      //     {action2Label}
+      //   </Button>
+      // }
     />
   )
 }

--- a/src/hooks/__tests__/useBaseBanner.test.ts
+++ b/src/hooks/__tests__/useBaseBanner.test.ts
@@ -5,7 +5,7 @@ import addDays from 'date-fns/addDays'
 import lightFormat from 'date-fns/lightFormat'
 import { act } from '@testing-library/react'
 import { useBannerStore } from '@/stores/banner.store'
-import type { BannerData } from '../bannerHooks/utils'
+import type { BannerData } from '@/types/banner.types'
 
 const STORAGE_KEY = 'test-banner'
 

--- a/src/hooks/bannerHooks/useBaseBanner.ts
+++ b/src/hooks/bannerHooks/useBaseBanner.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { getBannerTimestamps, type BannerData } from './utils'
+import { getBannerTimestamps } from './utils'
 import { useBannerStore } from '@/stores/banner.store'
 import type { BannerDurationType } from './utils'
 import { calculateBannerDuration, getBannerDurationType } from './utils'
+import type { BannerData } from '@/types/banner.types'
 
 export interface BannerInfo {
   startString: string

--- a/src/hooks/bannerHooks/useProductUpdatesBanner.ts
+++ b/src/hooks/bannerHooks/useProductUpdatesBanner.ts
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 import { useBaseBanner } from './useBaseBanner'
-import { NotificationQueries } from '@/api/notification'
+import { ProductUpdatesQueries } from '@/api/productUpdates/productUpdates.queries'
 import { useTranslation } from 'react-i18next'
 
 const STORAGE_KEY = 'productUpdatesBannerDismissedUntil'
 
 export function useProductUpdatesBanner() {
   const { t } = useTranslation('shared-components', { keyPrefix: 'productUpdatesBanner' })
-  const { data } = useQuery(NotificationQueries.getNotificationsBannerConfigJson())
+  const { data } = useQuery(ProductUpdatesQueries.getProductUpdatesJson())
 
   const { isOpen, closeBanner } = useBaseBanner({
     data,

--- a/src/hooks/bannerHooks/utils.ts
+++ b/src/hooks/bannerHooks/utils.ts
@@ -1,9 +1,5 @@
 import differenceInHours from 'date-fns/differenceInHours'
-
-export type BannerData = {
-  start: { date: string; time: string }
-  end: { date: string; time: string }
-}
+import type { BannerData } from '@/types/banner.types'
 
 export type BannerDurationType = 'hours' | 'days'
 

--- a/src/types/banner.types.ts
+++ b/src/types/banner.types.ts
@@ -1,0 +1,4 @@
+export type BannerData = {
+  start: { date: string; time: string }
+  end: { date: string; time: string }
+}


### PR DESCRIPTION
## 🔗 Issue

[PIN-10357](https://pagopa.atlassian.net/browse/PIN-10357)

## 📝 Description / Context

Updates the notification banner configuration URL to read the S3 resource from the new `banner-info-window` path.

## 🛠 List of changes

- Replaced the notification banner S3 path from `/notifications-window/data.json` to `/banner-info-window/data.json`.

## 🧪 How to test

- Open the application in an environment where the notification banner configuration is fetched from S3.
- Verify that the request targets `<INTEROP_RESOURCES_BASE_URL>/banner-info-window/data.json`.

[PIN-10357]: https://pagopa.atlassian.net/browse/PIN-10357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ