### PR TITLE
fix: redirect by role (PIN-10382)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ if (redirectUrl) {
   window.location.replace(url)
 } else if (requestedLang) {
   fragmentParams.delete('lang')
-  const url = `/ui/${lang}/catalogo-e-service#${fragmentParams.toString()}`
+  const url = `/ui/${lang}/#${fragmentParams.toString()}`
 
   window.location.replace(url)
 } else {

--- a/src/hooks/__tests__/useResolveError.test.tsx
+++ b/src/hooks/__tests__/useResolveError.test.tsx
@@ -48,6 +48,12 @@ const ThrowErrorComponent: React.FC<{ error: Error }> = ({ error }) => {
   return null
 }
 
+vi.mock('@/api/auth', () => ({
+  AuthHooks: {
+    useJwt: vi.fn(() => ({ isReviewer: false })),
+  },
+}))
+
 describe('', () => {
   it('should correctly resolve the generic Error throw', () => {
     const screen = render(<ThrowErrorComponent error={new Error('test')} />, {

--- a/src/hooks/__tests__/useResolveError.test.tsx
+++ b/src/hooks/__tests__/useResolveError.test.tsx
@@ -48,12 +48,6 @@ const ThrowErrorComponent: React.FC<{ error: Error }> = ({ error }) => {
   return null
 }
 
-vi.mock('@/api/auth', () => ({
-  AuthHooks: {
-    useJwt: vi.fn(() => ({ isReviewer: false })),
-  },
-}))
-
 describe('', () => {
   it('should correctly resolve the generic Error throw', () => {
     const screen = render(<ThrowErrorComponent error={new Error('test')} />, {

--- a/src/hooks/useResolveError.tsx
+++ b/src/hooks/useResolveError.tsx
@@ -21,7 +21,6 @@ import { parseJwt } from '@/api/auth/auth.utils'
 import { hasSessionExpired } from '@/utils/common.utils'
 import { DialogSessionExpired } from '@/components/dialogs/DialogSessionExpired'
 import { useErrorData } from '@/stores/error-data.store'
-import { AuthHooks } from '@/api/auth'
 
 type UseResolveErrorReturnType = {
   title: string
@@ -33,7 +32,6 @@ function useResolveError(fallbackProps: FallbackProps): UseResolveErrorReturnTyp
   const { t } = useTranslation('error')
 
   const { error, resetErrorBoundary } = fallbackProps
-  const { isReviewer } = AuthHooks.useJwt()
 
   let title, description: string | undefined
   let content: JSX.Element | null = null
@@ -66,11 +64,7 @@ function useResolveError(fallbackProps: FallbackProps): UseResolveErrorReturnTyp
   )
 
   const backToHomeButton = (
-    <Link
-      as="button"
-      variant="contained"
-      to={isReviewer ? 'SUBSCRIBE_RISK_ANALYSIS_LIST' : 'SUBSCRIBE_CATALOG_LIST'}
-    >
+    <Link as="button" variant="contained" to={'DEFAULT'}>
       {t('actions.backToHome')}
     </Link>
   )

--- a/src/hooks/useResolveError.tsx
+++ b/src/hooks/useResolveError.tsx
@@ -64,7 +64,7 @@ function useResolveError(fallbackProps: FallbackProps): UseResolveErrorReturnTyp
   )
 
   const backToHomeButton = (
-    <Link as="button" variant="contained" to={'DEFAULT'}>
+    <Link as="button" variant="contained" to="DEFAULT">
       {t('actions.backToHome')}
     </Link>
   )

--- a/src/hooks/useResolveError.tsx
+++ b/src/hooks/useResolveError.tsx
@@ -21,6 +21,7 @@ import { parseJwt } from '@/api/auth/auth.utils'
 import { hasSessionExpired } from '@/utils/common.utils'
 import { DialogSessionExpired } from '@/components/dialogs/DialogSessionExpired'
 import { useErrorData } from '@/stores/error-data.store'
+import { AuthHooks } from '@/api/auth'
 
 type UseResolveErrorReturnType = {
   title: string
@@ -32,6 +33,7 @@ function useResolveError(fallbackProps: FallbackProps): UseResolveErrorReturnTyp
   const { t } = useTranslation('error')
 
   const { error, resetErrorBoundary } = fallbackProps
+  const { isReviewer } = AuthHooks.useJwt()
 
   let title, description: string | undefined
   let content: JSX.Element | null = null
@@ -64,7 +66,11 @@ function useResolveError(fallbackProps: FallbackProps): UseResolveErrorReturnTyp
   )
 
   const backToHomeButton = (
-    <Link as="button" variant="contained" to="SUBSCRIBE_CATALOG_LIST">
+    <Link
+      as="button"
+      variant="contained"
+      to={isReviewer ? 'SUBSCRIBE_RISK_ANALYSIS_LIST' : 'SUBSCRIBE_CATALOG_LIST'}
+    >
       {t('actions.backToHome')}
     </Link>
   )

--- a/src/pages/AssistanceTenantSelectionPage/AssistanceTenantSelection.page.tsx
+++ b/src/pages/AssistanceTenantSelectionPage/AssistanceTenantSelection.page.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Stack, Typography } from '@mui/material'
 import { TenantSelect, TenantSelectSkeleton } from './components/TenantSelect'
 import { useTranslation } from 'react-i18next'
 import { AssistencePartySelectionError } from '@/utils/errors.utils'
-import { AuthMutations, AuthQueries } from '@/api/auth'
+import { AuthHooks, AuthMutations, AuthQueries } from '@/api/auth'
 import type { CompactTenant } from '@/api/api.generatedTypes'
 import { useNavigate } from '@/router'
 import { useQueryClient } from '@tanstack/react-query'
@@ -11,6 +11,7 @@ import { STORAGE_KEY_SESSION_TOKEN } from '@/config/constants'
 
 const AssistanceTenantSelectionPage: React.FC = () => {
   const { t } = useTranslation('assistance', { keyPrefix: 'tenantSelection' })
+  const { isReviewer } = AuthHooks.useJwt()
 
   const queryClient = useQueryClient()
   const navigate = useNavigate()
@@ -30,7 +31,7 @@ const AssistanceTenantSelectionPage: React.FC = () => {
         onSuccess: ({ session_token }) => {
           queryClient.setQueryData(AuthQueries.getSessionToken().queryKey, session_token)
           window.localStorage.setItem(STORAGE_KEY_SESSION_TOKEN, session_token)
-          navigate('SUBSCRIBE_CATALOG_LIST')
+          navigate(isReviewer ? 'SUBSCRIBE_RISK_ANALYSIS_LIST' : 'SUBSCRIBE_CATALOG_LIST')
         },
       }
     )

--- a/src/pages/AssistanceTenantSelectionPage/AssistanceTenantSelection.page.tsx
+++ b/src/pages/AssistanceTenantSelectionPage/AssistanceTenantSelection.page.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Stack, Typography } from '@mui/material'
 import { TenantSelect, TenantSelectSkeleton } from './components/TenantSelect'
 import { useTranslation } from 'react-i18next'
 import { AssistencePartySelectionError } from '@/utils/errors.utils'
-import { AuthHooks, AuthMutations, AuthQueries } from '@/api/auth'
+import { AuthMutations, AuthQueries } from '@/api/auth'
 import type { CompactTenant } from '@/api/api.generatedTypes'
 import { useNavigate } from '@/router'
 import { useQueryClient } from '@tanstack/react-query'
@@ -11,7 +11,6 @@ import { STORAGE_KEY_SESSION_TOKEN } from '@/config/constants'
 
 const AssistanceTenantSelectionPage: React.FC = () => {
   const { t } = useTranslation('assistance', { keyPrefix: 'tenantSelection' })
-  const { isReviewer } = AuthHooks.useJwt()
 
   const queryClient = useQueryClient()
   const navigate = useNavigate()
@@ -31,7 +30,7 @@ const AssistanceTenantSelectionPage: React.FC = () => {
         onSuccess: ({ session_token }) => {
           queryClient.setQueryData(AuthQueries.getSessionToken().queryKey, session_token)
           window.localStorage.setItem(STORAGE_KEY_SESSION_TOKEN, session_token)
-          navigate(isReviewer ? 'SUBSCRIBE_RISK_ANALYSIS_LIST' : 'SUBSCRIBE_CATALOG_LIST')
+          navigate('DEFAULT')
         },
       }
     )

--- a/src/pages/NotFoundPage/NotFound.page.tsx
+++ b/src/pages/NotFoundPage/NotFound.page.tsx
@@ -1,4 +1,3 @@
-import { AuthHooks } from '@/api/auth'
 import { PageContainer } from '@/components/layout/containers'
 import { Link } from '@/router'
 import React from 'react'
@@ -6,7 +5,6 @@ import { useTranslation } from 'react-i18next'
 
 const NotFoundPage: React.FC = () => {
   const { t } = useTranslation('error')
-  const { isReviewer } = AuthHooks.useJwt()
 
   return (
     <PageContainer
@@ -14,11 +12,7 @@ const NotFoundPage: React.FC = () => {
       title={t('notFound.title')}
       description={t('notFound.description')}
     >
-      <Link
-        as="button"
-        variant="contained"
-        to={isReviewer ? 'SUBSCRIBE_RISK_ANALYSIS_LIST' : 'PROVIDE_ESERVICE_LIST'}
-      >
+      <Link as="button" variant="contained" to={'DEFAULT'}>
         {t('actions.backToHome')}
       </Link>
     </PageContainer>

--- a/src/pages/NotFoundPage/NotFound.page.tsx
+++ b/src/pages/NotFoundPage/NotFound.page.tsx
@@ -12,7 +12,7 @@ const NotFoundPage: React.FC = () => {
       title={t('notFound.title')}
       description={t('notFound.description')}
     >
-      <Link as="button" variant="contained" to={'DEFAULT'}>
+      <Link as="button" variant="contained" to="DEFAULT">
         {t('actions.backToHome')}
       </Link>
     </PageContainer>

--- a/src/pages/NotFoundPage/NotFound.page.tsx
+++ b/src/pages/NotFoundPage/NotFound.page.tsx
@@ -1,3 +1,4 @@
+import { AuthHooks } from '@/api/auth'
 import { PageContainer } from '@/components/layout/containers'
 import { Link } from '@/router'
 import React from 'react'
@@ -5,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 
 const NotFoundPage: React.FC = () => {
   const { t } = useTranslation('error')
+  const { isReviewer } = AuthHooks.useJwt()
 
   return (
     <PageContainer
@@ -12,7 +14,11 @@ const NotFoundPage: React.FC = () => {
       title={t('notFound.title')}
       description={t('notFound.description')}
     >
-      <Link as="button" variant="contained" to="PROVIDE_ESERVICE_LIST">
+      <Link
+        as="button"
+        variant="contained"
+        to={isReviewer ? 'SUBSCRIBE_RISK_ANALYSIS_LIST' : 'PROVIDE_ESERVICE_LIST'}
+      >
         {t('actions.backToHome')}
       </Link>
     </PageContainer>

--- a/src/pages/NotFoundPage/__tests__/NotFound.page.test.tsx
+++ b/src/pages/NotFoundPage/__tests__/NotFound.page.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import NotFoundPage from '../NotFound.page'
 import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
 
@@ -18,35 +17,5 @@ describe('NotFound page', () => {
     expect(screen.getByText('notFound.title')).toBeInTheDocument()
     expect(screen.getByText('notFound.description')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'actions.backToHome' })).toBeInTheDocument()
-  })
-
-  it('should navigate to PROVIDE_ESERVICE_LIST when user is not reviewer', async () => {
-    mockUseJwt({
-      isReviewer: false,
-    })
-
-    const { history } = renderWithApplicationContext(<NotFoundPage />, {
-      withRouterContext: true,
-      withReactQueryContext: false,
-    })
-
-    await userEvent.click(screen.getByRole('link', { name: 'actions.backToHome' }))
-
-    expect(history.location.pathname).toContain('/erogazione/e-service')
-  })
-
-  it('should navigate to SUBSCRIBE_RISK_ANALYSIS_LIST when user is reviewer', async () => {
-    mockUseJwt({
-      isReviewer: true,
-    })
-
-    const { history } = renderWithApplicationContext(<NotFoundPage />, {
-      withRouterContext: true,
-      withReactQueryContext: false,
-    })
-
-    await userEvent.click(screen.getByRole('link', { name: 'actions.backToHome' }))
-
-    expect(history.location.pathname).toContain('/analisi-del-rischio')
   })
 })

--- a/src/pages/NotFoundPage/__tests__/NotFound.page.test.tsx
+++ b/src/pages/NotFoundPage/__tests__/NotFound.page.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import NotFoundPage from '../NotFound.page'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+
+describe('NotFound page', () => {
+  it('should render title, description and back button', () => {
+    mockUseJwt({
+      isReviewer: false,
+    })
+
+    renderWithApplicationContext(<NotFoundPage />, {
+      withRouterContext: true,
+      withReactQueryContext: false,
+    })
+
+    expect(screen.getByText('notFound.title')).toBeInTheDocument()
+    expect(screen.getByText('notFound.description')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'actions.backToHome' })).toBeInTheDocument()
+  })
+
+  it('should navigate to PROVIDE_ESERVICE_LIST when user is not reviewer', async () => {
+    mockUseJwt({
+      isReviewer: false,
+    })
+
+    const { history } = renderWithApplicationContext(<NotFoundPage />, {
+      withRouterContext: true,
+      withReactQueryContext: false,
+    })
+
+    await userEvent.click(screen.getByRole('link', { name: 'actions.backToHome' }))
+
+    expect(history.location.pathname).toContain('/erogazione/e-service')
+  })
+
+  it('should navigate to SUBSCRIBE_RISK_ANALYSIS_LIST when user is reviewer', async () => {
+    mockUseJwt({
+      isReviewer: true,
+    })
+
+    const { history } = renderWithApplicationContext(<NotFoundPage />, {
+      withRouterContext: true,
+      withReactQueryContext: false,
+    })
+
+    await userEvent.click(screen.getByRole('link', { name: 'actions.backToHome' }))
+
+    expect(history.location.pathname).toContain('/analisi-del-rischio')
+  })
+})


### PR DESCRIPTION
## Issue
- [PIN-10382](https://pagopa.atlassian.net/browse/PIN-10382)
## Description / Context / Why
- Fixed redirect url on useResolveError.tsx hook
- Fixed redirect url on AssistanceTenantSelection.page.tsx
- Fixed redirect url on NotFound.page.tsx
- Fixed redirect url on src/App.tsx (redirect will be handled by <LandingByRole /> component
- Updated tests

[PIN-10382]: https://pagopa.atlassian.net/browse/PIN-10382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ