### PR TITLE
chore/PIN-9981: changed purpose isFreeOfCharge into a switch

### DIFF
--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneral.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneral.tsx
@@ -27,7 +27,7 @@ export const PurposeEditStepGeneral: React.FC<ActiveStepProps> = (props) => {
     title: purpose.title,
     description: purpose.description,
     dailyCalls: purpose.versions[0]?.dailyCalls ?? 1,
-    isFreeOfCharge: purpose.isFreeOfCharge ? 'YES' : 'NO',
+    isFreeOfCharge: purpose.isFreeOfCharge,
     freeOfChargeReason: purpose.freeOfChargeReason,
   }
 

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
@@ -103,7 +103,6 @@ const PurposeEditStepGeneralForm: React.FC<PurposeEditStepGeneralFormProps> = ({
             name="isFreeOfCharge"
             label={t('edit.stepGeneral.isFreeOfChargeField.label')}
             sx={{ pl: 2 }}
-            rules={{ required: true }}
           />
 
           {isFreeOfCharge && (

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
@@ -14,11 +14,8 @@ import { PurposeLoadEstimationSection } from '@/components/shared/PurposeLoadEst
 
 export type PurposeEditStepGeneralFormValues = Omit<
   PurposeUpdateContent,
-  'riskAnalysisForm' | 'isFreeOfCharge' | 'eserviceId'
-> & {
-  dailyCalls: number
-  isFreeOfCharge: boolean
-}
+  'riskAnalysisForm' | 'eserviceId'
+>
 
 type PurposeEditStepGeneralFormProps = ActiveStepProps & {
   purpose: Purpose

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
@@ -58,7 +58,7 @@ const PurposeEditStepGeneralForm: React.FC<PurposeEditStepGeneralFormProps> = ({
     const requestPayload = {
       ...updateDraftPayload,
       isFreeOfCharge,
-      freeOfChargeReason: isFreeOfCharge ? freeOfChargeReason : undefined,
+      ...(isFreeOfCharge ? { freeOfChargeReason } : {}),
       purposeId,
       dailyCalls: dailyCalls,
     }

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Box } from '@mui/material'
 import { FormProvider, useForm } from 'react-hook-form'
-import { RHFRadioGroup, RHFTextField } from '@/components/shared/react-hook-form-inputs'
+import { RHFSwitch, RHFTextField } from '@/components/shared/react-hook-form-inputs'
 import { useTranslation } from 'react-i18next'
 import { StepActions } from '@/components/shared/StepActions'
 import { SectionContainer, SectionContainerSkeleton } from '@/components/layout/containers'
@@ -17,7 +17,7 @@ export type PurposeEditStepGeneralFormValues = Omit<
   'riskAnalysisForm' | 'isFreeOfCharge' | 'eserviceId'
 > & {
   dailyCalls: number
-  isFreeOfCharge: 'YES' | 'NO'
+  isFreeOfCharge: boolean
 }
 
 type PurposeEditStepGeneralFormProps = ActiveStepProps & {
@@ -53,13 +53,12 @@ const PurposeEditStepGeneralForm: React.FC<PurposeEditStepGeneralFormProps> = ({
 
   const onSubmit = (values: PurposeEditStepGeneralFormValues) => {
     const { dailyCalls, isFreeOfCharge, freeOfChargeReason, ...updateDraftPayload } = values
-    const isFreeOfChargeBool = isFreeOfCharge === 'YES'
     const purposeId = purpose.id
 
     const requestPayload = {
       ...updateDraftPayload,
-      isFreeOfCharge: isFreeOfChargeBool,
-      freeOfChargeReason: isFreeOfChargeBool ? freeOfChargeReason : undefined,
+      isFreeOfCharge,
+      freeOfChargeReason: isFreeOfCharge ? freeOfChargeReason : undefined,
       purposeId,
       dailyCalls: dailyCalls,
     }
@@ -100,17 +99,14 @@ const PurposeEditStepGeneralForm: React.FC<PurposeEditStepGeneralFormProps> = ({
             required
           />
 
-          <RHFRadioGroup
+          <RHFSwitch
             name="isFreeOfCharge"
             label={t('edit.stepGeneral.isFreeOfChargeField.label')}
-            options={[
-              { label: t('edit.stepGeneral.isFreeOfChargeField.options.YES'), value: 'YES' },
-              { label: t('edit.stepGeneral.isFreeOfChargeField.options.NO'), value: 'NO' },
-            ]}
+            sx={{ pl: 2 }}
             required
           />
 
-          {isFreeOfCharge === 'YES' && (
+          {isFreeOfCharge && (
             <RHFTextField
               name="freeOfChargeReason"
               label={t('edit.stepGeneral.freeOfChargeReasonField.label')}

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/PurposeEditStepGeneralForm.tsx
@@ -103,7 +103,7 @@ const PurposeEditStepGeneralForm: React.FC<PurposeEditStepGeneralFormProps> = ({
             name="isFreeOfCharge"
             label={t('edit.stepGeneral.isFreeOfChargeField.label')}
             sx={{ pl: 2 }}
-            required
+            rules={{ required: true }}
           />
 
           {isFreeOfCharge && (

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/__tests__/PurposeEditStepGeneral.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/__tests__/PurposeEditStepGeneral.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+import { useQuery } from '@tanstack/react-query'
+import { PurposeEditStepGeneral } from '../PurposeEditStepGeneral'
+import PurposeEditStepGeneralForm from '../PurposeEditStepGeneralForm'
+import { NotFoundError } from '@/utils/errors.utils'
+import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
+
+vi.mock('@/router', () => ({
+  useParams: () => ({ purposeId: 'purpose-123' }),
+}))
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+  return {
+    ...actual,
+    useQuery: vi.fn(),
+  }
+})
+
+vi.mock('@/api/purpose', () => ({
+  PurposeQueries: {
+    getSingle: (purposeId: string) => ({ queryKey: ['PurposeGetSingle', purposeId] }),
+  },
+}))
+
+vi.mock('../PurposeEditStepGeneralForm', async () => {
+  const actual = await vi.importActual<typeof import('../PurposeEditStepGeneralForm')>(
+    '../PurposeEditStepGeneralForm'
+  )
+  return {
+    ...actual,
+    default: vi.fn(() => <div data-testid="purpose-edit-step-general-form" />),
+    PurposeEditStepGeneralFormSkeleton: vi.fn(() => (
+      <div data-testid="purpose-edit-step-general-skeleton" />
+    )),
+  }
+})
+
+function mockPurposeQuery({
+  purpose,
+  isLoadingPurpose = false,
+}: {
+  purpose?: ReturnType<typeof createMockPurpose>
+  isLoadingPurpose?: boolean
+}) {
+  ;(useQuery as Mock).mockReturnValue({ data: purpose, isLoading: isLoadingPurpose })
+}
+
+describe('PurposeEditStepGeneral', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the skeleton while purpose is loading', () => {
+    mockPurposeQuery({ purpose: undefined, isLoadingPurpose: true })
+
+    render(<PurposeEditStepGeneral back={vi.fn()} forward={vi.fn()} activeStep={0} />)
+
+    expect(screen.getByTestId('purpose-edit-step-general-skeleton')).toBeInTheDocument()
+  })
+
+  it('throws NotFoundError when purpose is missing after loading', () => {
+    mockPurposeQuery({ purpose: undefined, isLoadingPurpose: false })
+
+    expect(() =>
+      render(<PurposeEditStepGeneral back={vi.fn()} forward={vi.fn()} activeStep={0} />)
+    ).toThrow(NotFoundError)
+  })
+
+  it('passes purpose and computed defaultValues to PurposeEditStepGeneralForm', () => {
+    const purpose = createMockPurpose({
+      id: 'purpose-123',
+      title: 'Purpose title',
+      description: 'Purpose description',
+      isFreeOfCharge: true,
+      freeOfChargeReason: 'No cost for testing',
+      versions: [
+        {
+          createdAt: '2023-02-03T07:59:52.458Z',
+          dailyCalls: 99,
+          id: 'version-1',
+          state: 'DRAFT',
+        },
+      ],
+    })
+
+    mockPurposeQuery({ purpose, isLoadingPurpose: false })
+
+    const forwardMock = vi.fn()
+    const backMock = vi.fn()
+
+    render(<PurposeEditStepGeneral back={backMock} forward={forwardMock} activeStep={1} />)
+
+    expect(PurposeEditStepGeneralForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        purpose,
+        defaultValues: {
+          title: 'Purpose title',
+          description: 'Purpose description',
+          dailyCalls: 99,
+          isFreeOfCharge: true,
+          freeOfChargeReason: 'No cost for testing',
+        },
+        activeStep: 1,
+        forward: forwardMock,
+        back: backMock,
+      }),
+      expect.anything()
+    )
+  })
+
+  it('falls back dailyCalls to 1 when purpose has no versions', () => {
+    const purpose = createMockPurpose({
+      id: 'purpose-123',
+      versions: [],
+    })
+
+    mockPurposeQuery({ purpose, isLoadingPurpose: false })
+
+    render(<PurposeEditStepGeneral back={vi.fn()} forward={vi.fn()} activeStep={0} />)
+
+    expect(PurposeEditStepGeneralForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultValues: expect.objectContaining({
+          dailyCalls: 1,
+        }),
+      }),
+      expect.anything()
+    )
+  })
+})

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/__tests__/PurposeEditStepGeneralForm.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/__tests__/PurposeEditStepGeneralForm.test.tsx
@@ -29,13 +29,13 @@ vi.mock('@/components/shared/PurposeLoadEstimationSection', () => ({
 const defaultValues: PurposeEditStepGeneralFormValues = {
   title: 'Test purpose',
   description: 'A test purpose description',
-  isFreeOfCharge: 'NO',
+  isFreeOfCharge: false,
   dailyCalls: 100,
 }
 
 function renderComponent(overrides?: {
   purposeMode?: 'DELIVER' | 'RECEIVE'
-  isFreeOfCharge?: 'YES' | 'NO'
+  isFreeOfCharge?: boolean
 }) {
   const purpose = createMockPurpose({
     eservice: {
@@ -67,7 +67,7 @@ function renderComponent(overrides?: {
 
 describe('PurposeEditStepGeneralForm', () => {
   it('should not show freeOfChargeReason field when isFreeOfCharge is NO', () => {
-    renderComponent({ isFreeOfCharge: 'NO' })
+    renderComponent({ isFreeOfCharge: false })
 
     expect(
       screen.queryByRole('textbox', { name: 'edit.stepGeneral.freeOfChargeReasonField.label' })
@@ -75,7 +75,7 @@ describe('PurposeEditStepGeneralForm', () => {
   })
 
   it('should show freeOfChargeReason field when isFreeOfCharge is YES', () => {
-    renderComponent({ isFreeOfCharge: 'YES' })
+    renderComponent({ isFreeOfCharge: true })
 
     expect(
       screen.getByRole('textbox', { name: 'edit.stepGeneral.freeOfChargeReasonField.label' })
@@ -84,16 +84,16 @@ describe('PurposeEditStepGeneralForm', () => {
 
   it('should show freeOfChargeReason field when user selects YES', async () => {
     const user = userEvent.setup()
-    renderComponent({ isFreeOfCharge: 'NO' })
+    renderComponent({ isFreeOfCharge: false })
 
     expect(
       screen.queryByRole('textbox', { name: 'edit.stepGeneral.freeOfChargeReasonField.label' })
     ).not.toBeInTheDocument()
 
-    const yesRadio = screen.getByRole('radio', {
-      name: 'edit.stepGeneral.isFreeOfChargeField.options.YES',
+    const freeOfChargeSwitch = screen.getByRole('checkbox', {
+      name: 'edit.stepGeneral.isFreeOfChargeField.label',
     })
-    await user.click(yesRadio)
+    await user.click(freeOfChargeSwitch)
 
     expect(
       screen.getByRole('textbox', { name: 'edit.stepGeneral.freeOfChargeReasonField.label' })

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/__tests__/PurposeEditStepGeneralForm.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/__tests__/PurposeEditStepGeneralForm.test.tsx
@@ -131,7 +131,6 @@ describe('PurposeEditStepGeneralForm', () => {
         personalData: true,
         descriptor: { id: 'descriptor-id', state: 'PUBLISHED', version: '1', audience: [] },
       },
-      riskAnalysisForm: { answers: { purpose: ['INSTITUTIONAL'] }, version: '2.0' },
     })
 
     renderWithApplicationContext(

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/__tests__/PurposeEditStepGeneralForm.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/__tests__/PurposeEditStepGeneralForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { describe, it, expect, vi } from 'vitest'
-import { screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import PurposeEditStepGeneralForm from '../PurposeEditStepGeneralForm'
 import type { PurposeEditStepGeneralFormValues } from '../PurposeEditStepGeneralForm'
@@ -9,6 +9,7 @@ import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
 
 const updateDraftMock = vi.fn()
 const updateDraftForReceiveMock = vi.fn()
+const navigateMock = vi.fn()
 
 vi.mock('@/api/purpose', () => ({
   PurposeMutations: {
@@ -18,7 +19,7 @@ vi.mock('@/api/purpose', () => ({
 }))
 
 vi.mock('@/router', () => ({
-  useNavigate: vi.fn(() => vi.fn()),
+  useNavigate: vi.fn(() => navigateMock),
   Link: vi.fn(({ children, ...props }: React.PropsWithChildren) => <a {...props}>{children}</a>),
 }))
 
@@ -66,6 +67,10 @@ function renderComponent(overrides?: {
 }
 
 describe('PurposeEditStepGeneralForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should not show freeOfChargeReason field when isFreeOfCharge is NO', () => {
     renderComponent({ isFreeOfCharge: false })
 
@@ -110,5 +115,161 @@ describe('PurposeEditStepGeneralForm', () => {
     renderComponent({ purposeMode: 'RECEIVE' })
 
     expect(screen.getByRole('button', { name: 'edit.endWithSaveBtn' })).toBeInTheDocument()
+  })
+
+  it('submits with DELIVER mode and calls updateDraft with riskAnalysisForm', async () => {
+    const user = userEvent.setup()
+    const forwardMock = vi.fn()
+
+    const purpose = createMockPurpose({
+      id: 'purpose-id',
+      eservice: {
+        id: 'eservice-id',
+        name: 'Test Eservice',
+        mode: 'DELIVER',
+        producer: { id: 'producer-id', name: 'Producer' },
+        personalData: true,
+        descriptor: { id: 'descriptor-id', state: 'PUBLISHED', version: '1', audience: [] },
+      },
+      riskAnalysisForm: { answers: { purpose: ['INSTITUTIONAL'] }, version: '2.0' },
+    })
+
+    renderWithApplicationContext(
+      <PurposeEditStepGeneralForm
+        purpose={purpose}
+        defaultValues={{
+          ...defaultValues,
+          title: 'Valid title for submit',
+          description: 'Valid description that is long enough',
+          isFreeOfCharge: true,
+          freeOfChargeReason: 'Valid reason for free of charge flow',
+        }}
+        activeStep={0}
+        forward={forwardMock}
+        back={vi.fn()}
+      />,
+      { withReactQueryContext: true, withRouterContext: true }
+    )
+
+    await user.click(screen.getByRole('button', { name: 'edit.forwardWithSaveBtn' }))
+
+    await waitFor(() => {
+      expect(updateDraftForReceiveMock).not.toHaveBeenCalled()
+      expect(updateDraftMock).toHaveBeenCalledTimes(1)
+      expect(updateDraftMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          purposeId: 'purpose-id',
+          title: 'Valid title for submit',
+          description: 'Valid description that is long enough',
+          isFreeOfCharge: true,
+          freeOfChargeReason: 'Valid reason for free of charge flow',
+          dailyCalls: 100,
+          riskAnalysisForm: purpose.riskAnalysisForm,
+        }),
+        expect.objectContaining({ onSuccess: forwardMock })
+      )
+    })
+  })
+
+  it('submits with RECEIVE mode and navigates to summary on success', async () => {
+    const user = userEvent.setup()
+
+    const purpose = createMockPurpose({
+      id: 'purpose-receive',
+      eservice: {
+        id: 'eservice-id',
+        name: 'Test Eservice',
+        mode: 'RECEIVE',
+        producer: { id: 'producer-id', name: 'Producer' },
+        personalData: true,
+        descriptor: { id: 'descriptor-id', state: 'PUBLISHED', version: '1', audience: [] },
+      },
+    })
+
+    renderWithApplicationContext(
+      <PurposeEditStepGeneralForm
+        purpose={purpose}
+        defaultValues={{
+          ...defaultValues,
+          title: 'Valid title for submit',
+          description: 'Valid description that is long enough',
+          isFreeOfCharge: true,
+          freeOfChargeReason: 'Valid reason for free of charge flow',
+        }}
+        activeStep={0}
+        forward={vi.fn()}
+        back={vi.fn()}
+      />,
+      { withReactQueryContext: true, withRouterContext: true }
+    )
+
+    await user.click(screen.getByRole('button', { name: 'edit.endWithSaveBtn' }))
+
+    expect(updateDraftMock).not.toHaveBeenCalled()
+    expect(updateDraftForReceiveMock).toHaveBeenCalledTimes(1)
+    expect(updateDraftForReceiveMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        purposeId: 'purpose-receive',
+        title: 'Valid title for submit',
+        description: 'Valid description that is long enough',
+        isFreeOfCharge: true,
+        freeOfChargeReason: 'Valid reason for free of charge flow',
+        dailyCalls: 100,
+      }),
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    )
+
+    const onSuccess = updateDraftForReceiveMock.mock.calls[0]?.[1]?.onSuccess
+    expect(onSuccess).toBeTypeOf('function')
+    onSuccess?.()
+
+    expect(navigateMock).toHaveBeenCalledWith('SUBSCRIBE_PURPOSE_SUMMARY', {
+      params: { purposeId: 'purpose-receive' },
+    })
+  })
+
+  it('calls forward when DELIVER update succeeds', async () => {
+    const user = userEvent.setup()
+    const forwardMock = vi.fn()
+
+    const purpose = createMockPurpose({
+      id: 'purpose-id-clear-reason',
+      eservice: {
+        id: 'eservice-id',
+        name: 'Test Eservice',
+        mode: 'DELIVER',
+        producer: { id: 'producer-id', name: 'Producer' },
+        personalData: true,
+        descriptor: { id: 'descriptor-id', state: 'PUBLISHED', version: '1', audience: [] },
+      },
+    })
+
+    renderWithApplicationContext(
+      <PurposeEditStepGeneralForm
+        purpose={purpose}
+        defaultValues={{
+          ...defaultValues,
+          title: 'Valid title for submit',
+          description: 'Valid description that is long enough',
+          isFreeOfCharge: true,
+          freeOfChargeReason: 'Valid reason for free of charge flow',
+        }}
+        activeStep={0}
+        forward={forwardMock}
+        back={vi.fn()}
+      />,
+      { withReactQueryContext: true, withRouterContext: true }
+    )
+
+    await user.click(screen.getByRole('button', { name: 'edit.forwardWithSaveBtn' }))
+
+    await waitFor(() => {
+      expect(updateDraftMock).toHaveBeenCalledTimes(1)
+    })
+
+    const onSuccess = updateDraftMock.mock.calls[0]?.[1]?.onSuccess
+    expect(onSuccess).toBe(forwardMock)
+    onSuccess?.()
+    expect(forwardMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/__tests__/PurposeEditStepGeneralForm.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepGeneral/__tests__/PurposeEditStepGeneralForm.test.tsx
@@ -170,6 +170,60 @@ describe('PurposeEditStepGeneralForm', () => {
     })
   })
 
+  it('submits with DELIVER mode, keeps isFreeOfCharge false and omits freeOfChargeReason in payload', async () => {
+    const user = userEvent.setup()
+    const forwardMock = vi.fn()
+
+    const purpose = createMockPurpose({
+      id: 'purpose-id-free-of-charge-off',
+      eservice: {
+        id: 'eservice-id',
+        name: 'Test Eservice',
+        mode: 'DELIVER',
+        producer: { id: 'producer-id', name: 'Producer' },
+        personalData: true,
+        descriptor: { id: 'descriptor-id', state: 'PUBLISHED', version: '1', audience: [] },
+      },
+    })
+
+    renderWithApplicationContext(
+      <PurposeEditStepGeneralForm
+        purpose={purpose}
+        defaultValues={{
+          ...defaultValues,
+          title: 'Valid title for submit',
+          description: 'Valid description that is long enough',
+          isFreeOfCharge: false,
+          freeOfChargeReason: 'This reason should not be sent',
+        }}
+        activeStep={0}
+        forward={forwardMock}
+        back={vi.fn()}
+      />,
+      { withReactQueryContext: true, withRouterContext: true }
+    )
+
+    await user.click(screen.getByRole('button', { name: 'edit.forwardWithSaveBtn' }))
+
+    await waitFor(() => {
+      expect(updateDraftForReceiveMock).not.toHaveBeenCalled()
+      expect(updateDraftMock).toHaveBeenCalledTimes(1)
+      expect(updateDraftMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          purposeId: 'purpose-id-free-of-charge-off',
+          title: 'Valid title for submit',
+          description: 'Valid description that is long enough',
+          isFreeOfCharge: false,
+          dailyCalls: 100,
+          riskAnalysisForm: purpose.riskAnalysisForm,
+        }),
+        expect.objectContaining({ onSuccess: forwardMock })
+      )
+    })
+
+    expect(updateDraftMock.mock.calls[0]?.[0]).not.toHaveProperty('freeOfChargeReason')
+  })
+
   it('submits with RECEIVE mode and navigates to summary on success', async () => {
     const user = userEvent.setup()
 

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -39,7 +39,7 @@
     "defaultPurpose": {
       "title": "New purpose",
       "description": "Lorem ipsum dolor sit amet...",
-      "freeOfChargeReason": "I'm a Public Administration"
+      "freeOfChargeReason": "Specify the legal basis or reason that allows free access (e.g. institutional activity, legal provision, etc...)"
     },
     "riskAnalysisPreviewTitle": "Risk analysis",
     "purposeTemplateField": {
@@ -85,15 +85,11 @@
         "infoLabel": "Min 10 characters, max 250 characters"
       },
       "isFreeOfChargeField": {
-        "label": "How will you make the data you receive from this e-service available?",
-        "options": {
-          "YES": "Free of charge",
-          "NO": "For a fee"
-        }
+        "label": "I am entitled to use the e-service free of charge"
       },
       "freeOfChargeReasonField": {
-        "label": "Free of charge reason",
-        "infoLabel": "Explain why you will make this data available free of charge. Indicate whether you are doing so under a statutory exemption or exclusion, or for another reason. Minimum 10 characters, maximum 250 characters."
+        "label": "Specify the legal basis or reason that allows free access (required)",
+        "infoLabel": "Specify whether this is based on a legal exemption or exclusion, or on another reason. Min 10, max 250 characters"
       }
     },
     "stepAssignment": {

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -39,7 +39,7 @@
     "defaultPurpose": {
       "title": "Nuova finalità",
       "description": "Lorem ipsum dolor sit amet...",
-      "freeOfChargeReason": "Sono una Pubblica Amministrazione"
+      "freeOfChargeReason": "Indica la base giuridica o il motivo che consente l'accesso gratuito (es: attività istituzionale, norma di legge, ecc...)"
     },
     "riskAnalysisPreviewTitle": "Analisi del rischio",
     "purposeTemplateField": {
@@ -85,15 +85,11 @@
         "infoLabel": "Min 10 caratteri, max 250 caratteri"
       },
       "isFreeOfChargeField": {
-        "label": "Come metterai a disposizione i dati che riceverai da questo e-service?",
-        "options": {
-          "YES": "A titolo gratuito",
-          "NO": "A pagamento"
-        }
+        "label": "Ho diritto all'utilizzo dell'e-service a titolo gratuito"
       },
       "freeOfChargeReasonField": {
-        "label": "Motivazione titolo gratuito",
-        "infoLabel": "Spiega perché metterai questi dati a disposizione gratuitamente. Indica se lo fai in base a un’esenzione o a un’esclusione prevista dalla legge, oppure per un altro motivo. Min 10, max 250 caratteri"
+        "label": "Indica la base giuridica o il motivo che consente l'accesso gratuito (richiesto)",
+        "infoLabel": "Specifica se lo fai in base a un’esenzione o a un’esclusione prevista dalla legge, oppure per un altro motivo. Min 10, max 250 caratteri"
       }
     },
     "stepAssignment": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-9981](https://pagopa.atlassian.net/browse/PIN-9981)

## 📝 Description / Context

This PR updates the UX of the new Purpose creation flow (**Submitted Purposes → Create New**) by replacing the radio button selection with a switch for the option related to making the data received from the e-service available free of charge.

Specifically, the "free of charge" option is no longer managed through radio buttons and is now represented by a switch:

* **Switch enabled:** the Purpose is free of charge, and an additional section (reason for free-of-charge availability) is displayed.
* **Switch disabled:** behavior is equivalent to the paid option.

This change introduces a more intuitive interaction pattern while preserving the existing business logic and submission behavior.

## 🛠 List of changes

* Replaced the free-of-charge radio button selection with a switch in the new Purpose creation flow.
* Added conditional rendering of the related details section when the switch is enabled.
* Preserved payload structure and submission behavior according to the selected switch state.
* Updated labels and form interactions to align with the new UX pattern.

## 🧪 How to test

1. Open the flow: **Submitted Purposes → Create New**.
2. Navigate to the step where users choose how the data received from the e-service will be made available.
3. Verify that a switch is displayed instead of the previous radio buttons.
4. Enable the switch.
5. Verify that the additional section for the free-of-charge reason appears below the field.
6. Disable the switch.
7. Verify that the additional section is hidden.
8. Complete and save the Purpose in both scenarios (switch enabled and disabled) and verify that the final behavior is consistent with the selected option.
9. Perform a quick regression check on the Purpose edit and summary views to confirm that the selected value is correctly persisted and displayed.

[PIN-9981]: https://pagopa.atlassian.net/browse/PIN-9981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ