### PR TITLE
feature: assignment section purpose detail (PIN-10383)

### DIFF
--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsAssignmentSection.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsAssignmentSection.tsx
@@ -1,0 +1,44 @@
+import type { Purpose } from '@/api/api.generatedTypes'
+import { SectionContainer } from '@/components/layout/containers'
+import { Stack } from '@mui/material'
+import { InformationContainer } from '@pagopa/interop-fe-commons'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { match } from 'ts-pattern'
+
+type ConsumerPurposeDetailsAssignmentSectionProps = {
+  purpose: Purpose
+}
+
+export const ConsumerPurposeDetailsAssignmentSection: React.FC<
+  ConsumerPurposeDetailsAssignmentSectionProps
+> = ({ purpose }) => {
+  const { t } = useTranslation('purpose', {
+    keyPrefix: 'consumerView.sections.riskAnalysisAssignment',
+  })
+
+  const reviewMode = purpose.reviewerWorkflow?.reviewMode
+
+  const modeLabel = match(reviewMode)
+    .with(undefined, () => t('mode.autonomy'))
+    .with('ADMIN_WRITES_REVIEWER_SIGNS', () => t('mode.adminWritesReviewerSigns'))
+    .with('REVIEWER_WRITES_REVIEWER_SIGNS', () => t('mode.reviewerWritesReviewerSigns'))
+    .exhaustive()
+
+  // We surface only the first reviewer: the BE models `reviewerIds` as a list to allow multiple
+  // reviewers in the future, but today at most one reviewer is ever assigned.
+  // TODO: the BE does not expose the reviewer's name yet, only `reviewerId`. We render the raw id
+  // as a placeholder. Replace it with the reviewer's name/surname once the BE exposes them.
+  const reviewerId = purpose.reviewerWorkflow?.reviewerIds[0]
+
+  return (
+    <SectionContainer title={t('title')}>
+      <Stack spacing={2}>
+        <InformationContainer label={t('mode.label')} direction="row" content={modeLabel} />
+        {reviewerId && (
+          <InformationContainer label={t('reviewer.label')} direction="row" content={reviewerId} />
+        )}
+      </Stack>
+    </SectionContainer>
+  )
+}

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsAssignmentSection.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsAssignmentSection.tsx
@@ -4,7 +4,7 @@ import { Stack } from '@mui/material'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { match } from 'ts-pattern'
+import { getReviewModeLabel } from '@/utils/purpose.utils'
 
 type ConsumerPurposeDetailsAssignmentSectionProps = {
   purpose: Purpose
@@ -13,17 +13,9 @@ type ConsumerPurposeDetailsAssignmentSectionProps = {
 export const ConsumerPurposeDetailsAssignmentSection: React.FC<
   ConsumerPurposeDetailsAssignmentSectionProps
 > = ({ purpose }) => {
-  const { t } = useTranslation('purpose', {
-    keyPrefix: 'consumerView.sections.riskAnalysisAssignment',
-  })
+  const { t } = useTranslation('purpose', { keyPrefix: 'riskAnalysisAssignment' })
 
-  const reviewMode = purpose.reviewerWorkflow?.reviewMode
-
-  const modeLabel = match(reviewMode)
-    .with(undefined, () => t('mode.autonomy'))
-    .with('ADMIN_WRITES_REVIEWER_SIGNS', () => t('mode.adminWritesReviewerSigns'))
-    .with('REVIEWER_WRITES_REVIEWER_SIGNS', () => t('mode.reviewerWritesReviewerSigns'))
-    .exhaustive()
+  const modeLabel = getReviewModeLabel(purpose.reviewerWorkflow?.reviewMode, t)
 
   // We surface only the first reviewer: the BE models `reviewerIds` as a list to allow multiple
   // reviewers in the future, but today at most one reviewer is ever assigned.

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/PurposeDetailsTab.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/PurposeDetailsTab.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { Purpose } from '@/api/api.generatedTypes'
+import { ConsumerPurposeDetailsAssignmentSection } from './ConsumerPurposeDetailsAssignmentSection'
 import { ConsumerPurposeDetailsGeneralInfoSection } from './ConsumerPurposeDetailsGeneralInfoSection'
 import { ConsumerPurposeDetailsLoadEstimateSection } from './ConsumerPurposeDetailsLoadEstimateSection'
 import { SectionContainerSkeleton } from '@/components/layout/containers'
@@ -16,6 +17,7 @@ export const PurposeDetailsTab: React.FC<PurposeDetailsTabProps> = ({
 }) => {
   return (
     <Stack spacing={3}>
+      <ConsumerPurposeDetailsAssignmentSection purpose={purpose} />
       <ConsumerPurposeDetailsGeneralInfoSection purpose={purpose} />
       <ConsumerPurposeDetailsLoadEstimateSection
         purpose={purpose}
@@ -28,6 +30,7 @@ export const PurposeDetailsTab: React.FC<PurposeDetailsTabProps> = ({
 export const PurposeDetailTabSkeleton: React.FC = () => {
   return (
     <Stack spacing={3}>
+      <SectionContainerSkeleton height={140} />
       <SectionContainerSkeleton height={317} />
       <SectionContainerSkeleton height={538} />
     </Stack>

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsAssignmentSection.test.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsAssignmentSection.test.tsx
@@ -1,0 +1,42 @@
+import { screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ConsumerPurposeDetailsAssignmentSection } from '../ConsumerPurposeDetailsAssignmentSection'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
+
+mockUseJwt()
+
+const reviewerId = 'b7f6b32e-6252-4994-ac7b-47622e674e5a'
+
+describe('ConsumerPurposeDetailsAssignmentSection', () => {
+  it('shows the autonomy mode and no reviewer when there is no reviewer workflow', () => {
+    renderWithApplicationContext(
+      <ConsumerPurposeDetailsAssignmentSection
+        purpose={createMockPurpose({ reviewerWorkflow: undefined })}
+      />,
+      { withReactQueryContext: true }
+    )
+
+    expect(screen.getByText('mode.autonomy')).toBeInTheDocument()
+    expect(screen.queryByText('reviewer.label')).not.toBeInTheDocument()
+  })
+
+  it('shows the assigned mode and the reviewer id', () => {
+    renderWithApplicationContext(
+      <ConsumerPurposeDetailsAssignmentSection
+        purpose={createMockPurpose({
+          reviewerWorkflow: {
+            reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+            reviewerIds: [reviewerId],
+            signingState: 'ASSIGNED',
+          },
+        })}
+      />,
+      { withReactQueryContext: true }
+    )
+
+    expect(screen.getByText('mode.adminWritesReviewerSigns')).toBeInTheDocument()
+    expect(screen.getByText('reviewer.label')).toBeInTheDocument()
+    expect(screen.getByText(reviewerId)).toBeInTheDocument()
+  })
+})

--- a/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
@@ -3,8 +3,8 @@ import { InformationContainer } from '@pagopa/interop-fe-commons'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { match } from 'ts-pattern'
 import { PurposeQueries } from '@/api/purpose'
+import { getReviewModeLabel } from '@/utils/purpose.utils'
 
 type ConsumerPurposeSummaryAssignmentAccordionProps = {
   purposeId: string
@@ -14,15 +14,9 @@ export const ConsumerPurposeSummaryAssignmentAccordion: React.FC<
   ConsumerPurposeSummaryAssignmentAccordionProps
 > = ({ purposeId }) => {
   const { data: purpose } = useSuspenseQuery(PurposeQueries.getSingle(purposeId))
-  const { t } = useTranslation('purpose', { keyPrefix: 'summary.assignmentSection' })
+  const { t } = useTranslation('purpose', { keyPrefix: 'riskAnalysisAssignment' })
 
-  const reviewMode = purpose.reviewerWorkflow?.reviewMode
-
-  const modeLabel = match(reviewMode)
-    .with(undefined, () => t('mode.autonomy'))
-    .with('ADMIN_WRITES_REVIEWER_SIGNS', () => t('mode.adminWritesReviewerSigns'))
-    .with('REVIEWER_WRITES_REVIEWER_SIGNS', () => t('mode.reviewerWritesReviewerSigns'))
-    .exhaustive()
+  const modeLabel = getReviewModeLabel(purpose.reviewerWorkflow?.reviewMode, t)
 
   // BE does not yet expose the reviewer's first/last name: we render the raw UUID as a placeholder.
   // We surface only the first reviewer: the BE models `reviewerIds` as a list to allow multiple

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -498,6 +498,18 @@
           "label": "Go to agreement"
         }
       },
+      "riskAnalysisAssignment": {
+        "title": "Risk analysis assignment",
+        "mode": {
+          "label": "Mode",
+          "autonomy": "Completed and approved autonomously",
+          "adminWritesReviewerSigns": "Completed autonomously, approved by the reviewer",
+          "reviewerWritesReviewerSigns": "Completed and approved by the reviewer"
+        },
+        "reviewer": {
+          "label": "Reviewer"
+        }
+      },
       "loadEstimate": {
         "title": "API call estimation",
         "description": "The number of calls expected each day to the e-service",

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -285,16 +285,7 @@
       }
     },
     "assignmentSection": {
-      "title": "Assignment",
-      "mode": {
-        "label": "Mode",
-        "autonomy": "Completed and approved autonomously",
-        "adminWritesReviewerSigns": "Completed autonomously, approved by the reviewer",
-        "reviewerWritesReviewerSigns": "Completed and approved by the reviewer"
-      },
-      "reviewer": {
-        "label": "Reviewer"
-      }
+      "title": "Assignment"
     },
     "riskAnalysisSection": {
       "title": "Risk analysis",
@@ -448,6 +439,18 @@
       }
     }
   },
+  "riskAnalysisAssignment": {
+    "title": "Risk analysis assignment",
+    "mode": {
+      "label": "Mode",
+      "autonomy": "Completed and approved autonomously",
+      "adminWritesReviewerSigns": "Completed autonomously, approved by the reviewer",
+      "reviewerWritesReviewerSigns": "Completed and approved by the reviewer"
+    },
+    "reviewer": {
+      "label": "Reviewer"
+    }
+  },
   "consumerView": {
     "suspendedAlert": "This purpose is suspended. Until it is reactivated you will not be able to access the data made available through the API.",
     "waitingForApprovalAlert": "This scope is waiting for approval. <strong>Until its activation</strong> by the producer you will <strong>not be able to access the data</strong> made available through the API and you will <strong>not be able to associate clients</strong>.",
@@ -496,18 +499,6 @@
         },
         "agreementLink": {
           "label": "Go to agreement"
-        }
-      },
-      "riskAnalysisAssignment": {
-        "title": "Risk analysis assignment",
-        "mode": {
-          "label": "Mode",
-          "autonomy": "Completed and approved autonomously",
-          "adminWritesReviewerSigns": "Completed autonomously, approved by the reviewer",
-          "reviewerWritesReviewerSigns": "Completed and approved by the reviewer"
-        },
-        "reviewer": {
-          "label": "Reviewer"
         }
       },
       "loadEstimate": {

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -285,16 +285,7 @@
       }
     },
     "assignmentSection": {
-      "title": "Assegnazione",
-      "mode": {
-        "label": "Modalità",
-        "autonomy": "Compilazione e approvazione in autonomia",
-        "adminWritesReviewerSigns": "Compilazione in autonomia e approvazione del valutatore",
-        "reviewerWritesReviewerSigns": "Compilazione e approvazione del valutatore"
-      },
-      "reviewer": {
-        "label": "Valutatore"
-      }
+      "title": "Assegnazione"
     },
     "riskAnalysisSection": {
       "title": "Analisi del rischio",
@@ -448,6 +439,18 @@
       }
     }
   },
+  "riskAnalysisAssignment": {
+    "title": "Assegnazione analisi del rischio",
+    "mode": {
+      "label": "Modalità",
+      "autonomy": "Compilazione e approvazione in autonomia",
+      "adminWritesReviewerSigns": "Compilazione in autonomia e approvazione del valutatore",
+      "reviewerWritesReviewerSigns": "Compilazione e approvazione del valutatore"
+    },
+    "reviewer": {
+      "label": "Valutatore"
+    }
+  },
   "consumerView": {
     "suspendedAlert": "Questa finalità è sospesa. Fino alla sua riattivazione non potrai accedere ai dati resi disponibili attraverso l’API.",
     "waitingForApprovalAlert": "Questa finalità è in attesa di approvazione. <strong>Fino alla sua attivazione</strong> da parte dell’erogatore <strong>non potrai accedere ai dati</strong> resi disponibili attraverso l’API e <strong>non potrai associare client</strong>.",
@@ -496,18 +499,6 @@
         },
         "agreementLink": {
           "label": "Vai a richiesta di fruizione"
-        }
-      },
-      "riskAnalysisAssignment": {
-        "title": "Assegnazione analisi del rischio",
-        "mode": {
-          "label": "Modalità",
-          "autonomy": "Compilazione e approvazione in autonomia",
-          "adminWritesReviewerSigns": "Compilazione in autonomia e approvazione del valutatore",
-          "reviewerWritesReviewerSigns": "Compilazione e approvazione del valutatore"
-        },
-        "reviewer": {
-          "label": "Valutatore"
         }
       },
       "loadEstimate": {

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -498,6 +498,18 @@
           "label": "Vai a richiesta di fruizione"
         }
       },
+      "riskAnalysisAssignment": {
+        "title": "Assegnazione analisi del rischio",
+        "mode": {
+          "label": "Modalità",
+          "autonomy": "Compilazione e approvazione in autonomia",
+          "adminWritesReviewerSigns": "Compilazione in autonomia e approvazione del valutatore",
+          "reviewerWritesReviewerSigns": "Compilazione e approvazione del valutatore"
+        },
+        "reviewer": {
+          "label": "Valutatore"
+        }
+      },
       "loadEstimate": {
         "title": "Stima di chiamate API",
         "description": "Il numero di chiamate previste ogni giorno verso l'e-service",

--- a/src/utils/__tests__/purpose.utils.test.ts
+++ b/src/utils/__tests__/purpose.utils.test.ts
@@ -187,7 +187,9 @@ describe('getReviewModeLabel', () => {
   })
 
   it('maps ADMIN_WRITES_REVIEWER_SIGNS to its label', () => {
-    expect(getReviewModeLabel('ADMIN_WRITES_REVIEWER_SIGNS', t)).toBe('mode.adminWritesReviewerSigns')
+    expect(getReviewModeLabel('ADMIN_WRITES_REVIEWER_SIGNS', t)).toBe(
+      'mode.adminWritesReviewerSigns'
+    )
   })
 
   it('maps REVIEWER_WRITES_REVIEWER_SIGNS to its label', () => {

--- a/src/utils/__tests__/purpose.utils.test.ts
+++ b/src/utils/__tests__/purpose.utils.test.ts
@@ -4,7 +4,9 @@ import {
   getDaysToExpiration,
   checkIsRulesetExpired,
   getFormattedExpirationDate,
+  getReviewModeLabel,
 } from '../purpose.utils'
+import type { TFunction } from 'i18next'
 import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 
@@ -173,5 +175,24 @@ describe('checkIsRulesetExpired', () => {
   it('should return false if the date is in the future', () => {
     const result = checkIsRulesetExpired('2099-12-25')
     expect(result).toBeFalsy()
+  })
+})
+
+describe('getReviewModeLabel', () => {
+  // Stub `t` returning the requested key, so we assert the mode-to-key mapping regardless of copy.
+  const t = ((key: string) => key) as unknown as TFunction<'purpose', 'riskAnalysisAssignment'>
+
+  it('maps an undefined review mode to the autonomy label', () => {
+    expect(getReviewModeLabel(undefined, t)).toBe('mode.autonomy')
+  })
+
+  it('maps ADMIN_WRITES_REVIEWER_SIGNS to its label', () => {
+    expect(getReviewModeLabel('ADMIN_WRITES_REVIEWER_SIGNS', t)).toBe('mode.adminWritesReviewerSigns')
+  })
+
+  it('maps REVIEWER_WRITES_REVIEWER_SIGNS to its label', () => {
+    expect(getReviewModeLabel('REVIEWER_WRITES_REVIEWER_SIGNS', t)).toBe(
+      'mode.reviewerWritesReviewerSigns'
+    )
   })
 })

--- a/src/utils/purpose.utils.ts
+++ b/src/utils/purpose.utils.ts
@@ -1,4 +1,6 @@
-import type { Purpose } from '@/api/api.generatedTypes'
+import type { Purpose, RiskAnalysisReviewMode } from '@/api/api.generatedTypes'
+import type { TFunction } from 'i18next'
+import { match } from 'ts-pattern'
 
 export function getPurposeFailureReasons(
   purpose: Purpose
@@ -60,4 +62,20 @@ export function getFormattedExpirationDate(expirationDate?: string) {
 export function checkIsRulesetExpired(expirationDate: string | undefined) {
   const now = new Date()
   return expirationDate ? new Date(expirationDate) < now : false
+}
+
+/**
+ * Returns the localized label for the risk analysis review mode. An undefined mode means the risk
+ * analysis was completed and approved autonomously, with no reviewer assigned. Both the purpose
+ * summary and details surfaces share the `riskAnalysisAssignment` i18n block.
+ */
+export function getReviewModeLabel(
+  reviewMode: RiskAnalysisReviewMode | undefined,
+  t: TFunction<'purpose', 'riskAnalysisAssignment'>
+) {
+  return match(reviewMode)
+    .with(undefined, () => t('mode.autonomy'))
+    .with('ADMIN_WRITES_REVIEWER_SIGNS', () => t('mode.adminWritesReviewerSigns'))
+    .with('REVIEWER_WRITES_REVIEWER_SIGNS', () => t('mode.reviewerWritesReviewerSigns'))
+    .exhaustive()
 }


### PR DESCRIPTION
## 🔗 Issue
[PIN-10383](https://pagopa.atlassian.net/browse/PIN-10383)

## 📝 Description / Context
The details tab of a forwarded purpose (consumer side) did not surface how the
risk analysis was assigned. This adds an "Assegnazione analisi del rischio"
section at the top of the details, showing the review mode and, when present,
the assigned reviewer.

## 🛠 List of changes
- Add `ConsumerPurposeDetailsAssignmentSection` rendered as the first section of the purpose details tab
- Show the review mode label, mapping `reviewerWorkflow.reviewMode` (and autonomy when no workflow is present)
- Show the reviewer when assigned; the BE does not expose the reviewer name yet, so the raw `reviewerId` is displayed as a placeholder (TODO to replace with name/surname once available)
- Extract the review-mode-to-label logic into a shared `getReviewModeLabel` util, reused by both the purpose details section and `ConsumerPurposeSummaryAssignmentAccordion`
- Move the shared assignment strings into a common `riskAnalysisAssignment` i18n block (it/en), removing the duplicated keys
- Update the details tab skeleton to account for the new section
- Add unit tests for the shared util and the new section

## 🧪 How to test
- Open a forwarded purpose detail (Finalità inoltrate → Dettagli finalità)
- For a purpose compiled in autonomy: the section shows Modalità = "Compilazione e approvazione in autonomia" and no Valutatore
- For a purpose assigned to a reviewer: the section shows the corresponding Modalità and the Valutatore (reviewer id for now)
- Check the purpose summary (Riepilogo) "Assegnazione" accordion still shows the same Modalità/Valutatore copy

[PIN-10383]: https://pagopa.atlassian.net/browse/PIN-10383