### PR TITLE
fix/PIN-10160: navigate with purposeId to ConsumerDebugVoucherPage

### DIFF
--- a/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
+++ b/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
@@ -25,7 +25,7 @@ const ConsumerClientManagePage: React.FC = () => {
   const { t: tCommon } = useTranslation('common', { keyPrefix: 'actions' })
   const { clientId } = useParams<'SUBSCRIBE_CLIENT_EDIT' | 'SUBSCRIBE_INTEROP_M2M_CLIENT_EDIT'>()
   const [searchParams] = useSearchParams()
-  const purposeId = searchParams.get('purposeId') || ''
+  const purposeId = searchParams.get('purposeId')
   const clientKind = useClientKind()
   const { activeTab, updateActiveTab } = useActiveTab('clientOperators')
   const navigate = useNavigate()

--- a/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
+++ b/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
@@ -1,6 +1,6 @@
 import { ClientMutations, ClientQueries } from '@/api/client'
 import { PageContainer, SectionContainer } from '@/components/layout/containers'
-import { useParams } from '@/router'
+import { useParams, useNavigate } from '@/router'
 import { useActiveTab } from '@/hooks/useActiveTab'
 import { useMarkNotificationsAsRead } from '@/hooks/useMarkNotificationsAsRead'
 import { TabContext, TabList, TabPanel } from '@mui/lab'
@@ -17,13 +17,15 @@ import DeleteIcon from '@mui/icons-material/DeleteOutline'
 import SyncIcon from '@mui/icons-material/Sync'
 import { useDrawerState } from '@/hooks/useDrawerState'
 import { SetClientAdminDrawer } from './components/SetClientAdminDrawer/SetClientAdminDrawer'
-import { useNavigate } from '@/router'
 import type { ActionItemButton } from '@/types/common.types'
+import { useSearchParams } from 'react-router-dom'
 
 const ConsumerClientManagePage: React.FC = () => {
   const { t } = useTranslation('client', { keyPrefix: 'edit' })
   const { t: tCommon } = useTranslation('common', { keyPrefix: 'actions' })
   const { clientId } = useParams<'SUBSCRIBE_CLIENT_EDIT' | 'SUBSCRIBE_INTEROP_M2M_CLIENT_EDIT'>()
+  const [searchParams] = useSearchParams()
+  const purposeId = searchParams.get('purposeId') || ''
   const clientKind = useClientKind()
   const { activeTab, updateActiveTab } = useActiveTab('clientOperators')
   const navigate = useNavigate()
@@ -50,7 +52,7 @@ const ConsumerClientManagePage: React.FC = () => {
     action: () =>
       navigate(
         clientKind === 'API' ? 'SIMULATE_GET_VOUCHER_API' : 'SIMULATE_GET_VOUCHER_CONSUMER',
-        { urlParams: { clientId } }
+        { urlParams: { clientId, purposeId } }
       ),
     label: tCommon('simulateVoucher'),
     variant: 'contained',

--- a/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
+++ b/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
@@ -52,7 +52,7 @@ const ConsumerClientManagePage: React.FC = () => {
     action: () =>
       navigate(
         clientKind === 'API' ? 'SIMULATE_GET_VOUCHER_API' : 'SIMULATE_GET_VOUCHER_CONSUMER',
-        { urlParams: { clientId, purposeId } }
+        { urlParams: { clientId, ...(purposeId ? { purposeId } : {}) } }
       ),
     label: tCommon('simulateVoucher'),
     variant: 'contained',

--- a/src/pages/ConsumerClientManagePage/__tests__/ConsumerClientManage.page.test.tsx
+++ b/src/pages/ConsumerClientManagePage/__tests__/ConsumerClientManage.page.test.tsx
@@ -37,7 +37,7 @@ const {
         userId: 'admin-id',
         name: 'Mario',
         familyName: 'Rossi',
-      },
+      } as { userId: string; name: string; familyName: string } | undefined,
     },
   },
 }))

--- a/src/pages/ConsumerClientManagePage/__tests__/ConsumerClientManage.page.test.tsx
+++ b/src/pages/ConsumerClientManagePage/__tests__/ConsumerClientManage.page.test.tsx
@@ -1,0 +1,312 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import ConsumerClientManagePage from '../ConsumerClientManage.page'
+
+const {
+  mockedNavigate,
+  mockedRemoveClientAdmin,
+  mockedOpenDrawer,
+  mockedCloseDrawer,
+  mockedUpdateActiveTab,
+  mockedMarkNotificationsAsRead,
+  mockedGetSingle,
+  state,
+} = vi.hoisted(() => ({
+  mockedNavigate: vi.fn(),
+  mockedRemoveClientAdmin: vi.fn(),
+  mockedOpenDrawer: vi.fn(),
+  mockedCloseDrawer: vi.fn(),
+  mockedUpdateActiveTab: vi.fn(),
+  mockedMarkNotificationsAsRead: vi.fn(),
+  mockedGetSingle: vi.fn(),
+  state: {
+    clientKind: 'API' as 'API' | 'CONSUMER',
+    activeTab: 'clientOperators',
+    isDrawerOpen: false,
+    searchParams: new URLSearchParams(),
+    isLoadingClient: false,
+    additionalActions: [] as Array<{ label: string; action: VoidFunction; variant: string }>,
+    client: {
+      id: 'client-id',
+      name: 'Client Name',
+      description: 'Client Description',
+      admin: {
+        userId: 'admin-id',
+        name: 'Mario',
+        familyName: 'Rossi',
+      },
+    },
+  },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (_ns: string, options?: { keyPrefix?: string }) => ({
+    t: (key: string) => (options?.keyPrefix ? `${options.keyPrefix}.${key}` : key),
+  }),
+}))
+
+vi.mock('@/router', () => ({
+  useParams: () => ({ clientId: 'client-id' }),
+  useNavigate: () => mockedNavigate,
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useSearchParams: () => [state.searchParams],
+}))
+
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
+  useQuery: () => ({ data: state.client, isLoading: state.isLoadingClient }),
+}))
+
+vi.mock('@/api/client', () => ({
+  ClientQueries: {
+    getSingle: mockedGetSingle,
+  },
+  ClientMutations: {
+    useRemoveClientAdmin: () => ({ mutate: mockedRemoveClientAdmin }),
+  },
+}))
+
+vi.mock('@/hooks/useClientKind', () => ({
+  useClientKind: () => state.clientKind,
+}))
+
+vi.mock('@/hooks/useActiveTab', () => ({
+  useActiveTab: () => ({ activeTab: state.activeTab, updateActiveTab: mockedUpdateActiveTab }),
+}))
+
+vi.mock('@/hooks/useDrawerState', () => ({
+  useDrawerState: () => ({
+    isOpen: state.isDrawerOpen,
+    openDrawer: mockedOpenDrawer,
+    closeDrawer: mockedCloseDrawer,
+  }),
+}))
+
+vi.mock('@/hooks/useMarkNotificationsAsRead', () => ({
+  useMarkNotificationsAsRead: mockedMarkNotificationsAsRead,
+}))
+
+vi.mock('@/hooks/useGetClientActions', () => ({
+  default: () => ({ actions: state.additionalActions }),
+}))
+
+vi.mock('@/components/layout/containers', () => ({
+  PageContainer: ({
+    children,
+    title,
+    description,
+    topSideActions,
+  }: {
+    children: React.ReactNode
+    title: string
+    description?: string
+    topSideActions?: Array<{ label: string; action: VoidFunction }>
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      <div>
+        {(topSideActions ?? []).map((action) => (
+          <button key={action.label} type="button" onClick={action.action}>
+            {action.label}
+          </button>
+        ))}
+      </div>
+      {children}
+    </div>
+  ),
+  SectionContainer: ({
+    title,
+    description,
+    children,
+  }: {
+    title: string
+    description: string
+    children: React.ReactNode
+  }) => (
+    <section>
+      <h2>{title}</h2>
+      <p>{description}</p>
+      {children}
+    </section>
+  ),
+}))
+
+vi.mock('@pagopa/interop-fe-commons', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@pagopa/interop-fe-commons')>()),
+  InformationContainer: ({ label, content }: { label: string; content: string }) => (
+    <div>
+      <span>{label}</span>
+      <span>{content}</span>
+    </div>
+  ),
+}))
+
+vi.mock('../components/ClientOperators', () => ({
+  ClientOperators: ({ clientId }: { clientId: string }) => (
+    <div data-testid="client-operators">{clientId}</div>
+  ),
+}))
+
+vi.mock('../components/ClientPublicKeys', () => ({
+  ClientPublicKeys: ({ clientId }: { clientId: string }) => (
+    <div data-testid="client-public-keys">{clientId}</div>
+  ),
+}))
+
+vi.mock('../components/SetClientAdminDrawer/SetClientAdminDrawer', () => ({
+  SetClientAdminDrawer: ({
+    isOpen,
+    clientId,
+    admin,
+  }: {
+    isOpen: boolean
+    clientId: string
+    admin?: { userId: string }
+  }) => (
+    <div data-testid="set-client-admin-drawer">
+      {`${isOpen ? 'open' : 'closed'}-${clientId}-${admin?.userId ?? 'no-admin'}`}
+    </div>
+  ),
+}))
+
+describe('ConsumerClientManagePage', () => {
+  beforeEach(() => {
+    mockedNavigate.mockReset()
+    mockedRemoveClientAdmin.mockReset()
+    mockedOpenDrawer.mockReset()
+    mockedCloseDrawer.mockReset()
+    mockedUpdateActiveTab.mockReset()
+    mockedMarkNotificationsAsRead.mockReset()
+    mockedGetSingle.mockReset()
+
+    state.clientKind = 'API'
+    state.activeTab = 'clientOperators'
+    state.isDrawerOpen = false
+    state.searchParams = new URLSearchParams()
+    state.isLoadingClient = false
+    state.additionalActions = []
+    state.client = {
+      id: 'client-id',
+      name: 'Client Name',
+      description: 'Client Description',
+      admin: {
+        userId: 'admin-id',
+        name: 'Mario',
+        familyName: 'Rossi',
+      },
+    }
+
+    mockedGetSingle.mockReturnValue({ queryKey: ['ClientGetSingle'] })
+  })
+
+  it('renders API admin section, tabs, and marks notifications as read', () => {
+    renderWithApplicationContext(<ConsumerClientManagePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByRole('heading', { name: 'Client Name' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'edit.adminSection.title' })).toBeInTheDocument()
+    expect(screen.getByText('edit.adminSection.adminLabel')).toBeInTheDocument()
+    expect(screen.getByText('Mario Rossi')).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'edit.tabs.clientOperators' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'edit.tabs.publicKeys' })).toBeInTheDocument()
+    expect(mockedMarkNotificationsAsRead).toHaveBeenCalledWith('client-id')
+    expect(screen.getByTestId('set-client-admin-drawer')).toHaveTextContent(
+      'closed-client-id-admin-id'
+    )
+  })
+
+  it('navigates to API voucher simulation including purposeId when present', async () => {
+    const user = userEvent.setup()
+    state.searchParams = new URLSearchParams('purposeId=purpose-123')
+
+    renderWithApplicationContext(<ConsumerClientManagePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.click(screen.getByRole('button', { name: 'actions.simulateVoucher' }))
+
+    expect(mockedNavigate).toHaveBeenCalledWith('SIMULATE_GET_VOUCHER_API', {
+      urlParams: {
+        clientId: 'client-id',
+        purposeId: 'purpose-123',
+      },
+    })
+  })
+
+  it('navigates to consumer voucher simulation without purposeId when absent', async () => {
+    const user = userEvent.setup()
+    state.clientKind = 'CONSUMER'
+
+    renderWithApplicationContext(<ConsumerClientManagePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.click(screen.getByRole('button', { name: 'actions.simulateVoucher' }))
+
+    expect(mockedNavigate).toHaveBeenCalledWith('SIMULATE_GET_VOUCHER_CONSUMER', {
+      urlParams: {
+        clientId: 'client-id',
+      },
+    })
+    expect(
+      screen.queryByRole('heading', { name: 'edit.adminSection.title' })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId('set-client-admin-drawer')).not.toBeInTheDocument()
+  })
+
+  it('removes admin when remove button is clicked', async () => {
+    const user = userEvent.setup()
+
+    renderWithApplicationContext(<ConsumerClientManagePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.click(
+      screen.getByRole('button', { name: 'edit.adminSection.actions.removeAdminLabel' })
+    )
+
+    expect(mockedRemoveClientAdmin).toHaveBeenCalledWith({
+      clientId: 'client-id',
+      adminId: 'admin-id',
+      userName: 'Mario Rossi',
+    })
+  })
+
+  it('shows select admin button when admin is missing and opens drawer', async () => {
+    const user = userEvent.setup()
+    state.client = {
+      id: 'client-id',
+      name: 'Client Name',
+      description: 'Client Description',
+      admin: undefined,
+    }
+
+    renderWithApplicationContext(<ConsumerClientManagePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    const selectAdminButton = screen.getByRole('button', {
+      name: 'edit.adminSection.actions.selectAdminLabel',
+    })
+
+    await user.click(selectAdminButton)
+
+    expect(mockedOpenDrawer).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('set-client-admin-drawer')).toHaveTextContent(
+      'closed-client-id-no-admin'
+    )
+  })
+})

--- a/src/pages/ConsumerClientManagePage/components/ClientOperators/__tests__/ClientOperators.test.tsx
+++ b/src/pages/ConsumerClientManagePage/components/ClientOperators/__tests__/ClientOperators.test.tsx
@@ -1,0 +1,199 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { ClientOperators } from '../ClientOperators'
+
+const {
+  mockedAddOperators,
+  mockedCloseDrawer,
+  mockedOpenDrawer,
+  mockedPrefetchQuery,
+  mockedGetOperatorsList,
+  mockedGetPartyUsersList,
+  state,
+} = vi.hoisted(() => ({
+  mockedAddOperators: vi.fn(),
+  mockedCloseDrawer: vi.fn(),
+  mockedOpenDrawer: vi.fn(),
+  mockedPrefetchQuery: vi.fn(),
+  mockedGetOperatorsList: vi.fn(),
+  mockedGetPartyUsersList: vi.fn(),
+  state: {
+    isAdmin: true,
+    isOpen: false,
+    currentOperators: [{ userId: 'u-1', name: 'Mario', familyName: 'Rossi' }],
+  },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/api/auth', () => ({
+  AuthHooks: {
+    useJwt: () => ({ jwt: { organizationId: 'org-id' }, isAdmin: state.isAdmin }),
+  },
+}))
+
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
+  useQueryClient: () => ({ prefetchQuery: mockedPrefetchQuery }),
+  useQuery: () => ({ data: state.currentOperators }),
+}))
+
+vi.mock('@/api/client', () => ({
+  ClientQueries: {
+    getOperatorsList: mockedGetOperatorsList,
+  },
+  ClientMutations: {
+    useAddOperators: () => ({ mutateAsync: mockedAddOperators }),
+  },
+}))
+
+vi.mock('@/api/tenant', () => ({
+  TenantQueries: {
+    getPartyUsersList: mockedGetPartyUsersList,
+  },
+}))
+
+vi.mock('@/hooks/useDrawerState', () => ({
+  useDrawerState: () => ({
+    isOpen: state.isOpen,
+    closeDrawer: mockedCloseDrawer,
+    openDrawer: mockedOpenDrawer,
+  }),
+}))
+
+vi.mock('@/components/shared/HeadSection', () => ({
+  HeadSection: ({
+    title,
+    description,
+    actions,
+  }: {
+    title: string
+    description: string
+    actions: Array<{
+      label: string
+      action: VoidFunction
+      disabled?: boolean
+      onPointerEnter?: VoidFunction
+    }>
+  }) => (
+    <div>
+      <h2>{title}</h2>
+      <p>{description}</p>
+      {actions.map((action) => (
+        <button
+          key={action.label}
+          type="button"
+          disabled={action.disabled}
+          onClick={action.action}
+          onPointerEnter={action.onPointerEnter}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('../ClientOperatorsTable', () => ({
+  ClientOperatorsTable: ({ clientId }: { clientId: string }) => (
+    <div data-testid="operators-table">{clientId}</div>
+  ),
+  ClientOperatorsTableSkeleton: () => <div data-testid="operators-table-skeleton" />,
+}))
+
+vi.mock('@/components/shared/AddOperatorsToClientDrawer', () => ({
+  AddOperatorsToClientDrawer: ({
+    onSubmit,
+    isOpen,
+    excludeOperatorsIdsList,
+  }: {
+    onSubmit: (operators: Array<{ userId: string }>) => void
+    isOpen: boolean
+    excludeOperatorsIdsList: string[]
+  }) => (
+    <div data-testid="add-operators-drawer">
+      <span>{isOpen ? 'open' : 'closed'}</span>
+      <span>{excludeOperatorsIdsList.join(',')}</span>
+      <button type="button" onClick={() => onSubmit([{ userId: 'u-2' }])}>
+        submit-drawer
+      </button>
+    </div>
+  ),
+}))
+
+describe('ClientOperators', () => {
+  beforeEach(() => {
+    mockedAddOperators.mockReset()
+    mockedCloseDrawer.mockReset()
+    mockedOpenDrawer.mockReset()
+    mockedPrefetchQuery.mockReset()
+    mockedGetOperatorsList.mockReset()
+    mockedGetPartyUsersList.mockReset()
+
+    state.isAdmin = true
+    state.isOpen = false
+    state.currentOperators = [{ userId: 'u-1', name: 'Mario', familyName: 'Rossi' }]
+
+    mockedGetOperatorsList.mockReturnValue({ queryKey: ['ClientGetOperatorsList'] })
+    mockedGetPartyUsersList.mockReturnValue({ queryKey: ['TenantGetPartyUsersList'] })
+  })
+
+  it('renders head section, table and drawer for admin', () => {
+    renderWithApplicationContext(<ClientOperators clientId="client-id" />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByRole('heading', { name: 'clientOperatorsTab.title' })).toBeInTheDocument()
+    expect(screen.getByTestId('operators-table')).toHaveTextContent('client-id')
+    expect(screen.getByTestId('add-operators-drawer')).toBeInTheDocument()
+  })
+
+  it('prefetches users on add button hover when admin', async () => {
+    const user = userEvent.setup()
+
+    renderWithApplicationContext(<ClientOperators clientId="client-id" />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.hover(screen.getByRole('button', { name: 'addBtn' }))
+
+    expect(mockedGetPartyUsersList).toHaveBeenCalledWith({
+      roles: ['admin', 'security'],
+      tenantId: 'org-id',
+    })
+    expect(mockedPrefetchQuery).toHaveBeenCalledTimes(1)
+  })
+
+  it('submits selected operators and closes drawer', async () => {
+    const user = userEvent.setup()
+
+    renderWithApplicationContext(<ClientOperators clientId="client-id" />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.click(screen.getByRole('button', { name: 'submit-drawer' }))
+
+    expect(mockedAddOperators).toHaveBeenCalledWith({ clientId: 'client-id', userIds: ['u-2'] })
+    expect(mockedCloseDrawer).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables add operator action and hides drawer for non admin', () => {
+    state.isAdmin = false
+
+    renderWithApplicationContext(<ClientOperators clientId="client-id" />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByRole('button', { name: 'addBtn' })).toBeDisabled()
+    expect(screen.queryByTestId('add-operators-drawer')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/ConsumerClientManagePage/components/ClientPublicKeys/__tests__/ClientPublicKeysHeadSection.test.tsx
+++ b/src/pages/ConsumerClientManagePage/components/ClientPublicKeys/__tests__/ClientPublicKeysHeadSection.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { ClientPublicKeysHeadSection } from '../ClientPublicKeysHeadSection'
+
+const { mockedOpenDrawer, mockedCloseDrawer, state } = vi.hoisted(() => ({
+  mockedOpenDrawer: vi.fn(),
+  mockedCloseDrawer: vi.fn(),
+  state: {
+    isSupport: false,
+    uid: 'operator-1',
+    userIds: ['operator-1'],
+    keys: [{ keyId: 'k1' }],
+    isDrawerOpen: false,
+  },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/api/auth', () => ({
+  AuthHooks: {
+    useJwt: () => ({ jwt: { uid: state.uid }, isSupport: state.isSupport }),
+  },
+}))
+
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
+  useSuspenseQuery: () => ({ data: state.userIds }),
+  useQuery: () => ({ data: { keys: state.keys } }),
+  keepPreviousData: vi.fn(),
+}))
+
+vi.mock('@/api/client', () => ({
+  ClientQueries: {
+    getOperatorsList: () => ({ queryKey: ['ClientGetOperatorsList'] }),
+    getKeyList: () => ({ queryKey: ['ClientGetKeyList'] }),
+  },
+}))
+
+vi.mock('@/hooks/useDrawerState', () => ({
+  useDrawerState: () => ({
+    isOpen: state.isDrawerOpen,
+    openDrawer: mockedOpenDrawer,
+    closeDrawer: mockedCloseDrawer,
+  }),
+}))
+
+vi.mock('@/components/shared/HeadSection', () => ({
+  HeadSection: ({
+    title,
+    description,
+    actions,
+  }: {
+    title: string
+    description: string
+    actions: Array<{ label: string; action: VoidFunction; disabled?: boolean; tooltip?: string }>
+  }) => (
+    <div>
+      <h2>{title}</h2>
+      <p>{description}</p>
+      {actions.map((action) => (
+        <button
+          key={action.label}
+          type="button"
+          disabled={action.disabled}
+          data-tooltip={action.tooltip}
+          onClick={action.action}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
+  HeadSectionSkeleton: () => <div data-testid="head-skeleton" />,
+}))
+
+vi.mock('../ClientAddPublicKeyDrawer', () => ({
+  ClientAddPublicKeyDrawer: ({ isOpen, clientId }: { isOpen: boolean; clientId: string }) => (
+    <div data-testid="add-key-drawer">{`${isOpen ? 'open' : 'closed'}-${clientId}`}</div>
+  ),
+}))
+
+describe('ClientPublicKeysHeadSection', () => {
+  beforeEach(() => {
+    mockedOpenDrawer.mockReset()
+    mockedCloseDrawer.mockReset()
+
+    state.isSupport = false
+    state.uid = 'operator-1'
+    state.userIds = ['operator-1']
+    state.keys = [{ keyId: 'k1' }]
+    state.isDrawerOpen = false
+  })
+
+  it('renders enabled add action and drawer when user can add keys', async () => {
+    const user = userEvent.setup()
+
+    renderWithApplicationContext(<ClientPublicKeysHeadSection clientId="client-id" />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    const addButton = screen.getByRole('button', { name: 'addBtn' })
+    expect(addButton).toBeEnabled()
+    expect(screen.getByTestId('add-key-drawer')).toBeInTheDocument()
+
+    await user.click(addButton)
+    expect(mockedOpenDrawer).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables add action for support user and hides drawer', () => {
+    state.isSupport = true
+
+    renderWithApplicationContext(<ClientPublicKeysHeadSection clientId="client-id" />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    const addButton = screen.getByRole('button', { name: 'addBtn' })
+    expect(addButton).toBeDisabled()
+    expect(addButton).toHaveAttribute('data-tooltip', 'list.supportDisableInfo')
+    expect(screen.queryByTestId('add-key-drawer')).not.toBeInTheDocument()
+  })
+
+  it('disables add action when user is not in client operators', () => {
+    state.userIds = ['another-user']
+
+    renderWithApplicationContext(<ClientPublicKeysHeadSection clientId="client-id" />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    const addButton = screen.getByRole('button', { name: 'addBtn' })
+    expect(addButton).toBeDisabled()
+    expect(addButton).toHaveAttribute('data-tooltip', 'list.userEnableInfo')
+  })
+})

--- a/src/pages/ConsumerClientManagePage/components/SetClientAdminDrawer/__tests__/SetClientAdminDrawer.test.tsx
+++ b/src/pages/ConsumerClientManagePage/components/SetClientAdminDrawer/__tests__/SetClientAdminDrawer.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useFormContext } from 'react-hook-form'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { SetClientAdminDrawer } from '../SetClientAdminDrawer'
+
+const { mockedSetClientAdmin, mockedOnClose, state } = vi.hoisted(() => ({
+  mockedSetClientAdmin: vi.fn(),
+  mockedOnClose: vi.fn(),
+  state: {
+    users: [
+      { userId: 'admin-1', name: 'Mario', familyName: 'Rossi' },
+      { userId: 'admin-2', name: 'Luigi', familyName: 'Bianchi' },
+    ],
+  },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (_ns: string, options?: { keyPrefix?: string }) => ({
+    t: (key: string) => (options?.keyPrefix ? `${options.keyPrefix}.${key}` : key),
+  }),
+}))
+
+vi.mock('@/api/auth', () => ({
+  AuthHooks: {
+    useJwt: () => ({ jwt: { organizationId: 'org-id' } }),
+  },
+}))
+
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@tanstack/react-query')>()),
+  useQuery: () => ({ data: state.users, isLoading: false }),
+}))
+
+vi.mock('@/api/client', () => ({
+  ClientMutations: {
+    useSetClientAdmin: () => ({ mutate: mockedSetClientAdmin }),
+  },
+}))
+
+vi.mock('@/api/tenant', () => ({
+  TenantQueries: {
+    getPartyUsersList: () => ({ queryKey: ['TenantGetPartyUsersList'] }),
+  },
+}))
+
+vi.mock('@/components/shared/Drawer', () => ({
+  Drawer: ({
+    title,
+    subtitle,
+    children,
+    buttonAction,
+    onTransitionExited,
+  }: {
+    title: string
+    subtitle: React.ReactNode
+    children: React.ReactNode
+    buttonAction: { label: string; action: VoidFunction }
+    onTransitionExited?: VoidFunction
+  }) => (
+    <div>
+      <h2>{title}</h2>
+      <div>{subtitle}</div>
+      {children}
+      <button type="button" onClick={buttonAction.action}>
+        {buttonAction.label}
+      </button>
+      <button type="button" onClick={onTransitionExited}>
+        transition-exit
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/shared/react-hook-form-inputs', () => ({
+  RHFAutocompleteSingle: ({ name }: { name: string }) => {
+    const { setValue } = useFormContext()
+    return (
+      <button type="button" onClick={() => setValue(name, 'admin-2')}>
+        set-admin
+      </button>
+    )
+  },
+}))
+
+describe('SetClientAdminDrawer', () => {
+  beforeEach(() => {
+    mockedSetClientAdmin.mockReset()
+    mockedOnClose.mockReset()
+  })
+
+  it('renders substitute title when admin exists', () => {
+    renderWithApplicationContext(
+      <SetClientAdminDrawer
+        isOpen
+        onClose={mockedOnClose}
+        clientId="client-id"
+        admin={{ userId: 'admin-1', name: 'Mario', familyName: 'Rossi' }}
+      />,
+      { withReactQueryContext: true, withRouterContext: true }
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'edit.setClientAdminDrawer.title.substitute' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'actions.substituteAdmin' })).toBeInTheDocument()
+  })
+
+  it('submits selected admin and closes on success', async () => {
+    const user = userEvent.setup()
+
+    renderWithApplicationContext(
+      <SetClientAdminDrawer
+        isOpen
+        onClose={mockedOnClose}
+        clientId="client-id"
+        admin={{ userId: 'admin-1', name: 'Mario', familyName: 'Rossi' }}
+      />,
+      { withReactQueryContext: true, withRouterContext: true }
+    )
+
+    await user.click(screen.getByRole('button', { name: 'set-admin' }))
+    await user.click(screen.getByRole('button', { name: 'actions.substituteAdmin' }))
+
+    expect(mockedSetClientAdmin).toHaveBeenCalledWith(
+      {
+        clientId: 'client-id',
+        payload: { adminId: 'admin-2' },
+      },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    )
+
+    const onSuccess = mockedSetClientAdmin.mock.calls[0]?.[1]?.onSuccess
+    onSuccess?.()
+    expect(mockedOnClose).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## 🔗 Issue

[PIN-10160](https://pagopa.atlassian.net/browse/PIN-10160)

## 📝 Description / Context

This PR fixes a navigation issue affecting the Voucher Debug page when the `purposeId` parameter is missing.

In the `bugfix/PIN-10160_missing-purposeId` branch, the navigation to `ConsumerDebugVoucherPage` has been updated to ensure that the `purposeId` is correctly passed through the voucher simulation flow. This prevents the debug page from opening in an incomplete state or with data that is inconsistent with the selected Purpose.

## 🛠 List of changes

* Fixed the propagation of the `purposeId` parameter when navigating to the Voucher Debug page.
* Aligned the voucher simulation flow to preserve the selected Purpose context during redirects to the debug page.
* Reduced the risk of errors caused by missing query parameters during the debug/simulation process.

## 🧪 How to test

1. Start the application locally.
2. Navigate to the consumer voucher simulation flow and select a valid Purpose.
3. From the screen that exposes the Voucher Debug action, click the link/button that navigates to the debug page.
4. Verify that the Voucher Debug page opens while preserving the context of the selected Purpose (`purposeId` is present in the URL parameters and the expected data is correctly loaded).
5. Repeat the test using the different entry points of the flow (where the debug link/button is available) to verify that no regressions have been introduced.


[PIN-10160]: https://pagopa.atlassian.net/browse/PIN-10160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ