### PR TITLE
chore/PIN-9971: changed labels for tresholds info

### DIFF
--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -139,16 +139,16 @@
         }
       },
       "providerThresholdsInfo": {
-        "label": "Thresholds defined by the provider",
-        "description": "Residual calls may vary if the provider receives other purposes before your publication.",
+        "label": "Available API calls per day",
+        "description": "Available calls may vary if the provider receives other purposes before your publication.",
         "na": "n/a",
         "dailyCallsPerConsumer": {
-          "label": "Threshold per user",
-          "value": "{{min}} of {{max}} API calls/day"
+          "label": "Per consumer",
+          "value": "{{min}} available calls out of {{max}}"
         },
         "dailyCallsTotal": {
-          "label": "Total threshold",
-          "value": "{{min}} of {{max}} API calls/day"
+          "label": "Total",
+          "value": "{{min}} available calls out of {{max}}"
         }
       },
       "alerts": {
@@ -534,15 +534,16 @@
             }
           },
           "providerThresholdsInfo": {
-            "label": "Thresholds defined by the provider",
-            "description": "Residual calls may vary if the provider receives other purposes before your publication.",
+            "label": "Available API calls per day",
+            "description": "Available calls may vary if the provider receives other purposes before your publication.",
+            "na": "n/a",
             "dailyCallsPerConsumer": {
-              "label": "Threshold per user",
-              "value": "{{min}} of {{max}} API calls/day"
+              "label": "Per consumer",
+              "value": "{{min}} available calls out of {{max}}"
             },
             "dailyCallsTotal": {
-              "label": "Total threshold",
-              "value": "{{min}} of {{max}} API calls/day"
+              "label": "Total",
+              "value": "{{min}} available calls out of {{max}}"
             }
           },
           "riskAnalysisSection": {

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -139,16 +139,16 @@
         }
       },
       "providerThresholdsInfo": {
-        "label": "Soglie definite dall’erogatore",
-        "description": "Le chiamate residue possono variare se l'erogatore riceve altre finalità prima della tua pubblicazione.",
+        "label": "Chiamate API disponibili al giorno",
+        "description": "Le chiamate disponibili possono variare se l'erogatore riceve altre finalità prima della tua pubblicazione.",
         "na": "n/a",
         "dailyCallsPerConsumer": {
-          "label": "Soglia per fruitore",
-          "value": "{{min}} di {{max}} chiamate API/giorno"
+          "label": "Per fruitore",
+          "value": "{{min}} chiamate disponibili su {{max}}"
         },
         "dailyCallsTotal": {
-          "label": "Soglia totale",
-          "value": "{{min}} di {{max}} chiamate API/giorno"
+          "label": "Totali",
+          "value": "{{min}} chiamate disponibili su {{max}}"
         }
       },
       "alerts": {
@@ -534,15 +534,16 @@
             }
           },
           "providerThresholdsInfo": {
-            "label": "Soglie definite dall’erogatore",
-            "description": "Le chiamate residue possono variare se l'erogatore riceve altre finalità prima della tua pubblicazione.",
+            "label": "Chiamate API disponibili al giorno",
+            "description": "Le chiamate disponibili possono variare se l'erogatore riceve altre finalità prima della tua pubblicazione.",
+            "na": "n/a",
             "dailyCallsPerConsumer": {
-              "label": "Soglia per fruitore",
-              "value": "{{min}} di {{max}} chiamate API/giorno"
+              "label": "Per fruitore",
+              "value": "{{min}} chiamate disponibili su {{max}}"
             },
             "dailyCallsTotal": {
-              "label": "Soglia totale",
-              "value": "{{min}} di {{max}} chiamate API/giorno"
+              "label": "Totali",
+              "value": "{{min}} chiamate disponibili su {{max}}"
             }
           },
           "riskAnalysisSection": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-9971](https://pagopa.atlassian.net/browse/PIN-9971)

## 📝 Description / Context

This PR updates the threshold information copy in the Purpose section, making the text clearer and more focused on the concept of **available API calls** rather than **remaining thresholds**.

Specifically, labels and descriptive texts have been updated in both Italian and English to improve the understanding of:

* The total number of API calls available per day.
* The per-consumer allocation.
* The overall available total.

## 🛠 List of changes

* Updated `providerThresholdsInfo` copy in the Italian locale.
* Updated `providerThresholdsInfo` copy in the English locale.
* Standardized terminology, replacing references to *Thresholds* and *Remaining quotas* with *Available API calls*.
* Added the missing `na` key to the corresponding block in the English locale.

## 🧪 How to test

1. Start the application locally.
2. Navigate to the Purpose creation, edit, and summary screens where the thresholds/available API calls information box is displayed.
3. Verify that, in Italian, the updated texts include:

   * **Chiamate API disponibili al giorno**
   * **Per fruitore**
   * **Totali**
4. Verify that, in English, the updated texts include:

   * **Available API calls per day**
   * **Per consumer**
   * **Total**
5. Verify that the `min` and `max` placeholders are correctly rendered within the updated strings.


[PIN-9971]: https://pagopa.atlassian.net/browse/PIN-9971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ