### PR TITLE
fix: show "Crea finalità" title during purpose draft creation (PIN-7610)

### DIFF
--- a/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
@@ -185,6 +185,7 @@ export const PurposeCreateForm: React.FC<PurposeCreateFormProps> = ({ purposeTem
           const purposeId = data.id
           navigate('SUBSCRIBE_PURPOSE_EDIT', {
             params: { purposeId },
+            state: { isFirstEdit: true },
           })
         },
       })
@@ -207,6 +208,7 @@ export const PurposeCreateForm: React.FC<PurposeCreateFormProps> = ({ purposeTem
           const purposeId = data.id
           navigate('SUBSCRIBE_PURPOSE_EDIT', {
             params: { purposeId },
+            state: { isFirstEdit: true },
           })
         },
       })

--- a/src/pages/ConsumerPurposeCreatePage/components/__tests__/PurposeCreateForm.navigation.test.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/__tests__/PurposeCreateForm.navigation.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useFormContext } from 'react-hook-form'
+import { PurposeCreateForm } from '../PurposeCreateForm'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+
+const { mockNavigate, mockEserviceMode } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockEserviceMode: { current: 'DELIVER' as 'DELIVER' | 'RECEIVE' },
+}))
+
+vi.mock('@/router', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+vi.mock('@/api/purpose', () => ({
+  PurposeMutations: {
+    useCreateDraft: () => ({
+      mutate: (_payload: unknown, opts?: { onSuccess?: (data: { id: string }) => void }) =>
+        opts?.onSuccess?.({ id: 'new-purpose-id' }),
+    }),
+    useCreateDraftForReceiveEService: () => ({
+      mutate: (_payload: unknown, opts?: { onSuccess?: (data: { id: string }) => void }) =>
+        opts?.onSuccess?.({ id: 'new-purpose-id' }),
+    }),
+    useCreateDraftFromPurposeTemplate: () => ({ mutate: vi.fn() }),
+  },
+  PurposeQueries: {
+    getSingle: () => ({ queryKey: ['purpose-single'], queryFn: vi.fn() }),
+  },
+}))
+
+vi.mock('@/api/eservice', () => ({
+  EServiceQueries: {
+    getAllCatalogEServices: () => ({ queryKey: ['eservices'], queryFn: vi.fn() }),
+    getDescriptorCatalog: () => ({ queryKey: ['descriptor'], queryFn: vi.fn() }),
+  },
+}))
+
+vi.mock('@/api/purposeTemplate/purposeTemplate.queries', () => ({
+  PurposeTemplateQueries: {
+    getCatalogPurposeTemplates: () => ({ queryKey: ['purpose-templates'], queryFn: vi.fn() }),
+  },
+}))
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+  return {
+    ...actual,
+    useQuery: vi.fn(({ queryKey }: { queryKey: Array<string> }) => {
+      if (queryKey?.[0] === 'eservices') return { data: 'descriptor-id-1', isLoading: false }
+      if (queryKey?.[0] === 'descriptor')
+        return { data: { eservice: { mode: mockEserviceMode.current } }, isLoading: false }
+      if (queryKey?.[0] === 'purpose-templates')
+        return { data: { results: [], totalCount: 0 }, isLoading: false }
+      return { data: undefined, isLoading: false }
+    }),
+  }
+})
+
+vi.mock('../PurposeCreateConsumerAutocomplete', () => ({
+  PurposeCreateConsumerAutocomplete: () => <div>ConsumerAutocomplete</div>,
+}))
+
+vi.mock('../PurposeCreateEServiceAutocomplete', () => ({
+  PurposeCreateEServiceAutocomplete: () => {
+    const { setValue } = useFormContext()
+    return (
+      <button
+        type="button"
+        onClick={() => setValue('eservice', { id: 'es-1', name: 'es', producer: { id: 'p-1' } })}
+      >
+        set-eservice
+      </button>
+    )
+  },
+}))
+
+vi.mock('../PurposeCreateProviderRiskAnalysisAutocomplete', () => ({
+  PurposeCreateProviderRiskAnalysisAutocomplete: () => {
+    const { setValue } = useFormContext()
+    return (
+      <button type="button" onClick={() => setValue('providerRiskAnalysisId', 'risk-analysis-1')}>
+        set-risk-analysis
+      </button>
+    )
+  },
+}))
+
+vi.mock('@/components/shared/RiskAnalysisInfoSummary', () => ({
+  EServiceRiskAnalysisInfoSummary: () => <div>RiskAnalysisInfoSummary</div>,
+}))
+
+vi.mock('../PurposeCreatePurposeTemplateSection/PurposeCreatePurposeTemplateSection', () => ({
+  PurposeCreatePurposeTemplateSection: () => null,
+}))
+
+describe('PurposeCreateForm — first-edit navigation state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseJwt()
+  })
+
+  it('navigates to the edit page with isFirstEdit state after creating a DELIVER draft', async () => {
+    mockEserviceMode.current = 'DELIVER'
+    renderWithApplicationContext(<PurposeCreateForm />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await userEvent.click(screen.getByText('set-eservice'))
+    await userEvent.click(screen.getByRole('button', { name: 'create.createNewPurposeBtn' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith('SUBSCRIBE_PURPOSE_EDIT', {
+      params: { purposeId: 'new-purpose-id' },
+      state: { isFirstEdit: true },
+    })
+  })
+
+  it('navigates to the edit page with isFirstEdit state after creating a RECEIVE draft', async () => {
+    mockEserviceMode.current = 'RECEIVE'
+    renderWithApplicationContext(<PurposeCreateForm />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await userEvent.click(screen.getByText('set-eservice'))
+    await userEvent.click(screen.getByText('set-risk-analysis'))
+    await userEvent.click(screen.getByRole('button', { name: 'create.createNewPurposeBtn' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith('SUBSCRIBE_PURPOSE_EDIT', {
+      params: { purposeId: 'new-purpose-id' },
+      state: { isFirstEdit: true },
+    })
+  })
+})

--- a/src/pages/ConsumerPurposeEditPage/ConsumerPurposeEdit.page.tsx
+++ b/src/pages/ConsumerPurposeEditPage/ConsumerPurposeEdit.page.tsx
@@ -7,7 +7,7 @@ import type { StepperStep } from '@/types/common.types'
 import { PurposeEditStepGeneral } from './components/PurposeEditStepGeneral'
 import { PurposeEditStepAssignment } from './components/PurposeEditStepAssignment'
 import { PurposeEditStepRiskAnalysis } from './components/PurposeEditStepRiskAnalysis'
-import { useParams, useNavigate } from '@/router'
+import { useParams, useNavigate, useLocation } from '@/router'
 import { PurposeQueries } from '@/api/purpose'
 import { useQuery } from '@tanstack/react-query'
 import { RequiredTextLabel } from '@/components/shared/RequiredTextLabel'
@@ -18,6 +18,9 @@ const ConsumerPurposeEditPage: React.FC = () => {
   const navigate = useNavigate()
 
   const { purposeId } = useParams<'SUBSCRIBE_PURPOSE_EDIT'>()
+
+  const locationState = useLocation().state as { isFirstEdit?: boolean } | null
+  const isFirstEdit = Boolean(locationState?.isFirstEdit)
 
   const { data: purpose, isLoading: isLoadingPurpose } = useQuery(
     PurposeQueries.getSingle(purposeId)
@@ -59,7 +62,7 @@ const ConsumerPurposeEditPage: React.FC = () => {
 
   return (
     <PageContainer
-      title={t('edit.emptyTitle')}
+      title={isFirstEdit ? t('create.emptyTitle') : t('edit.emptyTitle')}
       isLoading={isLoadingPurpose}
       backToAction={{
         label: t('backToListBtn'),

--- a/src/pages/ConsumerPurposeEditPage/__tests__/ConsumerPurposeEdit.page.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/__tests__/ConsumerPurposeEdit.page.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { createMemoryHistory } from 'history'
+import ConsumerPurposeEditPage from '../ConsumerPurposeEdit.page'
+import { mockUseJwt, mockUseParams, renderWithApplicationContext } from '@/utils/testing.utils'
+import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
+
+mockUseJwt()
+mockUseParams({ purposeId: 'test-purpose-id' })
+
+vi.mock('../components/PurposeEditStepGeneral', () => ({
+  PurposeEditStepGeneral: () => <div>PurposeEditStepGeneral</div>,
+}))
+vi.mock('../components/PurposeEditStepAssignment', () => ({
+  PurposeEditStepAssignment: () => <div>PurposeEditStepAssignment</div>,
+}))
+vi.mock('../components/PurposeEditStepRiskAnalysis', () => ({
+  PurposeEditStepRiskAnalysis: () => <div>PurposeEditStepRiskAnalysis</div>,
+}))
+
+const useQueryMock = vi.fn()
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+  return {
+    ...actual,
+    useQuery: () => useQueryMock(),
+  }
+})
+
+describe('ConsumerPurposeEditPage', () => {
+  beforeEach(() => {
+    useQueryMock.mockReturnValue({ data: createMockPurpose(), isLoading: false })
+  })
+
+  it('shows the create title when the draft is opened right after creation (isFirstEdit location state)', () => {
+    const history = createMemoryHistory({
+      initialEntries: [{ pathname: '/', state: { isFirstEdit: true } }],
+    })
+
+    renderWithApplicationContext(
+      <ConsumerPurposeEditPage />,
+      { withReactQueryContext: true, withRouterContext: true },
+      history
+    )
+
+    expect(screen.getByText('create.emptyTitle')).toBeInTheDocument()
+    expect(screen.queryByText('edit.emptyTitle')).not.toBeInTheDocument()
+  })
+
+  it('shows the edit title on a regular draft edit (no location state)', () => {
+    renderWithApplicationContext(<ConsumerPurposeEditPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('edit.emptyTitle')).toBeInTheDocument()
+    expect(screen.queryByText('create.emptyTitle')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## 🔗 Issue
[PIN-7610](https://pagopa.atlassian.net/browse/PIN-7610)

## 📝 Description / Context
When creating a purpose, after filling in the consumer and the e-service and clicking "Crea bozza", the user lands on the purpose edit step: the draft already exists technically, but the key information has not been entered yet. In this phase the page title showed "Modifica finalità", while it should read "Crea finalità". The edit page is reached both from the creation flow (first edit) and from re-editing an existing draft, and nothing distinguished the two cases: the purpose is in `DRAFT` state in both, and its data is filled in progressively during the flow, so there is no reliable data-only signal. The discriminator is therefore passed as navigation state (`isFirstEdit`), the same idiom already used elsewhere in the app (e.g. `stepIndexDestination`). The "Crea finalità" copy already exists in the locale files (`create.emptyTitle`), so no new copy was introduced.

## 🛠 List of changes
- `PurposeCreateForm`: pass `state: { isFirstEdit: true }` when navigating to the edit page after a successful draft creation (both the DELIVER and the RECEIVE flows).
- `ConsumerPurposeEditPage`: read `useLocation().state.isFirstEdit` and render `create.emptyTitle` ("Crea finalità") during the creation phase, `edit.emptyTitle` ("Modifica finalità") otherwise.
- Tests: page-level regression test on the conditional title, plus a create-form test asserting the navigation state is sent on both creation flows.

## 🧪 How to test
- Go to Fruizione → Finalità → "Crea finalità", select a consumer and an e-service, then click "Crea bozza".
- On the resulting edit step the page title reads "Crea finalità" (see attached screenshot).
- Open an existing draft from the purpose summary ("modifica"): the title reads "Modifica finalità".

## ⚠️ Known limitations / out of scope
- On a hard refresh of the edit step the navigation state is lost, so the title falls back to "Modifica finalità". There is no reliable data-only way to tell "just created" from "re-editing a draft" (both are `DRAFT`).
- The breadcrumb still reads "Modifica finalità": it is a route-derived label rendered by a global shared component, not driven by navigation state, so it is left out of scope (the ticket targets the page title).
- The "purpose from template" edit page (`ConsumerPurposeFromTemplateEditPage`) has the same hardcoded title and is intentionally not addressed here, leaving it for the "template finalità" feature as noted in the ticket.

---

<img width="1200" height="942" alt="PIN-7610-crea-finalita-title" src="https://github.com/user-attachments/assets/2318c736-995a-4de2-be23-b2e12fc4cf98" />


[PIN-7610]: https://pagopa.atlassian.net/browse/PIN-7610
