### PR TITLE
fix: hide keychain tab from API operators (PIN-9909)

### DIFF
--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -20,12 +20,16 @@ import {
   isDescriptorPendingArchiving,
 } from '@/utils/eservice.utils'
 import { ProviderEServiceDetailsAlerts } from './components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts'
+import { AuthHooks } from '@/api/auth'
 
 const ProviderEServiceDetailsPage: React.FC = () => {
   const { t } = useTranslation('eservice', { keyPrefix: 'read' })
   const { eserviceId, descriptorId } = useParams<'PROVIDE_ESERVICE_MANAGE'>()
 
   const { activeTab, updateActiveTab } = useActiveTab('eserviceDetails')
+  const { isAdmin } = AuthHooks.useJwt()
+  const canViewKeychains = isAdmin
+  const selectedTab = canViewKeychains ? activeTab : 'eserviceDetails'
   const { openDialog } = useDialog()
   const {
     isOpen: isVersionSelectorDrawerOpen,
@@ -47,6 +51,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
   )
 
   const handleViewKeychains = () => {
+    if (!canViewKeychains) return
     updateActiveTab(null, 'keychains')
   }
 
@@ -130,21 +135,23 @@ const ProviderEServiceDetailsPage: React.FC = () => {
     >
       <ProviderEServiceDetailsAlerts
         descriptor={descriptor}
-        onViewKeychains={handleViewKeychains}
+        onViewKeychains={canViewKeychains ? handleViewKeychains : undefined}
       />
-      <TabContext value={activeTab}>
+      <TabContext value={selectedTab}>
         <TabList onChange={updateActiveTab} aria-label={t('tabs.ariaLabel')} variant="fullWidth">
           <Tab label={t('tabs.eserviceDetails')} value="eserviceDetails" />
-          <Tab label={t('tabs.keychain')} value="keychains" />
+          {canViewKeychains && <Tab label={t('tabs.keychain')} value="keychains" />}
         </TabList>
 
         <TabPanel value="eserviceDetails">
           <ProviderEserviceDetailsTab />
         </TabPanel>
 
-        <TabPanel value="keychains">
-          <ProviderEserviceKeychainsTab />
-        </TabPanel>
+        {canViewKeychains && (
+          <TabPanel value="keychains">
+            <ProviderEserviceKeychainsTab />
+          </TabPanel>
+        )}
       </TabContext>
       {descriptor && (
         <EServiceVersionSelectorDrawer

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -27,8 +27,8 @@ const ProviderEServiceDetailsPage: React.FC = () => {
   const { eserviceId, descriptorId } = useParams<'PROVIDE_ESERVICE_MANAGE'>()
 
   const { activeTab, updateActiveTab } = useActiveTab('eserviceDetails')
-  const { isAdmin } = AuthHooks.useJwt()
-  const canViewKeychains = isAdmin
+  const { isAdmin, isSupport, isOperatorSecurity } = AuthHooks.useJwt()
+  const canViewKeychains = isAdmin || isSupport || isOperatorSecurity
   const selectedTab = canViewKeychains ? activeTab : 'eserviceDetails'
   const { openDialog } = useDialog()
   const {

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -43,6 +43,12 @@ const ProviderEServiceDetailsPage: React.FC = () => {
 
   useMarkNotificationsAsRead(`${eserviceId}/${descriptorId}`)
 
+  React.useEffect(() => {
+    if (!canViewKeychains && activeTab === 'keychains') {
+      updateActiveTab(null, 'eserviceDetails')
+    }
+  }, [activeTab, canViewKeychains, updateActiveTab])
+
   const isEserviceFromTemplate = Boolean(descriptor?.templateRef)
 
   const viewLatestVersionTargetId = React.useMemo(

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -51,7 +51,6 @@ const ProviderEServiceDetailsPage: React.FC = () => {
   )
 
   const handleViewKeychains = () => {
-    if (!canViewKeychains) return
     updateActiveTab(null, 'keychains')
   }
 

--- a/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetails.page.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetails.page.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { createMemoryHistory } from 'history'
+import ProviderEServiceDetailsPage from '../ProviderEServiceDetails.page'
+import { EServiceQueries } from '@/api/eservice'
+import { queryClient } from '@/config/query-client'
+import { mockUseJwt, mockUseParams, renderWithApplicationContext } from '@/utils/testing.utils'
+import { createMockEServiceDescriptorProvider } from '@/../__mocks__/data/eservice.mocks'
+
+vi.mock('@/hooks/useMarkNotificationsAsRead', () => ({
+  useMarkNotificationsAsRead: vi.fn(),
+}))
+
+vi.mock('@/hooks/useGetProviderEServiceActions', () => ({
+  useGetProviderEServiceActions: () => ({
+    primaryAction: undefined,
+    secondaryAction: undefined,
+    menuActions: [],
+    headerInfoActions: [],
+  }),
+}))
+
+vi.mock('../components/ProviderEServiceDetailsTab/ProviderEServiceDetailsTab', () => ({
+  ProviderEserviceDetailsTab: () => <div>ProviderEserviceDetailsTab</div>,
+}))
+
+vi.mock('../components/ProviderEServiceKeychainsTab/ProviderEServiceKeychainsTab', () => ({
+  ProviderEserviceKeychainsTab: () => <div>ProviderEserviceKeychainsTab</div>,
+}))
+
+vi.mock('@/components/shared/EServiceVersionSelectorDrawer', () => ({
+  EServiceVersionSelectorDrawer: () => null,
+}))
+
+const eserviceId = 'eservice-id'
+const descriptorId = 'descriptor-id'
+
+function renderPage(search = '') {
+  mockUseParams({ eserviceId, descriptorId })
+
+  queryClient.setQueryData(
+    EServiceQueries.getDescriptorProvider(eserviceId, descriptorId).queryKey,
+    createMockEServiceDescriptorProvider({
+      id: descriptorId,
+      eservice: {
+        id: eserviceId,
+        descriptors: [
+          {
+            id: descriptorId,
+            state: 'PUBLISHED',
+            version: '1',
+            audience: [],
+          },
+        ],
+      },
+    })
+  )
+
+  const history = createMemoryHistory({ initialEntries: [`/${search}`] })
+
+  return renderWithApplicationContext(
+    <ProviderEServiceDetailsPage />,
+    {
+      withReactQueryContext: true,
+      withRouterContext: true,
+      withDialogContext: true,
+    },
+    history
+  )
+}
+
+describe('ProviderEServiceDetailsPage', () => {
+  beforeEach(() => {
+    queryClient.clear()
+  })
+
+  it('shows the keychain tab to admins', async () => {
+    mockUseJwt({ isAdmin: true, isOperatorAPI: false })
+
+    renderPage()
+
+    expect(await screen.findByRole('tab', { name: 'tabs.eserviceDetails' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'tabs.keychain' })).toBeInTheDocument()
+  })
+
+  it('hides the keychain tab from API operators', async () => {
+    mockUseJwt({ isAdmin: false, isOperatorAPI: true })
+
+    renderPage()
+
+    expect(await screen.findByRole('tab', { name: 'tabs.eserviceDetails' })).toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: 'tabs.keychain' })).not.toBeInTheDocument()
+  })
+
+  it('keeps API operators on the details tab when the URL requests the keychains tab', async () => {
+    mockUseJwt({ isAdmin: false, isOperatorAPI: true })
+
+    renderPage('?tab=keychains')
+
+    expect(await screen.findByText('ProviderEserviceDetailsTab')).toBeInTheDocument()
+    expect(screen.queryByText('ProviderEserviceKeychainsTab')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetails.page.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetails.page.test.tsx
@@ -114,9 +114,10 @@ describe('ProviderEServiceDetailsPage', () => {
   it('keeps API operators on the details tab when the URL requests the keychains tab', async () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
 
-    renderPage('?tab=keychains')
+    const { history } = renderPage('?tab=keychains')
 
     expect(await screen.findByText('ProviderEserviceDetailsTab')).toBeInTheDocument()
     expect(screen.queryByText('ProviderEserviceKeychainsTab')).not.toBeInTheDocument()
+    expect(history.location.search).toBe('?tab=eserviceDetails')
   })
 })

--- a/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetails.page.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDetails.page.test.tsx
@@ -84,6 +84,24 @@ describe('ProviderEServiceDetailsPage', () => {
     expect(screen.getByRole('tab', { name: 'tabs.keychain' })).toBeInTheDocument()
   })
 
+  it('shows the keychain tab to support users', async () => {
+    mockUseJwt({ isAdmin: false, isSupport: true })
+
+    renderPage()
+
+    expect(await screen.findByRole('tab', { name: 'tabs.eserviceDetails' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'tabs.keychain' })).toBeInTheDocument()
+  })
+
+  it('shows the keychain tab to security operators', async () => {
+    mockUseJwt({ isAdmin: false, isOperatorSecurity: true })
+
+    renderPage()
+
+    expect(await screen.findByRole('tab', { name: 'tabs.eserviceDetails' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'tabs.keychain' })).toBeInTheDocument()
+  })
+
   it('hides the keychain tab from API operators', async () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
 


### PR DESCRIPTION
## 🔗 Issue

[PIN-9909](https://pagopa.atlassian.net/browse/PIN-9909)

## 📝 Description / Context

API operators could see and open the producer Keychain tab from the provider EService details page, even though the backend does not allow them to access that area.

## 🛠 List of changes

- Hide the Keychain tab and panel for non-admin users.
- Keep non-admin users on the EService details tab when the URL requests `?tab=keychains`.
- Remove the keychain alert navigation action when the user cannot access the Keychain tab.
- Add focused tests for admin visibility and API operator restrictions.

## 🧪 How to test

- Open a provider EService details page as an admin: the Keychain tab should be visible and accessible.
- Open the same page as an API operator: the Keychain tab should not be visible.
- As an API operator, open the page with `?tab=keychains`: the EService details tab should remain selected and the Keychain content should not render.

[PIN-9909]: https://pagopa.atlassian.net/browse/PIN-9909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ