### PR TITLE
fix: use local maintenance font stylesheet (PIN-7939)

### DIFF
--- a/maintenance-page/fonts.css
+++ b/maintenance-page/fonts.css
@@ -36,36 +36,3 @@
     url('https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf')
       format('truetype');
 }
-
-@font-face {
-  font-family: 'Titillium Sans Pro';
-  font-display: swap;
-  font-weight: 400;
-  src:
-    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2')
-      format('woff2'),
-    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff')
-      format('woff');
-}
-
-@font-face {
-  font-family: 'Titillium Sans Pro';
-  font-display: swap;
-  font-weight: 600;
-  src:
-    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2')
-      format('woff2'),
-    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff')
-      format('woff');
-}
-
-@font-face {
-  font-family: 'Titillium Sans Pro';
-  font-display: swap;
-  font-weight: 700;
-  src:
-    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2')
-      format('woff2'),
-    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff')
-      format('woff');
-}

--- a/maintenance-page/fonts.css
+++ b/maintenance-page/fonts.css
@@ -1,0 +1,71 @@
+@font-face {
+  font-family: 'Titillium Web';
+  font-display: swap;
+  font-weight: 400;
+  src:
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff2')
+      format('woff2'),
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.woff')
+      format('woff'),
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Regular.ttf')
+      format('truetype');
+}
+
+@font-face {
+  font-family: 'Titillium Web';
+  font-weight: 600;
+  font-display: swap;
+  src:
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff2')
+      format('woff2'),
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.woff')
+      format('woff'),
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-SemiBold.ttf')
+      format('truetype');
+}
+
+@font-face {
+  font-family: 'Titillium Web';
+  font-display: swap;
+  font-weight: 700;
+  src:
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff2')
+      format('woff2'),
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.woff')
+      format('woff'),
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Web/TitilliumWeb-Bold.ttf')
+      format('truetype');
+}
+
+@font-face {
+  font-family: 'Titillium Sans Pro';
+  font-display: swap;
+  font-weight: 400;
+  src:
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff2')
+      format('woff2'),
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Regular.woff')
+      format('woff');
+}
+
+@font-face {
+  font-family: 'Titillium Sans Pro';
+  font-display: swap;
+  font-weight: 600;
+  src:
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff2')
+      format('woff2'),
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-SemiBold.woff')
+      format('woff');
+}
+
+@font-face {
+  font-family: 'Titillium Sans Pro';
+  font-display: swap;
+  font-weight: 700;
+  src:
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff2')
+      format('woff2'),
+    url('https://selfcare.pagopa.it/assets/font/Titillium_Sans_Pro/TitilliumSansPro-Bold.woff')
+      format('woff');
+}

--- a/maintenance-page/maintenance-standard.html
+++ b/maintenance-page/maintenance-standard.html
@@ -4,12 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Maintenance page</title>
-    <link
-      rel="stylesheet"
-      href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-      integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-      crossorigin="anonymous"
-    />
+    <link rel="stylesheet" href="./fonts.css" />
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>

--- a/maintenance-page/maintenance-token-down.html
+++ b/maintenance-page/maintenance-token-down.html
@@ -4,12 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Maintenance page</title>
-    <link
-      rel="stylesheet"
-      href="https://selfcare.pagopa.it/assets/font/selfhostedfonts.css"
-      integrity="sha384-pTEX27xRwV9gE3zi2iAdapYn6pEZ+f//cYR7Wm31DbTWyxHmn8eVK+BIz6vMb70r"
-      crossorigin="anonymous"
-    />
+    <link rel="stylesheet" href="./fonts.css" />
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>

--- a/src/utils/__tests__/maintenance-page-assets.test.ts
+++ b/src/utils/__tests__/maintenance-page-assets.test.ts
@@ -24,5 +24,6 @@ describe('maintenance page assets', () => {
 
     expect(fontStylesheet).toContain('@font-face')
     expect(fontStylesheet).toMatch(/font-family:\s*['"]Titillium Web['"]/)
+    expect(fontStylesheet).not.toMatch(/font-family:\s*['"]Titillium Sans Pro['"]/)
   })
 })

--- a/src/utils/__tests__/maintenance-page-assets.test.ts
+++ b/src/utils/__tests__/maintenance-page-assets.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parse } from 'node-html-parser'
+
+const maintenancePagePath = join(process.cwd(), 'maintenance-page')
+const maintenancePages = ['maintenance-standard.html', 'maintenance-token-down.html']
+
+describe('maintenance page assets', () => {
+  it.each(maintenancePages)('loads font styles from a local versioned stylesheet: %s', (page) => {
+    const document = parse(readFileSync(join(maintenancePagePath, page), 'utf8'))
+    const stylesheetLinks = document.querySelectorAll('link[rel="stylesheet"]')
+
+    expect(stylesheetLinks.map((link) => link.getAttribute('href'))).toContain('./fonts.css')
+    expect(
+      stylesheetLinks.some((link) =>
+        link.getAttribute('href')?.includes('selfcare.pagopa.it/assets/font')
+      )
+    ).toBe(false)
+    expect(stylesheetLinks.every((link) => link.getAttribute('integrity') === undefined)).toBe(true)
+  })
+
+  it('keeps the local font stylesheet versioned with the maintenance pages', () => {
+    const fontStylesheet = readFileSync(join(maintenancePagePath, 'fonts.css'), 'utf8')
+
+    expect(fontStylesheet).toContain('@font-face')
+    expect(fontStylesheet).toMatch(/font-family:\s*['"]Titillium Web['"]/)
+  })
+})


### PR DESCRIPTION
## 🔗 Issue

[PIN-7939](https://pagopa.atlassian.net/browse/PIN-7939)

## 📝 Description / Context

Maintenance pages no longer depend on the SelfCare hosted font stylesheet with a fixed SRI hash, avoiding failures when the remote CSS changes.

## 🛠 List of changes

- Added a local versioned `maintenance-page/fonts.css` stylesheet.
- Updated both maintenance HTML pages to load the local font stylesheet.
- Added a guard test for maintenance page font assets.

## 🧪 How to test

- Open `maintenance-page/maintenance-standard.html` and `maintenance-page/maintenance-token-down.html` and verify the pages still use Titillium Web styling.
- Inspect the page source and verify the font stylesheet is loaded from `./fonts.css`, without the old SelfCare CSS `integrity` link.

[PIN-7939]: https://pagopa.atlassian.net/browse/PIN-7939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ