### PR TITLE
fix: disabled purpose btns if delegator (PIN-10401)

### DIFF
--- a/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
@@ -189,43 +189,43 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
           {riskAnalysisInfoAlertText}
         </Alert>
       )}
-      <Stack spacing={1} sx={{ mt: 4 }} direction="row" justifyContent="end">
-        <Button
-          disabled={isDelegator}
-          startIcon={<DeleteOutlineIcon />}
-          variant="text"
-          color="error"
-          onClick={handleDeleteDraft}
-        >
-          {tCommon('deleteDraft')}
-        </Button>
-        <Button
-          disabled={arePublishOrEditButtonsDisabled || isDelegator}
-          startIcon={<CreateIcon />}
-          variant="text"
-          onClick={handleEditDraft}
-        >
-          {tCommon('editDraft')}
-        </Button>
+      {!isDelegator && (
+        <Stack spacing={1} sx={{ mt: 4 }} direction="row" justifyContent="end">
+          <Button
+            startIcon={<DeleteOutlineIcon />}
+            variant="text"
+            color="error"
+            onClick={handleDeleteDraft}
+          >
+            {tCommon('deleteDraft')}
+          </Button>
+          <Button
+            disabled={arePublishOrEditButtonsDisabled}
+            startIcon={<CreateIcon />}
+            variant="text"
+            onClick={handleEditDraft}
+          >
+            {tCommon('editDraft')}
+          </Button>
 
-        <Tooltip title={publishDisabledTooltip} arrow>
-          <span>
-            <Button
-              disabled={
-                arePublishOrEditButtonsDisabled ||
-                isPublishButtonDisabled ||
-                isPublishDisabledByReview ||
-                isDelegator
-              }
-              startIcon={<PublishIcon />}
-              variant="contained"
-              onClick={handlePublishDraft}
-            >
-              {t('summary.publishBtn')}
-            </Button>
-          </span>
-        </Tooltip>
-      </Stack>
+          <Tooltip title={publishDisabledTooltip} arrow>
+            <span>
+              <Button
+                disabled={
+                  arePublishOrEditButtonsDisabled ||
+                  isPublishButtonDisabled ||
+                  isPublishDisabledByReview
+                }
+                startIcon={<PublishIcon />}
+                variant="contained"
+                onClick={handlePublishDraft}
+              >
+                {t('summary.publishBtn')}
+              </Button>
+            </span>
+          </Tooltip>
+        </Stack>
+      )}
     </PageContainer>
   )
 }

--- a/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
@@ -88,7 +88,9 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
   const isThereConsumerDelegation = Boolean(purpose?.delegation)
   const isDelegationMine =
     isThereConsumerDelegation && purpose?.delegation?.delegate.id === jwt?.organizationId //consumer side delegation
-
+  const isDelegator = Boolean(
+    purpose?.delegation && purpose?.delegation?.delegator.id === jwt?.organizationId
+  )
   const handleDeleteDraft = () => {
     deleteDraft(
       { purposeId },
@@ -189,6 +191,7 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
       )}
       <Stack spacing={1} sx={{ mt: 4 }} direction="row" justifyContent="end">
         <Button
+          disabled={isDelegator}
           startIcon={<DeleteOutlineIcon />}
           variant="text"
           color="error"
@@ -197,7 +200,7 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
           {tCommon('deleteDraft')}
         </Button>
         <Button
-          disabled={arePublishOrEditButtonsDisabled}
+          disabled={arePublishOrEditButtonsDisabled || isDelegator}
           startIcon={<CreateIcon />}
           variant="text"
           onClick={handleEditDraft}
@@ -211,7 +214,8 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
               disabled={
                 arePublishOrEditButtonsDisabled ||
                 isPublishButtonDisabled ||
-                isPublishDisabledByReview
+                isPublishDisabledByReview ||
+                isDelegator
               }
               startIcon={<PublishIcon />}
               variant="contained"

--- a/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
@@ -335,9 +335,9 @@ describe('ConsumerPurposeSummaryPage', () => {
         withRouterContext: true,
       })
 
-      expect(screen.getByRole('button', { name: 'deleteDraft' })).toBeDisabled()
-      expect(screen.getByRole('button', { name: 'editDraft' })).toBeDisabled()
-      expect(screen.getByRole('button', { name: 'summary.publishBtn' })).toBeDisabled()
+      expect(screen.queryByRole('button', { name: 'deleteDraft' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'editDraft' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'summary.publishBtn' })).not.toBeInTheDocument()
     })
   })
 })

--- a/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
@@ -312,7 +312,7 @@ describe('ConsumerPurposeSummaryPage', () => {
       expect(getPublishButton()).toBeDisabled()
     })
 
-    it('should disable delete, edit and publish buttons when current user is delegator', () => {
+    it('should not show delete, edit and publish buttons when current user is delegator', () => {
       useQueryMock.mockReturnValue({
         data: {
           ...createMockPurposeCompatiblePersonalDataYes(),

--- a/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
@@ -311,5 +311,33 @@ describe('ConsumerPurposeSummaryPage', () => {
       expect(screen.queryByText('infoAlert.reviewerWritesReviewerSigns')).not.toBeInTheDocument()
       expect(getPublishButton()).toBeDisabled()
     })
+
+    it('should disable delete, edit and publish buttons when current user is delegator', () => {
+      useQueryMock.mockReturnValue({
+        data: {
+          ...createMockPurposeCompatiblePersonalDataYes(),
+          delegation: {
+            id: 'delegation-id',
+            delegator: {
+              id: 'org-1',
+            },
+            delegate: {
+              id: 'another-org',
+            },
+          },
+        },
+        isLoading: false,
+      })
+      mockUseJwt({ jwt: { organizationId: 'org-1' } })
+
+      renderWithApplicationContext(<ConsumerPurposeSummaryPage />, {
+        withReactQueryContext: true,
+        withRouterContext: true,
+      })
+
+      expect(screen.getByRole('button', { name: 'deleteDraft' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'editDraft' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'summary.publishBtn' })).toBeDisabled()
+    })
   })
 })


### PR DESCRIPTION
## Issue
- [PIN-10401](https://pagopa.atlassian.net/browse/PIN-10401)
## Description / Context / Why
- Disabled purpose CTAs if user is delegator
- Updated tests

[PIN-10401]: https://pagopa.atlassian.net/browse/PIN-10401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ