### PR TITLE
fix: PIN-10396 offer version upgrade instead of new fruition request on obsolete version

### DIFF
--- a/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
+++ b/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
@@ -1012,4 +1012,35 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     expect(result.current.secondaryAction?.label).toBe('tableEServiceCatalog.subscribe')
     expect(result.current.secondaryAction?.variant).toBe('outlined')
   })
+
+  it('should show the upgrade action as primary and the inspect action as outlined secondary when the requester is subscribed and viewing an obsolete upgradeable version', () => {
+    mockUseJwt({ isAdmin: true })
+
+    const eserviceMock = createMockCatalogDescriptorEService({
+      agreements: [],
+      isMine: false,
+      isSubscribed: true,
+      hasCertifiedAttributes: true,
+    })
+
+    const { result } = renderUseGetEServiceConsumerActionsHook(
+      createMockEServiceDescriptorCatalog({ eservice: eserviceMock }),
+      undefined,
+      false,
+      undefined,
+      {
+        blocksSubscribe: true,
+        upgrade: {
+          agreement: createMockAgreement(),
+          hasMissingAttributes: false,
+          hasAllCertifiedAttributes: true,
+        },
+      }
+    )
+
+    expect(result.current.primaryAction?.label).toBe('tableEServiceCatalog.upgradeToNewVersion')
+    expect(result.current.primaryAction?.variant).toBe('contained')
+    expect(result.current.secondaryAction?.label).toBe('tableEServiceCatalog.inspect')
+    expect(result.current.secondaryAction?.variant).toBe('outlined')
+  })
 })

--- a/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
+++ b/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
@@ -5,6 +5,7 @@ import {
   createMockCatalogDescriptorEService,
   createMockEServiceDescriptorCatalog,
 } from '@/../__mocks__/data/eservice.mocks'
+import { createMockAgreement } from '@/../__mocks__/data/agreement.mocks'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
@@ -22,6 +23,10 @@ vi.mock('@/components/dialogs/DialogSelectAgreementConsumer/DialogSelectAgreemen
       DialogSelectAgreementConsumer
     </button>
   ),
+}))
+
+vi.mock('@/components/dialogs/DialogUpgradeAgreementVersion', () => ({
+  DialogUpgradeAgreementVersion: () => <button>DialogUpgradeAgreementVersion</button>,
 }))
 
 const server = setupServer(
@@ -53,7 +58,8 @@ function renderUseGetEServiceConsumerActionsHook(
   descriptorMock?: CatalogEServiceDescriptor,
   delegatorsMock?: Array<DelegationTenant>,
   isDelegatorMock?: boolean,
-  viewLatestVersionTargetIdMock?: string
+  viewLatestVersionTargetIdMock?: string,
+  requesterEserviceAgreementMock?: Parameters<typeof useGetEServiceConsumerActions>[4]
 ) {
   return renderHookWithApplicationContext(
     () =>
@@ -61,7 +67,8 @@ function renderUseGetEServiceConsumerActionsHook(
         descriptorMock,
         delegatorsMock,
         isDelegatorMock,
-        viewLatestVersionTargetIdMock
+        viewLatestVersionTargetIdMock,
+        requesterEserviceAgreementMock
       ),
     {
       withReactQueryContext: true,
@@ -825,5 +832,128 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
 
     expect(result.current.secondaryAction).toBeUndefined()
     expect(result.current.headerInfoActions).toHaveLength(0)
+  })
+
+  it('should not show the subscribe action when the requester already has a blocking agreement on an obsolete version', () => {
+    mockUseJwt({ isAdmin: true })
+
+    const eserviceMock = createMockCatalogDescriptorEService({
+      agreements: [],
+      isMine: false,
+      isSubscribed: false,
+      hasCertifiedAttributes: true,
+    })
+
+    const { result } = renderUseGetEServiceConsumerActionsHook(
+      createMockEServiceDescriptorCatalog({ eservice: eserviceMock }),
+      undefined,
+      false,
+      undefined,
+      { blocksSubscribe: true }
+    )
+
+    expect(result.current.primaryAction).toBeUndefined()
+    expect(result.current.secondaryAction).toBeUndefined()
+  })
+
+  it('should show the upgrade action as primary when the requester has an upgradeable agreement on an obsolete version', async () => {
+    mockUseJwt({ isAdmin: true })
+
+    const eserviceMock = createMockCatalogDescriptorEService({
+      agreements: [],
+      isMine: false,
+      isSubscribed: false,
+      hasCertifiedAttributes: true,
+    })
+
+    const { result } = renderUseGetEServiceConsumerActionsHook(
+      createMockEServiceDescriptorCatalog({ eservice: eserviceMock }),
+      undefined,
+      false,
+      undefined,
+      {
+        blocksSubscribe: true,
+        upgrade: {
+          agreement: createMockAgreement(),
+          hasMissingAttributes: false,
+          hasAllCertifiedAttributes: true,
+        },
+      }
+    )
+
+    const upgradeAction = result.current.primaryAction!
+    expect(upgradeAction.label).toBe('tableEServiceCatalog.upgradeToNewVersion')
+    expect(upgradeAction.disabled).toBeFalsy()
+    expect(result.current.secondaryAction).toBeUndefined()
+
+    act(() => {
+      upgradeAction.action()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('DialogUpgradeAgreementVersion')).toBeInTheDocument()
+    })
+  })
+
+  it('should disable the upgrade action with a tooltip when the requester is missing certified attributes', () => {
+    mockUseJwt({ isAdmin: true })
+
+    const eserviceMock = createMockCatalogDescriptorEService({
+      agreements: [],
+      isMine: false,
+      isSubscribed: false,
+      hasCertifiedAttributes: false,
+    })
+
+    const { result } = renderUseGetEServiceConsumerActionsHook(
+      createMockEServiceDescriptorCatalog({ eservice: eserviceMock }),
+      undefined,
+      false,
+      undefined,
+      {
+        blocksSubscribe: true,
+        upgrade: {
+          agreement: createMockAgreement(),
+          hasMissingAttributes: true,
+          hasAllCertifiedAttributes: false,
+        },
+      }
+    )
+
+    expect(result.current.primaryAction?.label).toBe('tableEServiceCatalog.upgradeToNewVersion')
+    expect(result.current.primaryAction?.disabled).toBe(true)
+    expect(result.current.primaryAction?.tooltip).toBe(
+      'consumerRead.noCertifiedAttributesForUpgradeTooltip'
+    )
+  })
+
+  it('should keep the subscribe action for a delegator without agreement while the requester has an obsolete-version agreement', () => {
+    mockUseJwt({ isAdmin: true })
+
+    const eserviceMock = createMockCatalogDescriptorEService({
+      agreements: [],
+      isMine: false,
+      isSubscribed: false,
+      hasCertifiedAttributes: true,
+    })
+
+    const { result } = renderUseGetEServiceConsumerActionsHook(
+      createMockEServiceDescriptorCatalog({ eservice: eserviceMock }),
+      [{ id: 'delegator-id', name: 'Delegator Name' }],
+      false,
+      undefined,
+      {
+        blocksSubscribe: true,
+        upgrade: {
+          agreement: createMockAgreement(),
+          hasMissingAttributes: false,
+          hasAllCertifiedAttributes: true,
+        },
+      }
+    )
+
+    expect(result.current.primaryAction?.label).toBe('tableEServiceCatalog.upgradeToNewVersion')
+    expect(result.current.secondaryAction?.label).toBe('tableEServiceCatalog.subscribe')
+    expect(result.current.secondaryAction?.variant).toBe('outlined')
   })
 })

--- a/src/hooks/useGetEServiceConsumerActions.ts
+++ b/src/hooks/useGetEServiceConsumerActions.ts
@@ -22,19 +22,21 @@ import noop from 'lodash/noop'
 import { useDialog } from '@/stores'
 import { match } from 'ts-pattern'
 
+export type RequesterEserviceAgreement = {
+  blocksSubscribe: boolean
+  upgrade?: {
+    agreement: Agreement
+    hasMissingAttributes: boolean
+    hasAllCertifiedAttributes: boolean
+  }
+}
+
 function useGetEServiceConsumerActions(
   descriptor?: CatalogEServiceDescriptor,
   delegators?: Array<DelegationTenant>,
   isDelegator?: boolean,
   viewLatestVersionTargetId?: string,
-  requesterEserviceAgreement?: {
-    blocksSubscribe: boolean
-    upgrade?: {
-      agreement: Agreement
-      hasMissingAttributes: boolean
-      hasAllCertifiedAttributes: boolean
-    }
-  }
+  requesterEserviceAgreement?: RequesterEserviceAgreement
 ): {
   primaryAction: ActionItemButton | undefined
   secondaryAction: ActionItemButton | undefined
@@ -266,20 +268,20 @@ function useGetEServiceConsumerActions(
       }
     : undefined
 
-  const upgrade = requesterEserviceAgreement?.upgrade
-  const upgradeAction: ActionItemButton | undefined = upgrade
+  const upgradeAgreement = requesterEserviceAgreement?.upgrade
+  const upgradeAction: ActionItemButton | undefined = upgradeAgreement
     ? {
         action: () =>
           openDialog({
             type: 'upgradeAgreementVersion',
-            agreement: upgrade.agreement,
-            hasMissingAttributes: upgrade.hasMissingAttributes,
+            agreement: upgradeAgreement.agreement,
+            hasMissingAttributes: upgradeAgreement.hasMissingAttributes,
           }),
         label: t('tableEServiceCatalog.upgradeToNewVersion'),
         icon: UpdateIcon,
         variant: 'contained',
-        disabled: !upgrade.hasAllCertifiedAttributes,
-        tooltip: !upgrade.hasAllCertifiedAttributes
+        disabled: !upgradeAgreement.hasAllCertifiedAttributes,
+        tooltip: !upgradeAgreement.hasAllCertifiedAttributes
           ? tAgreement('consumerRead.noCertifiedAttributesForUpgradeTooltip')
           : undefined,
       }

--- a/src/hooks/useGetEServiceConsumerActions.ts
+++ b/src/hooks/useGetEServiceConsumerActions.ts
@@ -1,5 +1,6 @@
 import { AgreementMutations } from '@/api/agreement'
 import type {
+  Agreement,
   AgreementState,
   CatalogEServiceDescriptor,
   DelegationTenant,
@@ -16,6 +17,7 @@ import SendIcon from '@mui/icons-material/Send'
 import PendingActionsIcon from '@mui/icons-material/PendingActions'
 import ArticleIcon from '@mui/icons-material/Article'
 import ReplayCircleFilledIcon from '@mui/icons-material/ReplayCircleFilled'
+import UpdateIcon from '@mui/icons-material/Update'
 import noop from 'lodash/noop'
 import { useDialog } from '@/stores'
 import { match } from 'ts-pattern'
@@ -24,7 +26,15 @@ function useGetEServiceConsumerActions(
   descriptor?: CatalogEServiceDescriptor,
   delegators?: Array<DelegationTenant>,
   isDelegator?: boolean,
-  viewLatestVersionTargetId?: string
+  viewLatestVersionTargetId?: string,
+  requesterEserviceAgreement?: {
+    blocksSubscribe: boolean
+    upgrade?: {
+      agreement: Agreement
+      hasMissingAttributes: boolean
+      hasAllCertifiedAttributes: boolean
+    }
+  }
 ): {
   primaryAction: ActionItemButton | undefined
   secondaryAction: ActionItemButton | undefined
@@ -33,6 +43,7 @@ function useGetEServiceConsumerActions(
 } {
   const { t } = useTranslation('eservice')
   const { t: tEserviceActions } = useTranslation('eservice', { keyPrefix: 'read.actions' })
+  const { t: tAgreement } = useTranslation('agreement')
   const { jwt, isAdmin } = AuthHooks.useJwt()
 
   const navigate = useNavigate()
@@ -223,7 +234,9 @@ function useGetEServiceConsumerActions(
     : (delegators ?? [])
 
   const tenantsWithoutAgreement = tenants.filter(
-    (tenant) => !existingAgreements.some((agreement) => agreement.consumerId === tenant.id)
+    (tenant) =>
+      !existingAgreements.some((agreement) => agreement.consumerId === tenant.id) &&
+      !(requesterEserviceAgreement?.blocksSubscribe && tenant.id === jwt?.organizationId)
   )
 
   const canShowSubscribe =
@@ -253,9 +266,30 @@ function useGetEServiceConsumerActions(
       }
     : undefined
 
+  const upgrade = requesterEserviceAgreement?.upgrade
+  const upgradeAction: ActionItemButton | undefined = upgrade
+    ? {
+        action: () =>
+          openDialog({
+            type: 'upgradeAgreementVersion',
+            agreement: upgrade.agreement,
+            hasMissingAttributes: upgrade.hasMissingAttributes,
+          }),
+        label: t('tableEServiceCatalog.upgradeToNewVersion'),
+        icon: UpdateIcon,
+        variant: 'contained',
+        disabled: !upgrade.hasAllCertifiedAttributes,
+        tooltip: !upgrade.hasAllCertifiedAttributes
+          ? tAgreement('consumerRead.noCertifiedAttributesForUpgradeTooltip')
+          : undefined,
+      }
+    : undefined
+
   const shouldShowhasMissingAttributesTooltip =
     // ...the e-service is not owned by the active party...
     !isMine &&
+    // ... the requester has no blocking agreement for this e-service...
+    !requesterEserviceAgreement?.blocksSubscribe &&
     // ... the party doesn't own all the certified attributes required...
     !hasCertifiedAttributes &&
     // ... the e-service's latest active descriptor is the actual descriptor the user is viewing...
@@ -300,9 +334,13 @@ function useGetEServiceConsumerActions(
     : undefined
 
   const primaryAction: ActionItemButton | undefined =
-    inspectAction ?? editDraftAction ?? subscribeAction ?? subscribeDisabledMissingAttributesAction
+    inspectAction ??
+    editDraftAction ??
+    upgradeAction ??
+    subscribeAction ??
+    subscribeDisabledMissingAttributesAction
 
-  const hasPrimaryAgreementAction = Boolean(inspectAction ?? editDraftAction)
+  const hasPrimaryAgreementAction = Boolean(inspectAction ?? editDraftAction ?? upgradeAction)
   const secondaryAction: ActionItemButton | undefined =
     hasPrimaryAgreementAction && subscribeAction
       ? { ...subscribeAction, variant: 'outlined' }

--- a/src/hooks/useGetEServiceConsumerActions.ts
+++ b/src/hooks/useGetEServiceConsumerActions.ts
@@ -357,18 +357,20 @@ function useGetEServiceConsumerActions(
     : undefined
 
   const primaryAction: ActionItemButton | undefined =
+    upgradeAction ??
     inspectAction ??
     editDraftAction ??
-    upgradeAction ??
     subscribeAction ??
     subscribeDisabledMissingAttributesAction ??
     subscribeDisabledArchivingAction
 
   const hasPrimaryAgreementAction = Boolean(inspectAction ?? editDraftAction ?? upgradeAction)
   const secondaryAction: ActionItemButton | undefined =
-    hasPrimaryAgreementAction && subscribeAction
-      ? { ...subscribeAction, variant: 'outlined' }
-      : undefined
+    upgradeAction && inspectAction
+      ? { ...inspectAction, variant: 'outlined' }
+      : hasPrimaryAgreementAction && subscribeAction
+        ? { ...subscribeAction, variant: 'outlined' }
+        : undefined
 
   return {
     primaryAction,

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { EServiceQueries } from '@/api/eservice'
+import { AgreementQueries } from '@/api/agreement'
 import useGetEServiceConsumerActions from '@/hooks/useGetEServiceConsumerActions'
+import { useDescriptorAttributesPartyOwnership } from '@/hooks/useDescriptorAttributesPartyOwnership'
 import { useParams } from '@/router'
 import { useTranslation } from 'react-i18next'
 import { Tab } from '@mui/material'
@@ -16,6 +18,10 @@ import { useMarkNotificationsAsRead } from '@/hooks/useMarkNotificationsAsRead'
 import { NewPageContainer } from '@/components/layout/containers/NewPageContainer'
 import { useDialog } from '@/stores'
 import { getViewLatestVersionTargetId, isDescriptorPendingArchiving } from '@/utils/eservice.utils'
+import {
+  canAgreementBeUpgraded,
+  getRequesterObsoleteVersionAgreement,
+} from '@/utils/agreement.utils'
 import { ConsumerEServiceDetailsAlerts } from './components/ConsumerEServiceDetailsTab/ConsumerEServiceDetailsAlerts'
 
 const ConsumerEServiceDetailsPage: React.FC = () => {
@@ -62,8 +68,56 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
     [descriptor?.eservice.descriptors, descriptorId]
   )
 
+  const consumerAgreementsQuery = useQuery({
+    ...AgreementQueries.getConsumerAgreementsList({
+      limit: 50,
+      offset: 0,
+      eservicesIds: [eserviceId],
+    }),
+    enabled: Boolean(jwt?.organizationId) && !isReviewer,
+    select: ({ results }) => results ?? [],
+  })
+
+  const { hasBlockingAgreement, upgradeableAgreementId } = getRequesterObsoleteVersionAgreement(
+    consumerAgreementsQuery.data ?? [],
+    jwt?.organizationId
+  )
+
+  const { data: upgradeableAgreement } = useQuery({
+    ...AgreementQueries.getSingle(upgradeableAgreementId as string),
+    enabled: Boolean(upgradeableAgreementId),
+  })
+
+  const { hasAllCertifiedAttributes, hasAllDeclaredAttributes, hasAllVerifiedAttributes } =
+    useDescriptorAttributesPartyOwnership(
+      upgradeableAgreementId ? eserviceId : undefined,
+      upgradeableAgreementId ? descriptor?.eservice.activeDescriptor?.id : undefined,
+      upgradeableAgreementId ? jwt?.organizationId : undefined
+    )
+
+  const requesterEserviceAgreement =
+    consumerAgreementsQuery.isLoading || hasBlockingAgreement
+      ? {
+          blocksSubscribe: true,
+          upgrade:
+            upgradeableAgreement && canAgreementBeUpgraded(upgradeableAgreement)
+              ? {
+                  agreement: upgradeableAgreement,
+                  hasMissingAttributes: !hasAllDeclaredAttributes || !hasAllVerifiedAttributes,
+                  hasAllCertifiedAttributes,
+                }
+              : undefined,
+        }
+      : undefined
+
   const { primaryAction, secondaryAction, menuActions, headerInfoActions } =
-    useGetEServiceConsumerActions(descriptor, delegators, isDelegator, viewLatestVersionTargetId)
+    useGetEServiceConsumerActions(
+      descriptor,
+      delegators,
+      isDelegator,
+      viewLatestVersionTargetId,
+      requesterEserviceAgreement
+    )
 
   useTrackPageViewEvent('INTEROP_CATALOG_READ', {
     eserviceId: descriptor?.eservice.id,

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import { EServiceQueries } from '@/api/eservice'
-import { AgreementQueries } from '@/api/agreement'
 import useGetEServiceConsumerActions from '@/hooks/useGetEServiceConsumerActions'
-import { useDescriptorAttributesPartyOwnership } from '@/hooks/useDescriptorAttributesPartyOwnership'
 import { useParams } from '@/router'
 import { useTranslation } from 'react-i18next'
 import { Tab } from '@mui/material'
@@ -18,11 +16,8 @@ import { useMarkNotificationsAsRead } from '@/hooks/useMarkNotificationsAsRead'
 import { NewPageContainer } from '@/components/layout/containers/NewPageContainer'
 import { useDialog } from '@/stores'
 import { getViewLatestVersionTargetId, isDescriptorPendingArchiving } from '@/utils/eservice.utils'
-import {
-  canAgreementBeUpgraded,
-  getRequesterObsoleteVersionAgreement,
-} from '@/utils/agreement.utils'
 import { ConsumerEServiceDetailsAlerts } from './components/ConsumerEServiceDetailsTab/ConsumerEServiceDetailsAlerts'
+import { useRequesterEserviceAgreement } from './hooks/useRequesterEserviceAgreement'
 
 const ConsumerEServiceDetailsPage: React.FC = () => {
   const { t } = useTranslation('eservice', { keyPrefix: 'read' })
@@ -68,47 +63,12 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
     [descriptor?.eservice.descriptors, descriptorId]
   )
 
-  const consumerAgreementsQuery = useQuery({
-    ...AgreementQueries.getConsumerAgreementsList({
-      limit: 50,
-      offset: 0,
-      eservicesIds: [eserviceId],
-    }),
-    enabled: Boolean(jwt?.organizationId) && !isReviewer,
-    select: ({ results }) => results ?? [],
+  const requesterEserviceAgreement = useRequesterEserviceAgreement({
+    eserviceId,
+    activeDescriptorId: descriptor?.eservice.activeDescriptor?.id,
+    requesterTenantId: jwt?.organizationId,
+    isReviewer,
   })
-
-  const { hasBlockingAgreement, upgradeableAgreementId } = getRequesterObsoleteVersionAgreement(
-    consumerAgreementsQuery.data ?? [],
-    jwt?.organizationId
-  )
-
-  const { data: upgradeableAgreement } = useQuery({
-    ...AgreementQueries.getSingle(upgradeableAgreementId as string),
-    enabled: Boolean(upgradeableAgreementId),
-  })
-
-  const { hasAllCertifiedAttributes, hasAllDeclaredAttributes, hasAllVerifiedAttributes } =
-    useDescriptorAttributesPartyOwnership(
-      upgradeableAgreementId ? eserviceId : undefined,
-      upgradeableAgreementId ? descriptor?.eservice.activeDescriptor?.id : undefined,
-      upgradeableAgreementId ? jwt?.organizationId : undefined
-    )
-
-  const requesterEserviceAgreement =
-    consumerAgreementsQuery.isLoading || hasBlockingAgreement
-      ? {
-          blocksSubscribe: true,
-          upgrade:
-            upgradeableAgreement && canAgreementBeUpgraded(upgradeableAgreement)
-              ? {
-                  agreement: upgradeableAgreement,
-                  hasMissingAttributes: !hasAllDeclaredAttributes || !hasAllVerifiedAttributes,
-                  hasAllCertifiedAttributes,
-                }
-              : undefined,
-        }
-      : undefined
 
   const { primaryAction, secondaryAction, menuActions, headerInfoActions } =
     useGetEServiceConsumerActions(

--- a/src/pages/ConsumerEServiceDetailsPage/hooks/__test__/useRequesterEserviceAgreement.test.ts
+++ b/src/pages/ConsumerEServiceDetailsPage/hooks/__test__/useRequesterEserviceAgreement.test.ts
@@ -1,0 +1,177 @@
+import type { Agreement, AgreementListEntry } from '@/api/api.generatedTypes'
+import { renderHookWithApplicationContext } from '@/utils/testing.utils'
+import { useRequesterEserviceAgreement } from '../useRequesterEserviceAgreement'
+import {
+  createMockAgreement,
+  createMockAgreementListingItem,
+} from '../../../../../__mocks__/data/agreement.mocks'
+import type { Mock } from 'vitest'
+import type * as ReactQuery from '@tanstack/react-query'
+
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactQuery>()),
+  useQuery: vi.fn(),
+}))
+
+vi.mock('@/hooks/useDescriptorAttributesPartyOwnership', () => ({
+  useDescriptorAttributesPartyOwnership: vi.fn(),
+}))
+
+import { useQuery } from '@tanstack/react-query'
+import { useDescriptorAttributesPartyOwnership } from '@/hooks/useDescriptorAttributesPartyOwnership'
+
+const REQUESTER_TENANT_ID = 'requester-tenant-id'
+
+const mockQueries = ({
+  agreements = [],
+  isLoading = false,
+  upgradeableAgreement = undefined,
+}: {
+  agreements?: Array<AgreementListEntry>
+  isLoading?: boolean
+  upgradeableAgreement?: Agreement | undefined
+}) => {
+  ;(useQuery as Mock).mockImplementation((options: { queryKey: ReadonlyArray<unknown> }) => {
+    if (options.queryKey[0] === 'AgreementGetConsumerAgreementsList') {
+      return { data: agreements, isLoading }
+    }
+    return { data: upgradeableAgreement }
+  })
+}
+
+const mockAttributesOwnership = ({
+  hasAllCertifiedAttributes = true,
+  hasAllDeclaredAttributes = true,
+  hasAllVerifiedAttributes = true,
+} = {}) => {
+  ;(useDescriptorAttributesPartyOwnership as Mock).mockReturnValue({
+    hasAllCertifiedAttributes,
+    hasAllDeclaredAttributes,
+    hasAllVerifiedAttributes,
+  })
+}
+
+function renderUseRequesterEserviceAgreementHook(
+  params?: Partial<Parameters<typeof useRequesterEserviceAgreement>[0]>
+) {
+  return renderHookWithApplicationContext(
+    () =>
+      useRequesterEserviceAgreement({
+        eserviceId: 'eservice-id',
+        activeDescriptorId: 'active-descriptor-id',
+        requesterTenantId: REQUESTER_TENANT_ID,
+        isReviewer: false,
+        ...params,
+      }),
+    { withReactQueryContext: true }
+  )
+}
+
+beforeEach(() => {
+  mockAttributesOwnership()
+})
+
+describe('useRequesterEserviceAgreement', () => {
+  it('returns undefined for a reviewer (the agreements query is disabled, no data and not loading)', () => {
+    mockQueries({ agreements: [], isLoading: false })
+    const { result } = renderUseRequesterEserviceAgreementHook({ isReviewer: true })
+    expect(result.current).toBeUndefined()
+  })
+
+  it('blocks subscribe while the agreements query is still loading', () => {
+    mockQueries({ agreements: [], isLoading: true })
+    const { result } = renderUseRequesterEserviceAgreementHook()
+    expect(result.current).toEqual({ blocksSubscribe: true, upgrade: undefined })
+  })
+
+  it('returns undefined when the requester has no blocking agreement', () => {
+    mockQueries({
+      agreements: [
+        createMockAgreementListingItem({
+          id: 'archived-id',
+          consumer: { id: REQUESTER_TENANT_ID },
+          state: 'ARCHIVED',
+          canBeUpgraded: false,
+        }),
+      ],
+    })
+    const { result } = renderUseRequesterEserviceAgreementHook()
+    expect(result.current).toBeUndefined()
+  })
+
+  it('blocks subscribe without an upgrade when the blocking agreement is not upgradeable', () => {
+    mockQueries({
+      agreements: [
+        createMockAgreementListingItem({
+          id: 'agreement-id',
+          consumer: { id: REQUESTER_TENANT_ID },
+          state: 'ACTIVE',
+          canBeUpgraded: false,
+        }),
+      ],
+    })
+    const { result } = renderUseRequesterEserviceAgreementHook()
+    expect(result.current).toEqual({ blocksSubscribe: true, upgrade: undefined })
+  })
+
+  it('returns the upgrade payload when the requester has an upgradeable agreement and owns all attributes', () => {
+    const upgradeableAgreement = createMockAgreement({
+      id: 'upgradeable-id',
+      state: 'ACTIVE',
+      eservice: { version: '1', activeDescriptor: { state: 'PUBLISHED', version: '2' } },
+    })
+    mockQueries({
+      agreements: [
+        createMockAgreementListingItem({
+          id: 'upgradeable-id',
+          consumer: { id: REQUESTER_TENANT_ID },
+          state: 'ACTIVE',
+          canBeUpgraded: true,
+        }),
+      ],
+      upgradeableAgreement,
+    })
+    const { result } = renderUseRequesterEserviceAgreementHook()
+    expect(result.current).toEqual({
+      blocksSubscribe: true,
+      upgrade: {
+        agreement: upgradeableAgreement,
+        hasMissingAttributes: false,
+        hasAllCertifiedAttributes: true,
+      },
+    })
+  })
+
+  it('flags missing attributes in the upgrade payload when the requester does not own them', () => {
+    const upgradeableAgreement = createMockAgreement({
+      id: 'upgradeable-id',
+      state: 'ACTIVE',
+      eservice: { version: '1', activeDescriptor: { state: 'PUBLISHED', version: '2' } },
+    })
+    mockAttributesOwnership({
+      hasAllCertifiedAttributes: false,
+      hasAllDeclaredAttributes: false,
+      hasAllVerifiedAttributes: true,
+    })
+    mockQueries({
+      agreements: [
+        createMockAgreementListingItem({
+          id: 'upgradeable-id',
+          consumer: { id: REQUESTER_TENANT_ID },
+          state: 'ACTIVE',
+          canBeUpgraded: true,
+        }),
+      ],
+      upgradeableAgreement,
+    })
+    const { result } = renderUseRequesterEserviceAgreementHook()
+    expect(result.current).toEqual({
+      blocksSubscribe: true,
+      upgrade: {
+        agreement: upgradeableAgreement,
+        hasMissingAttributes: true,
+        hasAllCertifiedAttributes: false,
+      },
+    })
+  })
+})

--- a/src/pages/ConsumerEServiceDetailsPage/hooks/useRequesterEserviceAgreement.ts
+++ b/src/pages/ConsumerEServiceDetailsPage/hooks/useRequesterEserviceAgreement.ts
@@ -1,0 +1,61 @@
+import { AgreementQueries } from '@/api/agreement'
+import { useDescriptorAttributesPartyOwnership } from '@/hooks/useDescriptorAttributesPartyOwnership'
+import type { RequesterEserviceAgreement } from '@/hooks/useGetEServiceConsumerActions'
+import {
+  canAgreementBeUpgraded,
+  getRequesterObsoleteVersionAgreement,
+} from '@/utils/agreement.utils'
+import { useQuery } from '@tanstack/react-query'
+
+export function useRequesterEserviceAgreement({
+  eserviceId,
+  activeDescriptorId,
+  requesterTenantId,
+  isReviewer,
+}: {
+  eserviceId: string
+  activeDescriptorId: string | undefined
+  requesterTenantId: string | undefined
+  isReviewer: boolean
+}): RequesterEserviceAgreement | undefined {
+  const consumerAgreementsQuery = useQuery({
+    ...AgreementQueries.getConsumerAgreementsList({
+      limit: 50,
+      offset: 0,
+      eservicesIds: [eserviceId],
+    }),
+    enabled: Boolean(requesterTenantId) && !isReviewer,
+    select: ({ results }) => results ?? [],
+  })
+
+  const { hasBlockingAgreement, upgradeableAgreementId } = getRequesterObsoleteVersionAgreement(
+    consumerAgreementsQuery.data ?? [],
+    requesterTenantId
+  )
+
+  const { data: upgradeableAgreement } = useQuery({
+    ...AgreementQueries.getSingle(upgradeableAgreementId as string),
+    enabled: Boolean(upgradeableAgreementId),
+  })
+
+  const { hasAllCertifiedAttributes, hasAllDeclaredAttributes, hasAllVerifiedAttributes } =
+    useDescriptorAttributesPartyOwnership(
+      upgradeableAgreementId ? eserviceId : undefined,
+      upgradeableAgreementId ? activeDescriptorId : undefined,
+      upgradeableAgreementId ? requesterTenantId : undefined
+    )
+
+  return consumerAgreementsQuery.isLoading || hasBlockingAgreement
+    ? {
+        blocksSubscribe: true,
+        upgrade:
+          upgradeableAgreement && canAgreementBeUpgraded(upgradeableAgreement)
+            ? {
+                agreement: upgradeableAgreement,
+                hasMissingAttributes: !hasAllDeclaredAttributes || !hasAllVerifiedAttributes,
+                hasAllCertifiedAttributes,
+              }
+            : undefined,
+      }
+    : undefined
+}

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -1196,6 +1196,7 @@
     "subscribe": "Request fruition",
     "editDraft": "Complete request",
     "inspect": "Inspect request",
+    "upgradeToNewVersion": "Update to new version",
     "eserviceSuspendedTooltip": "It is currently not possible to submit new requests; the e-service is suspended",
     "missingCertifiedAttributesTooltip": "Your institution does not have the certified attributes necessary to register"
   },

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -1196,6 +1196,7 @@
     "subscribe": "Richiedi fruizione",
     "editDraft": "Completa richiesta",
     "inspect": "Visualizza richiesta",
+    "upgradeToNewVersion": "Aggiorna a nuova versione",
     "eserviceSuspendedTooltip": "Non è attualmente possibile presentare nuove richieste, l’e-service è sospeso",
     "missingCertifiedAttributesTooltip": "Il tuo ente non ha gli attributi certificati necessari per iscriversi"
   },

--- a/src/utils/__tests__/agreement.utils.test.ts
+++ b/src/utils/__tests__/agreement.utils.test.ts
@@ -1,10 +1,14 @@
 import type { TFunction } from 'i18next'
-import { createMockAgreement } from '@/../__mocks__/data/agreement.mocks'
+import {
+  createMockAgreement,
+  createMockAgreementListingItem,
+} from '@/../__mocks__/data/agreement.mocks'
 import {
   canAgreementBeUpgraded,
   checkIfcanCreateAgreementDraft,
   checkIfhasAlreadyAgreementDraft,
   getConsumerAgreementVersionAlertSpec,
+  getRequesterObsoleteVersionAgreement,
   isNewEServiceVersionAvailable,
 } from '../agreement.utils'
 import {
@@ -329,5 +333,98 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
 
   it('returns empty array for ARCHIVING without a scope (no matching branch)', () => {
     expect(getConsumerAgreementVersionAlertSpec({ ...baseArgs, state: 'ARCHIVING' })).toEqual([])
+  })
+})
+
+describe('getRequesterObsoleteVersionAgreement', () => {
+  it('returns no blocking agreement and no upgradeable id when the list is empty', () => {
+    expect(getRequesterObsoleteVersionAgreement([], 'organizationId')).toEqual({
+      hasBlockingAgreement: false,
+      upgradeableAgreementId: undefined,
+    })
+  })
+
+  it('ignores agreements that belong to other organizations', () => {
+    const result = getRequesterObsoleteVersionAgreement(
+      [
+        createMockAgreementListingItem({
+          id: 'other-id',
+          consumer: { id: 'another-org' },
+          state: 'ACTIVE',
+          canBeUpgraded: true,
+        }),
+      ],
+      'organizationId'
+    )
+    expect(result).toEqual({ hasBlockingAgreement: false, upgradeableAgreementId: undefined })
+  })
+
+  it('flags a blocking agreement when the requester has a non archived/rejected agreement', () => {
+    const result = getRequesterObsoleteVersionAgreement(
+      [
+        createMockAgreementListingItem({
+          id: 'agreement-id',
+          consumer: { id: 'organizationId' },
+          state: 'ACTIVE',
+          canBeUpgraded: false,
+        }),
+      ],
+      'organizationId'
+    )
+    expect(result).toEqual({ hasBlockingAgreement: true, upgradeableAgreementId: undefined })
+  })
+
+  it('does not flag a blocking agreement when the requester only has archived or rejected agreements', () => {
+    const result = getRequesterObsoleteVersionAgreement(
+      [
+        createMockAgreementListingItem({
+          id: 'archived-id',
+          consumer: { id: 'organizationId' },
+          state: 'ARCHIVED',
+          canBeUpgraded: false,
+        }),
+        createMockAgreementListingItem({
+          id: 'rejected-id',
+          consumer: { id: 'organizationId' },
+          state: 'REJECTED',
+          canBeUpgraded: false,
+        }),
+      ],
+      'organizationId'
+    )
+    expect(result).toEqual({ hasBlockingAgreement: false, upgradeableAgreementId: undefined })
+  })
+
+  it('returns the id of the requester upgradeable agreement', () => {
+    const result = getRequesterObsoleteVersionAgreement(
+      [
+        createMockAgreementListingItem({
+          id: 'upgradeable-id',
+          consumer: { id: 'organizationId' },
+          state: 'ACTIVE',
+          canBeUpgraded: true,
+        }),
+      ],
+      'organizationId'
+    )
+    expect(result).toEqual({
+      hasBlockingAgreement: true,
+      upgradeableAgreementId: 'upgradeable-id',
+    })
+  })
+
+  it('does not select a canBeUpgraded agreement whose state is not ACTIVE or SUSPENDED', () => {
+    const result = getRequesterObsoleteVersionAgreement(
+      [
+        createMockAgreementListingItem({
+          id: 'draft-id',
+          consumer: { id: 'organizationId' },
+          state: 'DRAFT',
+          canBeUpgraded: true,
+        }),
+      ],
+      'organizationId'
+    )
+    expect(result).toEqual({ hasBlockingAgreement: true, upgradeableAgreementId: undefined })
   })
 })

--- a/src/utils/agreement.utils.ts
+++ b/src/utils/agreement.utils.ts
@@ -99,10 +99,10 @@ export const canAgreementBeUpgraded = (agreement?: Agreement) => {
 
 export function getRequesterObsoleteVersionAgreement(
   consumerAgreements: AgreementListEntry[],
-  requesterId: string | undefined
+  requesterTenantId: string | undefined
 ): { hasBlockingAgreement: boolean; upgradeableAgreementId: string | undefined } {
   const ownAgreements = consumerAgreements.filter(
-    (agreement) => agreement.consumer.id === requesterId
+    (agreement) => agreement.consumer.id === requesterTenantId
   )
 
   return {

--- a/src/utils/agreement.utils.ts
+++ b/src/utils/agreement.utils.ts
@@ -1,5 +1,6 @@
 import type {
   Agreement,
+  AgreementListEntry,
   ArchivingScope,
   CatalogDescriptorEService,
   CatalogEServiceDescriptor,
@@ -94,6 +95,24 @@ export const canAgreementBeUpgraded = (agreement?: Agreement) => {
   const isAgreementActiveOrSuspended = ['ACTIVE', 'SUSPENDED'].includes(agreement.state)
 
   return hasNewVersion && isActiveDescriptorPublishedOrSuspended && isAgreementActiveOrSuspended
+}
+
+export function getRequesterObsoleteVersionAgreement(
+  consumerAgreements: AgreementListEntry[],
+  requesterId: string | undefined
+): { hasBlockingAgreement: boolean; upgradeableAgreementId: string | undefined } {
+  const ownAgreements = consumerAgreements.filter(
+    (agreement) => agreement.consumer.id === requesterId
+  )
+
+  return {
+    hasBlockingAgreement: ownAgreements.some(
+      (agreement) => agreement.state !== 'ARCHIVED' && agreement.state !== 'REJECTED'
+    ),
+    upgradeableAgreementId: ownAgreements.find(
+      (agreement) => agreement.canBeUpgraded && ['ACTIVE', 'SUSPENDED'].includes(agreement.state)
+    )?.id,
+  }
 }
 
 /**


### PR DESCRIPTION
## 🔗 Issue

[PIN-10396](https://pagopa.atlassian.net/browse/PIN-10396)

## 📝 Description / Context

In the consumer e-service catalog detail, "Richiedi fruizione" was enabled even when the requester already had an agreement for that e-service on an obsolete descriptor version, so clicking it returned a `409 Agreement already exists`. Root cause: the catalog descriptor payload of the active version does not expose agreements that live on older descriptor versions (`agreements: []`, `isSubscribed: false`), so the action logic computed "no agreement → can subscribe". The signal that an upgradeable agreement exists lives only in the `GET /consumers/agreements` response (`canBeUpgraded`). Per the "Fruitore di versione obsoleta" design, in this state the correct primary action is "Aggiorna a nuova versione", reusing the existing agreement upgrade flow, instead of a new fruition request.

## 🛠 List of changes

- `ConsumerEServiceDetails.page.tsx`: fetch the requester's agreements for the e-service, derive whether a blocking agreement exists and which one is upgradeable, and (only when needed) fetch the full agreement plus attribute ownership for the upgrade dialog; the subscribe action is suppressed while that query is still loading to avoid a brief wrong state.
- `useGetEServiceConsumerActions.ts`: new `requesterEserviceAgreement` input that suppresses "Richiedi fruizione" when a blocking agreement exists and adds the "Aggiorna a nuova versione" action (reuses the `upgradeAgreementVersion` dialog and the `Update` icon, disabled with a tooltip when certified attributes are missing); the subscribe action is preserved for delegators without an agreement.
- `agreement.utils.ts`: new `getRequesterObsoleteVersionAgreement` helper that flags a blocking agreement and picks the upgradeable one only when its state is `ACTIVE`/`SUSPENDED`, consistent with the agreements list.
- New i18n key `tableEServiceCatalog.upgradeToNewVersion` (it/en).
- Unit tests for the new hook branches and the helper.

## 🧪 How to test

- As a consumer that already holds an active agreement on an older version of an e-service, open that e-service from the catalog on its active (newer) version: the primary action is "Aggiorna a nuova versione" and clicking it opens the upgrade dialog (no more `409`).
- For an e-service where you have no agreement, "Richiedi fruizione" still appears as before.
- For a delegator without an agreement, the subscribe action still shows as a secondary button alongside the upgrade action.

---
<img width="1440" height="900" alt="PIN-10396-upgrade-action" src="https://github.com/user-attachments/assets/8ba3f03e-1f30-4d7f-af3e-7bc221ac41ef" />


[PIN-10396]: https://pagopa.atlassian.net/browse/PIN-10396
