### PR TITLE
fix: PIN-10395 align version-archiving dialog copy to Figma reference

### DIFF
--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -675,7 +675,7 @@
       "intro": "What suspension does:",
       "bullets": {
         "suspended": "the version cannot be used and will remain suspended until reactivated;",
-        "archivingNotAffected": "suspension <strong>does not change</strong> the ongoing archival of this version and <strong>does not interrupt</strong> the notice period;",
+        "archivingNotAffected": "suspension <strong>does not change</strong> and <strong>does not interrupt</strong> the ongoing archival of this version;",
         "archivedAfterNotice": "once the notice period elapses, the version will be permanently archived."
       }
     },
@@ -684,7 +684,7 @@
       "intro": "What reactivation does:",
       "bullets": {
         "usableAgain": "the version becomes usable again, while remaining under archival;",
-        "archivingNotAffected": "reactivation <strong>does not change</strong> the ongoing archival of this version and <strong>does not interrupt</strong> the notice period;",
+        "archivingNotAffected": "reactivation <strong>does not change</strong> and <strong>does not interrupt</strong> the ongoing archival of this version;",
         "archivedAfterNotice": "once the notice period elapses, the version will be permanently archived."
       },
       "proceedLabel": "Reactivate"

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -675,7 +675,7 @@
       "intro": "Cosa succede con la sospensione:",
       "bullets": {
         "suspended": "la versione non potrà essere utilizzata e resterà sospesa fino a un’eventuale riattivazione;",
-        "archivingNotAffected": "la sospensione <strong>non modifica</strong> l’archiviazione già avviata per questa versione e <strong>non interrompe</strong> il periodo di preavviso;",
+        "archivingNotAffected": "la sospensione <strong>non modifica</strong> e <strong>non interrompe</strong> l’archiviazione già avviata per questa versione;",
         "archivedAfterNotice": "dopo il periodo di preavviso, la versione sarà archiviata definitivamente."
       }
     },
@@ -684,7 +684,7 @@
       "intro": "Cosa succede con la riattivazione:",
       "bullets": {
         "usableAgain": "la versione torna a essere utilizzabile, pur restando in fase di archiviazione;",
-        "archivingNotAffected": "la riattivazione <strong>non modifica</strong> l’archiviazione già avviata per questa versione e <strong>non interrompe</strong> il periodo di preavviso;",
+        "archivingNotAffected": "la riattivazione <strong>non modifica</strong> e <strong>non interrompe</strong> l’archiviazione già avviata per questa versione;",
         "archivedAfterNotice": "dopo il periodo di preavviso, la versione sarà archiviata definitivamente."
       },
       "proceedLabel": "Riattiva"


### PR DESCRIPTION
## 🔗 Issue

[PIN-10395](https://pagopa.atlassian.net/browse/PIN-10395)

## 📝 Description / Context

The two version-level archiving dialogs, "Sospendi versione in fase di archiviazione" and "Riattiva versione in fase di archiviazione", showed a second bullet phrased differently from the Figma reference (same meaning, different wording). This aligns that bullet to Figma: the two bold verbs are merged and the "notice period" clause is dropped, so both verbs apply to "l'archiviazione già avviata per questa versione".

Scope is limited to the descriptor-level dialogs flagged in PIN-10395. The e-service-level twins ("Sospendi/Riattiva versione di e-service in fase di archiviazione") are intentionally left untouched: they are tracked separately in PIN-10403, which also asks for a second wording change on the third bullet.

## 🛠 List of changes

- `it/eservice.json` and `en/eservice.json`: reworded `dialogSuspendArchivingDescriptor.bullets.archivingNotAffected` and `dialogReactivateArchivingDescriptor.bullets.archivingNotAffected` to match the Figma copy. The English bullets mirror the approved Italian change structurally.

## 🧪 How to test

- As a provider, open an e-service version that is being archived ("in fase di archiviazione", still active), then trigger "Sospendi versione": the dialog's second bullet should read "la sospensione non modifica e non interrompe l'archiviazione già avviata per questa versione;".
- For a version in the archiving-suspended state, trigger "Riattiva versione": the second bullet should read "la riattivazione non modifica e non interrompe l'archiviazione già avviata per questa versione;".

<img width="640" height="358" alt="PIN-10395-reactivate-archiving-dialog" src="https://github.com/user-attachments/assets/cb20fb02-f796-45ab-926f-df23da9b5708" />

<img width="640" height="358" alt="PIN-10395-suspend-archiving-dialog" src="https://github.com/user-attachments/assets/8dfb5606-e5b9-4ebd-ad06-6cd85931fa76" />


[PIN-10395]: https://pagopa.atlassian.net/browse/PIN-10395
