### PR TITLE
fix: PIN-10400 add line break in archive e-service dialog copy

### DIFF
--- a/src/components/dialogs/DialogArchiveEservice.tsx
+++ b/src/components/dialogs/DialogArchiveEservice.tsx
@@ -70,7 +70,7 @@ const DialogArchiveEservice: React.FC<DialogArchiveEserviceProps> = ({ eserviceI
       <FormProvider {...formMethods}>
         <DialogContent>
           {activeStep === 'ADVISE' && (
-            <Typography variant="body2">
+            <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>
               <Trans
                 components={{
                   strong: <Typography component="span" variant="inherit" fontWeight={600} />,

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -306,7 +306,7 @@
     "title": "Archive e-service",
     "content": {
       "advice": {
-        "description": "By archiving the e-service, all versions will be archived and draft versions will be deleted. If you confirm this choice, archiving will occur on <strong>{{date}}</strong>. Before this date, the e-service will remain active to allow users to adapt. You can cancel archiving only before this date."
+        "description": "By archiving the e-service, all versions will be archived and draft versions will be deleted.\nIf you confirm this choice, archiving will occur on <strong>{{date}}</strong>. Before this date, the e-service will remain active to allow users to adapt. You can cancel archiving only before this date."
       },
       "confirm": {
         "description": "All users will be informed of the notice period and the reason for the archiving.",

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -306,7 +306,7 @@
     "title": "Archivia e-service",
     "content": {
       "advice": {
-        "description": "Con l’archiviazione dell’e-service, tutte le sue versioni saranno archiviate e quelle in bozza eliminate.Se confermi questa scelta, l’archiviazione avverrà il giorno <strong>{{date}}</strong>. Prima di questa data, l’e-service resterà attivo per consentire ai fruitori di adeguarsi. Potrai annullare l’archiviazione solo prima di questa data."
+        "description": "Con l’archiviazione dell’e-service, tutte le sue versioni saranno archiviate e quelle in bozza eliminate.\nSe confermi questa scelta, l’archiviazione avverrà il giorno <strong>{{date}}</strong>. Prima di questa data, l’e-service resterà attivo per consentire ai fruitori di adeguarsi. Potrai annullare l’archiviazione solo prima di questa data."
       },
       "confirm": {
         "description": "Tutti i fruitori saranno informati sul periodo di preavviso e sul motivo dell’archiviazione.",


### PR DESCRIPTION
## 🔗 Issue

[PIN-10400](https://pagopa.atlassian.net/browse/PIN-10400)

## 📝 Description / Context

In the "Archivia e-service" dialog, the advice paragraph rendered the first sentence's closing period glued to the next sentence ("eliminate.Se confermi"). The source string had no separator at that point, and the host `Typography` did not preserve newlines, so even a newline would have collapsed to a space. The Figma reference shows a line break there, after "…in bozza eliminate." and before "Se confermi questa scelta, …". This adds that line break in both locales and lets the dialog render it.

## 🛠 List of changes

- `it/shared-components.json` and `en/shared-components.json`: added a line break (`\n`) in `dialogArchiveEservice.content.advice.description` after the first sentence (`…eliminate.` / `…deleted.`), to match the Figma reference. The English string mirrors the Italian change for parity.
- `DialogArchiveEservice.tsx`: set `whiteSpace: 'pre-line'` on the advice `Typography` so the newline renders as a line break, consistent with how the project renders `\n` line breaks elsewhere.

## 🧪 How to test

- As a provider admin, open an active e-service and from the three-dots menu choose "Archivia e-service": the first paragraph should break after "…tutte le sue versioni saranno archiviate e quelle in bozza eliminate." with "Se confermi questa scelta, …" starting on a new line.
- Switch the UI to English and repeat: the paragraph should break after "…draft versions will be deleted." with "If you confirm this choice, …" on a new line.

---

<img width="640" height="414" alt="PIN-10400-archive-eservice-dialog-en" src="https://github.com/user-attachments/assets/8e4cf62e-e453-4e3b-ac8a-8f97f7538fbe" />

<img width="640" height="436" alt="PIN-10400-archive-eservice-dialog-it" src="https://github.com/user-attachments/assets/4fbfe76d-43b7-42c7-94c1-6891c7f8cc29" />



[PIN-10400]: https://pagopa.atlassian.net/browse/PIN-10400
