### PR TITLE
fix: PIN-10403 align e-service archiving dialog copy to Figma reference

### DIFF
--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -656,8 +656,8 @@
       "intro": "What happens with the suspension:",
       "bullets": {
         "suspended": "the version will not be usable and will remain inactive until any reactivation;",
-        "archivingNotAffected": "the suspension <strong>does not modify</strong> the archiving already started for the e-service and <strong>does not interrupt</strong> the notice period;",
-        "archivedAfterNotice": "after the notice period, the e-service and all its versions will be permanently archived."
+        "archivingNotAffected": "the suspension <strong>does not modify</strong> and <strong>does not interrupt</strong> the archiving already started for the e-service;",
+        "archivedAfterNotice": "after archiving, you will no longer be able to reactivate the e-service and all its versions."
       }
     },
     "dialogReactivateArchivingEservice": {
@@ -665,8 +665,8 @@
       "intro": "What happens with the reactivation:",
       "bullets": {
         "usableAgain": "the version becomes usable again, but the e-service remains in the archiving phase;",
-        "archivingNotAffected": "the reactivation <strong>does not modify</strong> the archiving already started for the e-service and <strong>does not interrupt</strong> the notice period;",
-        "archivedAfterNotice": "after the notice period, the e-service and all its versions will be permanently archived."
+        "archivingNotAffected": "the reactivation <strong>does not modify</strong> and <strong>does not interrupt</strong> the archiving already started for the e-service;",
+        "archivedAfterNotice": "after archiving, you will no longer be able to reactivate the e-service and all its versions."
       },
       "proceedLabel": "Reactivate"
     },

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -656,8 +656,8 @@
       "intro": "Cosa succede con la sospensione:",
       "bullets": {
         "suspended": "la versione non potrà essere utilizzata e resterà disattiva fino a un’eventuale riattivazione;",
-        "archivingNotAffected": "la sospensione <strong>non modifica</strong> l’archiviazione già avviata per l’e-service e <strong>non interrompe</strong> il periodo di preavviso;",
-        "archivedAfterNotice": "dopo il periodo di preavviso, l’e-service e tutte le sue versioni saranno archiviate definitivamente."
+        "archivingNotAffected": "la sospensione <strong>non modifica</strong> e <strong>non interrompe</strong> l’archiviazione già avviata per l’e-service;",
+        "archivedAfterNotice": "dopo l’archiviazione, non potrai più riattivare l’e-service e tutte le sue versioni."
       }
     },
     "dialogReactivateArchivingEservice": {
@@ -665,8 +665,8 @@
       "intro": "Cosa succede con la riattivazione:",
       "bullets": {
         "usableAgain": "la versione torna a essere utilizzabile, ma l’e-service resta in fase di archiviazione;",
-        "archivingNotAffected": "la riattivazione <strong>non modifica</strong> l’archiviazione già avviata per l’e-service e <strong>non interrompe</strong> il periodo di preavviso;",
-        "archivedAfterNotice": "dopo il periodo di preavviso, l’e-service e tutte le sue versioni saranno archiviate definitivamente."
+        "archivingNotAffected": "la riattivazione <strong>non modifica</strong> e <strong>non interrompe</strong> l’archiviazione già avviata per l’e-service;",
+        "archivedAfterNotice": "dopo l’archiviazione, non potrai più riattivare l’e-service e tutte le sue versioni."
       },
       "proceedLabel": "Riattiva"
     },


### PR DESCRIPTION
## 🔗 Issue

[PIN-10403](https://pagopa.atlassian.net/browse/PIN-10403)

## 📝 Description / Context

The two e-service-level archiving dialogs, "Sospendi versione di e-service in fase di archiviazione" and "Riattiva versione di e-service in fase di archiviazione", showed two bullets worded differently from the Figma reference (same meaning, different wording). The second bullet stated the two bold verbs separately and mentioned the "periodo di preavviso"; the third bullet described permanent archiving "dopo il periodo di preavviso". This aligns both to Figma: the second bullet merges the two bold verbs onto "l'archiviazione già avviata per l'e-service", and the third bullet is replaced with the new sentence about no longer being able to reactivate after archiving.

Scope is limited to the e-service-level dialogs flagged in PIN-10403. The descriptor-level twins ("Sospendi/Riattiva versione in fase di archiviazione") are tracked separately in [PIN-10395](https://pagopa.atlassian.net/browse/PIN-10395) and are intentionally left untouched here.

## 🛠 List of changes

- `it/eservice.json` and `en/eservice.json`: reworded `bullets.archivingNotAffected` (second bullet) and `bullets.archivedAfterNotice` (third bullet) under `dialogSuspendArchivingEservice` and `dialogReactivateArchivingEservice` to match the Figma copy. The English bullets mirror the approved Italian change (second bullet is a rearrangement of the existing words, third bullet is a translation of the new sentence).

## 🧪 How to test

- As a provider admin, with an e-service whose archiving has been started at e-service scope, trigger "Sospendi versione" on the active version: in "Sospendi versione di e-service in fase di archiviazione" the second bullet reads "la sospensione non modifica e non interrompe l'archiviazione già avviata per l'e-service;" and the third reads "dopo l'archiviazione, non potrai più riattivare l'e-service e tutte le sue versioni.".
- Trigger "Riattiva versione" on a version in the archiving-suspended state: in "Riattiva versione di e-service in fase di archiviazione" the second bullet reads "la riattivazione non modifica e non interrompe l'archiviazione già avviata per l'e-service;" and the third matches the suspend dialog.

<img width="640" height="384" alt="PIN-10403-suspend-archiving-eservice-it" src="https://github.com/user-attachments/assets/1531da73-0d69-4c95-a952-e1336cb78267" />

<img width="640" height="384" alt="PIN-10403-suspend-archiving-eservice-en" src="https://github.com/user-attachments/assets/b35a7608-6a89-4abf-9ac5-22e7992259dc" />

<img width="640" height="384" alt="PIN-10403-reactivate-archiving-eservice-it" src="https://github.com/user-attachments/assets/f9870bf9-a5f4-4aaf-9b79-b408b92dfaf0" />

<img width="640" height="384" alt="PIN-10403-reactivate-archiving-eservice-en" src="https://github.com/user-attachments/assets/fc19d0ad-dde7-48e2-87c2-afa60409743d" />


[PIN-10403]: https://pagopa.atlassian.net/browse/PIN-10403


[PIN-10395]: https://pagopa.atlassian.net/browse/PIN-10395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ