### PR TITLE
fix: align archived e-service version alert copy to Figma reference (PIN-10411)

### DIFF
--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -643,6 +643,7 @@
       "archivingEService": "This e-service is being archived but is still active. It will be automatically archived on {{date}}.",
       "archivingSuspendedDescriptor": "This e-service version is being archived and is currently suspended. It will be automatically archived on {{date}}.",
       "archivedDescriptor": "This e-service version was archived on {{date}}.",
+      "archivedDescriptorNoConsumers": "This version is archived. No consumer can access the data provided.",
       "archivingSuspendedEService": "This version is currently suspended. The e-service is being archived and will be automatically archived on {{date}}.",
       "archivedEService": "This e-service was permanently archived on {{date}}.",
       "missingProducerKeychain": "The producer has not linked the keychain to this async e-service yet. Data exchange is currently unavailable.",

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -643,6 +643,7 @@
       "archivingEService": "Questo e-service è in fase di archiviazione, ma è ancora attivo. Sarà archiviato automaticamente il giorno {{date}}.",
       "archivingSuspendedDescriptor": "Questa versione dell’e-service è in fase di archiviazione ed è al momento sospesa. Sarà archiviata automaticamente il giorno {{date}}.",
       "archivedDescriptor": "Questa versione dell’e-service è stata archiviata il giorno {{date}}.",
+      "archivedDescriptorNoConsumers": "Questa versione è archiviata. Nessun fruitore può accedere ai dati erogati.",
       "archivingSuspendedEService": "Questa versione è al momento sospesa. L’e-service è in fase di archiviazione e sarà archiviato automaticamente il giorno {{date}}.",
       "archivedEService": "Questo e-service è stato archiviato definitivamente il giorno {{date}}.",
       "missingProducerKeychain": "L’erogatore non ha ancora collegato il portachiavi a questo e-service asincrono. Lo scambio dati non è al momento disponibile.",

--- a/src/utils/__tests__/eservice.utils.test.ts
+++ b/src/utils/__tests__/eservice.utils.test.ts
@@ -250,30 +250,28 @@ describe('getEServiceDescriptorAlertSpec utility function testing', () => {
     })
   })
 
-  it('returns info archivedDescriptor for ARCHIVED with scope DESCRIPTOR (default branch)', () => {
+  it('returns info archivedDescriptorNoConsumers for ARCHIVED with scope DESCRIPTOR (default branch)', () => {
     expect(
       getEServiceDescriptorAlertSpec({
         ...baseArgs,
         state: 'ARCHIVED',
         scope: 'DESCRIPTOR',
-        archivedAt: '2026-12-01T00:00:00.000Z',
       })
     ).toEqual({
       severity: 'info',
-      content: expect.stringMatching(/^archivedDescriptor:.+/),
+      content: 'archivedDescriptorNoConsumers',
     })
   })
 
-  it('returns info archivedDescriptor for ARCHIVED with no scope (default branch fallback)', () => {
+  it('returns info archivedDescriptorNoConsumers for ARCHIVED with no scope (default branch fallback)', () => {
     expect(
       getEServiceDescriptorAlertSpec({
         ...baseArgs,
         state: 'ARCHIVED',
-        archivedAt: '2026-12-01T00:00:00.000Z',
       })
     ).toEqual({
       severity: 'info',
-      content: expect.stringMatching(/^archivedDescriptor:.+/),
+      content: 'archivedDescriptorNoConsumers',
     })
   })
 

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -126,7 +126,7 @@ export function getEServiceDescriptorAlertSpec(args: {
     }))
     .with({ state: 'ARCHIVED' }, () => ({
       severity: 'info',
-      content: t('archivedDescriptor', { date: archivedDate }),
+      content: t('archivedDescriptorNoConsumers'),
     }))
     .otherwise(() => undefined)
 }


### PR DESCRIPTION
## 🔗 Issue

[PIN-10411](https://pagopa.atlassian.net/browse/PIN-10411)

## 📝 Description / Context

When an e-service version is automatically archived (no consumers and a newer version published), the provider e-service detail page showed the archived-version alert with a date-based message ("Questa versione dell'e-service è stata archiviata il giorno X."), which differs from the Figma reference. Figma replaces it with a consequence-based, date-less message: "Questa versione è archiviata. Nessun fruitore può accedere ai dati erogati."

The existing `read.alert.archivedDescriptor` key is also reused by the combined alert that fires when an archived version is shown while the e-service itself is still being archived (it concatenates the dated sentence with the "e-service is being archived" one). To leave that combined alert untouched, the new copy lives in a dedicated key applied only to the standalone archived-version alert.

## 🛠 List of changes

- Added `read.alert.archivedDescriptorNoConsumers` to `it/eservice.json` and `en/eservice.json` with the new Figma copy (the English string mirrors the approved Italian one).
- `getEServiceDescriptorAlertSpec` (`src/utils/eservice.utils.ts`): the standalone `ARCHIVED` arm now renders `archivedDescriptorNoConsumers` (no date); the combined `ARCHIVED + isEServiceBeingArchived` arm and the `archivedEService` arm are intentionally unchanged.
- Updated the two unit tests covering the standalone `ARCHIVED` arm to assert the new key.

## 🧪 How to test

- As a provider admin, open an e-service whose version is archived (e.g. a version automatically archived after a newer one was published): the info alert on the e-service detail page reads "Questa versione è archiviata. Nessun fruitore può accedere ai dati erogati." (EN: "This version is archived. No consumer can access the data provided.").
- The combined case (an archived version shown while the e-service is still being archived) keeps its current dated message.

---

<img width="1200" height="942" alt="PIN-10411-archived-version-alert-it" src="https://github.com/user-attachments/assets/af7a79cc-0dc7-4ce4-8296-2c6a82d21fd4" />

<img width="1200" height="942" alt="PIN-10411-archived-version-alert-en" src="https://github.com/user-attachments/assets/091f5a62-82af-4b95-9b4f-7f971eadfdc2" />



[PIN-10411]: https://pagopa.atlassian.net/browse/PIN-10411
