### PR TITLE
fix: hidden purpose alert if user is viewer (PIN-10424)

### DIFF
--- a/src/pages/ConsumerAgreementDetailsPage/hooks/__test__/useGetConsumerAgreementAlertProps.test.ts
+++ b/src/pages/ConsumerAgreementDetailsPage/hooks/__test__/useGetConsumerAgreementAlertProps.test.ts
@@ -1,5 +1,5 @@
 import type { Agreement, Purpose } from '@/api/api.generatedTypes'
-import { renderHookWithApplicationContext } from '@/utils/testing.utils'
+import { mockUseJwt, renderHookWithApplicationContext } from '@/utils/testing.utils'
 import { useGetConsumerAgreementAlertProps } from '../useGetConsumerAgreementAlertProps'
 import { createMockAgreement } from '../../../../../__mocks__/data/agreement.mocks'
 import { waitFor } from '@testing-library/react'
@@ -35,6 +35,11 @@ function renderUseGetConsumerAgreementAlertPropsHook(agreementMock: Agreement) {
 }
 
 describe('check if useGetConsumerAgreementAlertProps returns the correct alertProps based on the passed agreement - no agreement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseJwt()
+  })
+
   it('shoud return the correct alertProps if suspended agreement with suspendedByProducer is given', () => {
     mockUseGetConsumersList([])
     const agreement = createMockAgreement({
@@ -184,6 +189,16 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
       },
     })
     mockUseGetConsumersList([purpose, purpose2])
+    const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+    expect(result.current).toBeUndefined()
+  })
+
+  it('should not return noPurpose alert if user is viewer and agreement has no purposes', () => {
+    mockUseJwt({ isViewer: true })
+    const agreement = createMockAgreement({
+      state: 'ACTIVE',
+    })
+    mockUseGetConsumersList([])
     const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
     expect(result.current).toBeUndefined()
   })

--- a/src/pages/ConsumerAgreementDetailsPage/hooks/__test__/useGetConsumerAgreementAlertProps.test.ts
+++ b/src/pages/ConsumerAgreementDetailsPage/hooks/__test__/useGetConsumerAgreementAlertProps.test.ts
@@ -34,12 +34,9 @@ function renderUseGetConsumerAgreementAlertPropsHook(agreementMock: Agreement) {
   })
 }
 
-describe('check if useGetConsumerAgreementAlertProps returns the correct alertProps based on the passed agreement - no agreement', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mockUseJwt()
-  })
+mockUseJwt()
 
+describe('check if useGetConsumerAgreementAlertProps returns the correct alertProps based on the passed agreement - no agreement', () => {
   it('shoud return the correct alertProps if suspended agreement with suspendedByProducer is given', () => {
     mockUseGetConsumersList([])
     const agreement = createMockAgreement({

--- a/src/pages/ConsumerAgreementDetailsPage/hooks/useGetConsumerAgreementAlertProps.ts
+++ b/src/pages/ConsumerAgreementDetailsPage/hooks/useGetConsumerAgreementAlertProps.ts
@@ -1,4 +1,5 @@
 import type { Agreement } from '@/api/api.generatedTypes'
+import { AuthHooks } from '@/api/auth'
 import { PurposeQueries } from '@/api/purpose'
 import type { Link, RouteKey } from '@/router'
 import type { AlertProps } from '@mui/material'
@@ -17,6 +18,7 @@ export function useGetConsumerAgreementAlertProps(agreement: Agreement):
     }
   | undefined {
   const { t } = useTranslation('agreement')
+  const { isViewer } = AuthHooks.useJwt()
 
   const { data: purposes } = useQuery({
     ...PurposeQueries.getConsumersList({
@@ -53,7 +55,7 @@ export function useGetConsumerAgreementAlertProps(agreement: Agreement):
     purposes?.results.length === 0 ||
     purposes?.results.every((purpose) => purpose.currentVersion?.state === 'ARCHIVED')
 
-  if (isWithoutPurposes) {
+  if (isWithoutPurposes && !isViewer) {
     return {
       severity: 'info',
       content: t('consumerRead.noPurposeAlert'),


### PR DESCRIPTION
## Issue
- [PIN-10424](https://pagopa.atlassian.net/browse/PIN-10424)
## Description / Context / Why
- Hidden purpose alert if user is viewer
- Updated tests

[PIN-10424]: https://pagopa.atlassian.net/browse/PIN-10424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ