### PR TITLE
fix: hide "create first purpose" consumer banner when the e-service is being archived (PIN-10429)

### DIFF
--- a/src/pages/ConsumerAgreementDetailsPage/hooks/__test__/useGetConsumerAgreementAlertProps.test.ts
+++ b/src/pages/ConsumerAgreementDetailsPage/hooks/__test__/useGetConsumerAgreementAlertProps.test.ts
@@ -1,4 +1,4 @@
-import type { Agreement, Purpose } from '@/api/api.generatedTypes'
+import type { Agreement, EServiceDescriptorState, Purpose } from '@/api/api.generatedTypes'
 import { renderHookWithApplicationContext } from '@/utils/testing.utils'
 import { useGetConsumerAgreementAlertProps } from '../useGetConsumerAgreementAlertProps'
 import { createMockAgreement } from '../../../../../__mocks__/data/agreement.mocks'
@@ -166,6 +166,23 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
       expect(result.current?.link?.to).toBe('SUBSCRIBE_PURPOSE_CREATE')
     })
   })
+
+  it.each<EServiceDescriptorState>(['ARCHIVING', 'ARCHIVING_SUSPENDED'])(
+    'shoud not return the noPurposeAlert when the e-service is being archived (active descriptor state %s), even without purposes',
+    (activeDescriptorState) => {
+      const agreement = createMockAgreement({
+        state: 'ACTIVE',
+        eservice: {
+          activeDescriptor: {
+            state: activeDescriptorState,
+          },
+        },
+      })
+      mockUseGetConsumersList([])
+      const { result } = renderUseGetConsumerAgreementAlertPropsHook(agreement)
+      expect(result.current).toBeUndefined()
+    }
+  )
 
   it('shoud not return any alertProps if nor suspended or missing certified attributes agreement is given and the agreement has purposes that are not all archived', () => {
     const agreement = createMockAgreement({

--- a/src/pages/ConsumerAgreementDetailsPage/hooks/__test__/useGetConsumerAgreementAlertProps.test.ts
+++ b/src/pages/ConsumerAgreementDetailsPage/hooks/__test__/useGetConsumerAgreementAlertProps.test.ts
@@ -35,7 +35,7 @@ function renderUseGetConsumerAgreementAlertPropsHook(agreementMock: Agreement) {
 }
 
 describe('check if useGetConsumerAgreementAlertProps returns the correct alertProps based on the passed agreement - no agreement', () => {
-  it('shoud return the correct alertProps if suspended agreement with suspendedByProducer is given', () => {
+  it('should return the correct alertProps if suspended agreement with suspendedByProducer is given', () => {
     mockUseGetConsumersList([])
     const agreement = createMockAgreement({
       state: 'SUSPENDED',
@@ -48,7 +48,7 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
     expect(result.current?.content).toBe('consumerRead.suspendedAlert.byProducer')
   })
 
-  it('shoud return the correct alertProps if suspended agreement with suspendedByConsumer is given', () => {
+  it('should return the correct alertProps if suspended agreement with suspendedByConsumer is given', () => {
     const agreement = createMockAgreement({
       state: 'SUSPENDED',
       suspendedByProducer: false,
@@ -60,7 +60,7 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
     expect(result.current?.content).toBe('consumerRead.suspendedAlert.byConsumer')
   })
 
-  it('shoud return the correct alertProps if suspended agreement with suspendedByPlatform is given', () => {
+  it('should return the correct alertProps if suspended agreement with suspendedByPlatform is given', () => {
     const agreement = createMockAgreement({
       state: 'SUSPENDED',
       suspendedByProducer: false,
@@ -72,7 +72,7 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
     expect(result.current?.content).toBe('consumerRead.suspendedAlert.byPlatform')
   })
 
-  it('shoud return the correct alertProps if suspended agreement with every suspendedBy is given', () => {
+  it('should return the correct alertProps if suspended agreement with every suspendedBy is given', () => {
     const agreement = createMockAgreement({
       state: 'SUSPENDED',
       suspendedByProducer: true,
@@ -84,7 +84,7 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
     expect(result.current?.content).toBe('consumerRead.suspendedAlert.byProducer')
   })
 
-  it('shoud return the correct alertProps if suspended agreement with only suspendedByProducer and suspendedByPlatform is given', () => {
+  it('should return the correct alertProps if suspended agreement with only suspendedByProducer and suspendedByPlatform is given', () => {
     const agreement = createMockAgreement({
       state: 'SUSPENDED',
       suspendedByProducer: true,
@@ -96,7 +96,7 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
     expect(result.current?.content).toBe('consumerRead.suspendedAlert.byProducer')
   })
 
-  it('shoud return the correct alertProps if suspended agreement with only suspendedByProducer and suspendedByConsumer is given', () => {
+  it('should return the correct alertProps if suspended agreement with only suspendedByProducer and suspendedByConsumer is given', () => {
     const agreement = createMockAgreement({
       state: 'SUSPENDED',
       suspendedByProducer: true,
@@ -108,7 +108,7 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
     expect(result.current?.content).toBe('consumerRead.suspendedAlert.byProducer')
   })
 
-  it('shoud return the correct alertProps if suspended agreement with only suspendedByConsumer and suspendedByPlatform is given', () => {
+  it('should return the correct alertProps if suspended agreement with only suspendedByConsumer and suspendedByPlatform is given', () => {
     const agreement = createMockAgreement({
       state: 'SUSPENDED',
       suspendedByProducer: false,
@@ -120,7 +120,7 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
     expect(result.current?.content).toBe('consumerRead.suspendedAlert.byConsumer')
   })
 
-  it('shoud return the correct alertProps if missing certified attributes agreement is given', () => {
+  it('should return the correct alertProps if missing certified attributes agreement is given', () => {
     const agreement = createMockAgreement({
       state: 'MISSING_CERTIFIED_ATTRIBUTES',
     })
@@ -129,7 +129,7 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
     expect(result.current?.content).toBe('consumerRead.missingCertifiedAttributesAlert')
   })
 
-  it('shoud return the correct alertProps if nor suspended or missing certified attributes agreement is given and that agreement has not purposes', async () => {
+  it('should return the correct alertProps if neither suspended nor missing certified attributes agreement is given and that agreement has no purposes', async () => {
     const agreement = createMockAgreement({
       state: 'ACTIVE',
     })
@@ -142,7 +142,7 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
     })
   })
 
-  it('shoud return the correct alertProps if nor suspended or missing certified attributes agreement is given and that agreement has only archived purposes', async () => {
+  it('should return the correct alertProps if neither suspended nor missing certified attributes agreement is given and that agreement has only archived purposes', async () => {
     const agreement = createMockAgreement({
       state: 'ACTIVE',
     })
@@ -167,8 +167,8 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
     })
   })
 
-  it.each<EServiceDescriptorState>(['ARCHIVING', 'ARCHIVING_SUSPENDED'])(
-    'shoud not return the noPurposeAlert when the e-service is being archived (active descriptor state %s), even without purposes',
+  it.each<EServiceDescriptorState>(['ARCHIVING', 'ARCHIVING_SUSPENDED', 'ARCHIVED'])(
+    'should not return the noPurposeAlert when the e-service is archived or being archived (active descriptor state %s), even without purposes',
     (activeDescriptorState) => {
       const agreement = createMockAgreement({
         state: 'ACTIVE',
@@ -184,7 +184,7 @@ describe('check if useGetConsumerAgreementAlertProps returns the correct alertPr
     }
   )
 
-  it('shoud not return any alertProps if nor suspended or missing certified attributes agreement is given and the agreement has purposes that are not all archived', () => {
+  it('should not return any alertProps if neither suspended nor missing certified attributes agreement is given and the agreement has purposes that are not all archived', () => {
     const agreement = createMockAgreement({
       state: 'ACTIVE',
     })

--- a/src/pages/ConsumerAgreementDetailsPage/hooks/useGetConsumerAgreementAlertProps.ts
+++ b/src/pages/ConsumerAgreementDetailsPage/hooks/useGetConsumerAgreementAlertProps.ts
@@ -1,6 +1,7 @@
 import type { Agreement } from '@/api/api.generatedTypes'
 import { PurposeQueries } from '@/api/purpose'
 import type { Link, RouteKey } from '@/router'
+import { isDescriptorPendingArchiving } from '@/utils/eservice.utils'
 import type { AlertProps } from '@mui/material'
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
@@ -53,7 +54,11 @@ export function useGetConsumerAgreementAlertProps(agreement: Agreement):
     purposes?.results.length === 0 ||
     purposes?.results.every((purpose) => purpose.currentVersion?.state === 'ARCHIVED')
 
-  if (isWithoutPurposes) {
+  const isEServiceBeingArchived = isDescriptorPendingArchiving(
+    agreement.eservice.activeDescriptor?.state
+  )
+
+  if (isWithoutPurposes && !isEServiceBeingArchived) {
     return {
       severity: 'info',
       content: t('consumerRead.noPurposeAlert'),

--- a/src/pages/ConsumerAgreementDetailsPage/hooks/useGetConsumerAgreementAlertProps.ts
+++ b/src/pages/ConsumerAgreementDetailsPage/hooks/useGetConsumerAgreementAlertProps.ts
@@ -54,11 +54,11 @@ export function useGetConsumerAgreementAlertProps(agreement: Agreement):
     purposes?.results.length === 0 ||
     purposes?.results.every((purpose) => purpose.currentVersion?.state === 'ARCHIVED')
 
-  const isEServiceBeingArchived = isDescriptorPendingArchiving(
-    agreement.eservice.activeDescriptor?.state
-  )
+  const activeDescriptorState = agreement.eservice.activeDescriptor?.state
+  const isEServiceArchivedOrArchiving =
+    isDescriptorPendingArchiving(activeDescriptorState) || activeDescriptorState === 'ARCHIVED'
 
-  if (isWithoutPurposes && !isEServiceBeingArchived) {
+  if (isWithoutPurposes && !isEServiceArchivedOrArchiving) {
     return {
       severity: 'info',
       content: t('consumerRead.noPurposeAlert'),


### PR DESCRIPTION
## 🔗 Issue

[PIN-10429](https://pagopa.atlassian.net/browse/PIN-10429)

## 📝 Description / Context

On the consumer "Gestisci richiesta di fruizione" page the blue info banner "Per accedere ai dati crea la tua prima finalità" (a CTA to create the first purpose) was shown whenever the agreement is active and the consumer has no non-archived purposes, with no check on whether the e-service itself is being archived. When the e-service as a whole is being archived a purpose can no longer be created, so the CTA is misleading and must not appear. The single-version case is different: if a version is archived while the e-service stays active (a newer version is published) subscribing is still possible, so the banner must keep showing.

## 🛠 List of changes

- `useGetConsumerAgreementAlertProps`: the `noPurposeAlert` banner is now suppressed when the e-service is being archived, detected via `isDescriptorPendingArchiving(agreement.eservice.activeDescriptor?.state)` (the same signal the provider side already uses for "e-service being archived"). The `suspended` and `missingCertifiedAttributes` alerts are left unchanged.
- Added regression tests for the `ARCHIVING` and `ARCHIVING_SUSPENDED` active-descriptor states (banner hidden), keeping the existing "no purposes" cases (active descriptor `PUBLISHED`) green.

## 🧪 How to test

- As a consumer with an active agreement and no purposes, on an e-service whose active version is being archived (whole e-service archiving): the blue "crea la tua prima finalità" banner is not shown.
- Same setup but only an older version is archiving while a newer version is published (e-service still active): the banner is still shown.
- Unit: `pnpm exec vitest run src/pages/ConsumerAgreementDetailsPage/hooks/__test__/useGetConsumerAgreementAlertProps.test.ts`

[PIN-10429]: https://pagopa.atlassian.net/browse/PIN-10429
