### PR TITLE
fix: hide associate client link for viewer role on purpose detail

### DIFF
--- a/src/pages/ConsumerPurposeDetailsPage/hooks/__tests__/useGetPurposeStateAlertProps.test.ts
+++ b/src/pages/ConsumerPurposeDetailsPage/hooks/__tests__/useGetPurposeStateAlertProps.test.ts
@@ -1,0 +1,44 @@
+import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
+import { mockUseJwt, renderHookWithApplicationContext } from '@/utils/testing.utils'
+import useGetPurposeStateAlertProps from '../useGetPurposeStateAlertProps'
+
+mockUseJwt()
+
+function renderUseGetPurposeStateAlertPropsHook(
+  ...hookArgs: Parameters<typeof useGetPurposeStateAlertProps>
+) {
+  return renderHookWithApplicationContext(() => useGetPurposeStateAlertProps(...hookArgs), {})
+}
+
+describe('useGetPurposeStateAlertProps', () => {
+  it('returns the "no clients" alert with the link to the clients tab for a non-viewer user', () => {
+    const purpose = createMockPurpose({ currentVersion: { state: 'ACTIVE' }, clients: [] })
+
+    const { result } = renderUseGetPurposeStateAlertPropsHook(purpose, true)
+
+    expect(result.current?.link).toEqual({
+      to: 'SUBSCRIBE_PURPOSE_DETAILS',
+      params: { purposeId: purpose.id },
+      options: { urlParams: { tab: 'clients' } },
+    })
+  })
+
+  it('does not return the "no clients" alert for a viewer (Consultatore) user', () => {
+    mockUseJwt({ isViewer: true })
+    const purpose = createMockPurpose({ currentVersion: { state: 'ACTIVE' }, clients: [] })
+
+    const { result } = renderUseGetPurposeStateAlertPropsHook(purpose, true)
+
+    expect(result.current).toBeUndefined()
+  })
+
+  it('still returns role-agnostic alerts (e.g. suspended) for a viewer user', () => {
+    mockUseJwt({ isViewer: true })
+    const purpose = createMockPurpose({ currentVersion: { state: 'SUSPENDED' } })
+
+    const { result } = renderUseGetPurposeStateAlertPropsHook(purpose, true)
+
+    expect(result.current?.severity).toBe('error')
+    expect(result.current?.link).toBeUndefined()
+  })
+})

--- a/src/pages/ConsumerPurposeDetailsPage/hooks/__tests__/useGetPurposeStateAlertProps.test.ts
+++ b/src/pages/ConsumerPurposeDetailsPage/hooks/__tests__/useGetPurposeStateAlertProps.test.ts
@@ -11,7 +11,7 @@ function renderUseGetPurposeStateAlertPropsHook(
 }
 
 describe('useGetPurposeStateAlertProps', () => {
-  it('returns the "no clients" alert with the link to the clients tab for a non-viewer user', () => {
+  it('returns the "no clients" alert with the link to the clients tab for user', () => {
     const purpose = createMockPurpose({ currentVersion: { state: 'ACTIVE' }, clients: [] })
 
     const { result } = renderUseGetPurposeStateAlertPropsHook(purpose, true)

--- a/src/pages/ConsumerPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
+++ b/src/pages/ConsumerPurposeDetailsPage/hooks/useGetPurposeStateAlertProps.ts
@@ -4,6 +4,7 @@ import type { AlertProps } from '@mui/material'
 import type { Link } from '@/router'
 import { useTranslation } from 'react-i18next'
 import type React from 'react'
+import { AuthHooks } from '@/api/auth'
 
 function useGetPurposeStateAlertProps(
   purpose: Purpose | undefined,
@@ -21,6 +22,7 @@ function useGetPurposeStateAlertProps(
     }
   | undefined {
   const { t } = useTranslation('purpose', { keyPrefix: 'consumerView' })
+  const { isViewer } = AuthHooks.useJwt()
 
   if (!purpose) return undefined
 
@@ -86,6 +88,7 @@ function useGetPurposeStateAlertProps(
   if (
     isPurposeActive &&
     purpose.clients.length === 0 &&
+    !isViewer &&
     !(purpose.delegation && !isEServiceClientAccessDelegable)
   ) {
     return {


### PR DESCRIPTION
## 🔗 Issue
[PIN-10425](https://pagopa.atlassian.net/browse/PIN-10425)

## 📝 Description / Context
A user with the **Consultatore** (viewer) role saw the **"Associa il tuo primo client"** link in the "Gestisci singola finalità" (purpose detail) page. Clicking it triggered no backend call (BE behavior is correct), but the UI still exposed an action the role cannot perform, creating confusion and a visual inconsistency with the role's permissions.

## 🛠 List of changes
- Hid the active-purpose "no clients" alert (which contains the "Associa il tuo primo client" link to the clients tab) for the viewer role in `useGetPurposeStateAlertProps`.
- The hook now reads `isViewer` internally via `AuthHooks.useJwt()`, in line with the existing hook conventions in the codebase.
- Added unit tests covering the viewer/non-viewer behavior and confirming role-agnostic alerts (e.g. suspended) are unaffected.

## 🧪 How to test
- Log in as a **Consultatore** user.
- Navigate to Fruizione > Finalità inoltrate > Visualizza on an active purpose with no associated clients.
- Verify the "Associa il tuo primo client" link/alert is no longer shown.
- Log in as an Admin on the same purpose and verify the alert with the link is still present.

[PIN-10425]: https://pagopa.atlassian.net/browse/PIN-10425