### PR TITLE
fix: show disabled "Richiedi fruizione" button on obsolete e-service version being archived (PIN-10426)

### DIFF
--- a/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
+++ b/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
@@ -1,6 +1,10 @@
 import useGetEServiceConsumerActions from '../useGetEServiceConsumerActions'
 import { mockUseJwt, renderHookWithApplicationContext } from '@/utils/testing.utils'
-import { type CatalogEServiceDescriptor, type DelegationTenant } from '@/api/api.generatedTypes'
+import {
+  type CatalogEServiceDescriptor,
+  type DelegationTenant,
+  type EServiceDescriptorState,
+} from '@/api/api.generatedTypes'
 import {
   createMockCatalogDescriptorEService,
   createMockEServiceDescriptorCatalog,
@@ -775,6 +779,58 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     expect(result.current.primaryAction?.label).toBe('tableEServiceCatalog.subscribe')
     expect(result.current.primaryAction?.disabled).toBe(true)
     expect(result.current.secondaryAction).toBeUndefined()
+  })
+
+  it.each<EServiceDescriptorState>(['ARCHIVING', 'ARCHIVING_SUSPENDED'])(
+    'should show the subscribe action disabled and without tooltip when viewing an obsolete version being archived (state %s) as a non-subscribed third party',
+    (state) => {
+      mockUseJwt({ isAdmin: true })
+
+      const eserviceMock = createMockCatalogDescriptorEService({
+        agreements: [],
+        isMine: false,
+        isSubscribed: false,
+        activeDescriptor: { id: 'latest-descriptor-id', state: 'PUBLISHED', version: '2' },
+      })
+
+      const descriptorMock = createMockEServiceDescriptorCatalog({
+        eservice: eserviceMock,
+        id: 'obsolete-descriptor-id',
+        state,
+      })
+
+      const { result } = renderUseGetEServiceConsumerActionsHook(
+        descriptorMock,
+        undefined,
+        false,
+        'latest-descriptor-id'
+      )
+
+      expect(result.current.primaryAction?.label).toBe('tableEServiceCatalog.subscribe')
+      expect(result.current.primaryAction?.disabled).toBe(true)
+      expect(result.current.primaryAction?.tooltip).toBeUndefined()
+      expect(result.current.secondaryAction).toBeUndefined()
+    }
+  )
+
+  it('should not show the disabled subscribe action when the archiving descriptor is the latest version (whole e-service archiving)', () => {
+    mockUseJwt({ isAdmin: true })
+
+    const eserviceMock = createMockCatalogDescriptorEService({
+      agreements: [],
+      isMine: false,
+      isSubscribed: false,
+      hasCertifiedAttributes: true,
+    })
+
+    const descriptorMock = createMockEServiceDescriptorCatalog({
+      eservice: eserviceMock,
+      state: 'ARCHIVING',
+    })
+
+    const { result } = renderUseGetEServiceConsumerActionsHook(descriptorMock)
+
+    expect(result.current.primaryAction).toBeUndefined()
   })
 
   it('should expose the view latest version action in the header info row when a target id is provided', () => {

--- a/src/hooks/useGetEServiceConsumerActions.ts
+++ b/src/hooks/useGetEServiceConsumerActions.ts
@@ -11,6 +11,7 @@ import {
   checkIfcanCreateAgreementDraft,
   checkIfhasAlreadyAgreementDraft,
 } from '@/utils/agreement.utils'
+import { isDescriptorPendingArchiving } from '@/utils/eservice.utils'
 import { AuthHooks } from '@/api/auth'
 import SendIcon from '@mui/icons-material/Send'
 import PendingActionsIcon from '@mui/icons-material/PendingActions'
@@ -283,6 +284,23 @@ function useGetEServiceConsumerActions(
         }
       : undefined
 
+  const subscribeDisabledArchivingAction: ActionItemButton | undefined =
+    isDescriptorPendingArchiving(descriptor.state) &&
+    Boolean(viewLatestVersionTargetId) &&
+    !isMine &&
+    !isSubscribed &&
+    !hasAgreementDraft &&
+    !isDelegator &&
+    !(delegators && delegators.length > 0)
+      ? {
+          action: noop,
+          label: t('tableEServiceCatalog.subscribe'),
+          icon: SendIcon,
+          variant: 'contained',
+          disabled: true,
+        }
+      : undefined
+
   const handleViewLatestVersion = () => {
     if (viewLatestVersionTargetId) {
       navigate('SUBSCRIBE_CATALOG_VIEW', {
@@ -300,7 +318,11 @@ function useGetEServiceConsumerActions(
     : undefined
 
   const primaryAction: ActionItemButton | undefined =
-    inspectAction ?? editDraftAction ?? subscribeAction ?? subscribeDisabledMissingAttributesAction
+    inspectAction ??
+    editDraftAction ??
+    subscribeAction ??
+    subscribeDisabledMissingAttributesAction ??
+    subscribeDisabledArchivingAction
 
   const hasPrimaryAgreementAction = Boolean(inspectAction ?? editDraftAction)
   const secondaryAction: ActionItemButton | undefined =

--- a/src/hooks/useGetEServiceConsumerActions.ts
+++ b/src/hooks/useGetEServiceConsumerActions.ts
@@ -284,7 +284,7 @@ function useGetEServiceConsumerActions(
         }
       : undefined
 
-  const subscribeDisabledArchivingAction: ActionItemButton | undefined =
+  const shouldShowDisabledArchivingSubscribe =
     isDescriptorPendingArchiving(descriptor.state) &&
     Boolean(viewLatestVersionTargetId) &&
     !isMine &&
@@ -292,6 +292,9 @@ function useGetEServiceConsumerActions(
     !hasAgreementDraft &&
     !isDelegator &&
     !(delegators && delegators.length > 0)
+
+  const subscribeDisabledArchivingAction: ActionItemButton | undefined =
+    shouldShowDisabledArchivingSubscribe
       ? {
           action: noop,
           label: t('tableEServiceCatalog.subscribe'),


### PR DESCRIPTION
## 🔗 Issue
[PIN-10426](https://pagopa.atlassian.net/browse/PIN-10426)

## 📝 Description / Context
On the consumer catalog e-service detail page (`Fruizione > Catalogo e-service > Visualizza e-service`), when a non-subscriber viewed an obsolete descriptor that is also being archived (single-descriptor archiving while the e-service stays active because a newer version is published), the disabled "Richiedi fruizione" button was missing entirely. Per the Figma reference ([F07](https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW/Interop-%E2%80%94-Delivery-FE---QA?node-id=8225-70432)) the button must still be shown, but disabled, to signal that fruition cannot be requested on that version. The button was suppressed because the subscribe action is gated by `checkIfcanCreateAgreementDraft`, which returns `false` whenever the viewed descriptor is not `PUBLISHED`/`SUSPENDED` (an obsolete archiving version is in state `ARCHIVING`), and the existing disabled-subscribe fallback only applies while viewing the active descriptor.

## 🛠 List of changes
- `useGetEServiceConsumerActions`: added a `subscribeDisabledArchivingAction` that renders the "Richiedi fruizione" button disabled (no tooltip, matching Figma) when the viewed descriptor is being archived (`isDescriptorPendingArchiving`) and it is an obsolete version (`viewLatestVersionTargetId` set, the same signal that shows the "Vedi ultima versione" link), for a non-subscribed, non-owner, non-delegator admin with no agreement draft. It is appended last in the `primaryAction` fallback chain, so no existing scenario changes.
- Added regression tests for the `ARCHIVING` and `ARCHIVING_SUSPENDED` states (button shown and disabled, no tooltip) plus a negative test confirming no disabled button when the archiving descriptor is the latest version (whole e-service archiving case).

## 🧪 How to test
- As a consumer admin with no agreement on the e-service, open an obsolete version that is being archived while a newer version is published: the "Richiedi fruizione" button is shown but disabled.
- Same page but viewing the latest version: behaviour is unchanged.
- Unit: `pnpm exec vitest run src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx`

---

<img width="1200" height="886" alt="PIN-10426-disabled-subscribe-obsolete-archiving" src="https://github.com/user-attachments/assets/559254f6-0fe4-4833-b577-d2af7ef20fab" />


[PIN-10426]: https://pagopa.atlassian.net/browse/PIN-10426
