### PR TITLE
fix: remove spurious obsolete-version alert when archiving whole e-service (PIN-10428)

### DIFF
--- a/src/pages/ConsumerAgreementDetailsPage/components/__tests__/ConsumerAgreementVersionAlerts.test.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/__tests__/ConsumerAgreementVersionAlerts.test.tsx
@@ -43,7 +43,7 @@ describe('ConsumerAgreementVersionAlerts', () => {
     expect(screen.queryByRole('button', { name: 'seeDetails' })).toBeNull()
   })
 
-  it('renders two alerts and a see-details button when state is ARCHIVING + scope ESERVICE', () => {
+  it('renders a single warning alert and a see-details button when state is ARCHIVING + scope ESERVICE', () => {
     renderAlerts(
       createMockEServiceDescriptorCatalog({
         state: 'ARCHIVING',
@@ -51,9 +51,8 @@ describe('ConsumerAgreementVersionAlerts', () => {
       })
     )
     const alerts = screen.getAllByRole('alert')
-    expect(alerts).toHaveLength(2)
+    expect(alerts).toHaveLength(1)
     expect(alerts[0]).toHaveClass(/MuiAlert-standardWarning/)
-    expect(alerts[1]).toHaveClass(/MuiAlert-standardInfo/)
     expect(screen.getByRole('button', { name: 'seeDetails' })).toBeInTheDocument()
   })
 

--- a/src/static/locales/en/agreement.json
+++ b/src/static/locales/en/agreement.json
@@ -133,7 +133,6 @@
     "noPurposeAlert": "To access the data <1>create your first purpose</1>.",
     "versionAlert": {
       "deprecatedActive": "This e-service version is obsolete but still active. A new version is available.",
-      "deprecatedActiveShort": "This e-service version is obsolete but still active.",
       "archivingDescriptor": "This e-service version will be archived on {{date}}. After that date, you will only be able to use the new version to exchange data with the e-service.",
       "archivingSuspendedDescriptor": "This e-service version will be archived on {{date}}. It is currently suspended and cannot be used. A new version is available.",
       "suspendedLast": "This e-service version is currently suspended and cannot be used.",

--- a/src/static/locales/it/agreement.json
+++ b/src/static/locales/it/agreement.json
@@ -133,7 +133,6 @@
     "noPurposeAlert": "Per accedere ai dati <1>crea la tua prima finalità</1>.",
     "versionAlert": {
       "deprecatedActive": "Questa versione dell’e-service è obsoleta, ma è ancora attiva. È disponibile una nuova versione.",
-      "deprecatedActiveShort": "Questa versione dell’e-service è obsoleta, ma è ancora attiva.",
       "archivingDescriptor": "Questa versione dell’e-service sarà archiviata il giorno {{date}}. Dopo questa data potrai utilizzare solo la nuova versione per scambiare dati con l’e-service.",
       "archivingSuspendedDescriptor": "Questa versione dell’e-service sarà archiviata il giorno {{date}}. Al momento è sospesa e non può essere utilizzata. È disponibile una nuova versione.",
       "suspendedLast": "Questa versione dell’e-service è al momento sospesa e non può essere utilizzata.",

--- a/src/utils/__tests__/agreement.utils.test.ts
+++ b/src/utils/__tests__/agreement.utils.test.ts
@@ -259,17 +259,16 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     expect(result[0].showSeeDetailsAction).toBeUndefined()
   })
 
-  it('returns two alerts with see-details for ARCHIVING + scope ESERVICE', () => {
+  it('returns a single warning alert with see-details for ARCHIVING + scope ESERVICE', () => {
     const result = getConsumerAgreementVersionAlertSpec({
       ...baseArgs,
       state: 'ARCHIVING',
       scope: 'ESERVICE',
       archivableOn: '2026-12-01T00:00:00.000Z',
     })
-    expect(result).toHaveLength(2)
+    expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({ severity: 'warning', showSeeDetailsAction: true })
     expect(result[0].content).toMatch(/^archivingEService:/)
-    expect(result[1]).toEqual({ severity: 'info', content: 'deprecatedActiveShort' })
   })
 
   it('returns single error alert for ARCHIVING_SUSPENDED + scope DESCRIPTOR', () => {

--- a/src/utils/agreement.utils.ts
+++ b/src/utils/agreement.utils.ts
@@ -137,7 +137,6 @@ export function getConsumerAgreementVersionAlertSpec(args: {
         content: t('archivingEService', { date: scheduledDate }),
         showSeeDetailsAction: true,
       },
-      { severity: 'info', content: t('deprecatedActiveShort') },
     ])
     .with({ state: 'ARCHIVING_SUSPENDED', scope: 'DESCRIPTOR' }, () => [
       { severity: 'error', content: t('archivingSuspendedDescriptor', { date: scheduledDate }) },


### PR DESCRIPTION
## 🔗 Issue

[PIN-10428](https://pagopa.atlassian.net/browse/PIN-10428)

## 📝 Description / Context

On the consumer agreement detail page (`Fruizione > Richieste inoltrate > Gestisci richiesta di fruizione`), when the whole e-service is being archived (the agreement points to the latest version and the descriptor's `archivingSchedule.scope` is `ESERVICE`), the page showed two alerts: the correct "Questo e-service sarà archiviato il giorno {date}…" warning, plus a spurious info alert "Questa versione dell'e-service è obsoleta, ma è ancora attiva.". The second message is wrong: when the entire e-service is being archived there is no newer active version, so the version the agreement is on is the latest one, not an obsolete one.

The genuine "obsolete but still active" scenario is the `DEPRECATED` state (a version superseded by a newer published one while the e-service stays active), which keeps its own alert (`deprecatedActive`, the long form that also states a new version is available). That path is untouched: only the misused short variant in the whole-e-service archiving branch is removed.

## 🛠 List of changes

- `getConsumerAgreementVersionAlertSpec` (`src/utils/agreement.utils.ts`): removed the `deprecatedActiveShort` info alert from the `ARCHIVING + scope ESERVICE` branch, leaving only the `archivingEService` warning (with the see-details action).
- Removed the now-orphaned `deprecatedActiveShort` key from `src/static/locales/it/agreement.json` and `src/static/locales/en/agreement.json` (no other references in the codebase).
- Updated the two existing tests that asserted two alerts for `ARCHIVING + ESERVICE` (`agreement.utils.test.ts` and `ConsumerAgreementVersionAlerts.test.tsx`) to expect a single warning alert with the see-details action.

## 🧪 How to test

- As a consumer with an active agreement on an e-service whose latest version is being archived (whole-e-service archiving, scope `ESERVICE`), open `Fruizione > Richieste inoltrate > Gestisci richiesta di fruizione`: only the "Questo e-service sarà archiviato il giorno {date}…" warning is shown, with no "obsoleta, ma è ancora attiva" alert below it.
- The `DEPRECATED` version case (genuine obsolescence) and the single-descriptor archiving case are unchanged.
- Unit: `pnpm exec vitest run src/utils/__tests__/agreement.utils.test.ts src/pages/ConsumerAgreementDetailsPage/components/__tests__/ConsumerAgreementVersionAlerts.test.tsx`

[PIN-10428]: https://pagopa.atlassian.net/browse/PIN-10428
