### PR TITLE
fix: show upgrade and inspect actions together on obsolete e-service version (PIN-10439)

### DIFF
--- a/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
+++ b/src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx
@@ -956,4 +956,35 @@ describe('useGetEServiceConsumerActions tests - actions', () => {
     expect(result.current.secondaryAction?.label).toBe('tableEServiceCatalog.subscribe')
     expect(result.current.secondaryAction?.variant).toBe('outlined')
   })
+
+  it('should show the upgrade action as primary and the inspect action as outlined secondary when the requester is subscribed and viewing an obsolete upgradeable version', () => {
+    mockUseJwt({ isAdmin: true })
+
+    const eserviceMock = createMockCatalogDescriptorEService({
+      agreements: [],
+      isMine: false,
+      isSubscribed: true,
+      hasCertifiedAttributes: true,
+    })
+
+    const { result } = renderUseGetEServiceConsumerActionsHook(
+      createMockEServiceDescriptorCatalog({ eservice: eserviceMock }),
+      undefined,
+      false,
+      undefined,
+      {
+        blocksSubscribe: true,
+        upgrade: {
+          agreement: createMockAgreement(),
+          hasMissingAttributes: false,
+          hasAllCertifiedAttributes: true,
+        },
+      }
+    )
+
+    expect(result.current.primaryAction?.label).toBe('tableEServiceCatalog.upgradeToNewVersion')
+    expect(result.current.primaryAction?.variant).toBe('contained')
+    expect(result.current.secondaryAction?.label).toBe('tableEServiceCatalog.inspect')
+    expect(result.current.secondaryAction?.variant).toBe('outlined')
+  })
 })

--- a/src/hooks/useGetEServiceConsumerActions.ts
+++ b/src/hooks/useGetEServiceConsumerActions.ts
@@ -334,17 +334,19 @@ function useGetEServiceConsumerActions(
     : undefined
 
   const primaryAction: ActionItemButton | undefined =
+    upgradeAction ??
     inspectAction ??
     editDraftAction ??
-    upgradeAction ??
     subscribeAction ??
     subscribeDisabledMissingAttributesAction
 
   const hasPrimaryAgreementAction = Boolean(inspectAction ?? editDraftAction ?? upgradeAction)
   const secondaryAction: ActionItemButton | undefined =
-    hasPrimaryAgreementAction && subscribeAction
-      ? { ...subscribeAction, variant: 'outlined' }
-      : undefined
+    upgradeAction && inspectAction
+      ? { ...inspectAction, variant: 'outlined' }
+      : hasPrimaryAgreementAction && subscribeAction
+        ? { ...subscribeAction, variant: 'outlined' }
+        : undefined
 
   return {
     primaryAction,


### PR DESCRIPTION
## 🔗 Issue

[PIN-10439](https://pagopa.atlassian.net/browse/PIN-10439) · [PIN-10442](https://pagopa.atlassian.net/browse/PIN-10442)

## 📝 Description / Context

On the consumer catalog e-service detail page (`Fruizione > Catalogo e-service > Visualizza e-service`), when a subscriber views an obsolete version of an e-service that has a newer version available, the "Aggiorna a nuova versione" button was missing and "Visualizza richiesta" was rendered as a filled (contained) button instead of outlined. Per the Figma reference ([F07](https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW/Interop-%E2%80%94-Delivery-FE---QA?node-id=8225-70432) for the obsolete-and-archiving case, [F05](https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW/Interop-%E2%80%94-Delivery-FE---QA?node-id=8225-70270) for the obsolete-but-active case) the page must show two buttons: "Visualizza richiesta" (outlined) and "Aggiorna a nuova versione" (contained). The same fix covers both [PIN-10439](https://pagopa.atlassian.net/browse/PIN-10439) (obsolete + archiving) and [PIN-10442](https://pagopa.atlassian.net/browse/PIN-10442) (obsolete, not archiving).

This PR builds on [#2036](https://github.com/pagopa/pdnd-interop-frontend/pull/2036) (PIN-10396), which already added the `upgradeAction` (it opens the `upgradeAgreementVersion` dialog in place) and the `requesterEserviceAgreement` plumbing on the catalog page. #2036 covers the case of viewing the latest active version while subscribed to an older one (where the catalog payload reports `isSubscribed: false`, so there is no inspect button and the upgrade action is the primary). When the user views the obsolete version itself, the payload reports `isSubscribed: true`, so `inspectAction` exists and won the primary slot, dropping the upgrade action entirely. This PR fixes the primary/secondary selection so both buttons appear in that scenario.

On the QA report's third point ("the second character of 'Visualizza richiesta' is uppercase"): the i18n value is correctly cased ("Visualizza richiesta") and the live render confirms it, so there is no copy change.

## 🛠 List of changes

- `useGetEServiceConsumerActions`: when both the upgrade action and the inspect action are available (subscriber viewing an obsolete, upgradeable version), the upgrade action becomes the primary (contained) button and "Visualizza richiesta" becomes the outlined secondary. The `upgradeAction` itself (which opens the `upgradeAgreementVersion` dialog in place) is unchanged; all other scenarios keep their existing behaviour.
- Added a regression test for the subscriber-on-obsolete-upgradeable-version case (primary = `upgradeToNewVersion` contained, secondary = inspect outlined).

## 🧪 How to test

- As a consumer with an active, upgradeable agreement on an e-service, open the obsolete version from the catalog (`Fruizione > Catalogo e-service > Visualizza e-service`): the page shows "Visualizza richiesta" (outlined) + "Aggiorna a nuova versione" (contained), and clicking the latter opens the upgrade dialog in place.
- This holds both when the obsolete version is being archived (PIN-10439) and when it is simply obsolete and active (PIN-10442).
- Unit: `pnpm exec vitest run src/hooks/__tests__/useGetEServiceConsumerActions.test.tsx`

---

<img width="1200" height="942" alt="PIN-10439-two-buttons-obsolete-version" src="https://github.com/user-attachments/assets/9c4cd4a0-4430-43db-8539-f66cc50a9566" />

<img width="1200" height="942" alt="PIN-10439-upgrade-modal-open" src="https://github.com/user-attachments/assets/334dd146-2bee-4b67-9231-6b1712bd6477" />


[PIN-10439]: https://pagopa.atlassian.net/browse/PIN-10439
[PIN-10442]: https://pagopa.atlassian.net/browse/PIN-10442
