### PR TITLE
fix: risk analysis list empty description (PIN-10452)

### DIFF
--- a/src/pages/RiskAnalysisListPage/RiskAnalysisList.page.tsx
+++ b/src/pages/RiskAnalysisListPage/RiskAnalysisList.page.tsx
@@ -69,7 +69,7 @@ const RiskAnalysisListPage: React.FC = () => {
   return (
     <PageContainer
       title={t('title')}
-      description={data?.results.length === 0 ? t('emptyDescription') : t('description')}
+      description={isInitialEmptyState ? t('emptyDescription') : t('description')}
     >
       {isInitialEmptyState ? (
         <Box

--- a/src/pages/RiskAnalysisListPage/RiskAnalysisList.page.tsx
+++ b/src/pages/RiskAnalysisListPage/RiskAnalysisList.page.tsx
@@ -67,7 +67,10 @@ const RiskAnalysisListPage: React.FC = () => {
   const isInitialEmptyState = !!data && data.results.length === 0 && !hasActiveFilters
 
   return (
-    <PageContainer title={t('title')} description={t('description')}>
+    <PageContainer
+      title={t('title')}
+      description={data?.results.length === 0 ? t('emptyDescription') : t('description')}
+    >
       {isInitialEmptyState ? (
         <Box
           sx={{

--- a/src/pages/RiskAnalysisListPage/__test__/RiskAnalysisList.page.test.tsx
+++ b/src/pages/RiskAnalysisListPage/__test__/RiskAnalysisList.page.test.tsx
@@ -5,6 +5,22 @@ import type { RiskAnalysisSigningState } from '@/api/api.generatedTypes'
 import { useQuery } from '@tanstack/react-query'
 import type * as ReactQuery from '@tanstack/react-query'
 import { RiskAnalysisTableSkeleton } from '../components/RiskAnalysisTable'
+import { useFilters } from '@pagopa/interop-fe-commons'
+
+vi.mock('@pagopa/interop-fe-commons', async () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await vi.importActual<typeof import('@pagopa/interop-fe-commons')>(
+    '@pagopa/interop-fe-commons'
+  )
+
+  return {
+    ...actual,
+    useFilters: vi.fn(),
+    Filters: () => <div data-testid="filters" />,
+  }
+})
+
+const mockedUseFilters = vi.mocked(useFilters)
 
 vi.mock('@/components/shared/StatusChip', () => ({
   StatusChip: ({ state }: { state: RiskAnalysisSigningState }) => (
@@ -77,14 +93,23 @@ describe('RiskAnalysisListPage', () => {
       isFetching: false,
     } as unknown as ReturnType<typeof useQuery>)
 
-    renderPage()
+    mockedUseFilters.mockReturnValue({
+      filtersParams: {},
+      fields: [],
+      activeFilters: [],
+      onChangeActiveFilter: vi.fn(),
+      onRemoveActiveFilter: vi.fn(),
+      onResetActiveFilters: vi.fn(),
+    } as unknown as ReturnType<typeof useFilters>)
   })
 
   it('should render page title', () => {
+    renderPage()
     expect(screen.getByText('title')).toBeInTheDocument()
   })
 
   it('should render page description', () => {
+    renderPage()
     expect(screen.getByText('description')).toBeInTheDocument()
   })
 
@@ -103,24 +128,28 @@ describe('RiskAnalysisListPage', () => {
   })
 
   it('should render filters', () => {
-    expect(screen.getByLabelText('filters.eserviceField.label')).toBeInTheDocument()
-    expect(screen.getByLabelText('filters.riskAnalysisState.label')).toBeInTheDocument()
+    renderPage()
+    expect(screen.getByTestId('filters')).toBeInTheDocument()
   })
 
   it('should render table row content', async () => {
+    renderPage()
     expect(await screen.findByText('Test E-service')).toBeInTheDocument()
     expect(screen.getByText('PagoPA')).toBeInTheDocument()
   })
 
   it('should render status chip', async () => {
+    renderPage()
     expect(await screen.findByText('ASSIGNED')).toBeInTheDocument()
   })
 
   it('should render today label', async () => {
+    renderPage()
     expect(await screen.findByText('today.label')).toBeInTheDocument()
   })
 
   it('should not show noData label when data exists', () => {
+    renderPage()
     expect(screen.queryByText('noData.label')).not.toBeInTheDocument()
   })
 
@@ -142,5 +171,32 @@ describe('RiskAnalysisListPage', () => {
 
     const skeletons = container.querySelectorAll('.MuiSkeleton-root')
     expect(skeletons.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('should not render initial empty state when filters are active and results are empty', () => {
+    mockedUseQuery.mockReturnValue({
+      data: {
+        results: [],
+        pagination: { totalCount: 0 },
+      },
+      isFetching: false,
+    } as unknown as ReturnType<typeof useQuery>)
+
+    mockedUseFilters.mockReturnValue({
+      filtersParams: {
+        signingStates: 'ASSIGNED',
+      },
+      fields: [],
+      activeFilters: [],
+      onChangeActiveFilter: vi.fn(),
+      onRemoveActiveFilter: vi.fn(),
+      onResetActiveFilters: vi.fn(),
+    } as unknown as ReturnType<typeof useFilters>)
+
+    renderPage()
+
+    expect(screen.getByText('description')).toBeInTheDocument()
+    expect(screen.queryByText('emptyDescription')).not.toBeInTheDocument()
+    expect(screen.queryByText('noData.label')).not.toBeInTheDocument()
   })
 })

--- a/src/pages/RiskAnalysisListPage/__test__/RiskAnalysisList.page.test.tsx
+++ b/src/pages/RiskAnalysisListPage/__test__/RiskAnalysisList.page.test.tsx
@@ -80,37 +80,51 @@ describe('RiskAnalysisListPage', () => {
     renderPage()
   })
 
-  it('renders page title', () => {
+  it('should render page title', () => {
     expect(screen.getByText('title')).toBeInTheDocument()
   })
 
-  it('renders page description', () => {
+  it('should render page description', () => {
     expect(screen.getByText('description')).toBeInTheDocument()
   })
 
-  it('renders filters', () => {
+  it('should render empty page description', () => {
+    mockedUseQuery.mockReturnValue({
+      data: {
+        results: [],
+        pagination: { totalCount: 0 },
+      },
+      isFetching: false,
+    } as unknown as ReturnType<typeof useQuery>)
+
+    renderPage()
+
+    expect(screen.getByText('emptyDescription')).toBeInTheDocument()
+  })
+
+  it('should render filters', () => {
     expect(screen.getByLabelText('filters.eserviceField.label')).toBeInTheDocument()
     expect(screen.getByLabelText('filters.riskAnalysisState.label')).toBeInTheDocument()
   })
 
-  it('renders table row content', async () => {
+  it('should render table row content', async () => {
     expect(await screen.findByText('Test E-service')).toBeInTheDocument()
     expect(screen.getByText('PagoPA')).toBeInTheDocument()
   })
 
-  it('renders status chip', async () => {
+  it('should render status chip', async () => {
     expect(await screen.findByText('ASSIGNED')).toBeInTheDocument()
   })
 
-  it('renders today label', async () => {
+  it('should render today label', async () => {
     expect(await screen.findByText('today.label')).toBeInTheDocument()
   })
 
-  it('does not show noData label when data exists', () => {
+  it('should not show noData label when data exists', () => {
     expect(screen.queryByText('noData.label')).not.toBeInTheDocument()
   })
 
-  it('does not render noData label while initial data is loading', () => {
+  it('should not render noData label while initial data is loading', () => {
     mockedUseQuery.mockReturnValueOnce({
       data: undefined,
       isFetching: true,
@@ -121,7 +135,7 @@ describe('RiskAnalysisListPage', () => {
     expect(screen.queryByText('noData.label')).not.toBeInTheDocument()
   })
 
-  it('renders skeleton rows', () => {
+  it('should render skeleton rows', () => {
     const { container } = renderWithApplicationContext(<RiskAnalysisTableSkeleton />, {
       withReactQueryContext: true,
     })

--- a/src/static/locales/en/pages.json
+++ b/src/static/locales/en/pages.json
@@ -69,6 +69,7 @@
   },
   "riskAnalysisList": {
     "title": "Risk Analysis",
-    "description": "Here you'll only find the risk analyses you need to complete or approve. If a purpose is deleted, you'll no longer see it in this section."
+    "description": "Here you'll only find the risk analyses you need to complete or approve. If a purpose is deleted, you'll no longer see it in this section.",
+    "emptyDescription": "Here you'll find the risk analyses assigned to you. If a purpose is deleted, you'll no longer see it in this section."
   }
 }

--- a/src/static/locales/it/pages.json
+++ b/src/static/locales/it/pages.json
@@ -69,6 +69,7 @@
   },
   "riskAnalysisList": {
     "title": "Analisi del rischio",
-    "description": "Qui trovi solo le analisi del rischio che devi compilare o approvare. Se una finalità sarà eliminata, non la vedrai più in questa sezione."
+    "description": "Qui trovi solo le analisi del rischio che devi compilare o approvare. Se una finalità sarà eliminata, non la vedrai più in questa sezione.",
+    "emptyDescription": "Qui trovi le analisi del rischio assegnate a te. Se una finalità sarà eliminata, non la vedrai più in questa sezione."
   }
 }


### PR DESCRIPTION
## Issue
- [PIN-10452](https://pagopa.atlassian.net/browse/PIN-10452)
## Description / Context / Why
- Added empty description label on risk analysis list (https://www.figma.com/design/CpRV3kPvFEWLXGtJUgWeZW/Interop-%E2%80%94-Delivery-FE---QA?node-id=7093-111951&t=aUKuzKATBxujVpfi-4)
- Updated tests

[PIN-10452]: https://pagopa.atlassian.net/browse/PIN-10452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ