### PR TITLE
fix: risk analysis assign request snackbar (PIN-10458)

### DIFF
--- a/src/api/purpose/purpose.mutations.ts
+++ b/src/api/purpose/purpose.mutations.ts
@@ -219,14 +219,16 @@ function useCreateDraftFromPurposeTemplate() {
   })
 }
 
-function useAssignRiskAnalysisReviewer() {
+function useAssignRiskAnalysisReviewer({ showSuccessToast }: { showSuccessToast: boolean }) {
   const { t } = useTranslation('mutations-feedback', {
     keyPrefix: 'purpose.assignRiskAnalysisReviewer',
   })
   return useMutation({
     mutationFn: PurposeServices.assignRiskAnalysisReviewer,
     meta: {
+      successToastLabel: showSuccessToast ? t('outcome.success') : undefined,
       errorToastLabel: t('outcome.error'),
+      loadingLabel: t('loading'),
     },
   })
 }
@@ -238,6 +240,7 @@ function useSubmitRiskAnalysis() {
   return useMutation({
     mutationFn: PurposeServices.submitRiskAnalysis,
     meta: {
+      successToastLabel: t('outcome.success'),
       errorToastLabel: t('outcome.error'),
       loadingLabel: t('loading'),
     },

--- a/src/components/dialogs/DialogRequestRiskAnalysisCompilation.tsx
+++ b/src/components/dialogs/DialogRequestRiskAnalysisCompilation.tsx
@@ -26,7 +26,9 @@ export const DialogRequestRiskAnalysisCompilation: React.FC<
 
   const { closeDialog } = useDialog()
   const navigate = useNavigate()
-  const { mutate: assignReviewer, isPending } = PurposeMutations.useAssignRiskAnalysisReviewer()
+  const { mutate: assignReviewer, isPending } = PurposeMutations.useAssignRiskAnalysisReviewer({
+    showSuccessToast: true,
+  })
 
   const handleConfirm = () => {
     assignReviewer(

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentForm.tsx
@@ -66,7 +66,9 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
 }) => {
   const { t } = useTranslation('purpose', { keyPrefix: 'edit.stepAssignment' })
   const { t: tEdit } = useTranslation('purpose', { keyPrefix: 'edit' })
-  const { mutate: assignReviewer } = PurposeMutations.useAssignRiskAnalysisReviewer()
+  const { mutate: assignReviewer } = PurposeMutations.useAssignRiskAnalysisReviewer({
+    showSuccessToast: false,
+  })
   const { openDialog } = useDialog()
 
   const hasNoReviewers = reviewers.length === 0

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -660,14 +660,17 @@
       }
     },
     "assignRiskAnalysisReviewer": {
+      "loading": "We are assigning the risk analysis to a reviewer",
       "outcome": {
-        "error": "The reviewer could not be assigned. Please try again!"
+        "success": "You have assigned a reviewer to compile and approve the risk analysis.",
+        "error": "It was not possible to assign the risk analysis."
       }
     },
     "submitRiskAnalysis": {
-      "loading": "Submitting the risk analysis to the reviewer",
+      "loading": "We are assigning the risk analysis to a reviewer",
       "outcome": {
-        "error": "The risk analysis could not be submitted to the reviewer. Please try again!"
+        "success": "You have assigned risk analysis approval to a reviewer.",
+        "error": "It was not possible to assign the risk analysis."
       }
     },
     "signRiskAnalysis": {

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -660,14 +660,17 @@
       }
     },
     "assignRiskAnalysisReviewer": {
+      "loading": "Stiamo assegnando l'analisi del rischio a un valutatore",
       "outcome": {
-        "error": "Non è stato possibile assegnare il valutatore. Per favore, riprova!"
+        "success": "Hai assegnato la compilazione e l’approvazione dell’analisi del rischio a un valutatore.",
+        "error": "Non è stato possibile assegnare l’analisi del rischio."
       }
     },
     "submitRiskAnalysis": {
-      "loading": "Stiamo inviando l’analisi del rischio al valutatore",
+      "loading": "Stiamo assegnando l’analisi del rischio a un valutatore",
       "outcome": {
-        "error": "Non è stato possibile inviare l’analisi del rischio al valutatore. Riprova!"
+        "success": "Hai assegnato l’approvazione dell’analisi del rischio a un valutatore.",
+        "error": "Non è stato possibile assegnare l’analisi del rischio."
       }
     },
     "signRiskAnalysis": {


### PR DESCRIPTION
## Issue
- [PIN-10458](https://pagopa.atlassian.net/browse/PIN-10458)
## Description / Context / Why
- Added snackbar success/error/loading labels for useAssignRiskAnalysisReviewer and useSubmitRiskAnalysis mutations
- Added a parameter to useAssignRiskAnalysisReviewer (it is used in both flows, but only on one of them the snackbar is needed)

[PIN-10458]: https://pagopa.atlassian.net/browse/PIN-10458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ