### PR TITLE
fix: sanitize import e-service zip filename suffix (PIN-10161)

### DIFF
--- a/src/api/eservice/__tests__/eservice.services.test.ts
+++ b/src/api/eservice/__tests__/eservice.services.test.ts
@@ -1,0 +1,63 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
+import axiosInstance from '@/config/axios'
+import { EServiceServices } from '../eservice.services'
+
+// Mock axiosInstance
+vi.mock('@/config/axios', () => ({
+  default: {
+    get: vi.fn(),
+    put: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+describe('EServiceServices.importVersion', () => {
+  const presignedUrl = { url: 'https://presigned.example.com/upload' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(axiosInstance.get).mockResolvedValue({ data: presignedUrl })
+    vi.mocked(axiosInstance.put).mockResolvedValue({})
+    vi.mocked(axiosInstance.post).mockResolvedValue({ data: {} })
+  })
+
+  it('sends the sanitized file name to both the presigned-URL param and the imported FileResource', async () => {
+    const eserviceFile = new File(['content'], 'abc123_def456 (1).zip')
+
+    await EServiceServices.importVersion({ eserviceFile })
+
+    // the presigned-URL request uses the sanitized name as `fileName` param
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      `${BACKEND_FOR_FRONTEND_URL}/import/eservices/presignedUrl`,
+      { params: { fileName: 'abc123_def456.zip' } }
+    )
+
+    // the posted FileResource carries the sanitized name as `filename`
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      `${BACKEND_FOR_FRONTEND_URL}/import/eservices`,
+      {
+        filename: 'abc123_def456.zip',
+        url: presignedUrl.url,
+      }
+    )
+  })
+
+  it('leaves an already-clean file name unchanged on both calls', async () => {
+    const eserviceFile = new File(['content'], 'abc123_def456.zip')
+
+    await EServiceServices.importVersion({ eserviceFile })
+
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      `${BACKEND_FOR_FRONTEND_URL}/import/eservices/presignedUrl`,
+      { params: { fileName: 'abc123_def456.zip' } }
+    )
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      `${BACKEND_FOR_FRONTEND_URL}/import/eservices`,
+      {
+        filename: 'abc123_def456.zip',
+        url: presignedUrl.url,
+      }
+    )
+  })
+})

--- a/src/api/eservice/eservice.services.ts
+++ b/src/api/eservice/eservice.services.ts
@@ -39,6 +39,7 @@ import type {
 } from '../api.generatedTypes'
 import type { AttributeKey } from '@/types/attribute.types'
 import { getAllFromPaginated, waitFor } from '@/utils/common.utils'
+import { sanitizeImportEserviceFileName } from '@/utils/eservice.utils'
 
 async function getCatalogList(params: GetEServicesCatalogParams) {
   const response = await axiosInstance.get<CatalogEServices>(
@@ -450,7 +451,7 @@ async function exportVersion({
 }
 
 async function importVersion({ eserviceFile }: { eserviceFile: File }) {
-  const fileName = eserviceFile.name
+  const fileName = sanitizeImportEserviceFileName(eserviceFile.name)
   const { data: presignedUrl } = await axiosInstance.get<PresignedUrl>(
     `${BACKEND_FOR_FRONTEND_URL}/import/eservices/presignedUrl`,
     { params: { fileName } }

--- a/src/utils/__tests__/eservice.utils.test.ts
+++ b/src/utils/__tests__/eservice.utils.test.ts
@@ -8,6 +8,7 @@ import {
   getLastDescriptor,
   getViewLatestVersionTargetId,
   isDescriptorPendingArchiving,
+  sanitizeImportEserviceFileName,
 } from '../eservice.utils'
 
 describe('getDownloadDocumentName utility function testing', () => {
@@ -328,5 +329,47 @@ describe('getAsyncExchangePropertiesWithDefaults utility function testing', () =
       confirmation: false,
       bulk: false,
     })
+  })
+})
+
+describe('sanitizeImportEserviceFileName utility function testing', () => {
+  it.each([
+    {
+      scenario: 'strips the browser ` (1)` collision suffix',
+      input: 'abc123_def456 (1).zip',
+      expected: 'abc123_def456.zip',
+    },
+    {
+      scenario: 'strips a multi-digit ` (n)` suffix',
+      input: 'abc123_def456 (12).zip',
+      expected: 'abc123_def456.zip',
+    },
+    {
+      scenario: 'leaves an untouched file name unchanged',
+      input: 'abc123_def456.zip',
+      expected: 'abc123_def456.zip',
+    },
+    {
+      scenario: 'does not strip a suffix that is not right before the extension',
+      input: 'abc (1) def.zip',
+      expected: 'abc (1) def.zip',
+    },
+    {
+      scenario: 'only strips the suffix adjacent to the .zip extension',
+      input: 'abc (2) def (1).zip',
+      expected: 'abc (2) def.zip',
+    },
+    {
+      scenario: 'does not strip the suffix when the extension is not .zip',
+      input: 'abc (1).txt',
+      expected: 'abc (1).txt',
+    },
+    {
+      scenario: 'keeps parentheses that are part of the name (no number)',
+      input: 'abc (copy).zip',
+      expected: 'abc (copy).zip',
+    },
+  ])('should $scenario', ({ input, expected }) => {
+    expect(sanitizeImportEserviceFileName(input)).toEqual(expected)
   })
 })

--- a/src/utils/__tests__/eservice.utils.test.ts
+++ b/src/utils/__tests__/eservice.utils.test.ts
@@ -345,6 +345,11 @@ describe('sanitizeImportEserviceFileName utility function testing', () => {
       expected: 'abc123_def456.zip',
     },
     {
+      scenario: 'strips the no-space `(n)` suffix (e.g. Firefox)',
+      input: 'abc123_def456(1).zip',
+      expected: 'abc123_def456.zip',
+    },
+    {
       scenario: 'leaves an untouched file name unchanged',
       input: 'abc123_def456.zip',
       expected: 'abc123_def456.zip',

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -143,13 +143,15 @@ export function isDescriptorPendingArchiving(state: EServiceDescriptorState | un
 }
 
 /**
- * Removes the ` (n)` suffix that browsers append to a downloaded file name to
- * avoid overwriting an existing one (e.g. `my-eservice (1).zip` -> `my-eservice.zip`).
+ * Removes the `(n)` suffix that browsers append to a downloaded file name to
+ * avoid overwriting an existing one. The leading space is optional because some
+ * browsers add it (Chrome/Edge: `my-eservice (1).zip`) and some don't
+ * (Firefox: `my-eservice(1).zip`); both become `my-eservice.zip`.
  *
  * The e-service import on the BFF derives the zip's root folder name from the
  * uploaded file name, so a renamed file breaks the import (PIN-10161). Stripping
  * the suffix restores the original name produced at export time.
  */
 export function sanitizeImportEserviceFileName(fileName: string): string {
-  return fileName.replace(/ \(\d+\)(?=\.zip$)/, '')
+  return fileName.replace(/ ?\(\d+\)(?=\.zip$)/, '')
 }

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -142,16 +142,6 @@ export function isDescriptorPendingArchiving(state: EServiceDescriptorState | un
   return state === 'ARCHIVING' || state === 'ARCHIVING_SUSPENDED'
 }
 
-/**
- * Removes the `(n)` suffix that browsers append to a downloaded file name to
- * avoid overwriting an existing one. The leading space is optional because some
- * browsers add it (Chrome/Edge: `my-eservice (1).zip`) and some don't
- * (Firefox: `my-eservice(1).zip`); both become `my-eservice.zip`.
- *
- * The e-service import on the BFF derives the zip's root folder name from the
- * uploaded file name, so a renamed file breaks the import (PIN-10161). Stripping
- * the suffix restores the original name produced at export time.
- */
 export function sanitizeImportEserviceFileName(fileName: string): string {
   return fileName.replace(/ ?\(\d+\)(?=\.zip$)/, '')
 }

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -141,3 +141,15 @@ export function calculateArchivableOn(now: Date, gracePeriodDays: number): Date 
 export function isDescriptorPendingArchiving(state: EServiceDescriptorState | undefined): boolean {
   return state === 'ARCHIVING' || state === 'ARCHIVING_SUSPENDED'
 }
+
+/**
+ * Removes the ` (n)` suffix that browsers append to a downloaded file name to
+ * avoid overwriting an existing one (e.g. `my-eservice (1).zip` -> `my-eservice.zip`).
+ *
+ * The e-service import on the BFF derives the zip's root folder name from the
+ * uploaded file name, so a renamed file breaks the import (PIN-10161). Stripping
+ * the suffix restores the original name produced at export time.
+ */
+export function sanitizeImportEserviceFileName(fileName: string): string {
+  return fileName.replace(/ \(\d+\)(?=\.zip$)/, '')
+}


### PR DESCRIPTION
## 🔗 Issue
[PIN-10161](https://pagopa.atlassian.net/browse/PIN-10161)

## 📝 Description / Context
Importing an e-service via `.zip` fails with `400 Bad Request` (`Invalid zip structure: Error reading configuration.json`, 008-0021) when the external zip file name differs from the archive's internal root folder name.

This happens because the BFF derives the internal root folder from the uploaded file name (`filename` minus `.zip`) instead of reading it from the archive content. The export side couples the two names (`zipFolderName = ${eserviceId}_${descriptorId}` is used both as the inner folder and as the file name), so the import only works while the file is not renamed. As soon as the browser appends a ` (1)` suffix on download (to avoid overwriting an existing file), the invariant breaks and the import is rejected even though `configuration.json` is valid.

This PR is the **frontend mitigation**: it normalizes the uploaded file name before upload so the real production incident (the ` (1)` download-collision suffix) is covered immediately. The **definitive fix lives in the BFF** (read the root folder dynamically from the zip content) and is tracked on the ticket.

## 🛠 List of changes
- Add pure utility `sanitizeImportEserviceFileName` that strips a ` (n)` suffix located right before the `.zip` extension (conservative regex: it leaves legitimate parentheses such as `(copy)` untouched).
- Use the sanitized name in `importVersion` (`eservice.services.ts`) for both the presigned-URL `fileName` param and the `FileResource.filename` sent to the BFF.
- Add data-driven `it.each` tests covering single/multi-digit suffix, untouched names, non-adjacent parentheses, non-`.zip` extensions, and `(copy)`.

## 🧪 How to test
- Export an e-service descriptor and download the resulting `.zip`.
- Rename the local file by adding a ` (1)` suffix before the extension (e.g. `abc_def (1).zip`), or download it twice so the browser adds the suffix automatically.
- Import the file via the e-service import drawer.
- The import succeeds (before this change it failed with `400 Bad Request`).

[PIN-10161]: https://pagopa.atlassian.net/browse/PIN-10161
