### PR TITLE
feature: add accessibility ids to checkbox group component (PIN-2684, INT-57)

### DIFF
--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisCheckboxGroup.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisCheckboxGroup.tsx
@@ -4,7 +4,7 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import type { InputOption } from '@/types/common.types'
 import type { ControllerProps } from 'react-hook-form/dist/types'
 import { useTranslation } from 'react-i18next'
-import { mapValidationErrorMessages } from '@/utils/form.utils'
+import { getAriaAccessibilityInputProps, mapValidationErrorMessages } from '@/utils/form.utils'
 import RiskAnalysisInputWrapper from './RiskAnalysisInputWrapper'
 import { isRiskAnalysisQuestionDisabled } from '@/utils/common.utils'
 import { usePurposeCreateContext } from '../PurposeCreateContext'
@@ -41,6 +41,13 @@ export const RiskAnalysisCheckboxGroup: React.FC<RiskAnalysisCheckboxGroupProps>
 
   const error = useRiskAnalysisDisplayError(questionKey)
 
+  const { accessibilityProps, ids } = getAriaAccessibilityInputProps(name, {
+    label,
+    infoLabel,
+    error,
+    helperText,
+  })
+
   const conditionalRules =
     isAssignedToTemplateUsersSwitch && type === 'creator'
       ? { validate: () => true }
@@ -53,12 +60,13 @@ export const RiskAnalysisCheckboxGroup: React.FC<RiskAnalysisCheckboxGroupProps>
       infoLabel={infoLabel}
       helperText={helperText}
       error={error}
+      {...ids}
       isFromPurposeTemplate={isFromPurposeTemplate}
       questionKey={questionKey}
       type={type}
       isAssignedToTemplateUsersSwitch={isAssignedToTemplateUsersSwitch}
     >
-      <FormGroup>
+      <FormGroup {...accessibilityProps}>
         <Controller
           name={name}
           rules={conditionalRules}

--- a/src/components/shared/react-hook-form-inputs/RHFCheckboxGroup.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFCheckboxGroup.tsx
@@ -43,7 +43,7 @@ export const RHFCheckboxGroup: React.FC<RHFCheckboxGroupProps> = ({
   return (
     <InputWrapper component="fieldset" error={error} sx={sx} infoLabel={infoLabel} {...ids}>
       <FormLabel component="legend">{label}</FormLabel>
-      <FormGroup>
+      <FormGroup {...accessibilityProps}>
         <Controller
           name={name}
           rules={mapValidationErrorMessages(rules, t)}
@@ -72,7 +72,6 @@ export const RHFCheckboxGroup: React.FC<RHFCheckboxGroupProps> = ({
                         checked={field.value?.includes(o.value) ?? false}
                         onChange={onChange}
                         name={String(o.value)}
-                        inputProps={{ ...accessibilityProps }}
                       />
                     }
                     label={o.label}

--- a/src/components/shared/react-hook-form-inputs/RHFCheckboxGroup.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFCheckboxGroup.tsx
@@ -5,7 +5,7 @@ import { Controller, useFormContext } from 'react-hook-form'
 import type { InputOption } from '@/types/common.types'
 import type { ControllerProps } from 'react-hook-form/dist/types'
 import { useTranslation } from 'react-i18next'
-import { mapValidationErrorMessages } from '@/utils/form.utils'
+import { getAriaAccessibilityInputProps, mapValidationErrorMessages } from '@/utils/form.utils'
 
 export type RHFCheckboxGroupProps = {
   sx?: SxProps
@@ -35,8 +35,13 @@ export const RHFCheckboxGroup: React.FC<RHFCheckboxGroupProps> = ({
 
   const error = formState.errors[name]?.message as string | undefined
 
+  const { accessibilityProps, ids } = getAriaAccessibilityInputProps(name, {
+    infoLabel,
+    error,
+  })
+
   return (
-    <InputWrapper component="fieldset" error={error} sx={sx} infoLabel={infoLabel}>
+    <InputWrapper component="fieldset" error={error} sx={sx} infoLabel={infoLabel} {...ids}>
       <FormLabel component="legend">{label}</FormLabel>
       <FormGroup>
         <Controller
@@ -67,6 +72,7 @@ export const RHFCheckboxGroup: React.FC<RHFCheckboxGroupProps> = ({
                         checked={field.value?.includes(o.value) ?? false}
                         onChange={onChange}
                         name={String(o.value)}
+                        inputProps={{ ...accessibilityProps }}
                       />
                     }
                     label={o.label}

--- a/src/components/shared/react-hook-form-inputs/RHFCheckboxGroup.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFCheckboxGroup.tsx
@@ -43,7 +43,7 @@ export const RHFCheckboxGroup: React.FC<RHFCheckboxGroupProps> = ({
   return (
     <InputWrapper component="fieldset" error={error} sx={sx} infoLabel={infoLabel} {...ids}>
       <FormLabel component="legend">{label}</FormLabel>
-      <FormGroup {...accessibilityProps}>
+      <FormGroup {...accessibilityProps} data-testId="checkbox-group">
         <Controller
           name={name}
           rules={mapValidationErrorMessages(rules, t)}

--- a/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFRadioGroup.tsx
@@ -11,7 +11,7 @@ import { Controller, useFormContext } from 'react-hook-form'
 import type { InputRadioGroupOption } from '@/types/common.types'
 import type { ControllerProps } from 'react-hook-form/dist/types'
 import { useTranslation } from 'react-i18next'
-import { mapValidationErrorMessages } from '@/utils/form.utils'
+import { getAriaAccessibilityInputProps, mapValidationErrorMessages } from '@/utils/form.utils'
 import { theme } from '@pagopa/mui-italia'
 
 export type RHFRadioGroupProps = Omit<MUIRadioGroupProps, 'onChange'> & {
@@ -49,8 +49,13 @@ export const RHFRadioGroup: React.FC<RHFRadioGroupProps> = ({
 
   const error = formState.errors[name]?.message as string | undefined
 
+  const { accessibilityProps, ids } = getAriaAccessibilityInputProps(name, {
+    infoLabel,
+    error,
+  })
+
   return (
-    <InputWrapper error={error} sx={sx} infoLabel={infoLabel}>
+    <InputWrapper error={error} sx={sx} infoLabel={infoLabel} {...ids}>
       {label && (
         <FormLabel
           sx={{
@@ -74,6 +79,7 @@ export const RHFRadioGroup: React.FC<RHFRadioGroupProps> = ({
             aria-labelledby={labelId}
             {...props}
             {...fieldProps}
+            {...accessibilityProps}
             onChange={(_, val) => {
               let value: string | boolean = val
               if (isOptionValueAsBoolean) {

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFCheckboxGroup.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFCheckboxGroup.test.tsx
@@ -5,6 +5,8 @@ import userEvent from '@testing-library/user-event'
 import { TestInputWrapper } from '@/components/shared/react-hook-form-inputs/__tests__/test-utils'
 import { RHFCheckboxGroup } from '@/components/shared/react-hook-form-inputs'
 import { vi } from 'vitest'
+import { FormProvider, useForm } from 'react-hook-form'
+import { Box, Button } from '@mui/material'
 
 const checkboxGroupOptions = [
   { label: 'option1', value: 'option1' },
@@ -106,5 +108,67 @@ describe('determine whether the integration between react-hook-form and MUI’s 
     )
 
     expect(checkboxResult.queryByRole('checkbox')).toBeNull()
+  })
+
+  it('should have infoLabel id and corresponding describedBy when infoLabel passed', () => {
+    const screen = render(
+      <TestInputWrapper>
+        <RHFCheckboxGroup {...checkboxGroupProps.standard} infoLabel="testInfoLabel" />
+      </TestInputWrapper>
+    )
+
+    const infoLabel = screen.getByText('testInfoLabel')
+    const checkboxGroup = screen.getByTestId('checkbox-group')
+
+    expect(infoLabel).toHaveAttribute('id', 'testText-infoLabel')
+    expect(checkboxGroup).toHaveAttribute('aria-describedby', 'testText-infoLabel')
+  })
+
+  it('should have error label id and corresponding describedBy and aria-invalid when there is an error', async () => {
+    const user = userEvent.setup()
+    const FormWrapper = ({ children }: { children: React.ReactNode }) => {
+      const formMethods = useForm({
+        defaultValues: {
+          testText: [],
+        },
+      })
+
+      const onSubmit = vi.fn()
+
+      return (
+        <FormProvider {...formMethods}>
+          <Box component="form" noValidate onSubmit={formMethods.handleSubmit(onSubmit)}>
+            {children}
+            <Button type="submit">form submit</Button>
+          </Box>
+        </FormProvider>
+      )
+    }
+
+    const screen = render(
+      <FormWrapper>
+        <RHFCheckboxGroup
+          {...checkboxGroupProps.standard}
+          rules={{
+            validate: (value: Array<string>) => {
+              if (value.length === 0) {
+                return 'error'
+              }
+              return true
+            },
+          }}
+        />
+      </FormWrapper>
+    )
+
+    const submitButton = screen.getByRole('button', { name: 'form submit' })
+    await user.click(submitButton)
+
+    const errorLabel = screen.getByText('error')
+    const checkboxGroup = screen.getByTestId('checkbox-group')
+
+    expect(errorLabel).toHaveAttribute('id', 'testText-error')
+    expect(checkboxGroup).toHaveAttribute('aria-describedby', 'testText-error')
+    expect(checkboxGroup).toHaveAttribute('aria-invalid', 'true')
   })
 })

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFRadioGroup.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFRadioGroup.test.tsx
@@ -5,6 +5,8 @@ import userEvent from '@testing-library/user-event'
 import { TestInputWrapper } from '@/components/shared/react-hook-form-inputs/__tests__/test-utils'
 import { RHFRadioGroup } from '@/components/shared/react-hook-form-inputs'
 import { vi } from 'vitest'
+import { Box, Button } from '@mui/material'
+import { FormProvider, useForm } from 'react-hook-form'
 
 const radioGroupOptions = [
   { label: 'option1', value: 'option1' },
@@ -87,5 +89,74 @@ describe('determine whether the integration between react-hook-form and MUI’s 
     await user.click(radioOption1)
     expect(onValueChange).toHaveBeenCalledTimes(1)
     expect(onValueChange).toHaveBeenCalledWith('option1')
+  })
+
+  it('should have infoLabel id and corresponding describedBy when infoLabel passed', () => {
+    const screen = render(
+      <TestInputWrapper>
+        <RHFRadioGroup {...radioGroupProps.standard} infoLabel="testInfoLabel" />
+      </TestInputWrapper>
+    )
+
+    const infoLabel = screen.getByText('testInfoLabel')
+    const radioGroup = screen.getByRole('radiogroup')
+
+    expect(infoLabel).toHaveAttribute('id', 'testText-infoLabel')
+    expect(radioGroup).toHaveAttribute('aria-describedby', 'testText-infoLabel')
+  })
+
+  it('should have error label id and corresponding describedBy and aria-invalid when there is an error', async () => {
+    const user = userEvent.setup()
+    const FormWrapper = ({ children }: { children: React.ReactNode }) => {
+      const formMethods = useForm({
+        defaultValues: {
+          testText: null,
+        },
+      })
+
+      const onSubmit = vi.fn()
+
+      return (
+        <FormProvider {...formMethods}>
+          <Box component="form" noValidate onSubmit={formMethods.handleSubmit(onSubmit)}>
+            {children}
+            <Button type="submit">form submit</Button>
+          </Box>
+        </FormProvider>
+      )
+    }
+
+    const screen = render(
+      <FormWrapper>
+        <RHFRadioGroup
+          {...radioGroupProps.standard}
+          rules={{
+            validate: (value: string) => {
+              if (value === 'option1') {
+                return 'error'
+              }
+              return true
+            },
+          }}
+        />
+      </FormWrapper>
+    )
+
+    const radioOption1 = screen.getByRole('radio', {
+      name: 'option1',
+    }) as HTMLInputElement
+
+    await user.click(radioOption1)
+    expect(radioOption1).toBeChecked()
+
+    const submitButton = screen.getByRole('button', { name: 'form submit' })
+    await user.click(submitButton)
+
+    const errorLabel = screen.getByText('error')
+    const radioGroup = screen.getByRole('radiogroup')
+
+    expect(errorLabel).toHaveAttribute('id', 'testText-error')
+    expect(radioGroup).toHaveAttribute('aria-describedby', 'testText-error')
+    expect(radioGroup).toHaveAttribute('aria-invalid', 'true')
   })
 })


### PR DESCRIPTION
## 🔗 Issue

[PIN-2684 INT-57](https://pagopa.atlassian.net/browse/A2-2684)

## 📝 Description / Context

The problem in the taks is that `infoLabel` and `error` label does not have an id that refers to the checkbox form component. This PR add the `getAriaAccessibilityInputProps` function to the `RHFCheckboxGroup`, this function returns the `accessibilityProps` and the `ids` that will be passed to the component.

## 🛠 List of changes

- add `getAriaAccessibilityInputProps` to `RHFCheckboxGroup` to generate the `accessibilityProps` and the `ids`
- pass the `accessibilityProps` and the `ids` to the component
