### PR TITLE
Bugfix/pin 10455 reviewer name surname

### DIFF
--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -2293,22 +2293,46 @@ export interface EServiceTemplateDetails {
 }
 
 export interface AsyncExchangeProperties {
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 999999
+   */
   responseTime: number;
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 999999
+   */
   resourceAvailableTime: number;
   confirmation: boolean;
   bulk: boolean;
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 99999
+   */
   maxResultSet: number;
 }
 
 export interface AsyncExchangePropertiesInstanceSeed {
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 999999
+   */
   responseTime?: number;
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 999999
+   */
   resourceAvailableTime?: number;
-  /** @format int32 */
+  /**
+   * @format int32
+   * @min 1
+   * @max 99999
+   */
   maxResultSet?: number;
 }
 
@@ -2403,6 +2427,7 @@ export interface UpdateEServiceTemplateSeed {
   mode: EServiceMode;
   isSignalHubEnabled?: boolean;
   personalData?: boolean;
+  asyncExchange?: boolean;
 }
 
 export interface EServiceTemplateSeed {
@@ -2440,7 +2465,7 @@ export interface InstanceEServiceSeed {
    * @maxLength 12
    */
   instanceLabel?: string;
-  asyncExchange?: boolean;
+  asyncExchangeProperties?: AsyncExchangePropertiesInstanceSeed;
 }
 
 export interface VersionSeedForEServiceTemplateCreation {
@@ -2819,6 +2844,7 @@ export interface ReviewerWorkflow {
   /** Risk analysis review mode */
   reviewMode: RiskAnalysisReviewMode;
   reviewerIds: string[];
+  reviewers?: CompactUser[];
   /** Risk analysis signing state */
   signingState: RiskAnalysisSigningState;
   /** @format uuid */
@@ -4277,7 +4303,7 @@ export interface GetCatalogPurposeTemplatesParams {
    */
   creatorIds?: string[];
   /**
-   * comma separated sequence of e-service IDs
+   * comma separated sequence of e-service IDs. For e-services that are instances of an e-service template, purpose templates linked to the originating e-service template are also returned.
    * @default []
    */
   eserviceIds?: string[];
@@ -7089,7 +7115,7 @@ export namespace Catalog {
        */
       creatorIds?: string[];
       /**
-       * comma separated sequence of e-service IDs
+       * comma separated sequence of e-service IDs. For e-services that are instances of an e-service template, purpose templates linked to the originating e-service template are also returned.
        * @default []
        */
       eserviceIds?: string[];

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsAssignmentSection.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsAssignmentSection.tsx
@@ -17,18 +17,21 @@ export const ConsumerPurposeDetailsAssignmentSection: React.FC<
 
   const modeLabel = getReviewModeLabel(purpose.reviewerWorkflow?.reviewMode, t)
 
-  // We surface only the first reviewer: the BE models `reviewerIds` as a list to allow multiple
+  // We surface only the first reviewer: the BE models `reviewers` as a list to allow multiple
   // reviewers in the future, but today at most one reviewer is ever assigned.
-  // TODO: the BE does not expose the reviewer's name yet, only `reviewerId`. We render the raw id
-  // as a placeholder. Replace it with the reviewer's name/surname once the BE exposes them.
-  const reviewerId = purpose.reviewerWorkflow?.reviewerIds[0]
+  const reviewer = purpose.reviewerWorkflow?.reviewers?.[0]
+  const reviewerName = reviewer ? `${reviewer.name} ${reviewer.familyName}`.trim() : undefined
 
   return (
     <SectionContainer title={t('title')}>
       <Stack spacing={2}>
         <InformationContainer label={t('mode.label')} direction="row" content={modeLabel} />
-        {reviewerId && (
-          <InformationContainer label={t('reviewer.label')} direction="row" content={reviewerId} />
+        {reviewerName && (
+          <InformationContainer
+            label={t('reviewer.label')}
+            direction="row"
+            content={reviewerName}
+          />
         )}
       </Stack>
     </SectionContainer>

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsAssignmentSection.test.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsAssignmentSection.test.tsx
@@ -21,7 +21,27 @@ describe('ConsumerPurposeDetailsAssignmentSection', () => {
     expect(screen.queryByText('reviewer.label')).not.toBeInTheDocument()
   })
 
-  it('shows the assigned mode and the reviewer id', () => {
+  it('shows the assigned mode and the reviewer name and surname', () => {
+    renderWithApplicationContext(
+      <ConsumerPurposeDetailsAssignmentSection
+        purpose={createMockPurpose({
+          reviewerWorkflow: {
+            reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+            reviewerIds: [reviewerId],
+            reviewers: [{ userId: reviewerId, name: 'Mario', familyName: 'Rossi' }],
+            signingState: 'ASSIGNED',
+          },
+        })}
+      />,
+      { withReactQueryContext: true }
+    )
+
+    expect(screen.getByText('mode.adminWritesReviewerSigns')).toBeInTheDocument()
+    expect(screen.getByText('reviewer.label')).toBeInTheDocument()
+    expect(screen.getByText('Mario Rossi')).toBeInTheDocument()
+  })
+
+  it('does not show the reviewer row when the reviewer workflow has no reviewers', () => {
     renderWithApplicationContext(
       <ConsumerPurposeDetailsAssignmentSection
         purpose={createMockPurpose({
@@ -36,7 +56,6 @@ describe('ConsumerPurposeDetailsAssignmentSection', () => {
     )
 
     expect(screen.getByText('mode.adminWritesReviewerSigns')).toBeInTheDocument()
-    expect(screen.getByText('reviewer.label')).toBeInTheDocument()
-    expect(screen.getByText(reviewerId)).toBeInTheDocument()
+    expect(screen.queryByText('reviewer.label')).not.toBeInTheDocument()
   })
 })

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignment.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignment.tsx
@@ -46,9 +46,7 @@ export const PurposeEditStepAssignment: React.FC<ActiveStepProps> = (props) => {
 
   const isEditableDraft = purpose.currentVersion?.state === 'DRAFT'
   if (purpose.reviewerWorkflow || !isEditableDraft) {
-    return (
-      <PurposeEditStepAssignmentReadOnly purpose={purpose} reviewers={reviewers ?? []} {...props} />
-    )
+    return <PurposeEditStepAssignmentReadOnly purpose={purpose} {...props} />
   }
 
   const isDelegate = Boolean(

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignment.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignment.tsx
@@ -30,10 +30,15 @@ export const PurposeEditStepAssignment: React.FC<ActiveStepProps> = (props) => {
     PurposeQueries.getSingle(purposeId)
   )
 
+  // The reviewers list is only consumed by the editable-draft form branch, so only
+  // fetch it when that branch will actually render (avoids a wasted call on the read-only step).
+  const isEditableDraft = purpose?.currentVersion?.state === 'DRAFT'
+  const shouldRenderForm = Boolean(purpose) && !purpose?.reviewerWorkflow && isEditableDraft
+
   const tenantId = jwt?.organizationId
   const { data: reviewers, isLoading: isLoadingReviewers } = useQuery({
     ...TenantQueries.getPartyUsersList({ tenantId: tenantId as string, roles: ['reviewer'] }),
-    enabled: Boolean(tenantId),
+    enabled: Boolean(tenantId) && shouldRenderForm,
   })
 
   if (isLoadingPurpose || isLoadingReviewers) {
@@ -44,7 +49,6 @@ export const PurposeEditStepAssignment: React.FC<ActiveStepProps> = (props) => {
     throw new NotFoundError()
   }
 
-  const isEditableDraft = purpose.currentVersion?.state === 'DRAFT'
   if (purpose.reviewerWorkflow || !isEditableDraft) {
     return <PurposeEditStepAssignmentReadOnly purpose={purpose} {...props} />
   }

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentReadOnly.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentReadOnly.tsx
@@ -7,17 +7,15 @@ import { StepActions } from '@/components/shared/StepActions'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import type { ActiveStepProps } from '@/hooks/useActiveStep'
-import type { Purpose, User } from '@/api/api.generatedTypes'
+import type { Purpose } from '@/api/api.generatedTypes'
 import { beEnumToReviewModeOption } from './PurposeEditStepAssignmentForm'
 
 type PurposeEditStepAssignmentReadOnlyProps = ActiveStepProps & {
   purpose: Purpose
-  reviewers: Array<User>
 }
 
 const PurposeEditStepAssignmentReadOnly: React.FC<PurposeEditStepAssignmentReadOnlyProps> = ({
   purpose,
-  reviewers,
   forward,
   back,
 }) => {
@@ -27,8 +25,7 @@ const PurposeEditStepAssignmentReadOnly: React.FC<PurposeEditStepAssignmentReadO
   const reviewerWorkflow = purpose.reviewerWorkflow
   const reviewModeOption = beEnumToReviewModeOption(reviewerWorkflow?.reviewMode)
 
-  const reviewerId = reviewerWorkflow?.reviewerIds[0]
-  const reviewer = reviewers.find((u) => u.userId === reviewerId)
+  const reviewer = reviewerWorkflow?.reviewers?.[0]
   // The assigned reviewer may no longer be resolvable (role revoked on SelfCare, left the
   // organization, or a different tenant in a delegation): fall back to a placeholder
   // instead of rendering a blank value.

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignment.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignment.test.tsx
@@ -258,7 +258,7 @@ describe('PurposeEditStepAssignment', () => {
     expect(PurposeEditStepAssignmentForm).not.toHaveBeenCalled()
   })
 
-  it('forwards the purpose and the reviewers list to the read-only step', () => {
+  it('forwards the purpose to the read-only step', () => {
     const reviewers = buildReviewers()
     const purpose = buildPurpose(
       {},
@@ -269,7 +269,7 @@ describe('PurposeEditStepAssignment', () => {
     render(<PurposeEditStepAssignment back={vi.fn()} forward={vi.fn()} activeStep={1} />)
 
     expect(PurposeEditStepAssignmentReadOnly).toHaveBeenCalledWith(
-      expect.objectContaining({ purpose, reviewers }),
+      expect.objectContaining({ purpose }),
       expect.anything()
     )
   })

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentReadOnly.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentReadOnly.test.tsx
@@ -13,10 +13,7 @@ const mockReviewer: CompactUser = {
   familyName: 'Rossi',
 }
 
-function buildPurpose(
-  reviewMode: RiskAnalysisReviewMode,
-  reviewers: Array<CompactUser>
-): Purpose {
+function buildPurpose(reviewMode: RiskAnalysisReviewMode, reviewers: Array<CompactUser>): Purpose {
   return {
     ...createMockPurpose({ id: 'purpose-id' }),
     reviewerWorkflow: {

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentReadOnly.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentReadOnly.test.tsx
@@ -5,22 +5,24 @@ import userEvent from '@testing-library/user-event'
 import PurposeEditStepAssignmentReadOnly from '../PurposeEditStepAssignmentReadOnly'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
-import type { Purpose, RiskAnalysisReviewMode, User } from '@/api/api.generatedTypes'
+import type { CompactUser, Purpose, RiskAnalysisReviewMode } from '@/api/api.generatedTypes'
 
-const mockReviewer: User = {
+const mockReviewer: CompactUser = {
   userId: 'reviewer-uuid-1',
-  tenantId: 'tenant-uuid',
   name: 'Mario',
   familyName: 'Rossi',
-  roles: ['reviewer'],
 }
 
-function buildPurpose(reviewMode: RiskAnalysisReviewMode, reviewerIds: string[]): Purpose {
+function buildPurpose(
+  reviewMode: RiskAnalysisReviewMode,
+  reviewers: Array<CompactUser>
+): Purpose {
   return {
     ...createMockPurpose({ id: 'purpose-id' }),
     reviewerWorkflow: {
       reviewMode,
-      reviewerIds,
+      reviewerIds: reviewers.map((r) => r.userId),
+      reviewers,
       signingState: 'ASSIGNED',
     },
   }
@@ -28,16 +30,12 @@ function buildPurpose(reviewMode: RiskAnalysisReviewMode, reviewerIds: string[])
 
 function renderComponent(overrides?: {
   purpose?: Purpose
-  reviewers?: Array<User>
   forward?: VoidFunction
   back?: VoidFunction
 }) {
   return renderWithApplicationContext(
     <PurposeEditStepAssignmentReadOnly
-      purpose={
-        overrides?.purpose ?? buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', ['reviewer-uuid-1'])
-      }
-      reviewers={overrides?.reviewers ?? [mockReviewer]}
+      purpose={overrides?.purpose ?? buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [mockReviewer])}
       activeStep={1}
       forward={overrides?.forward ?? vi.fn()}
       back={overrides?.back ?? vi.fn()}
@@ -57,7 +55,7 @@ describe('PurposeEditStepAssignmentReadOnly', () => {
   })
 
   it('renders the "mode" row with the option-2 label and the "reviewer" row for ADMIN_WRITES_REVIEWER_SIGNS', () => {
-    renderComponent({ purpose: buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', ['reviewer-uuid-1']) })
+    renderComponent({ purpose: buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [mockReviewer]) })
 
     expect(screen.getByText('readOnly.modeLabel')).toBeInTheDocument()
     expect(screen.getByText('reviewModeField.options.selfWritesReviewerSigns')).toBeInTheDocument()
@@ -67,7 +65,7 @@ describe('PurposeEditStepAssignmentReadOnly', () => {
 
   it('renders the "mode" row with the option-3 label and the "reviewer" row for REVIEWER_WRITES_REVIEWER_SIGNS', () => {
     renderComponent({
-      purpose: buildPurpose('REVIEWER_WRITES_REVIEWER_SIGNS', ['reviewer-uuid-1']),
+      purpose: buildPurpose('REVIEWER_WRITES_REVIEWER_SIGNS', [mockReviewer]),
     })
 
     expect(screen.getByText('readOnly.modeLabel')).toBeInTheDocument()
@@ -102,10 +100,9 @@ describe('PurposeEditStepAssignmentReadOnly', () => {
     expect(back).toHaveBeenCalledTimes(1)
   })
 
-  it('falls back to a placeholder when the assigned reviewer is not in the reviewers list', () => {
+  it('falls back to a placeholder when the workflow exposes no resolvable reviewer', () => {
     renderComponent({
-      purpose: buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', ['unknown-reviewer']),
-      reviewers: [mockReviewer],
+      purpose: buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', []),
     })
 
     expect(screen.getByText('readOnly.reviewerLabel')).toBeInTheDocument()

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { ActiveStepProps } from '@/hooks/useActiveStep'
+import type { CompactUser } from '@/api/api.generatedTypes'
 import { RiskAnalysisForm, RiskAnalysisFormSkeleton } from './RiskAnalysisForm/RiskAnalysisForm'
 import { useNavigate, useParams } from '@/router'
 import { PurposeMutations, PurposeQueries } from '@/api/purpose'
@@ -137,16 +138,21 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
   }
 
   const handleRequestApproval = (answers: Record<string, string[]>) => {
-    const reviewer = purpose.reviewerWorkflow?.reviewers?.[0]
-    if (!reviewer) {
-      // BE contract: option 2 always assigns at least one reviewer.
+    const reviewerId = purpose.reviewerWorkflow?.reviewerIds?.[0]
+    if (!reviewerId) {
       // If we land here the purpose is malformed;
       // log loudly and no-op rather than crashing the route —
       // this is a UI action handler, not a place to throw to the ErrorBoundary.
       console.error(
-        'PurposeEditStepRiskAnalysis: reviewers is missing on a purpose in ADMIN_WRITES_REVIEWER_SIGNS mode'
+        'PurposeEditStepRiskAnalysis: reviewerIds is missing on a purpose in ADMIN_WRITES_REVIEWER_SIGNS mode'
       )
       return
+    }
+
+    const reviewer: CompactUser = purpose.reviewerWorkflow?.reviewers?.[0] ?? {
+      userId: reviewerId,
+      name: '',
+      familyName: '',
     }
     openDialog({
       type: 'requestPurposeApproval',

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import type { ActiveStepProps } from '@/hooks/useActiveStep'
-import type { CompactUser } from '@/api/api.generatedTypes'
 import { RiskAnalysisForm, RiskAnalysisFormSkeleton } from './RiskAnalysisForm/RiskAnalysisForm'
 import { useNavigate, useParams } from '@/router'
 import { PurposeMutations, PurposeQueries } from '@/api/purpose'
@@ -138,20 +137,17 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
   }
 
   const handleRequestApproval = (answers: Record<string, string[]>) => {
-    const reviewerId = purpose.reviewerWorkflow?.reviewerIds?.[0]
-    if (!reviewerId) {
+    const reviewer = purpose.reviewerWorkflow?.reviewers?.[0]
+    if (!reviewer) {
       // BE contract: option 2 always assigns at least one reviewer.
       // If we land here the purpose is malformed;
       // log loudly and no-op rather than crashing the route —
       // this is a UI action handler, not a place to throw to the ErrorBoundary.
       console.error(
-        'PurposeEditStepRiskAnalysis: reviewerIds is missing on a purpose in ADMIN_WRITES_REVIEWER_SIGNS mode'
+        'PurposeEditStepRiskAnalysis: reviewers is missing on a purpose in ADMIN_WRITES_REVIEWER_SIGNS mode'
       )
       return
     }
-    // TODO: replace with `purpose.reviewerWorkflow.reviewers[0]` once the BE
-    // updates ReviewerWorkflow to return CompactUser[] instead of reviewerIds.
-    const reviewer: CompactUser = { userId: reviewerId, name: '', familyName: '' }
     openDialog({
       type: 'requestPurposeApproval',
       reviewer,

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
@@ -350,7 +350,7 @@ describe('PurposeEditStepRiskAnalysis', () => {
     })
   })
 
-  it('in option 2 logs and no-ops when reviewers is missing (BE contract violation) instead of opening a malformed dialog', () => {
+  it('in option 2 logs and no-ops when reviewerIds is missing (BE contract violation) instead of opening a malformed dialog', () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const purpose = buildPurpose({
       reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
@@ -364,10 +364,32 @@ describe('PurposeEditStepRiskAnalysis', () => {
 
     getLastFormProps().onSubmit({ purpose: ['OTHER'] })
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/reviewers/))
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/reviewerIds/))
     expect(openDialogMock).not.toHaveBeenCalled()
 
     consoleErrorSpy.mockRestore()
+  })
+
+  it('in option 2 still opens the dialog when reviewerIds is present but reviewers is not yet populated (staggered BE release)', () => {
+    const purpose = buildPurpose({
+      reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+      reviewerIds: ['reviewer-1'],
+      reviewers: [],
+      signingState: 'DRAFT',
+    })
+    mockQueries(purpose, createMockRiskAnalysisFormConfig())
+
+    render(<PurposeEditStepRiskAnalysis back={vi.fn()} forward={vi.fn()} activeStep={2} />)
+
+    getLastFormProps().onSubmit({ purpose: ['OTHER'] })
+
+    // The missing reviewers[] must not block the admin: the dialog opens with a placeholder
+    // reviewer built from reviewerId (name + surname simply unavailable until the BE backfills).
+    expect(openDialogMock).toHaveBeenCalledTimes(1)
+    expect(openDialogMock.mock.calls[0][0]).toMatchObject({
+      type: 'requestPurposeApproval',
+      reviewer: { userId: 'reviewer-1', name: '', familyName: '' },
+    })
   })
 
   it('in option 2 the draft save only persists and navigates without submitting', () => {

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
@@ -301,9 +301,11 @@ describe('PurposeEditStepRiskAnalysis', () => {
   })
 
   it('in option 2 opens the requestPurposeApproval dialog and the dialog onConfirm runs the submit+navigate chain', () => {
+    const reviewer = { userId: 'reviewer-1', name: 'Mario', familyName: 'Rossi' }
     const purpose = buildPurpose({
       reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
       reviewerIds: ['reviewer-1'],
+      reviewers: [reviewer],
       signingState: 'DRAFT',
     })
     const riskAnalysis = createMockRiskAnalysisFormConfig()
@@ -321,11 +323,9 @@ describe('PurposeEditStepRiskAnalysis', () => {
 
     expect(openDialogMock).toHaveBeenCalledTimes(1)
     const dialogPayload = openDialogMock.mock.calls[0][0]
-    // TODO: assert the real reviewer once the BE returns reviewers as CompactUser[];
-    // for now the component builds a placeholder from reviewerIds[0].
     expect(dialogPayload).toMatchObject({
       type: 'requestPurposeApproval',
-      reviewer: { userId: 'reviewer-1', name: '', familyName: '' },
+      reviewer,
     })
     expect(typeof dialogPayload.onConfirm).toBe('function')
 
@@ -350,11 +350,12 @@ describe('PurposeEditStepRiskAnalysis', () => {
     })
   })
 
-  it('in option 2 logs and no-ops when reviewerIds is missing (BE contract violation) instead of opening a malformed dialog', () => {
+  it('in option 2 logs and no-ops when reviewers is missing (BE contract violation) instead of opening a malformed dialog', () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const purpose = buildPurpose({
       reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
       reviewerIds: [],
+      reviewers: [],
       signingState: 'DRAFT',
     })
     mockQueries(purpose, createMockRiskAnalysisFormConfig())
@@ -363,7 +364,7 @@ describe('PurposeEditStepRiskAnalysis', () => {
 
     getLastFormProps().onSubmit({ purpose: ['OTHER'] })
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/reviewerIds/))
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/reviewers/))
     expect(openDialogMock).not.toHaveBeenCalled()
 
     consoleErrorSpy.mockRestore()

--- a/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
@@ -18,17 +18,16 @@ export const ConsumerPurposeSummaryAssignmentAccordion: React.FC<
 
   const modeLabel = getReviewModeLabel(purpose.reviewerWorkflow?.reviewMode, t)
 
-  // BE does not yet expose the reviewer's first/last name: we render the raw UUID as a placeholder.
-  // We surface only the first reviewer: the BE models `reviewerIds` as a list to allow multiple
+  // We surface only the first reviewer: the BE models `reviewers` as a list to allow multiple
   // reviewers in the future, but today at most one reviewer is ever assigned.
-  // BE invariant: when `reviewerWorkflow` is defined, `reviewerIds` is non-empty.
-  const reviewerId = purpose.reviewerWorkflow?.reviewerIds[0]
+  const reviewer = purpose.reviewerWorkflow?.reviewers?.[0]
+  const reviewerName = reviewer ? `${reviewer.name} ${reviewer.familyName}`.trim() : undefined
 
   return (
     <Stack spacing={2}>
       <InformationContainer content={modeLabel} direction="row" label={t('mode.label')} />
-      {reviewerId && (
-        <InformationContainer content={reviewerId} direction="row" label={t('reviewer.label')} />
+      {reviewerName && (
+        <InformationContainer content={reviewerName} direction="row" label={t('reviewer.label')} />
       )}
     </Stack>
   )

--- a/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryAssignmentAccordion.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryAssignmentAccordion.test.tsx
@@ -49,10 +49,11 @@ describe('ConsumerPurposeSummaryAssignmentAccordion', () => {
     expect(screen.queryByText('reviewer.label')).not.toBeInTheDocument()
   })
 
-  it('option 2 (ADMIN_WRITES_REVIEWER_SIGNS): renders "Modalità" + "Valutatore" rows', () => {
+  it('option 2 (ADMIN_WRITES_REVIEWER_SIGNS): renders "Modalità" + "Valutatore" rows with the reviewer name', () => {
     setPurpose({
       reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
       reviewerIds: [REVIEWER_ID],
+      reviewers: [{ userId: REVIEWER_ID, name: 'Mario', familyName: 'Rossi' }],
       signingState: 'ASSIGNED',
     })
 
@@ -64,13 +65,14 @@ describe('ConsumerPurposeSummaryAssignmentAccordion', () => {
     expect(screen.getByText('mode.label')).toBeInTheDocument()
     expect(screen.getByText('mode.adminWritesReviewerSigns')).toBeInTheDocument()
     expect(screen.getByText('reviewer.label')).toBeInTheDocument()
-    expect(screen.getByText(REVIEWER_ID)).toBeInTheDocument()
+    expect(screen.getByText('Mario Rossi')).toBeInTheDocument()
   })
 
-  it('option 3 (REVIEWER_WRITES_REVIEWER_SIGNS): renders "Modalità" + "Valutatore" rows', () => {
+  it('option 3 (REVIEWER_WRITES_REVIEWER_SIGNS): renders "Modalità" + "Valutatore" rows with the reviewer name', () => {
     setPurpose({
       reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
       reviewerIds: [REVIEWER_ID],
+      reviewers: [{ userId: REVIEWER_ID, name: 'Mario', familyName: 'Rossi' }],
       signingState: 'ASSIGNED',
     })
 
@@ -82,6 +84,22 @@ describe('ConsumerPurposeSummaryAssignmentAccordion', () => {
     expect(screen.getByText('mode.label')).toBeInTheDocument()
     expect(screen.getByText('mode.reviewerWritesReviewerSigns')).toBeInTheDocument()
     expect(screen.getByText('reviewer.label')).toBeInTheDocument()
-    expect(screen.getByText(REVIEWER_ID)).toBeInTheDocument()
+    expect(screen.getByText('Mario Rossi')).toBeInTheDocument()
+  })
+
+  it('does not render the "Valutatore" row when the reviewer workflow has no reviewers', () => {
+    setPurpose({
+      reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+      reviewerIds: [REVIEWER_ID],
+      signingState: 'ASSIGNED',
+    })
+
+    renderWithApplicationContext(
+      <ConsumerPurposeSummaryAssignmentAccordion purposeId="test-id" />,
+      { withReactQueryContext: true }
+    )
+
+    expect(screen.getByText('mode.adminWritesReviewerSigns')).toBeInTheDocument()
+    expect(screen.queryByText('reviewer.label')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
PR description (template del progetto, in inglese):

## 🔗 Issue
[PIN-10455](https://pagopa.atlassian.net/browse/PIN-10455) - [PIN-10454](https://pagopa.atlassian.net/browse/PIN-10454)

## 📝 Description / Context
The BE now exposes the reviewer's name and surname on the purpose risk-analysis review workflow via `reviewerWorkflow.reviewers` (`CompactUser[]`). 
Until now the FE either rendered the raw reviewer UUID as a placeholder or resolved the name through a separate users fetch. 
This PR consumes the new field everywhere the reviewer is shown, so the user always sees the reviewer's name and surname.

## 🛠 List of changes
- Purpose details – assignment section: show reviewer name + surname instead of the raw `reviewerId`
- Purpose summary – assignment accordion (riepilogo): show reviewer name + surname instead of the raw `reviewerId`
- Risk analysis edit step – request approval dialog: pass the real reviewer (`reviewerWorkflow.reviewers[0]`) instead of a placeholder `CompactUser` built from `reviewerIds[0]`; guard/log updated to reference `reviewers`
- Assignment read-only step: read the reviewer from `reviewerWorkflow.reviewers[0]` instead of matching `reviewerIds[0]` against the fetched users list; keep the "reviewer unknown" fallback; drop the now-unused `reviewers` prop
- Removed the related `reviewerWorkflow` reviewer-name TODOs
- Updated unit tests accordingly

## 🧪 How to test
- Create/assign a purpose risk-analysis review in option 2 (ADMIN_WRITES_REVIEWER_SIGNS) and option 3
(REVIEWER_WRITES_REVIEWER_SIGNS)
- Purpose details page → assignment section: the reviewer row shows name + surname (not a UUID)
- Purpose summary page → assignment hows name + surname (not a UUID)
- Risk analysis edit step → "Richiedi approvazione": the confirmation dialog shows the reviewer's name + surname
- Assignment read-only step: the reviewer row shows name + surname; if the reviewer can no longer be
resolved, the "reviewer unknown" placeholder is shown

[PIN-10455]: https://pagopa.atlassian.net/browse/PIN-10455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-10454]: https://pagopa.atlassian.net/browse/PIN-10454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ