### PR TITLE
fix: correct proceed button label on purpose risk analysis step

### DIFF
--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
@@ -232,6 +232,7 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
       isSubmitting={isSaving || isSubmittingForReviewer}
       isRejected={isRejected}
       rejectionReason={purpose.reviewerWorkflow?.rejectionReason}
+      submitLabel={t('forwardWithSaveBtn')}
     />
   )
 }

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
@@ -63,6 +63,7 @@ type RiskAnalysisFormSpyProps = {
   onSubmit: (answers: Record<string, string[]>) => void
   onSaveDraft?: (answers: Record<string, string[]>) => void
   isRejected?: boolean
+  submitLabel?: string
 }
 
 const formSpy = vi.fn<[RiskAnalysisFormSpyProps], null>()
@@ -118,6 +119,8 @@ describe('PurposeEditStepRiskAnalysis', () => {
     expect(getLastFormProps().isReviewerApprovalMode).toBe(false)
     expect(getLastFormProps().onSaveDraft).toBeUndefined()
     expect(getLastFormProps().isRejected).toBeFalsy()
+    // the editable step 3 forward CTA reads "Salva bozza e prosegui", not "Vai al riepilogo"
+    expect(getLastFormProps().submitLabel).toBe('forwardWithSaveBtn')
   })
 
   it('passes isReviewerApprovalMode=true with onSaveDraft when reviewMode is ADMIN_WRITES_REVIEWER_SIGNS', () => {


### PR DESCRIPTION
## 🔗 Issue
[PIN-10463](https://pagopa.atlassian.net/browse/PIN-10463)

## 📝 Description / Context
On the "Analisi del rischio" step (step 3) of the purpose creation flow, the proceed button showed the wrong label "Vai al riepilogo" instead of "Salva bozza e prosegui" (per Figma). Clicking the button does save the draft before navigating to the summary, so the previous copy was also misleading.

## 🛠 List of changes
- Pass `submitLabel={t('forwardWithSaveBtn')}` to the editable `RiskAnalysisForm` in `PurposeEditStepRiskAnalysis`, so the forward CTA now reads "Salva bozza e prosegui".
- Added a unit test assertion locking the `submitLabel` passed in option-1 (editable) mode.

## 🧪 How to test
- Create an e-service.
- Create a purpose (richiesta di fruizione) towards that e-service.
- At step 2, select the first available assignment mode.
- Reach step 3 ("Analisi del rischio") and verify the proceed button reads "Salva bozza e prosegui".

[PIN-10463]: https://pagopa.atlassian.net/browse/PIN-10463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ