### PR TITLE
fix: disable publish button when risk analysis is not compiled

### DIFF
--- a/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
@@ -71,12 +71,16 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
       checkIncompatibleAnswerValue()) ||
     (isEserviceDeliverMode && isRulesetExpired)
 
+  const isRiskAnalysisNotCompiled = isEserviceDeliverMode && !purpose?.riskAnalysisForm
+
   // Tooltip explaining why "Publish" is disabled, with the personal-data reason taking precedence.
   let publishDisabledTooltip = ''
   if (isPublishButtonDisabled) {
     publishDisabledTooltip = t('summary.publishBtnDisabled')
   } else if (isPublishDisabledByReview) {
     publishDisabledTooltip = t('summary.publishBtnDisabledByReview')
+  } else if (isRiskAnalysisNotCompiled) {
+    publishDisabledTooltip = t('summary.publishBtnDisabledNotCompiled')
   }
 
   const arePublishOrEditButtonsDisabled =
@@ -214,7 +218,8 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
                 disabled={
                   arePublishOrEditButtonsDisabled ||
                   isPublishButtonDisabled ||
-                  isPublishDisabledByReview
+                  isPublishDisabledByReview ||
+                  isRiskAnalysisNotCompiled
                 }
                 startIcon={<PublishIcon />}
                 variant="contained"

--- a/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
@@ -182,6 +182,47 @@ describe('ConsumerPurposeSummaryPage', () => {
     expect(publishButton).toBeEnabled()
   })
 
+  it('disables publish button when risk analysis is not compiled (DELIVER mode, self-compile assignment)', () => {
+    useQueryMock.mockReturnValue({
+      data: { ...createMockPurposeCompatiblePersonalDataYes(), riskAnalysisForm: undefined },
+      isLoading: false,
+    })
+
+    renderWithApplicationContext(<ConsumerPurposeSummaryPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    const publishButton = screen.getByRole('button', {
+      name: 'summary.publishBtn',
+    })
+
+    expect(publishButton).toBeDisabled()
+  })
+
+  it('enables publish button when risk analysis is not compiled but eservice is in RECEIVE mode (provider-supplied)', () => {
+    const purpose = createMockPurposeCompatiblePersonalDataYes()
+    useQueryMock.mockReturnValue({
+      data: {
+        ...purpose,
+        riskAnalysisForm: undefined,
+        eservice: { ...purpose.eservice, mode: 'RECEIVE' },
+      },
+      isLoading: false,
+    })
+
+    renderWithApplicationContext(<ConsumerPurposeSummaryPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    const publishButton = screen.getByRole('button', {
+      name: 'summary.publishBtn',
+    })
+
+    expect(publishButton).toBeEnabled()
+  })
+
   it('shows info alert when there is an expiration date to show', () => {
     useQueryMock.mockReturnValue({
       data: createMockPurposeUsesPersonalDataAnswerYes(),

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -310,6 +310,7 @@
     },
     "publishBtnDisabled": "Your declaration on personal data processing in the risk analysis prevents publication",
     "publishBtnDisabledByReview": "You will be able to publish once the reviewer has approved the risk analysis.",
+    "publishBtnDisabledNotCompiled": "To publish you must first complete the risk analysis.",
     "publishBtn": "Publish"
   },
   "riskAnalysisRejectionDrawer": {

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -310,6 +310,7 @@
     },
     "publishBtnDisabled": "La tua dichiarazione sul trattamento dei dati personali nell’analisi del rischio non permette la pubblicazione",
     "publishBtnDisabledByReview": "Potrai pubblicare quando il valutatore avrà approvato l’analisi del rischio.",
+    "publishBtnDisabledNotCompiled": "Per pubblicare devi prima compilare l’analisi del rischio.",
     "publishBtn": "Pubblica"
   },
   "riskAnalysisRejectionDrawer": {


### PR DESCRIPTION
## 🔗 Issue
[PIN-10474](https://pagopa.atlassian.net/browse/PIN-10474)

## 📝 Description / Context
On the consumer purpose summary page, the "Publish" button was enabled even when the risk analysis had not been compiled yet. This happened for DELIVER purposes using the "self-compile and self-approve" risk analysis assignment mode (no reviewer workflow): in that case `riskAnalysisForm` is absent and no condition disabled the button.

The existing publish gating only covered the personal-data incompatibility check (which requires a compiled form), the ruleset-expired case, and the reviewer-workflow states (options 2/3). The "risk analysis not compiled" case for the self-compile mode (option 1) was never gated.

## 🛠 List of changes
- Added `isRiskAnalysisNotCompiled` (DELIVER mode + missing `riskAnalysisForm`) to the "Publish" button disabled conditions; RECEIVE mode is excluded since the risk analysis is provider-supplied.
- Added a dedicated disabled tooltip (`publishBtnDisabledNotCompiled`) with IT/EN copy.
- Added unit tests: publish disabled when the risk analysis is not compiled (DELIVER), and publish enabled in RECEIVE mode without a compiled form.

## 🧪 How to test
- Log in as Admin and create a purpose for a DELIVER e-service with risk analysis assignment mode "Compilazione e approvazione in autonomia".
- Without compiling the risk analysis, open the purpose summary page (Fruizione > Finalità > Modifica on the draft).
- Verify the "Pubblica" button is disabled and the tooltip explains the risk analysis must be compiled first.
- Compile the risk analysis, return to the summary, and verify "Pubblica" is now enabled.
- For a RECEIVE e-service purpose, verify "Pubblica" is not blocked by this rule.

[PIN-10474]: https://pagopa.atlassian.net/browse/PIN-10474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ