### PR TITLE
fix: purpose draft signing state actions (PIN-10475)

### DIFF
--- a/src/hooks/__tests__/useGetConsumerPurposesActions.test.ts
+++ b/src/hooks/__tests__/useGetConsumerPurposesActions.test.ts
@@ -250,6 +250,17 @@ describe('check if useGetConsumerPurposesActions returns the correct actions bas
     expect(cloneAction).toBeUndefined()
   })
 
+  it('should return delete only if signingState is present and it is not SIGNED', () => {
+    const purposeMock = createMockPurpose({
+      currentVersion: { state: 'DRAFT' },
+      reviewerWorkflow: { signingState: 'REJECTED' },
+    })
+    const { result } = renderUseGetConsumerPurposesActionsHook(purposeMock)
+
+    expect(result.current.actions).toHaveLength(1)
+    expect(result.current.actions[0].label).toBe('delete')
+  })
+
   describe('clone action button', () => {
     it('should have tooltip when ruleset is expired and the button is disabled', () => {
       mockUseCurrentRoute({ routeKey: 'SUBSCRIBE_PURPOSE_DETAILS' })

--- a/src/hooks/useGetConsumerPurposesActions.ts
+++ b/src/hooks/useGetConsumerPurposesActions.ts
@@ -157,11 +157,13 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
     return actions
   }
 
+  const signingState = purpose?.reviewerWorkflow?.signingState
   const isDeliverMode = purpose.eservice.mode === 'DELIVER'
   const isSuspended = purpose?.currentVersion?.state === 'SUSPENDED'
   const isActive = purpose?.currentVersion?.state === 'ACTIVE'
   const isDraft = purpose?.currentVersion?.state === 'DRAFT'
   const isArchived = purpose?.currentVersion?.state === 'ARCHIVED'
+  const isNotSigned = Boolean(signingState) && signingState !== 'SIGNED'
   const isSuspendedByConsumer = checkPurposeSuspendedByConsumer(purpose, jwt?.organizationId)
 
   const hasCurrentVersion = Boolean(purpose?.currentVersion)
@@ -171,6 +173,7 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
   const actions = match({
     isDeliverMode,
     isDraft,
+    isNotSigned,
     isArchived,
     isActive,
     isSuspended,
@@ -204,6 +207,13 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
         isArchived: true,
       },
       () => []
+    )
+    .with(
+      {
+        isDraft: true,
+        isNotSigned: true,
+      },
+      () => [deleteAction]
     )
     // purpose in DRAFT state
     .with(


### PR DESCRIPTION
## Issue
- [PIN-10475](https://pagopa.atlassian.net/browse/PIN-10475)
## Description / Context / Why
- Added a condition to useGetConsumerPurposesActions.ts for `DRAFT` purpose with a `reviewerWorkflow.signingState` not equal to `SIGNED` to show the delete button only.

[PIN-10475]: https://pagopa.atlassian.net/browse/PIN-10475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ