### PR TITLE
fix: changed copy for no reviewer alert

### DIFF
--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -116,7 +116,7 @@
         "requiredError": "To proceed, please select a reviewer"
       },
       "noReviewersAlert": {
-        "message": "Your institution does not yet have a user with the reviewer role. You can add one from the Reserved Area.",
+        "message": "Your institution does not yet have a user with the reviewer role. You can add one from the Reserved Area or complete the risk analysis yourself.",
         "linkLabel": "Go to Users"
       },
       "delegateAlert": "As the delegate to consuming the e-service {{name}}, you cannot assign the risk analysis to a reviewer but you can complete it yourself.",

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -116,7 +116,7 @@
         "requiredError": "Per proseguire, seleziona un valutatore"
       },
       "noReviewersAlert": {
-        "message": "Il tuo ente non ha ancora un utente con ruolo di valutatore. Puoi aggiungerlo dall’Area Riservata.",
+        "message": "Il tuo ente non ha ancora un utente con ruolo di valutatore. Puoi aggiungerlo dall’Area Riservata o compilare in autonomia l’analisi del rischio.",
         "linkLabel": "Vai a Utenti"
       },
       "delegateAlert": "Come delegato alla fruizione dell’e-service {{name}}, non puoi assegnare l'analisi del rischio a un valutatore ma puoi compilarla in autonomia.",


### PR DESCRIPTION
## 🔗 Issue
[PIN-10461](https://pagopa.atlassian.net/browse/PIN-10461)

## 📝 Description / Context
On the purpose risk-analysis assignment step, the alert shown when the institution has no user with the reviewer role only mentioned adding a reviewer from the Reserved Area. It did not make clear that the current user can also complete the risk analysis themselves, leaving users without a clear path forward.

## 🛠 List of changes
- Updated the `noReviewersAlert.message` copy in `en/purpose.json` to add that the user can complete the risk analysis themselves.
- Updated the corresponding `noReviewersAlert.message` copy in `it/purpose.json` with the same clarification.

## 🧪 How to test
- Log in with an institution that has no user with the reviewer role.
- Start a new purpose and go to the risk-analysis reviewer assignment step.
- Verify the no-reviewers alert reads: "...You can add one from the Reserved Area or complete the risk analysis yourself." (IT: "...Puoi aggiungerlo dall'Area Riservata o compilare in autonomia l'analisi del rischio.").

[PIN-10461]: https://pagopa.atlassian.net/browse/PIN-10461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ