### PR TITLE
fix: handle router thrown errors (PIN-9963)

### DIFF
--- a/src/router/components/RoutesWrapper/__tests__/RoutesWrapper.test.tsx
+++ b/src/router/components/RoutesWrapper/__tests__/RoutesWrapper.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import RoutesWrapper from '../RoutesWrapper'
 import { RouterProvider, createBrowserRouter } from 'react-router-dom'
+import { router } from '@/router/routes'
 import { vi } from 'vitest'
 import * as useTOSAgreement from '../../../hooks/useTOSAgreement'
 import {
@@ -82,6 +83,10 @@ const renderRoutesWrapperWithError = () => {
 }
 
 describe('RoutesWrapper', () => {
+  it('should configure a React Router errorElement on the root route', () => {
+    expect('errorElement' in router.routes[0]).toBe(true)
+  })
+
   it('should show the TOSAgreement when isPublic is false and TOS are not accepted', () => {
     mockUseCurrentRoute({ isPublic: false, routeKey: 'TOS' })
     useTOSAgreementSpy.mockReturnValue({

--- a/src/router/components/RoutesWrapper/__tests__/RoutesWrapper.test.tsx
+++ b/src/router/components/RoutesWrapper/__tests__/RoutesWrapper.test.tsx
@@ -85,7 +85,7 @@ const renderRoutesWrapperWithError = () => {
 const renderRouterErrorPage = () => {
   const rootRoute = router.routes[0]
 
-  if (!('errorElement' in rootRoute)) {
+  if (!('errorElement' in rootRoute) || !React.isValidElement(rootRoute.errorElement)) {
     throw new Error('Expected root route to define an errorElement')
   }
 

--- a/src/router/components/RoutesWrapper/__tests__/RoutesWrapper.test.tsx
+++ b/src/router/components/RoutesWrapper/__tests__/RoutesWrapper.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import RoutesWrapper from '../RoutesWrapper'
-import { RouterProvider, createBrowserRouter } from 'react-router-dom'
+import { RouterProvider, createBrowserRouter, createMemoryRouter } from 'react-router-dom'
 import { router } from '@/router/routes'
 import { vi } from 'vitest'
 import * as useTOSAgreement from '../../../hooks/useTOSAgreement'
@@ -82,9 +82,42 @@ const renderRoutesWrapperWithError = () => {
   )
 }
 
+const renderRouterErrorPage = () => {
+  const rootRoute = router.routes[0]
+
+  if (!('errorElement' in rootRoute)) {
+    throw new Error('Expected root route to define an errorElement')
+  }
+
+  const routerWithError = createMemoryRouter([
+    {
+      path: '/',
+      element: <ErrorComponent />,
+      errorElement: rootRoute.errorElement,
+    },
+  ])
+
+  return renderWithApplicationContext(
+    <ThemeProvider theme={theme}>
+      <RouterProvider router={routerWithError} />
+    </ThemeProvider>,
+    {
+      withReactQueryContext: true,
+    }
+  )
+}
+
 describe('RoutesWrapper', () => {
   it('should configure a React Router errorElement on the root route', () => {
     expect('errorElement' in router.routes[0]).toBe(true)
+  })
+
+  it('should show the application ErrorPage when React Router catches a thrown route error', () => {
+    const screen = renderRouterErrorPage()
+
+    expect(screen.getByText('default.title')).toBeInTheDocument()
+    expect(screen.getByText('default.description')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'actions.reloadPage' })).toBeInTheDocument()
   })
 
   it('should show the TOSAgreement when isPublic is false and TOS are not accepted', () => {

--- a/src/router/components/RoutesWrapper/__tests__/RoutesWrapper.test.tsx
+++ b/src/router/components/RoutesWrapper/__tests__/RoutesWrapper.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import RoutesWrapper from '../RoutesWrapper'
 import { RouterProvider, createBrowserRouter, createMemoryRouter } from 'react-router-dom'
 import { router } from '@/router/routes'
-import { vi } from 'vitest'
+import { beforeEach, vi } from 'vitest'
 import * as useTOSAgreement from '../../../hooks/useTOSAgreement'
 import {
   mockUseCurrentRoute,
@@ -12,15 +12,19 @@ import {
 } from '@/utils/testing.utils'
 import { ThemeProvider } from '@mui/material'
 import { theme } from '@pagopa/interop-fe-commons'
+import { AuthHooks } from '@/api/auth'
+import { TokenExchangeError } from '@/utils/errors.utils'
 
 const useTOSAgreementSpy = vi.spyOn(useTOSAgreement, 'useTOSAgreement')
-useTOSAgreementSpy.mockReturnValue({
-  isTOSAccepted: true,
-  handleAcceptTOS: vi.fn(),
-})
 
-mockUseJwt()
-mockUseGetActiveUserParty()
+beforeEach(() => {
+  useTOSAgreementSpy.mockReturnValue({
+    isTOSAccepted: true,
+    handleAcceptTOS: vi.fn(),
+  })
+  mockUseJwt()
+  mockUseGetActiveUserParty()
+})
 
 vi.mock('@/api/hooks', () => ({
   useIsOrganizationAllowedToDelegations: vi.fn(() => ({ isAllowed: true, isLoading: false })),
@@ -83,19 +87,13 @@ const renderRoutesWrapperWithError = () => {
 }
 
 const renderRouterErrorPage = () => {
-  const rootRoute = router.routes[0]
+  vi.spyOn(AuthHooks, 'useJwt').mockImplementation(() => {
+    throw new TokenExchangeError()
+  })
 
-  if (!('errorElement' in rootRoute) || !React.isValidElement(rootRoute.errorElement)) {
-    throw new Error('Expected root route to define an errorElement')
-  }
-
-  const routerWithError = createMemoryRouter([
-    {
-      path: '/',
-      element: <ErrorComponent />,
-      errorElement: rootRoute.errorElement,
-    },
-  ])
+  const routerWithError = createMemoryRouter(router.routes, {
+    initialEntries: ['/'],
+  })
 
   return renderWithApplicationContext(
     <ThemeProvider theme={theme}>
@@ -108,16 +106,17 @@ const renderRouterErrorPage = () => {
 }
 
 describe('RoutesWrapper', () => {
-  it('should configure a React Router errorElement on the root route', () => {
+  it('should configure a React Router errorElement that covers every top-level route', () => {
     expect('errorElement' in router.routes[0]).toBe(true)
+    expect(router.routes).toHaveLength(1)
   })
 
-  it('should show the application ErrorPage when React Router catches a thrown route error', () => {
+  it('should show the application ErrorPage when React Router catches a thrown error on a top-level route', () => {
     const screen = renderRouterErrorPage()
 
-    expect(screen.getByText('default.title')).toBeInTheDocument()
-    expect(screen.getByText('default.description')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'actions.reloadPage' })).toBeInTheDocument()
+    expect(screen.getByText('tokenExchange.title')).toBeInTheDocument()
+    expect(screen.getByText('tokenExchange.description')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'actions.backToSelfcare' })).toBeInTheDocument()
   })
 
   it('should show the TOSAgreement when isPublic is false and TOS are not accepted', () => {

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -99,7 +99,7 @@ const RouterErrorPage = () => {
 
   return (
     <Box sx={{ p: 8 }}>
-      <ErrorPage error={error} resetErrorBoundary={() => undefined} />
+      <ErrorPage error={error} resetErrorBoundary={() => window.location.reload()} />
     </Box>
   )
 }

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { type InferRouteKey, InteropRouterBuilder } from '@pagopa/interop-fe-commons'
-import { createBrowserRouter } from 'react-router-dom'
+import { createBrowserRouter, useRouteError } from 'react-router-dom'
+import { Box } from '@mui/material'
 import {
   PartyRegistryPage,
   ConsumerEServiceCatalogPage,
@@ -55,6 +56,7 @@ import {
   RiskAnalysisExporterToolPage,
   PublishThankYouPage,
   ConsumerPurposePublishThankYouPage,
+  ErrorPage,
 } from '@/pages'
 import RoutesWrapper from './components/RoutesWrapper'
 import type { LangCode } from '@/types/common.types'
@@ -89,6 +91,16 @@ const LandingByRole = () => {
     <components.Redirect to="SUBSCRIBE_RISK_ANALYSIS_LIST" />
   ) : (
     <components.Redirect to="SUBSCRIBE_CATALOG_LIST" />
+  )
+}
+
+const RouterErrorPage = () => {
+  const error = useRouteError()
+
+  return (
+    <Box sx={{ p: 8 }}>
+      <ErrorPage error={error} resetErrorBoundary={() => undefined} />
+    </Box>
   )
 }
 
@@ -786,7 +798,11 @@ export type RouteKey = InferRouteKey<typeof routes>
 
 export const router = createBrowserRouter(
   [
-    { element: <RoutesWrapper />, children: reactRouterDOMRoutes },
+    {
+      element: <RoutesWrapper />,
+      errorElement: <RouterErrorPage />,
+      children: reactRouterDOMRoutes,
+    },
     { path: '/', element: <LandingByRole /> },
     { path: '/*', element: <components.Redirect to="NOT_FOUND" /> },
   ],

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -799,12 +799,13 @@ export type RouteKey = InferRouteKey<typeof routes>
 export const router = createBrowserRouter(
   [
     {
-      element: <RoutesWrapper />,
       errorElement: <RouterErrorPage />,
-      children: reactRouterDOMRoutes,
+      children: [
+        { element: <RoutesWrapper />, children: reactRouterDOMRoutes },
+        { path: '/', element: <LandingByRole /> },
+        { path: '/*', element: <components.Redirect to="NOT_FOUND" /> },
+      ],
     },
-    { path: '/', element: <LandingByRole /> },
-    { path: '/*', element: <components.Redirect to="NOT_FOUND" /> },
   ],
   { basename: '/ui' }
 )


### PR DESCRIPTION
## 🔗 Issue

[PIN-9963](https://pagopa.atlassian.net/browse/PIN-9963)

## 📝 Description / Context

This PR fixes the default React Router fallback shown when a thrown route error is not handled by the application router.

## 🛠 List of changes

- Added a root `errorElement` to the application `createBrowserRouter` configuration.
- Reused the existing `ErrorPage` for errors captured through React Router `useRouteError`.
- Added a regression test to ensure the root route is configured with an `errorElement`.

## 🧪 How to test

- Open an invalid malformed UI route that previously showed React Router's "Unhandled Thrown Error" developer fallback, such as the VAPT scenario from the ticket.
- Verify that the application renders the PDND error page instead of the default React Router developer message.

[PIN-9963]: https://pagopa.atlassian.net/browse/PIN-9963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ