### PR TITLE
fix: avoid polling active queries for notification mark as read (PIN-9620)

### DIFF
--- a/src/api/notification/__tests__/notification.mutations.test.ts
+++ b/src/api/notification/__tests__/notification.mutations.test.ts
@@ -1,0 +1,67 @@
+import { act, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import type * as ReactQuery from '@tanstack/react-query'
+
+const capturedMutationOptions: Array<Record<string, unknown>> = []
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof ReactQuery>('@tanstack/react-query')
+  return {
+    ...actual,
+    useMutation: (options: Record<string, unknown>) => {
+      capturedMutationOptions.push(options)
+      return actual.useMutation(options)
+    },
+  }
+})
+
+const { mockMarkNotificationsAsReadByEntityId } = vi.hoisted(() => ({
+  mockMarkNotificationsAsReadByEntityId: vi.fn(),
+}))
+
+vi.mock('../notification.services', () => ({
+  NotificationServices: {
+    markNotificationsAsReadByEntityId: mockMarkNotificationsAsReadByEntityId,
+  },
+}))
+
+import { renderHookWithApplicationContext } from '@/utils/testing.utils'
+import { NotificationMutations } from '../notification.mutations'
+
+afterEach(() => {
+  capturedMutationOptions.length = 0
+  vi.clearAllMocks()
+})
+
+describe('useMarkNotificationsAsReadByEntityId', () => {
+  it('opts out from active queries polling', () => {
+    renderHookWithApplicationContext(
+      () => NotificationMutations.useMarkNotificationsAsReadByEntityId(),
+      { withReactQueryContext: true }
+    )
+
+    expect(capturedMutationOptions).toContainEqual(
+      expect.objectContaining({
+        retry: false,
+        meta: { skipActiveQueriesPolling: true },
+      })
+    )
+  })
+
+  it('marks notifications as read for the provided entity', async () => {
+    const { result } = renderHookWithApplicationContext(
+      () => NotificationMutations.useMarkNotificationsAsReadByEntityId(),
+      { withReactQueryContext: true }
+    )
+
+    act(() => {
+      result.current.mutate({ entityId: 'entity-id' })
+    })
+
+    await waitFor(() => {
+      expect(mockMarkNotificationsAsReadByEntityId).toHaveBeenCalledWith({
+        entityId: 'entity-id',
+      })
+    })
+  })
+})

--- a/src/api/notification/notification.mutations.ts
+++ b/src/api/notification/notification.mutations.ts
@@ -115,6 +115,9 @@ function useMarkNotificationsAsReadByEntityId() {
     mutationFn: (payload: { entityId: string }) =>
       NotificationServices.markNotificationsAsReadByEntityId(payload),
     retry: false,
+    meta: {
+      skipActiveQueriesPolling: true,
+    },
   })
 }
 

--- a/src/config/__tests__/query-client.test.tsx
+++ b/src/config/__tests__/query-client.test.tsx
@@ -4,19 +4,33 @@ import { useMutation } from '@tanstack/react-query'
 import { queryClient } from '../query-client'
 import { useDialogStore } from '@/stores'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
-import type { ConfirmationDialogMeta } from '@tanstack/react-query'
+import type { ConfirmationDialogMeta, MutationMeta } from '@tanstack/react-query'
+
+const { mockedSetExponentialInterval, mockedClearExponentialInterval } = vi.hoisted(() => ({
+  mockedSetExponentialInterval: vi.fn(() => 'active-queries-polling-interval-id'),
+  mockedClearExponentialInterval: vi.fn(),
+}))
+
+vi.mock('@/utils/common.utils', async () => ({
+  ...(await vi.importActual('@/utils/common.utils')),
+  setExponentialInterval: mockedSetExponentialInterval,
+  clearExponentialInterval: mockedClearExponentialInterval,
+}))
 
 const TestMutation = ({
   confirmationDialog,
   mutationFn,
+  meta,
 }: {
-  confirmationDialog: ConfirmationDialogMeta | Array<ConfirmationDialogMeta>
+  confirmationDialog?: ConfirmationDialogMeta | Array<ConfirmationDialogMeta>
   mutationFn: () => Promise<void>
+  meta?: MutationMeta
 }) => {
   const { mutate } = useMutation({
     mutationFn,
     meta: {
       confirmationDialog,
+      ...meta,
     },
   })
 
@@ -27,6 +41,8 @@ describe('queryClient confirmation dialogs', () => {
   beforeEach(() => {
     queryClient.clear()
     useDialogStore.setState({ dialog: null })
+    mockedSetExponentialInterval.mockClear()
+    mockedClearExponentialInterval.mockClear()
   })
 
   it('should wait for ordered confirmation dialogs before running the mutation', async () => {
@@ -74,6 +90,21 @@ describe('queryClient confirmation dialogs', () => {
     await user.click(confirmButton)
 
     await waitFor(() => expect(mutationFn).toHaveBeenCalledTimes(1))
+  })
+
+  it('should not request active queries polling when the mutation opts out', async () => {
+    const user = userEvent.setup()
+    const mutationFn = vi.fn().mockResolvedValue(undefined)
+
+    renderWithApplicationContext(
+      <TestMutation mutationFn={mutationFn} meta={{ skipActiveQueriesPolling: true }} />,
+      { withReactQueryContext: true }
+    )
+
+    await user.click(screen.getByRole('button', { name: 'submit' }))
+
+    await waitFor(() => expect(mutationFn).toHaveBeenCalledTimes(1))
+    expect(mockedSetExponentialInterval).not.toHaveBeenCalled()
   })
 
   it('should not run the mutation when a confirmation dialog is cancelled', async () => {

--- a/src/config/__tests__/query-client.test.tsx
+++ b/src/config/__tests__/query-client.test.tsx
@@ -112,6 +112,20 @@ describe('queryClient confirmation dialogs', () => {
     expect(mockedSetExponentialInterval).not.toHaveBeenCalled()
   })
 
+  it('should request active queries polling when the mutation does not opt out', async () => {
+    const user = userEvent.setup()
+    const mutationFn = vi.fn().mockResolvedValue(undefined)
+
+    renderWithApplicationContext(<TestMutation mutationFn={mutationFn} />, {
+      withReactQueryContext: true,
+    })
+
+    await user.click(screen.getByRole('button', { name: 'submit' }))
+
+    await waitFor(() => expect(mutationFn).toHaveBeenCalledTimes(1))
+    expect(mockedSetExponentialInterval).toHaveBeenCalledWith(expect.any(Function), 20 * 1000)
+  })
+
   it('should not run the mutation when a confirmation dialog is cancelled', async () => {
     const user = userEvent.setup()
     const mutationFn = vi.fn().mockResolvedValue(undefined)

--- a/src/config/__tests__/query-client.test.tsx
+++ b/src/config/__tests__/query-client.test.tsx
@@ -5,17 +5,22 @@ import { queryClient } from '../query-client'
 import { useDialogStore } from '@/stores'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import type { ConfirmationDialogMeta, MutationMeta } from '@tanstack/react-query'
+import type * as CommonUtils from '@/utils/common.utils'
 
 const { mockedSetExponentialInterval, mockedClearExponentialInterval } = vi.hoisted(() => ({
   mockedSetExponentialInterval: vi.fn(() => 'active-queries-polling-interval-id'),
   mockedClearExponentialInterval: vi.fn(),
 }))
 
-vi.mock('@/utils/common.utils', async () => ({
-  ...(await vi.importActual('@/utils/common.utils')),
-  setExponentialInterval: mockedSetExponentialInterval,
-  clearExponentialInterval: mockedClearExponentialInterval,
-}))
+vi.mock('@/utils/common.utils', async () => {
+  const actual = await vi.importActual<typeof CommonUtils>('@/utils/common.utils')
+
+  return {
+    ...actual,
+    setExponentialInterval: mockedSetExponentialInterval,
+    clearExponentialInterval: mockedClearExponentialInterval,
+  }
+})
 
 const TestMutation = ({
   confirmationDialog,

--- a/src/config/query-client.ts
+++ b/src/config/query-client.ts
@@ -79,6 +79,7 @@ const resolveMeta = (query: {
     successToastLabel,
     errorToastLabel,
     confirmationDialog,
+    skipActiveQueriesPolling: meta.skipActiveQueriesPolling,
   }
 }
 
@@ -175,7 +176,7 @@ mutationCache.config.onMutate = async (variables, mutation) => {
 mutationCache.config.onSuccess = (data, variables, context, mutation) => {
   const meta = resolveMeta({ mutation, data, variables, context })
   if (meta.successToastLabel) getShowToast()(meta.successToastLabel, 'success')
-  requestPolling()
+  if (!meta.skipActiveQueriesPolling) requestPolling()
 }
 
 mutationCache.config.onError = (error, variables, context, mutation) => {

--- a/src/types/react-query.d.ts
+++ b/src/types/react-query.d.ts
@@ -15,6 +15,7 @@ declare module '@tanstack/react-query' {
     successToastLabel?: string | ((data: unknown, variables: unknown, context: unknown) => string)
     errorToastLabel?: string | ((error: unknown, variables: unknown, context: unknown) => string)
     confirmationDialog?: ConfirmationDialogMeta | Array<ConfirmationDialogMeta>
+    skipActiveQueriesPolling?: boolean
   }
 
   interface Register {


### PR DESCRIPTION
## 🔗 Issue

[PIN-9620](https://pagopa.atlassian.net/browse/PIN-9620)

## 📝 Description / Context

Opening a provider e-service detail page from "I miei e-service" triggers a silent notification mark-as-read mutation for the current entity.

Before this change, every successful mutation executed the global active-query polling logic in the shared React Query client. This also included silent/background mutations such as marking notifications as read. As a consequence, entering the e-service detail page could start polling and refetch stale active queries that were not strictly related to the current page, producing unnecessary API calls in addition to the expected notification count request.

This change introduces an explicit mutation meta opt-out for cases where a successful mutation should not trigger the global active-query polling. The notification mark-as-read-by-entity mutation now uses this opt-out, keeping the notification behavior unchanged while avoiding unrelated refetches.

## 🛠 List of changes

- Added a `skipActiveQueriesPolling` option to the custom React Query `MutationMeta` type.
- Updated the shared `queryClient` success handler to call active-query polling only when the mutation has not opted out.
- Marked the notification mark-as-read-by-entity mutation with `skipActiveQueriesPolling: true`.
- Added a focused query client test to verify that opt-out mutations do not start the active-query polling interval.
- Preserved the existing global polling behavior for all other mutations.

## 🧪 How to test

- Open the provider area and navigate to "I miei e-service".
- Open the detail page of one e-service.
- Verify that the page still loads correctly and notifications can still be marked as read for the opened entity.
- Verify from the browser network panel that opening the detail page no longer causes unrelated stale active queries to be refetched because of the notification mark-as-read mutation.
- The notification count request may still run as part of the sidebar/header behavior; the important check is that the silent mark-as-read mutation does not trigger additional unrelated polling.

[PIN-9620]: https://pagopa.atlassian.net/browse/PIN-9620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ