### PR TITLE
fix: added alert, changed label for RA to be compiled on edit (PIN-10…

### DIFF
--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
@@ -187,7 +187,7 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
         <SectionContainer
           title={t('stepRiskAnalysis.title')}
           titleEndAdornment={<StatusChip for="riskAnalysis" state={lockedState} size="small" />}
-          description={t(`stepRiskAnalysis.readOnlySubtitle.${lockedState}`)}
+          description={t(`stepRiskAnalysis.readOnlySubtitle`)}
           sx={{ mb: 2 }}
         >
           <InformationContainer

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
@@ -14,6 +14,7 @@ import { StepActions } from '@/components/shared/StepActions'
 import { RiskAnalysisInfoSummary } from '@/components/shared/RiskAnalysisInfoSummary'
 import { match, P } from 'ts-pattern'
 import { useDialog } from '@/stores'
+import { Alert } from '@mui/material'
 
 import { useQuery } from '@tanstack/react-query'
 
@@ -196,6 +197,11 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
             )}
           />
         </SectionContainer>
+        {stepMode.kind === 'awaiting-compilation' && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            {t('stepRiskAnalysis.reviewerWritesReviewerSigns')}
+          </Alert>
+        )}
         {stepMode.kind === 'read-only' && purpose.riskAnalysisForm && (
           <RiskAnalysisInfoSummary
             riskAnalysisConfig={riskAnalysis}

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
@@ -213,6 +213,7 @@ describe('PurposeEditStepRiskAnalysis', () => {
     expect(formSpy).not.toHaveBeenCalled()
     expect(screen.getByText('stepRiskAnalysis.readOnlySubtitle.ASSIGNED')).toBeInTheDocument()
     expect(screen.getByText('status.riskAnalysis.ASSIGNED')).toBeInTheDocument()
+    expect(screen.getByText('stepRiskAnalysis.reviewerWritesReviewerSigns')).toBeInTheDocument()
     // everything but the info card is hidden: no answers summary, no editable form
     expect(screen.queryByText('Question 1')).not.toBeInTheDocument()
   })

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@/router', () => ({
 
 vi.mock('@tanstack/react-query', async () => {
   const actual =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
   return {
     ...actual,
@@ -155,7 +156,7 @@ describe('PurposeEditStepRiskAnalysis', () => {
 
     expect(formSpy).not.toHaveBeenCalled()
     expect(screen.getByText('status.riskAnalysis.SUBMITTED')).toBeInTheDocument()
-    expect(screen.getByText('stepRiskAnalysis.readOnlySubtitle.SUBMITTED')).toBeInTheDocument()
+    expect(screen.getByText('stepRiskAnalysis.readOnlySubtitle')).toBeInTheDocument()
     // the compiled answers are shown as a read-only summary (question + given answer)
     expect(screen.getByText('Question 1')).toBeInTheDocument()
     expect(screen.getByText('option 1')).toBeInTheDocument()
@@ -177,7 +178,7 @@ describe('PurposeEditStepRiskAnalysis', () => {
 
     expect(formSpy).not.toHaveBeenCalled()
     expect(screen.getByText('status.riskAnalysis.SIGNED')).toBeInTheDocument()
-    expect(screen.getByText('stepRiskAnalysis.readOnlySubtitle.SIGNED')).toBeInTheDocument()
+    expect(screen.getByText('stepRiskAnalysis.readOnlySubtitle')).toBeInTheDocument()
   })
 
   it('in option 2 rejected keeps the form editable, flags the rejected alert and stays in approval mode', () => {
@@ -211,7 +212,7 @@ describe('PurposeEditStepRiskAnalysis', () => {
     )
 
     expect(formSpy).not.toHaveBeenCalled()
-    expect(screen.getByText('stepRiskAnalysis.readOnlySubtitle.ASSIGNED')).toBeInTheDocument()
+    expect(screen.getByText('stepRiskAnalysis.readOnlySubtitle')).toBeInTheDocument()
     expect(screen.getByText('status.riskAnalysis.ASSIGNED')).toBeInTheDocument()
     expect(screen.getByText('stepRiskAnalysis.reviewerWritesReviewerSigns')).toBeInTheDocument()
     // everything but the info card is hidden: no answers summary, no editable form
@@ -234,7 +235,7 @@ describe('PurposeEditStepRiskAnalysis', () => {
 
     expect(formSpy).not.toHaveBeenCalled()
     expect(screen.getByText('status.riskAnalysis.SIGNED')).toBeInTheDocument()
-    expect(screen.getByText('stepRiskAnalysis.readOnlySubtitle.SIGNED')).toBeInTheDocument()
+    expect(screen.getByText('stepRiskAnalysis.readOnlySubtitle')).toBeInTheDocument()
     // the values compiled by the reviewer are visible in the read-only summary
     expect(screen.getByText('Question 1')).toBeInTheDocument()
     expect(screen.getByText('option 1')).toBeInTheDocument()

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -164,11 +164,7 @@
       "title": "Risk analysis",
       "description": "The questions below will change based on the answers provided. If you edit an answer above, it may change the following questions",
       "personalInfoAlert": "Warning: do not put personal data inside text fields",
-      "readOnlySubtitle": {
-        "SUBMITTED": "You can't edit the risk analysis because it has been submitted to the reviewer for approval.",
-        "SIGNED": "The risk analysis can't be edited because it has been approved by the reviewer.",
-        "ASSIGNED": "You cannot modify the risk analysis because it has been submitted to the reviewer for approval."
-      },
+      "readOnlySubtitle": "You cannot modify the risk analysis because it has been sent to the reviewer.",
       "rejectedAlert": "The reviewer rejected the risk analysis. Edit the analysis and submit it again for approval.",
       "rejectedAlertLinkLabel": "Read reason",
       "reviewerWritesReviewerSigns": "Once the reviewer has compiled and approved the risk analysis, you will be able to publish the purpose.",

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -167,10 +167,11 @@
       "readOnlySubtitle": {
         "SUBMITTED": "You can't edit the risk analysis because it has been submitted to the reviewer for approval.",
         "SIGNED": "The risk analysis can't be edited because it has been approved by the reviewer.",
-        "ASSIGNED": "You can't edit the risk analysis because it has been assigned to the reviewer to fill it out."
+        "ASSIGNED": "You cannot modify the risk analysis because it has been submitted to the reviewer for approval."
       },
       "rejectedAlert": "The reviewer rejected the risk analysis. Edit the analysis and submit it again for approval.",
       "rejectedAlertLinkLabel": "Read reason",
+      "reviewerWritesReviewerSigns": "Once the reviewer has compiled and approved the risk analysis, you will be able to publish the purpose.",
       "versionMismatchDialog": {
         "title": "Risk analysis update",
         "description": "There is a new version of risk analysis available. The one compiled previously is obsolete and can no longer be used. If you click \"Update\", all the fields that have not changed and were filled in will already be filled in in the new version",

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -167,10 +167,11 @@
       "readOnlySubtitle": {
         "SUBMITTED": "Non puoi modificare l'analisi del rischio perché è stata inviata in approvazione al valutatore.",
         "SIGNED": "Non è possibile modificare l'analisi del rischio perché è stata approvata dal valutatore.",
-        "ASSIGNED": "Non puoi modificare l'analisi del rischio perché è stata assegnata al valutatore per la compilazione."
+        "ASSIGNED": "Non puoi modificare l’analisi del rischio perché è stata inviata in approvazione al valutatore."
       },
       "rejectedAlert": "Il valutatore ha rifiutato l'analisi del rischio. Modifica l'analisi e inviala di nuovo in approvazione.",
       "rejectedAlertLinkLabel": "Leggi motivazione",
+      "reviewerWritesReviewerSigns": "Quando il valutatore avrà compilato e approvato l’analisi del rischio, potrai pubblicare la finalità.",
       "versionMismatchDialog": {
         "title": "Aggiornamento analisi del rischio",
         "description": "C'è una nuova versione di analisi del rischio disponibile. Quella compilata in precedenza è obsoleta e non può più essere usata. Se clicchi “Aggiorna”, tutti i campi che non sono cambiati ed erano stati compilati li troverai già compilati nella nuova versione",

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -164,11 +164,7 @@
       "title": "Analisi del rischio",
       "description": "Le domande del questionario varieranno in base alle risposte fornite man mano. Modificando la risposta a una domanda precedente, le successive domande potrebbero variare.",
       "personalInfoAlert": "Attenzione: non inserire dati personali all'interno dei campi liberi di testo",
-      "readOnlySubtitle": {
-        "SUBMITTED": "Non puoi modificare l'analisi del rischio perché è stata inviata in approvazione al valutatore.",
-        "SIGNED": "Non è possibile modificare l'analisi del rischio perché è stata approvata dal valutatore.",
-        "ASSIGNED": "Non puoi modificare l’analisi del rischio perché è stata inviata in approvazione al valutatore."
-      },
+      "readOnlySubtitle": "Non puoi modificare l'analisi del rischio perché è stata inviata al valutatore.",
       "rejectedAlert": "Il valutatore ha rifiutato l'analisi del rischio. Modifica l'analisi e inviala di nuovo in approvazione.",
       "rejectedAlertLinkLabel": "Leggi motivazione",
       "reviewerWritesReviewerSigns": "Quando il valutatore avrà compilato e approvato l’analisi del rischio, potrai pubblicare la finalità.",


### PR DESCRIPTION
## Issue
- [PIN-10484](https://pagopa.atlassian.net/browse/PIN-10484)
## Description / Context / Why
On the purpose edit page, for a purpose with a risk analysis assigned to a reviewer (to be compiled and approved):
- Changed description label
- Added info alert
- Updated tests

[PIN-10484]: https://pagopa.atlassian.net/browse/PIN-10484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ