### PR TITLE
fix: align readonly assignment step subtitle copy with Figma

### DIFF
--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentReadOnly.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentReadOnly.tsx
@@ -35,7 +35,7 @@ const PurposeEditStepAssignmentReadOnly: React.FC<PurposeEditStepAssignmentReadO
 
   return (
     <>
-      <SectionContainer title={t('title')} description={t('description')}>
+      <SectionContainer title={t('title')} description={t('readOnly.subtitle')}>
         <Stack spacing={2}>
           <InformationContainer
             label={t('readOnly.modeLabel')}

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -123,6 +123,7 @@
       "forwardBtn": "Save draft and proceed",
       "requestReviewerCompilationBtn": "Request compilation",
       "readOnly": {
+        "subtitle": "The assignment can't be edited because the risk analysis has been submitted to the reviewer for approval.",
         "modeLabel": "Mode",
         "reviewerLabel": "Reviewer",
         "reviewerUnknown": "Reviewer not available",

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -123,7 +123,7 @@
       "forwardBtn": "Save draft and proceed",
       "requestReviewerCompilationBtn": "Request compilation",
       "readOnly": {
-        "subtitle": "The assignment can't be edited because the risk analysis has been submitted to the reviewer for approval.",
+        "subtitle": "You cannot modify the assignment because you have submitted the risk assessment to the evaluator.",
         "modeLabel": "Mode",
         "reviewerLabel": "Reviewer",
         "reviewerUnknown": "Reviewer not available",

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -123,6 +123,7 @@
       "forwardBtn": "Salva bozza e prosegui",
       "requestReviewerCompilationBtn": "Richiedi compilazione",
       "readOnly": {
+        "subtitle": "Non è possibile modificare l’assegnazione perché l’analisi del rischio è stata inviata per l’approvazione al valutatore.",
         "modeLabel": "Modalità",
         "reviewerLabel": "Valutatore",
         "reviewerUnknown": "Valutatore non disponibile",

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -123,7 +123,7 @@
       "forwardBtn": "Salva bozza e prosegui",
       "requestReviewerCompilationBtn": "Richiedi compilazione",
       "readOnly": {
-        "subtitle": "Non è possibile modificare l’assegnazione perché l’analisi del rischio è stata inviata per l’approvazione al valutatore.",
+        "subtitle": "Non puoi modificare l'assegnazione perché hai inviato l'analisi del rischio al valutatore.",
         "modeLabel": "Modalità",
         "reviewerLabel": "Valutatore",
         "reviewerUnknown": "Valutatore non disponibile",


### PR DESCRIPTION
## 🔗 Issue
[PIN-10482](https://pagopa.atlassian.net/browse/PIN-10482)

## 📝 Description / Context
In the "Self-compilation and reviewer approval" flow, after entering "Edit draft" the read-only Assignment step reused the editable form's description ("You can fill in the risk analysis on your own, or entrust a reviewer with the approval or the compilation."). This wrongly suggested the reviewer could still be asked to compile, and did not match the Figma copy.

## 🛠 List of changes
- `PurposeEditStepAssignmentReadOnly` now renders a dedicated subtitle (`readOnly.subtitle`) instead of the shared form `description`
- Added `edit.stepAssignment.readOnly.subtitle` translation key (it / en) with the Figma-approved copy

## 🧪 How to test
- Open a purpose whose risk analysis has been submitted for the reviewer's approval (mode "Self-compilation and reviewer approval")
- Enter the Assignment step in read-only mode (e.g. via "Edit draft")
- Verify the subtitle reads "Non è possibile modificare l'assegnazione perché l'analisi del rischio è stata inviata per l'approvazione al valutatore." (IT) / "The assignment can't be edited because the risk analysis has been submitted to the reviewer for approval." (EN)

[PIN-10482]: https://pagopa.atlassian.net/browse/PIN-10482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ