### PR TITLE
fix: disabled publish button if purpose has no workflow or ra (PIN-10475)

### DIFF
--- a/src/hooks/__tests__/useGetConsumerPurposesActions.test.ts
+++ b/src/hooks/__tests__/useGetConsumerPurposesActions.test.ts
@@ -288,5 +288,18 @@ describe('check if useGetConsumerPurposesActions returns the correct actions bas
       expect(cloneAction?.tooltip).toBeUndefined()
       expect(cloneAction?.disabled).toBe(false)
     })
+
+    it('should return only delete action if draft purpose has no reviewerWorkflow and no riskAnalysisForm', () => {
+      const purposeMock = createMockPurpose({
+        currentVersion: { state: 'DRAFT' },
+        reviewerWorkflow: undefined,
+        riskAnalysisForm: undefined,
+      })
+
+      const { result } = renderUseGetConsumerPurposesActionsHook(purposeMock)
+
+      expect(result.current.actions).toHaveLength(1)
+      expect(result.current.actions[0].label).toBe('delete')
+    })
   })
 })

--- a/src/hooks/__tests__/useGetConsumerPurposesActions.test.ts
+++ b/src/hooks/__tests__/useGetConsumerPurposesActions.test.ts
@@ -289,9 +289,10 @@ describe('check if useGetConsumerPurposesActions returns the correct actions bas
       expect(cloneAction?.disabled).toBe(false)
     })
 
-    it('should return only delete action if draft purpose has no reviewerWorkflow and no riskAnalysisForm', () => {
+    it('should return only delete action for DELIVER draft without reviewerWorkflow and riskAnalysisForm', () => {
       const purposeMock = createMockPurpose({
         currentVersion: { state: 'DRAFT' },
+        eservice: { mode: 'DELIVER' },
         reviewerWorkflow: undefined,
         riskAnalysisForm: undefined,
       })
@@ -300,6 +301,23 @@ describe('check if useGetConsumerPurposesActions returns the correct actions bas
 
       expect(result.current.actions).toHaveLength(1)
       expect(result.current.actions[0].label).toBe('delete')
+    })
+
+    it('should return activate and delete action for RECEIVE draft without reviewerWorkflow and riskAnalysisForm', () => {
+      const purposeMock = createMockPurpose({
+        currentVersion: { state: 'DRAFT' },
+        eservice: { mode: 'RECEIVE' },
+        reviewerWorkflow: undefined,
+        riskAnalysisForm: undefined,
+      })
+
+      const { result } = renderUseGetConsumerPurposesActionsHook(purposeMock)
+
+      const activateAction = result.current.actions.find((action) => action.label === 'activate')
+      const deleteAction = result.current.actions.find((action) => action.label === 'delete')
+
+      expect(activateAction).toBeTruthy()
+      expect(deleteAction).toBeTruthy()
     })
   })
 })

--- a/src/hooks/useGetConsumerPurposesActions.ts
+++ b/src/hooks/useGetConsumerPurposesActions.ts
@@ -169,8 +169,8 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
   const hasCurrentVersion = Boolean(purpose?.currentVersion)
   const hasWaitingForApprovalVersion = Boolean(purpose?.waitingForApprovalVersion)
   const hasRejectedVersion = Boolean(purpose?.rejectedVersion)
-  const hasNoReviewerWorkflowAndNoRiskAnalysis =
-    !Boolean(purpose.reviewerWorkflow) && !Boolean(purpose.riskAnalysisForm)
+  const hasReviewerWorkflow = Boolean(purpose.reviewerWorkflow)
+  const hasRiskAnalysisForm = Boolean(purpose.riskAnalysisForm)
 
   const actions = match({
     isDeliverMode,
@@ -185,7 +185,8 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
     hasCurrentVersion,
     hasWaitingForApprovalVersion,
     hasRejectedVersion,
-    hasNoReviewerWorkflowAndNoRiskAnalysis,
+    hasReviewerWorkflow,
+    hasRiskAnalysisForm,
     routeKey,
   })
     // purpose with no currentVersion but with waitingForApprovalVersion
@@ -215,7 +216,8 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
       {
         isDeliverMode: true,
         isDraft: true,
-        hasNoReviewerWorkflowAndNoRiskAnalysis: true,
+        hasReviewerWorkflow: false,
+        hasRiskAnalysisForm: false,
       },
       () => [deleteAction]
     )

--- a/src/hooks/useGetConsumerPurposesActions.ts
+++ b/src/hooks/useGetConsumerPurposesActions.ts
@@ -169,6 +169,8 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
   const hasCurrentVersion = Boolean(purpose?.currentVersion)
   const hasWaitingForApprovalVersion = Boolean(purpose?.waitingForApprovalVersion)
   const hasRejectedVersion = Boolean(purpose?.rejectedVersion)
+  const hasNoReviewerWorkflowAndNoRiskAnalysis =
+    !Boolean(purpose.reviewerWorkflow) && !Boolean(purpose.riskAnalysisForm)
 
   const actions = match({
     isDeliverMode,
@@ -183,6 +185,7 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
     hasCurrentVersion,
     hasWaitingForApprovalVersion,
     hasRejectedVersion,
+    hasNoReviewerWorkflowAndNoRiskAnalysis,
     routeKey,
   })
     // purpose with no currentVersion but with waitingForApprovalVersion
@@ -207,6 +210,13 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
         isArchived: true,
       },
       () => []
+    )
+    .with(
+      {
+        isDraft: true,
+        hasNoReviewerWorkflowAndNoRiskAnalysis: true,
+      },
+      () => [deleteAction]
     )
     .with(
       {

--- a/src/hooks/useGetConsumerPurposesActions.ts
+++ b/src/hooks/useGetConsumerPurposesActions.ts
@@ -213,6 +213,7 @@ function useGetConsumerPurposesActions(purpose?: Purpose) {
     )
     .with(
       {
+        isDeliverMode: true,
         isDraft: true,
         hasNoReviewerWorkflowAndNoRiskAnalysis: true,
       },


### PR DESCRIPTION
## Issue
- [PIN-10475](https://pagopa.atlassian.net/browse/PIN-10475)
## Description / Context / Why
- Added a condition to useGetConsumerPurposesActions.ts for `DRAFT` purpose without a `reviewerWorkflow.signingState` and no riskAnalysisForm compiled to show the delete button only.

[PIN-10475]: https://pagopa.atlassian.net/browse/PIN-10475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ