### PR TITLE
fix: align waiting for approval publish thank you page to design

### DIFF
--- a/src/pages/ConsumerPurposePublishThankYouPage/ConsumerPurposePublishThankYou.page.tsx
+++ b/src/pages/ConsumerPurposePublishThankYouPage/ConsumerPurposePublishThankYou.page.tsx
@@ -51,7 +51,7 @@ const ConsumerPurposePublishThankYouPage: React.FC = () => {
           {isActive ? t('active.description') : t('waitingForApproval.description')}
         </Typography>
       }
-      buttonLabel={t('action')}
+      buttonLabel={isActive ? t('action') : t('waitingForApproval.action')}
       onButtonClick={handleClose}
     />
   )

--- a/src/pages/ConsumerPurposePublishThankYouPage/__tests__/ConsumerPurposePublishThankYou.page.test.tsx
+++ b/src/pages/ConsumerPurposePublishThankYouPage/__tests__/ConsumerPurposePublishThankYou.page.test.tsx
@@ -101,6 +101,7 @@ describe('ConsumerPurposePublishThankYouPage', () => {
 
     expect(screen.getByRole('heading', { name: 'waitingForApproval.title' })).toBeInTheDocument()
     expect(screen.getByText('waitingForApproval.description')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'waitingForApproval.action' })).toBeInTheDocument()
   })
 
   it('navigates to purpose details when close button is clicked', async () => {

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -675,8 +675,9 @@
       "description": "The purpose is active. Associate your first client to access the e-service data."
     },
     "waitingForApproval": {
-      "title": "Your purpose has been forwarded to the provider for approval",
-      "description": "Until its activation by the provider, you will not be able to access data made available through the API and you will not be able to associate clients. You will receive a notification when the provider approves your purpose"
+      "title": "You have published a purpose. It will now have to be approved by the provider.",
+      "description": "When it is approved, you will receive a notification. Until approval, you will not be able to associate clients or access the e-service data.",
+      "action": "Go to purpose"
     },
     "action": "Close"
   },

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -675,8 +675,9 @@
       "description": "La finalità è attiva. Associa il tuo primo client per accedere ai dati dell'e-service."
     },
     "waitingForApproval": {
-      "title": "La tua finalità è stata inoltrata all'erogatore per l'approvazione",
-      "description": "Fino alla sua attivazione da parte dell'erogatore non potrai accedere ai dati resi disponibili attraverso l'API e non potrai associare client. Riceverai una notifica quando l'erogatore approverà la tua finalità"
+      "title": "Hai pubblicato una finalità. Ora dovrà essere approvata dall'erogatore.",
+      "description": "Quando sarà approvata, riceverai una notifica. Fino all'approvazione, non potrai associare client o accedere ai dati dell’e-service.",
+      "action": "Vai alla finalità"
     },
     "action": "Chiudi"
   },


### PR DESCRIPTION
## 🔗 Issue
[PIN-10490](https://pagopa.atlassian.net/browse/PIN-10490)

## 📝 Description / Context
When publishing a purpose that ends up in the "Waiting for Approval" state, the Thank You Page did not match the expected Figma design: both the copy and the CTA were misaligned. This PR updates the page to show the correct message and a CTA that takes the user to the purpose.

## 🛠 List of changes
- Updated the `waitingForApproval` Thank You Page title and description (IT/EN locales) to match the Figma copy
- Changed the CTA label from "Chiudi" to "Vai alla finalità" for the waiting-for-approval case (the button already navigates to the purpose detail page)
- Kept the "active" Thank You Page case unchanged (still "Chiudi")
- Added a test asserting the new CTA renders in the WAITING_FOR_APPROVAL state

## 🧪 How to test
- Publish a purpose that goes into the "Waiting for Approval" state
- On the resulting Thank You Page, verify the title reads "Hai pubblicato una finalità. Ora dovrà essere approvata dall'erogatore."
- Verify the description reads "Quando sarà approvata, riceverai una notifica. Fino all'approvazione, non potrai associare client o accedere ai dati dell'e-service."
- Verify the CTA reads "Vai alla finalità" and navigates to the purpose detail page
- Verify that publishing a purpose that becomes ACTIVE still shows the unchanged page with the "Chiudi" button

[PIN-10490]: https://pagopa.atlassian.net/browse/PIN-10490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ