### PR TITLE
feat: add optional description to e-service template instance server URLs (PIN-10354)

### DIFF
--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -684,7 +684,10 @@ export interface ProducerEServiceDescriptor {
   /** @format date-time */
   suspendedAt?: string;
   rejectionReasons?: DescriptorRejectionReason[];
-  serverUrls?: string[];
+  serverUrls?: {
+    url: string;
+    description?: string;
+  }[];
   templateRef?: EServiceTemplateRef;
   asyncExchangeProperties?: AsyncExchangeProperties;
   asyncExchangeCallbackInterface?: EServiceDoc;
@@ -908,6 +911,16 @@ export interface CompactDescriptor {
   archivableOn?: string;
 }
 
+export interface TemplateInstanceInterfaceServerUrlSeed {
+  /** @format uri */
+  url: string;
+  /**
+   * @minLength 10
+   * @maxLength 250
+   */
+  description?: string;
+}
+
 export interface TemplateInstanceInterfaceRESTSeed {
   contactName: string;
   /** @format email */
@@ -916,11 +929,11 @@ export interface TemplateInstanceInterfaceRESTSeed {
   contactUrl?: string;
   /** @format uri */
   termsAndConditionsUrl?: string;
-  serverUrls: string[];
+  serverUrls: TemplateInstanceInterfaceServerUrlSeed[];
 }
 
 export interface TemplateInstanceInterfaceSOAPSeed {
-  serverUrls: string[];
+  serverUrls: TemplateInstanceInterfaceServerUrlSeed[];
 }
 
 export interface TemplateInstanceInterfaceMetadata {

--- a/src/pages/ProviderEServiceCreatePage/components/components/GenerateInterfaceForm.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/components/GenerateInterfaceForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Stack, Box, Typography, Tooltip, Button } from '@mui/material'
+import { Stack, Box, Typography, Tooltip, Button, Divider } from '@mui/material'
 import { emailRegex, urlRegex } from '@/utils/form.utils'
 import DownloadIcon from '@mui/icons-material/Download'
 import AddIcon from '@mui/icons-material/Add'
@@ -10,6 +10,7 @@ import { useForm, FormProvider, type UseFieldArrayReturn, useFieldArray } from '
 import type {
   TemplateInstanceInterfaceMetadata,
   TemplateInstanceInterfaceRESTSeed,
+  TemplateInstanceInterfaceServerUrlSeed,
   TemplateInstanceInterfaceSOAPSeed,
 } from '@/api/api.generatedTypes'
 import { EServiceTemplateDownloads } from '@/api/eserviceTemplate/eserviceTemplate.downloads'
@@ -22,7 +23,7 @@ export interface ExtendedTemplateInstanceInterfaceMetadata extends Omit<
   TemplateInstanceInterfaceMetadata,
   'serverUrls'
 > {
-  serverUrls: { url: string }[]
+  serverUrls: { url: string; description: string }[]
 }
 
 export const GenerateInterfaceForm: React.FC = () => {
@@ -55,7 +56,10 @@ export const GenerateInterfaceForm: React.FC = () => {
     contactEmail: descriptor?.templateRef?.interfaceMetadata?.contactEmail ?? '',
     contactUrl: descriptor?.templateRef?.interfaceMetadata?.contactUrl ?? '',
     termsAndConditionsUrl: descriptor?.templateRef?.interfaceMetadata?.termsAndConditionsUrl ?? '',
-    serverUrls: descriptor?.serverUrls?.map((url) => ({ url })) ?? [{ url: '' }],
+    serverUrls: descriptor?.serverUrls?.map((serverUrl) => ({
+      url: serverUrl.url,
+      description: serverUrl.description ?? '',
+    })) ?? [{ url: '', description: '' }],
   }
 
   const { mutate: deleteAndUpdateEServiceRESTInterfaceInfo } =
@@ -75,8 +79,11 @@ export const GenerateInterfaceForm: React.FC = () => {
 
     const mapServerUrls = (
       serverUrls: ExtendedTemplateInstanceInterfaceMetadata['serverUrls']
-    ): string[] => {
-      return serverUrls.map((serverUrl) => serverUrl.url)
+    ): TemplateInstanceInterfaceServerUrlSeed[] => {
+      return serverUrls.map((serverUrl) => ({
+        url: serverUrl.url,
+        ...(serverUrl.description && { description: serverUrl.description }),
+      }))
     }
 
     if (descriptor.eservice.technology === 'REST') {
@@ -93,7 +100,7 @@ export const GenerateInterfaceForm: React.FC = () => {
 
   const onRestApiSubmit = (
     values: ExtendedTemplateInstanceInterfaceMetadata,
-    serverUrls: string[],
+    serverUrls: TemplateInstanceInterfaceServerUrlSeed[],
     eserviceId: string,
     descriptorId: string
   ) => {
@@ -112,7 +119,11 @@ export const GenerateInterfaceForm: React.FC = () => {
     })
   }
 
-  const onSoapApiSubmit = (serverUrls: string[], eserviceId: string, descriptorId: string) => {
+  const onSoapApiSubmit = (
+    serverUrls: TemplateInstanceInterfaceServerUrlSeed[],
+    eserviceId: string,
+    descriptorId: string
+  ) => {
     const payload: TemplateInstanceInterfaceSOAPSeed = {
       serverUrls,
     }
@@ -157,6 +168,7 @@ export const GenerateInterfaceForm: React.FC = () => {
               required: true,
             }}
           />
+          <ServerUrlDescriptionField index={0} />
           {fieldsArray.fields.slice(1).map((item, index) => {
             // Starting from 1 because first field is already rendered and need to be rendered always.
             return (
@@ -173,7 +185,7 @@ export const GenerateInterfaceForm: React.FC = () => {
             size="small"
             variant="naked"
             sx={{ my: 1, fontWeight: 800, alignSelf: 'start', fontSize: '1rem' }}
-            onClick={() => fieldsArray.append({ url: '' })}
+            onClick={() => fieldsArray.append({ url: '', description: '' })}
             startIcon={<AddIcon fontSize="small" />}
           >
             {t('serverSection.add')}
@@ -262,22 +274,47 @@ export const UrlInputField: React.FC<{
   const { t } = useTranslation('eservice', { keyPrefix: 'create.step4.eserviceTemplate.interface' })
 
   return (
-    <Stack direction="row" alignItems="center" key={id}>
-      {index >= 1 && (
-        <Tooltip title={t('serverSection.remove')}>
-          <Button color="error" sx={{ p: 1 }} onClick={() => remove(index)} variant="naked">
-            <RemoveCircleOutlineIcon fontSize="small" />
-          </Button>
-        </Tooltip>
-      )}
-      <RHFTextField
-        size="small"
-        sx={{ width: '50%' }}
-        name={`serverUrls`}
-        indexFieldArray={index}
-        fieldArrayKeyName="url"
-        label={t('serverSection.label')}
-      />
-    </Stack>
+    <React.Fragment key={id}>
+      <Divider sx={{ my: 3 }} />
+      <Stack direction="row" alignItems="flex-start">
+        {index >= 1 && (
+          <Tooltip title={t('serverSection.remove')}>
+            <Button color="error" sx={{ p: 1 }} onClick={() => remove(index)} variant="naked">
+              <RemoveCircleOutlineIcon fontSize="small" />
+            </Button>
+          </Tooltip>
+        )}
+        <Stack direction="column" sx={{ flex: 1 }}>
+          <RHFTextField
+            size="small"
+            sx={{ width: '50%' }}
+            name={`serverUrls`}
+            indexFieldArray={index}
+            fieldArrayKeyName="url"
+            label={t('serverSection.label')}
+          />
+          <ServerUrlDescriptionField index={index} />
+        </Stack>
+      </Stack>
+    </React.Fragment>
+  )
+}
+
+const ServerUrlDescriptionField: React.FC<{ index: number }> = ({ index }) => {
+  const { t } = useTranslation('eservice', { keyPrefix: 'create.step4.eserviceTemplate.interface' })
+
+  return (
+    <RHFTextField
+      size="small"
+      name={`serverUrls`}
+      indexFieldArray={index}
+      fieldArrayKeyName="description"
+      label={t('serverSection.descriptionLabel')}
+      infoLabel={t('serverSection.descriptionInfoLabel')}
+      multiline
+      rows={4}
+      inputProps={{ maxLength: 250 }}
+      rules={{ minLength: 10 }}
+    />
   )
 }

--- a/src/pages/ProviderEServiceCreatePage/components/components/GenerateInterfaceForm.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/components/GenerateInterfaceForm.tsx
@@ -140,6 +140,10 @@ export const GenerateInterfaceForm: React.FC = () => {
 
         {eServiceTechnology === 'REST' && <EditRESTInfoInterfaceFields />}
 
+        <Typography variant="body2" fontWeight={600}>
+          {t('serverSection.title')}
+        </Typography>
+
         <Stack direction="column">
           <RHFTextField
             size="small"
@@ -246,9 +250,6 @@ export const EditRESTInfoInterfaceFields: React.FC = () => {
           },
         }}
       />
-      <Typography variant="body2" fontWeight={600}>
-        {t('serverSection.title')}
-      </Typography>
     </>
   )
 }

--- a/src/pages/ProviderEServiceCreatePage/components/components/GenerateInterfaceForm.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/components/GenerateInterfaceForm.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Stack, Box, Typography, Tooltip, Button, Divider } from '@mui/material'
+import { Stack, Box, Typography, Button, Divider } from '@mui/material'
 import { emailRegex, urlRegex } from '@/utils/form.utils'
 import DownloadIcon from '@mui/icons-material/Download'
 import AddIcon from '@mui/icons-material/Add'
 import { RHFTextField } from '@/components/shared/react-hook-form-inputs'
-import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import { useForm, FormProvider, type UseFieldArrayReturn, useFieldArray } from 'react-hook-form'
 import type {
   TemplateInstanceInterfaceMetadata,
@@ -56,10 +56,13 @@ export const GenerateInterfaceForm: React.FC = () => {
     contactEmail: descriptor?.templateRef?.interfaceMetadata?.contactEmail ?? '',
     contactUrl: descriptor?.templateRef?.interfaceMetadata?.contactUrl ?? '',
     termsAndConditionsUrl: descriptor?.templateRef?.interfaceMetadata?.termsAndConditionsUrl ?? '',
-    serverUrls: descriptor?.serverUrls?.map((serverUrl) => ({
-      url: serverUrl.url,
-      description: serverUrl.description ?? '',
-    })) ?? [{ url: '', description: '' }],
+    serverUrls:
+      descriptor?.serverUrls && descriptor.serverUrls.length > 0
+        ? descriptor.serverUrls.map((serverUrl) => ({
+            url: serverUrl.url,
+            description: serverUrl.description ?? '',
+          }))
+        : [{ url: '', description: '' }],
   }
 
   const { mutate: deleteAndUpdateEServiceRESTInterfaceInfo } =
@@ -151,35 +154,15 @@ export const GenerateInterfaceForm: React.FC = () => {
 
         {eServiceTechnology === 'REST' && <EditRESTInfoInterfaceFields />}
 
-        <Typography variant="body2" fontWeight={600}>
-          {t('serverSection.title')}
-        </Typography>
-
         <Stack direction="column">
-          <RHFTextField
-            size="small"
-            sx={{ width: '50%' }}
-            name={`serverUrls`}
-            indexFieldArray={0}
-            fieldArrayKeyName="url"
-            label={t('serverSection.label')}
-            required
-            rules={{
-              required: true,
-            }}
-          />
-          <ServerUrlDescriptionField index={0} />
-          {fieldsArray.fields.slice(1).map((item, index) => {
-            // Starting from 1 because first field is already rendered and need to be rendered always.
-            return (
-              <UrlInputField
-                key={index}
-                id={item.id}
-                index={index + 1}
-                remove={fieldsArray.remove}
-              />
-            )
-          })}
+          {fieldsArray.fields.map((item, index) => (
+            <ServerUrlField
+              key={item.id}
+              index={index}
+              total={fieldsArray.fields.length}
+              remove={fieldsArray.remove}
+            />
+          ))}
 
           <Button
             size="small"
@@ -266,37 +249,48 @@ export const EditRESTInfoInterfaceFields: React.FC = () => {
   )
 }
 
-export const UrlInputField: React.FC<{
+const ServerUrlField: React.FC<{
   index: number
-  id: string
+  total: number
   remove: UseFieldArrayReturn<TemplateInstanceInterfaceMetadata, never, 'id'>['remove']
-}> = ({ index, id, remove }) => {
+}> = ({ index, total, remove }) => {
   const { t } = useTranslation('eservice', { keyPrefix: 'create.step4.eserviceTemplate.interface' })
 
+  const hasMultipleServers = total > 1
+
   return (
-    <React.Fragment key={id}>
-      <Divider sx={{ my: 3 }} />
-      <Stack direction="row" alignItems="flex-start">
-        {index >= 1 && (
-          <Tooltip title={t('serverSection.remove')}>
-            <Button color="error" sx={{ p: 1 }} onClick={() => remove(index)} variant="naked">
-              <RemoveCircleOutlineIcon fontSize="small" />
-            </Button>
-          </Tooltip>
-        )}
-        <Stack direction="column" sx={{ flex: 1 }}>
-          <RHFTextField
+    <>
+      {index > 0 && <Divider sx={{ my: 3 }} />}
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="body2" fontWeight={600}>
+          {hasMultipleServers
+            ? t('serverSection.counter', { current: index + 1, total })
+            : t('serverSection.title')}
+        </Typography>
+        {hasMultipleServers && (
+          <Button
+            color="error"
+            variant="naked"
             size="small"
-            sx={{ width: '50%' }}
-            name={`serverUrls`}
-            indexFieldArray={index}
-            fieldArrayKeyName="url"
-            label={t('serverSection.label')}
-          />
-          <ServerUrlDescriptionField index={index} />
-        </Stack>
+            startIcon={<DeleteOutlineIcon fontSize="small" />}
+            onClick={() => remove(index)}
+          >
+            {t('serverSection.removeServer')}
+          </Button>
+        )}
       </Stack>
-    </React.Fragment>
+      <RHFTextField
+        size="small"
+        sx={{ width: '50%' }}
+        name={`serverUrls`}
+        indexFieldArray={index}
+        fieldArrayKeyName="url"
+        label={t('serverSection.label')}
+        required
+        rules={{ required: true }}
+      />
+      <ServerUrlDescriptionField index={index} />
+    </>
   )
 }
 

--- a/src/pages/ProviderEServiceCreatePage/components/components/__tests__/GenerateInterfaceForm.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/components/__tests__/GenerateInterfaceForm.test.tsx
@@ -83,6 +83,29 @@ describe('GenerateInterfaceForm', () => {
     expect(screen.queryByText('contactSection.title')).not.toBeInTheDocument()
   })
 
+  it('should show the server section title when technology is SOAP', () => {
+    mockUseEServiceCreateContext({
+      descriptor: createMockEServiceDescriptorProviderWithTemplateRef({
+        eservice: {
+          description: 'Lorem ipsum',
+          descriptors: [],
+          producer: { id: 'org-id', tenantKind: 'PA' },
+          id: 'eservice-id',
+          name: 'Test',
+          technology: 'SOAP',
+          mode: 'DELIVER',
+          riskAnalysis: [],
+        },
+      }),
+    })
+    renderWithApplicationContext(<GenerateInterfaceForm />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('serverSection.title')).toBeInTheDocument()
+  })
+
   it('should add a new server URL field when add button is clicked', async () => {
     mockUseEServiceCreateContext({
       descriptor: createMockEServiceDescriptorProviderWithTemplateRef(),

--- a/src/pages/ProviderEServiceCreatePage/components/components/__tests__/GenerateInterfaceForm.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/components/__tests__/GenerateInterfaceForm.test.tsx
@@ -205,6 +205,69 @@ describe('GenerateInterfaceForm', () => {
     expect(urlFields.length).toBe(2)
   })
 
+  it('should not show the per-server counter or a remove button when there is a single server URL', () => {
+    mockUseEServiceCreateContext({
+      descriptor: createMockEServiceDescriptorProviderWithTemplateRef(),
+    })
+    renderWithApplicationContext(<GenerateInterfaceForm />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('serverSection.title')).toBeInTheDocument()
+    expect(screen.queryByText('serverSection.counter')).not.toBeInTheDocument()
+    expect(screen.queryByText('serverSection.removeServer')).not.toBeInTheDocument()
+  })
+
+  it('should show a counter and a remove button for every server when there is more than one', async () => {
+    mockUseEServiceCreateContext({
+      descriptor: createMockEServiceDescriptorProviderWithTemplateRef(),
+    })
+    renderWithApplicationContext(<GenerateInterfaceForm />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await userEvent.click(screen.getByText('serverSection.add'))
+
+    expect(screen.getAllByText('serverSection.counter')).toHaveLength(2)
+    expect(screen.getAllByText('serverSection.removeServer')).toHaveLength(2)
+    expect(screen.queryByText('serverSection.title')).not.toBeInTheDocument()
+  })
+
+  it('should remove a server URL and restore the single-server layout when a remove button is clicked', async () => {
+    mockUseEServiceCreateContext({
+      descriptor: createMockEServiceDescriptorProviderWithTemplateRef(),
+    })
+    renderWithApplicationContext(<GenerateInterfaceForm />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await userEvent.click(screen.getByText('serverSection.add'))
+    expect(screen.getAllByLabelText(/serverSection.label/)).toHaveLength(2)
+
+    await userEvent.click(screen.getAllByText('serverSection.removeServer')[1])
+
+    expect(screen.getAllByLabelText(/serverSection.label/)).toHaveLength(1)
+    expect(screen.queryByText('serverSection.removeServer')).not.toBeInTheDocument()
+    expect(screen.getByText('serverSection.title')).toBeInTheDocument()
+  })
+
+  it('should render a single empty server URL field when the descriptor has no server URLs', () => {
+    mockUseEServiceCreateContext({
+      descriptor: createMockEServiceDescriptorProviderWithTemplateRef({ serverUrls: [] }),
+    })
+    renderWithApplicationContext(<GenerateInterfaceForm />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getAllByLabelText(/serverSection.label/)).toHaveLength(1)
+    expect(screen.getByText('serverSection.title')).toBeInTheDocument()
+    expect(screen.queryByText('serverSection.removeServer')).not.toBeInTheDocument()
+  })
+
   it('should call REST mutation on submit when technology is REST', async () => {
     mockUseEServiceCreateContext({
       descriptor: createMockEServiceDescriptorProviderWithTemplateRef(),

--- a/src/pages/ProviderEServiceCreatePage/components/components/__tests__/GenerateInterfaceForm.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/components/__tests__/GenerateInterfaceForm.test.tsx
@@ -83,7 +83,7 @@ describe('GenerateInterfaceForm', () => {
     expect(screen.queryByText('contactSection.title')).not.toBeInTheDocument()
   })
 
-  it('should show the server section title when technology is SOAP', () => {
+  it('should show the server section title and the URL description field when technology is SOAP', () => {
     mockUseEServiceCreateContext({
       descriptor: createMockEServiceDescriptorProviderWithTemplateRef({
         eservice: {
@@ -104,6 +104,89 @@ describe('GenerateInterfaceForm', () => {
     })
 
     expect(screen.getByText('serverSection.title')).toBeInTheDocument()
+    expect(screen.getByLabelText(/serverSection.descriptionLabel/)).toBeInTheDocument()
+  })
+
+  it('should render the server URL description field when technology is REST', () => {
+    mockUseEServiceCreateContext({
+      descriptor: createMockEServiceDescriptorProviderWithTemplateRef(),
+    })
+    renderWithApplicationContext(<GenerateInterfaceForm />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByLabelText(/serverSection.descriptionLabel/)).toBeInTheDocument()
+  })
+
+  it('should include the server URL description in the payload when filled', async () => {
+    mockUseEServiceCreateContext({
+      descriptor: createMockEServiceDescriptorProviderWithTemplateRef(),
+    })
+    renderWithApplicationContext(<GenerateInterfaceForm />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await userEvent.type(screen.getByLabelText(/contactSection.contactNameField/), 'John')
+    await userEvent.type(screen.getByLabelText(/contactSection.emailField/), 'john@test.com')
+    await userEvent.type(screen.getByLabelText(/serverSection.label/), 'https://api.test.com')
+    await userEvent.type(
+      screen.getByLabelText(/serverSection.descriptionLabel/),
+      'Production environment'
+    )
+
+    await userEvent.click(screen.getByText('save'))
+
+    await waitFor(() => {
+      expect(deleteAndUpdateRESTInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serverUrls: [{ url: 'https://api.test.com', description: 'Production environment' }],
+        })
+      )
+    })
+  })
+
+  it('should omit the server URL description from the payload when empty', async () => {
+    mockUseEServiceCreateContext({
+      descriptor: createMockEServiceDescriptorProviderWithTemplateRef(),
+    })
+    renderWithApplicationContext(<GenerateInterfaceForm />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await userEvent.type(screen.getByLabelText(/contactSection.contactNameField/), 'John')
+    await userEvent.type(screen.getByLabelText(/contactSection.emailField/), 'john@test.com')
+    await userEvent.type(screen.getByLabelText(/serverSection.label/), 'https://api.test.com')
+
+    await userEvent.click(screen.getByText('save'))
+
+    await waitFor(() => {
+      expect(deleteAndUpdateRESTInfo).toHaveBeenCalledWith(
+        expect.objectContaining({ serverUrls: [{ url: 'https://api.test.com' }] })
+      )
+    })
+  })
+
+  it('should show a min-length error and not submit when the description is shorter than 10 characters', async () => {
+    mockUseEServiceCreateContext({
+      descriptor: createMockEServiceDescriptorProviderWithTemplateRef(),
+    })
+    renderWithApplicationContext(<GenerateInterfaceForm />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await userEvent.type(screen.getByLabelText(/contactSection.contactNameField/), 'John')
+    await userEvent.type(screen.getByLabelText(/contactSection.emailField/), 'john@test.com')
+    await userEvent.type(screen.getByLabelText(/serverSection.label/), 'https://api.test.com')
+    await userEvent.type(screen.getByLabelText(/serverSection.descriptionLabel/), 'short')
+
+    await userEvent.click(screen.getByText('save'))
+
+    expect(await screen.findByText('validation.string.minLength')).toBeInTheDocument()
+    expect(deleteAndUpdateRESTInfo).not.toHaveBeenCalled()
   })
 
   it('should add a new server URL field when add button is clicked', async () => {

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -289,7 +289,8 @@
             "descriptionLabel": "Server URL description",
             "descriptionInfoLabel": "Describe which environment the server URL link points to. Min 10 characters, max 250 characters",
             "add": "Add server URL",
-            "remove": "Remove field"
+            "counter": "Server {{current}} of {{total}}",
+            "removeServer": "Delete server"
           },
           "description": {
             "rest": "Compile following fields and openAPI will be automatically generated",

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -286,6 +286,8 @@
           "serverSection": {
             "title": "Server",
             "label": "Server URL",
+            "descriptionLabel": "Server URL description",
+            "descriptionInfoLabel": "Describe which environment the server URL link points to. Min 10 characters, max 250 characters",
             "add": "Add server URL",
             "remove": "Remove field"
           },

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -289,7 +289,8 @@
             "descriptionLabel": "Descrizione dell'URL server",
             "descriptionInfoLabel": "Descrivi verso quale ambiente è rivolto il link dell'URL server. Min 10 caratteri, max 250 caratteri",
             "add": "Aggiungi URL server",
-            "remove": "Rimuovi campo"
+            "counter": "Server {{current}} di {{total}}",
+            "removeServer": "Elimina server"
           },
           "description": {
             "rest": "Compila i seguenti campi e ti verrà generato automaticamente il file OpenAPI.",

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -286,6 +286,8 @@
           "serverSection": {
             "title": "Server",
             "label": "URL server",
+            "descriptionLabel": "Descrizione dell'URL server",
+            "descriptionInfoLabel": "Descrivi verso quale ambiente è rivolto il link dell'URL server. Min 10 caratteri, max 250 caratteri",
             "add": "Aggiungi URL server",
             "remove": "Rimuovi campo"
           },


### PR DESCRIPTION
## 🔗 Issue

[PIN-10354](https://pagopa.atlassian.net/browse/PIN-10354)

## 📝 Description / Context

Sub-task of [PIN-9920](https://pagopa.atlassian.net/browse/PIN-9920). In the e-service-from-template instantiation flow (Erogazione → I miei e-service → create instance from template → "Specifiche tecniche" step → "Server" section), each server URL now supports an optional description (10–250 characters when set) so the generated OpenAPI/WSDL spec passes the OAS Checker (Italian Guidelines Full ruleset). This required the BFF contract to change `serverUrls` from `string[]` to `Array<{ url: string; description?: string }>`, delivered by the BE twin [PIN-10355](https://pagopa.atlassian.net/browse/PIN-10355).

Kept in Draft: the BE twin is on a branch but not yet merged to `develop`, so `api.generatedTypes.ts` here carries a temporary hand-applied version of the new contract. Once the BE merges, the types will be regenerated cleanly via `pnpm generate-types` (the regenerated file should match this hand patch).

## 📌 Design note

Slight, intentional deviation from the [Figma](https://www.figma.com/design/8yOl4vl6vKDi7NlTIl01A4/-Fix--Istanziazione-template--aggiunta-campo-nel-file-OpenAPI?node-id=13352-23806&t=c8963yQFLf7RmFx0-4): when there is more than one server, the "Elimina server" button is shown on **every** server, including the first, whereas the Figma shows it only on the additional server. When a single server remains, no delete control is shown at all (and the header is just "Server", without the counter). This was agreed as the desired behavior.

## 🛠 List of changes

- `api.generatedTypes.ts`: added `TemplateInstanceInterfaceServerUrlSeed` (`{ url; description? }`, description 10–250); the REST and SOAP seeds' `serverUrls` now reference it; the read type `ProducerEServiceDescriptor.serverUrls` is now `{ url; description? }[]`. Hand-applied, to be replaced by a clean regen once the BE lands on `develop`.
- `GenerateInterfaceForm.tsx`: the "Server" heading is shown for both REST and SOAP (moved out of the REST-only fields); an optional description field (multiline, `maxLength` 250, `minLength` 10, with helper text) renders under each server URL.
- `GenerateInterfaceForm.tsx`: with more than one server, each server shows a "Server N di M" counter and an "Elimina server" button (on every server, including the first), and a divider separates each URL/description pair; with a single server the header is just "Server" with no counter and no delete control.
- `GenerateInterfaceForm.tsx`: `defaultValues` prefills `description` from `descriptor.serverUrls` and always renders at least one server field (falls back to a single empty field when `serverUrls` is empty or absent); the server URL is required on every server; `mapServerUrls` and the REST/SOAP payloads send `{ url, description }`, omitting an empty description.
- i18n (it/en): added `serverSection.descriptionLabel`, `serverSection.descriptionInfoLabel`, `serverSection.counter` and `serverSection.removeServer`; removed the now-unused `serverSection.remove`.
- Tests: description renders for REST and SOAP, is included in the payload when filled and omitted when empty, a min-length (10) error blocks submit, the counter and delete controls appear only with more than one server (and on every server), removing a server restores the single-server layout, and an empty/absent `serverUrls` still renders one field.

## 🧪 How to test

- Erogazione → I miei e-service → create an instance from a template → "Specifiche tecniche" step → "Server" section: each server URL has an optional "Descrizione dell'URL server" field below it, and the "Server" heading is shown for both REST and SOAP.
- Empty description → the entry is sent without `description`. 1–9 chars → "at least 10 characters" error and submit is blocked. 10–250 chars → sent as `description`; typing is hard-capped at 250.
- With a single server → header is "Server", no counter, no "Elimina server". Click "Aggiungi URL server" → each server gets a "Server N di M" counter, an "Elimina server" button (on every server), and a divider between pairs. Remove servers back down to one → the single-server layout is restored.
- `pnpm test src/pages/ProviderEServiceCreatePage/components/components/__tests__/GenerateInterfaceForm.test.tsx` → all green.

## ⏳ Before marking ready

- [x] Merge BE twin [PIN-10355](https://pagopa.atlassian.net/browse/PIN-10355) to `develop`.
- [x] Regenerate `api.generatedTypes.ts` via `pnpm generate-types` and confirm it matches the hand patch in this PR.

## Screenshots

<img width="1840" height="930" alt="PIN-10354-single-server" src="https://github.com/user-attachments/assets/8851ec6c-9a60-4f6b-85b7-4781fbef9535" />

<img width="1840" height="1578" alt="PIN-10354-multi-server" src="https://github.com/user-attachments/assets/8c399d7c-3d54-4e0d-9158-2c59d4c7e002" />

[PIN-10354]: https://pagopa.atlassian.net/browse/PIN-10354
[PIN-9920]: https://pagopa.atlassian.net/browse/PIN-9920
[PIN-10355]: https://pagopa.atlassian.net/browse/PIN-10355
