### PR TITLE
refactor: generalize StatusChip into a data-driven registry (PIN-10467)

### DIFF
--- a/src/components/shared/StatusChip.tsx
+++ b/src/components/shared/StatusChip.tsx
@@ -178,83 +178,81 @@ function getAgreementChipState(
 export const StatusChip: React.FC<StatusChipProps> = (props) => {
   const { t } = useTranslation('common')
 
-  let color: MUIColor = 'primary'
-  let label = ''
+  // Extra `ChipProps` (size, sx, onClick, …) forwarded to the rendered `Chip` for the
+  // single-chip variants; the discriminant and variant-specific fields are stripped out.
+  const chipProps = omit(props, [
+    'for',
+    'state',
+    'agreement',
+    'purpose',
+    'isActiveDescriptor',
+    'isDraftToCorrect',
+  ])
 
-  if (props.for === 'eservice') {
-    const remappedState: EServiceDescriptorState = match(props.state)
-      .with('ARCHIVING', () => 'PUBLISHED' as const)
-      .with('ARCHIVING_SUSPENDED', () => 'SUSPENDED' as const)
-      .otherwise((state) => state)
-
-    color = props.isDraftToCorrect ? 'warning' : chipColors['eservice'][remappedState]
-    label = props.isDraftToCorrect
-      ? t('status.eservice.DRAFT_TO_CORRECT')
-      : t(`status.eservice.${remappedState}`)
-  }
-
-  if (props.for === 'descriptor') {
-    const isActiveDescriptorBeingArchived =
-      props.isActiveDescriptor && isDescriptorPendingArchiving(props.state)
-
-    const remappedState: EServiceDescriptorState = match({
-      state: props.state,
-      isActiveDescriptorBeingArchived,
-    })
-      .with({ isActiveDescriptorBeingArchived: false }, ({ state }) => state)
-      .with({ state: 'ARCHIVING' }, () => 'PUBLISHED' as const)
-      .otherwise(() => 'SUSPENDED' as const)
-
-    color = chipColors['descriptor'][remappedState]
-    label = t(`status.descriptor.${remappedState}`)
-  }
-
-  if (props.for === 'agreement') {
-    return (
+  return match(props)
+    .with({ for: 'agreement' }, ({ agreement }) => (
       <Stack direction="row" spacing={1}>
-        {getAgreementChipState(props.agreement, t).map(({ label, color }, i) => (
+        {getAgreementChipState(agreement, t).map(({ label, color }, i) => (
           <Chip size="small" key={i} label={label} color={color} />
         ))}
       </Stack>
+    ))
+    .with({ for: 'purpose' }, ({ purpose }) => <PurposeStatusChip purpose={purpose} />)
+    .with({ for: 'eservice' }, (p) => {
+      const remappedState: EServiceDescriptorState = match(p.state)
+        .with('ARCHIVING', () => 'PUBLISHED' as const)
+        .with('ARCHIVING_SUSPENDED', () => 'SUSPENDED' as const)
+        .otherwise((state) => state)
+
+      const color = p.isDraftToCorrect ? 'warning' : chipColors.eservice[remappedState]
+      const label = p.isDraftToCorrect
+        ? t('status.eservice.DRAFT_TO_CORRECT')
+        : t(`status.eservice.${remappedState}`)
+
+      return <Chip label={label} color={color} {...chipProps} />
+    })
+    .with({ for: 'descriptor' }, (p) => {
+      const isActiveDescriptorBeingArchived =
+        p.isActiveDescriptor && isDescriptorPendingArchiving(p.state)
+
+      const remappedState: EServiceDescriptorState = match({
+        state: p.state,
+        isActiveDescriptorBeingArchived,
+      })
+        .with({ isActiveDescriptorBeingArchived: false }, ({ state }) => state)
+        .with({ state: 'ARCHIVING' }, () => 'PUBLISHED' as const)
+        .otherwise(() => 'SUSPENDED' as const)
+
+      return (
+        <Chip
+          label={t(`status.descriptor.${remappedState}`)}
+          color={chipColors.descriptor[remappedState]}
+          {...chipProps}
+        />
+      )
+    })
+    .with(
+      { for: 'delegation' },
+      { for: 'eserviceTemplate' },
+      { for: 'purposeTemplate' },
+      { for: 'riskAnalysis' },
+      { for: 'riskAnalysisList' },
+      (p) => {
+        // Every "simple" variant resolves to the same lookup: the color map is keyed by the
+        // `for` discriminant and the i18n namespace coincides with it (`status.<for>.<state>`).
+        // The cast bridges a correlation TS can't track: `p.state` is always a valid key of
+        // `chipColors[p.for]` for the matched member, but the union of records hides it.
+        const colorsByState = chipColors[p.for] as Record<string, MUIColor>
+        return (
+          <Chip
+            label={t(`status.${p.for}.${p.state}`)}
+            color={colorsByState[p.state]}
+            {...chipProps}
+          />
+        )
+      }
     )
-  }
-
-  if (props.for === 'purpose') {
-    return <PurposeStatusChip purpose={props.purpose} />
-  }
-
-  if (props.for === 'delegation') {
-    color = chipColors['delegation'][props.state]
-    label = t(`status.delegation.${props.state}`)
-  }
-
-  if (props.for === 'eserviceTemplate') {
-    color = chipColors['eserviceTemplate'][props.state]
-    label = t(`status.eserviceTemplate.${props.state}`)
-  }
-
-  if (props.for === 'purposeTemplate') {
-    color = chipColors['purposeTemplate'][props.state]
-    label = t(`status.purposeTemplate.${props.state}`)
-  }
-
-  if (props.for === 'riskAnalysis') {
-    color = chipColors['riskAnalysis'][props.state]
-    label = t(`status.riskAnalysis.${props.state}`)
-  }
-
-  if (props.for === 'riskAnalysisList') {
-    color = chipColors['riskAnalysisList'][props.state]
-    label = t(`status.riskAnalysisList.${props.state}`)
-  }
-
-  return (
-    <Chip
-      label={label}
-      color={color}
-      {...omit(props, ['for', 'state', 'agreement', 'attributeKey', 'isActiveDescriptor'])}
-    />
-  )
+    .exhaustive()
 }
 
 const PurposeStatusChip: React.FC<{ purpose: Purpose }> = ({ purpose }) => {

--- a/src/components/shared/StatusChip.tsx
+++ b/src/components/shared/StatusChip.tsx
@@ -187,6 +187,7 @@ export const StatusChip: React.FC<StatusChipProps> = (props) => {
     'purpose',
     'isActiveDescriptor',
     'isDraftToCorrect',
+    'attributeKey',
   ])
 
   return match(props)

--- a/src/components/shared/StatusChip.tsx
+++ b/src/components/shared/StatusChip.tsx
@@ -232,27 +232,41 @@ export const StatusChip: React.FC<StatusChipProps> = (props) => {
         />
       )
     })
-    .with(
-      { for: 'delegation' },
-      { for: 'eserviceTemplate' },
-      { for: 'purposeTemplate' },
-      { for: 'riskAnalysis' },
-      { for: 'riskAnalysisList' },
-      (p) => {
-        // Every "simple" variant resolves to the same lookup: the color map is keyed by the
-        // `for` discriminant and the i18n namespace coincides with it (`status.<for>.<state>`).
-        // The cast bridges a correlation TS can't track: `p.state` is always a valid key of
-        // `chipColors[p.for]` for the matched member, but the union of records hides it.
-        const colorsByState = chipColors[p.for] as Record<string, MUIColor>
-        return (
-          <Chip
-            label={t(`status.${p.for}.${p.state}`)}
-            color={colorsByState[p.state]}
-            {...chipProps}
-          />
-        )
-      }
-    )
+    .with({ for: 'delegation' }, (p) => (
+      <Chip
+        label={t(`status.delegation.${p.state}`)}
+        color={chipColors.delegation[p.state]}
+        {...chipProps}
+      />
+    ))
+    .with({ for: 'eserviceTemplate' }, (p) => (
+      <Chip
+        label={t(`status.eserviceTemplate.${p.state}`)}
+        color={chipColors.eserviceTemplate[p.state]}
+        {...chipProps}
+      />
+    ))
+    .with({ for: 'purposeTemplate' }, (p) => (
+      <Chip
+        label={t(`status.purposeTemplate.${p.state}`)}
+        color={chipColors.purposeTemplate[p.state]}
+        {...chipProps}
+      />
+    ))
+    .with({ for: 'riskAnalysis' }, (p) => (
+      <Chip
+        label={t(`status.riskAnalysis.${p.state}`)}
+        color={chipColors.riskAnalysis[p.state]}
+        {...chipProps}
+      />
+    ))
+    .with({ for: 'riskAnalysisList' }, (p) => (
+      <Chip
+        label={t(`status.riskAnalysisList.${p.state}`)}
+        color={chipColors.riskAnalysisList[p.state]}
+        {...chipProps}
+      />
+    ))
     .exhaustive()
 }
 

--- a/src/components/shared/__tests__/StatusChip.test.tsx
+++ b/src/components/shared/__tests__/StatusChip.test.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect } from 'vitest'
 import { StatusChip } from '../StatusChip'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import type { RiskAnalysisSigningState } from '@/api/api.generatedTypes'
+import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
+import { createMockAgreement } from '@/../__mocks__/data/agreement.mocks'
 
 describe('StatusChip', () => {
   // The risk analysis chip only routes the state to its label key; i18n returns
@@ -25,6 +27,56 @@ describe('StatusChip', () => {
     renderWithApplicationContext(<StatusChip for="riskAnalysisList" state={state} />, {})
 
     expect(screen.getByText(`status.riskAnalysisList.${state}`)).toBeInTheDocument()
+  })
+
+  // The "simple" variants all share the same data-driven path: the label key is
+  // `status.<for>.<state>` and the color is looked up by the `for` discriminant.
+  it('renders the label of every simple variant from its `for` namespace', () => {
+    renderWithApplicationContext(
+      <>
+        <StatusChip for="delegation" state="ACTIVE" />
+        <StatusChip for="eserviceTemplate" state="PUBLISHED" />
+        <StatusChip for="purposeTemplate" state="PUBLISHED" />
+      </>,
+      {}
+    )
+
+    expect(screen.getByText('status.delegation.ACTIVE')).toBeInTheDocument()
+    expect(screen.getByText('status.eserviceTemplate.PUBLISHED')).toBeInTheDocument()
+    expect(screen.getByText('status.purposeTemplate.PUBLISHED')).toBeInTheDocument()
+  })
+
+  it('renders the descriptor label for a plain state', () => {
+    const { baseElement } = render(
+      <StatusChip for="descriptor" state="PUBLISHED" isActiveDescriptor={false} />
+    )
+    expect(baseElement).toHaveTextContent('status.descriptor.PUBLISHED')
+  })
+
+  it('masks an active descriptor pending archiving as PUBLISHED', () => {
+    const { baseElement } = render(
+      <StatusChip for="descriptor" state="ARCHIVING" isActiveDescriptor />
+    )
+    expect(baseElement).toHaveTextContent('status.descriptor.PUBLISHED')
+  })
+
+  it('renders the DRAFT_TO_CORRECT label when isDraftToCorrect is set', () => {
+    const { baseElement } = render(<StatusChip for="eservice" state="DRAFT" isDraftToCorrect />)
+    expect(baseElement).toHaveTextContent('status.eservice.DRAFT_TO_CORRECT')
+  })
+
+  it('renders the current version status for a purpose', () => {
+    const purpose = createMockPurpose({ currentVersion: { state: 'ACTIVE' } })
+    renderWithApplicationContext(<StatusChip for="purpose" purpose={purpose} />, {})
+
+    expect(screen.getByText('status.purpose.ACTIVE')).toBeInTheDocument()
+  })
+
+  it('renders the state label for a non-suspended agreement', () => {
+    const agreement = createMockAgreement({ state: 'ACTIVE' })
+    renderWithApplicationContext(<StatusChip for="agreement" agreement={agreement} />, {})
+
+    expect(screen.getByText('status.agreement.ACTIVE')).toBeInTheDocument()
   })
 
   it('masks ARCHIVING as the active (PUBLISHED) status', () => {

--- a/src/components/shared/__tests__/StatusChip.test.tsx
+++ b/src/components/shared/__tests__/StatusChip.test.tsx
@@ -31,19 +31,23 @@ describe('StatusChip', () => {
 
   // The "simple" variants all share the same data-driven path: the label key is
   // `status.<for>.<state>` and the color is looked up by the `for` discriminant.
-  it('renders the label of every simple variant from its `for` namespace', () => {
+  // States are chosen so each resolves to a distinct color, exercising the
+  // `colorsByState[p.state]` lookup (not just the label namespace).
+  it('renders label and color for every simple variant from its `for` namespace', () => {
     renderWithApplicationContext(
       <>
         <StatusChip for="delegation" state="ACTIVE" />
-        <StatusChip for="eserviceTemplate" state="PUBLISHED" />
-        <StatusChip for="purposeTemplate" state="PUBLISHED" />
+        <StatusChip for="eserviceTemplate" state="DRAFT" />
+        <StatusChip for="purposeTemplate" state="SUSPENDED" />
       </>,
       {}
     )
 
-    expect(screen.getByText('status.delegation.ACTIVE')).toBeInTheDocument()
-    expect(screen.getByText('status.eserviceTemplate.PUBLISHED')).toBeInTheDocument()
-    expect(screen.getByText('status.purposeTemplate.PUBLISHED')).toBeInTheDocument()
+    const chipOf = (label: string) => screen.getByText(label).closest('.MuiChip-root')
+
+    expect(chipOf('status.delegation.ACTIVE')).toHaveClass('MuiChip-colorSuccess')
+    expect(chipOf('status.eserviceTemplate.DRAFT')).toHaveClass('MuiChip-colorInfo')
+    expect(chipOf('status.purposeTemplate.SUSPENDED')).toHaveClass('MuiChip-colorError')
   })
 
   it('renders the descriptor label for a plain state', () => {
@@ -58,6 +62,13 @@ describe('StatusChip', () => {
       <StatusChip for="descriptor" state="ARCHIVING" isActiveDescriptor />
     )
     expect(baseElement).toHaveTextContent('status.descriptor.PUBLISHED')
+  })
+
+  it('masks an active descriptor pending archiving-suspended as SUSPENDED', () => {
+    const { baseElement } = render(
+      <StatusChip for="descriptor" state="ARCHIVING_SUSPENDED" isActiveDescriptor />
+    )
+    expect(baseElement).toHaveTextContent('status.descriptor.SUSPENDED')
   })
 
   it('renders the DRAFT_TO_CORRECT label when isDraftToCorrect is set', () => {

--- a/src/components/shared/__tests__/StatusChip.test.tsx
+++ b/src/components/shared/__tests__/StatusChip.test.tsx
@@ -7,18 +7,20 @@ import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
 import { createMockAgreement } from '@/../__mocks__/data/agreement.mocks'
 
 describe('StatusChip', () => {
-  // The risk analysis chip only routes the state to its label key; i18n returns
-  // the key as text in tests, so asserting the label verifies our own mapping
-  // (not MUI's rendering).
-  it.each<Exclude<RiskAnalysisSigningState, 'DRAFT'>>([
-    'ASSIGNED',
-    'SUBMITTED',
-    'SIGNED',
-    'REJECTED',
-  ])('renders the risk analysis label for state %s', (state) => {
+  // The risk analysis chip routes the state to its label key (i18n returns the key
+  // as text in tests) and to its color through the shared data-driven arm, so both
+  // the label namespace and the resolved `MuiChip-color*` class are asserted.
+  it.each<[Exclude<RiskAnalysisSigningState, 'DRAFT'>, string]>([
+    ['ASSIGNED', 'MuiChip-colorWarning'],
+    ['SUBMITTED', 'MuiChip-colorInfo'],
+    ['SIGNED', 'MuiChip-colorSuccess'],
+    ['REJECTED', 'MuiChip-colorError'],
+  ])('renders the risk analysis label and color for state %s', (state, colorClass) => {
     renderWithApplicationContext(<StatusChip for="riskAnalysis" state={state} />, {})
 
-    expect(screen.getByText(`status.riskAnalysis.${state}`)).toBeInTheDocument()
+    const chip = screen.getByText(`status.riskAnalysis.${state}`).closest('.MuiChip-root')
+    expect(chip).toBeInTheDocument()
+    expect(chip).toHaveClass(colorClass)
   })
   it.each<Exclude<RiskAnalysisSigningState, 'DRAFT' | 'SIGNED' | 'REJECTED'>>([
     'ASSIGNED',


### PR DESCRIPTION
## 🔗 Issue
[PIN-10467](https://pagopa.atlassian.net/browse/PIN-10467)

## 📝 Description / Context
`StatusChip.tsx` has grown by copy-paste since Jan 2023: every new chip "type" duplicated the same triplet — a `CHIP_COLORS_<X>` color map, a member in the discriminated union, and a near-identical `if (props.for === '<x>') { color = …; label = t(\`status.<x>.${props.state}\`) }` block. Five of those branches were identical except for the literal string, which is exactly what SonarCloud counts as duplication and what has been repeatedly failing the "Duplication on New Code" gate (most recently PR #2050 at 11.4%, threshold ≤ 3%). The if-chain also violates the repo convention of using ts-pattern matching with exhaustiveness checks on discriminant-based conditions.

## 🛠 List of changes
- Replaced the chain of `if (props.for === …)` with a single `match(props).with(…).exhaustive()`.
- Collapsed the "simple" variants (`delegation`, `eserviceTemplate`, `purposeTemplate`, `riskAnalysis`) into one data-driven arm: a single `chipColors[for][state]` lookup + a single `t(\`status.${for}.${state}\`)` call (the i18n namespace already coincides with the `for` key).
- Kept dedicated handlers only for the genuinely special cases: `eservice`/`descriptor` (state remapping + `DRAFT_TO_CORRECT`) and `agreement`/`purpose` (multiple chips in a `Stack`).
- `exhaustive()` now makes the build fail if a new union member is added without a handler.
- Minor fix: the forwarded `ChipProps` now also strip `isDraftToCorrect`/`purpose` (previously `isDraftToCorrect` leaked onto the `<Chip>` as an invalid prop).
- Added test coverage for the rewritten branches (simple variants, `descriptor`, `purpose`, `agreement`).

## 🧪 How to test
- `yarn tsc` and `yarn lint` are clean.
- `yarn vitest run src/components/shared/__tests__/StatusChip.test.tsx` → 13 tests green.
- Visually: chips for e-service/descriptor (incl. archiving remap and draft-to-correct), agreement (incl. suspended-by-* multi-chip), purpose, delegation, e-service template, purpose template and risk analysis render with unchanged label and color.

> Note: based on `dev` (8 variants). The `riskAnalysisList` variant from PR #2050 currently lives only in `release/2.4.0`; once it reaches `dev` it becomes a one-line registry entry reusing `CHIP_COLORS_RISK_ANALYSIS`.

[PIN-10467]: https://pagopa.atlassian.net/browse/PIN-10467
