### PR TITLE
feat: add staleTime to prefetch queries to avoid duplicate requests (PIN-10389)

### DIFF
--- a/src/components/layout/containers/AttributeContainer.tsx
+++ b/src/components/layout/containers/AttributeContainer.tsx
@@ -13,6 +13,7 @@ import { ButtonNaked } from '@pagopa/mui-italia'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline'
 import { AttributeQueries } from '@/api/attribute'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
 import { useTranslation } from 'react-i18next'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -80,7 +81,10 @@ export const AttributeContainer = <
   const handlePrefetchAttribute = () => {
     if (alreadyPrefetched.current) return
     alreadyPrefetched.current = true
-    queryClient.prefetchQuery(AttributeQueries.getSingle(attribute.id))
+    queryClient.prefetchQuery({
+      ...AttributeQueries.getSingle(attribute.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const isAttributeCertifiedDiscrete =

--- a/src/components/layout/containers/EServiceContainer.tsx
+++ b/src/components/layout/containers/EServiceContainer.tsx
@@ -18,6 +18,7 @@ import { InformationContainer } from '@pagopa/interop-fe-commons'
 import { useTranslation } from 'react-i18next'
 import { useQueryClient } from '@tanstack/react-query'
 import { EServiceQueries } from '@/api/eservice'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { Link } from '@/router'
 import type { CatalogEService } from '@/api/api.generatedTypes'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
@@ -42,9 +43,10 @@ export const EServiceContainer = ({ eservice, showWarning, onRemove }: EServiceC
   const handlePrefetchEService = () => {
     if (alreadyPrefetched.current) return
     alreadyPrefetched.current = true
-    queryClient.prefetchQuery(
-      EServiceQueries.getDescriptorCatalog(eservice.id, eservice.activeDescriptor?.id as string)
-    )
+    queryClient.prefetchQuery({
+      ...EServiceQueries.getDescriptorCatalog(eservice.id, eservice.activeDescriptor?.id as string),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   return (

--- a/src/components/shared/ClientTable/ClientTableRow.tsx
+++ b/src/components/shared/ClientTable/ClientTableRow.tsx
@@ -1,5 +1,6 @@
 import type { ClientKind, CompactClient } from '@/api/api.generatedTypes'
 import { ClientQueries } from '@/api/client'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import useGetClientActions from '@/hooks/useGetClientActions'
 import { Link } from '@/router'
 import { Box, Skeleton, Stack } from '@mui/material'
@@ -23,7 +24,10 @@ export const ClientTableRow: React.FC<ClientTableRowProps> = ({ client, clientKi
   const { actions } = useGetClientActions(client)
 
   const handlePrefetch = () => {
-    queryClient.prefetchQuery(ClientQueries.getSingle(client.id))
+    queryClient.prefetchQuery({
+      ...ClientQueries.getSingle(client.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const clientName = (

--- a/src/components/shared/DelegationTable/DelegationsTableRow.tsx
+++ b/src/components/shared/DelegationTable/DelegationsTableRow.tsx
@@ -1,5 +1,6 @@
 import type { CompactDelegation } from '@/api/api.generatedTypes'
 import { DelegationQueries } from '@/api/delegation'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
 import { ButtonSkeleton } from '@/components/shared/MUI-skeletons'
 import { StatusChip, StatusChipSkeleton } from '@/components/shared/StatusChip'
@@ -30,7 +31,10 @@ export const DelegationsTableRow: React.FC<DelegationsTableRowProps> = ({
   const { actions } = useGetDelegationActions(delegation)
 
   const handlePrefetch = () => {
-    queryClient.prefetchQuery(DelegationQueries.getSingle({ delegationId: delegation.id }))
+    queryClient.prefetchQuery({
+      ...DelegationQueries.getSingle({ delegationId: delegation.id }),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const delegationKindLabel = match(delegation.kind)

--- a/src/components/shared/KeychainsTable/KeychainsTableRow.tsx
+++ b/src/components/shared/KeychainsTable/KeychainsTableRow.tsx
@@ -9,6 +9,7 @@ import useGetKeychainActions from '@/hooks/useGetKeychainActions'
 import type { CompactProducerKeychain } from '@/api/api.generatedTypes'
 import { useQueryClient } from '@tanstack/react-query'
 import { KeychainQueries } from '@/api/keychain/keychain.queries'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { Stack } from '@mui/material'
 import { NotificationBadgeDot } from '../NotificationBadgeDot/NotificationBadgeDot'
 
@@ -23,7 +24,10 @@ export const KeychainsTableRow: React.FC<KeychainsTableRow> = ({ keychain }) => 
   const { actions } = useGetKeychainActions(keychain)
 
   const handlePrefetch = () => {
-    queryClient.prefetchQuery(KeychainQueries.getSingle(keychain.id))
+    queryClient.prefetchQuery({
+      ...KeychainQueries.getSingle(keychain.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const keychainNameCellData = (

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -88,3 +88,5 @@ export const CLIENT_ASSERTION_HTM = 'POST'
 export const VOUCHER_FIRST_DPOP_FILENAME = 'create_dpop_proof_auth_server'
 export const VOUCHER_SECOND_DPOP_FILENAME = 'create_dpop_proof_resource_server'
 export const ESERVICE_DESCRIPTION_MAX_LENGTH = 400
+
+export const PREFETCH_STALE_TIME = 60_000

--- a/src/pages/ConsumerAgreementsListPage/components/ConsumerAgreementsTableRow.tsx
+++ b/src/pages/ConsumerAgreementsListPage/components/ConsumerAgreementsTableRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { AgreementQueries } from '@/api/agreement'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import type { AgreementListEntry } from '@/api/api.generatedTypes'
 import { AuthHooks } from '@/api/auth'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
@@ -35,7 +36,10 @@ export const ConsumerAgreementsTableRow: React.FC<{ agreement: AgreementListEntr
   const isAgreementEditable = isAdmin && agreement.state === 'DRAFT'
 
   const handlePrefetch = () => {
-    queryClient.prefetchQuery(AgreementQueries.getSingle(agreement.id))
+    queryClient.prefetchQuery({
+      ...AgreementQueries.getSingle(agreement.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const isDelegator = Boolean(

--- a/src/pages/ConsumerClientManagePage/components/ClientOperators/ClientOperators.tsx
+++ b/src/pages/ConsumerClientManagePage/components/ClientOperators/ClientOperators.tsx
@@ -8,6 +8,7 @@ import { ClientMutations, ClientQueries } from '@/api/client'
 import type { Users } from '@/api/api.generatedTypes'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { TenantQueries } from '@/api/tenant'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { AddOperatorsToClientDrawer } from '@/components/shared/AddOperatorsToClientDrawer'
 import { HeadSection } from '@/components/shared/HeadSection'
 import type { ActionItemButton } from '@/types/common.types'
@@ -39,12 +40,13 @@ export const ClientOperators: React.FC<ClientOperatorsProps> = ({ clientId }) =>
 
   const handlePrefetchUserList = () => {
     if (!canAddOperator) return
-    queryClient.prefetchQuery(
-      TenantQueries.getPartyUsersList({
+    queryClient.prefetchQuery({
+      ...TenantQueries.getPartyUsersList({
         roles: ['admin', 'security'],
         tenantId: jwt?.organizationId as string,
-      })
-    )
+      }),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const action: ActionItemButton[] = [

--- a/src/pages/ConsumerClientManagePage/components/ClientOperators/ClientOperatorsTableRow.tsx
+++ b/src/pages/ConsumerClientManagePage/components/ClientOperators/ClientOperatorsTableRow.tsx
@@ -11,6 +11,7 @@ import { useGetClientOperatorsActions } from '@/hooks/useGetClientOperatorsActio
 import type { CompactUser } from '@/api/api.generatedTypes'
 import { useQueryClient } from '@tanstack/react-query'
 import { SelfcareQueries } from '@/api/selfcare'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 
 interface ClientOperatorsTableRowProps {
   operator: CompactUser
@@ -29,7 +30,10 @@ export const ClientOperatorsTableRow: React.FC<ClientOperatorsTableRowProps> = (
   const { actions } = useGetClientOperatorsActions(operator.userId, clientId)
 
   const handlePrefetchOperator = () => {
-    queryClient.prefetchQuery(SelfcareQueries.getSingleUser(operator.userId))
+    queryClient.prefetchQuery({
+      ...SelfcareQueries.getSingleUser(operator.userId),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const inspectRouteKey =

--- a/src/pages/ConsumerClientManagePage/components/ClientPublicKeys/ClientPublicKeysTableRow.tsx
+++ b/src/pages/ConsumerClientManagePage/components/ClientPublicKeys/ClientPublicKeysTableRow.tsx
@@ -1,4 +1,5 @@
 import { ClientQueries } from '@/api/client'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
 import { Link } from '@/router'
 import { formatDateString } from '@/utils/format.utils'
@@ -33,7 +34,10 @@ export const ClientPublicKeysTableRow: React.FC<ClientPublicKeysTableRowProps> =
     clientKind === 'API' ? 'SUBSCRIBE_INTEROP_M2M_CLIENT_KEY_EDIT' : 'SUBSCRIBE_CLIENT_KEY_EDIT'
 
   const handlePrefetchKey = () => {
-    queryClient.prefetchQuery(ClientQueries.getSingleKey(clientId, kid))
+    queryClient.prefetchQuery({
+      ...ClientQueries.getSingleKey(clientId, kid),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   return (

--- a/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogGrid.tsx
+++ b/src/pages/ConsumerEServiceCatalogPage/components/EServiceCatalogGrid.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import type { CatalogEService } from '@/api/api.generatedTypes'
 import { AVATAR_BASEPATH, STAGE } from '@/config/env'
-import { SH_ESERVICES_TO_HIDE_TEMP } from '@/config/constants'
+import { PREFETCH_STALE_TIME, SH_ESERVICES_TO_HIDE_TEMP } from '@/config/constants'
 import { useQueryClient } from '@tanstack/react-query'
 import { EServiceQueries } from '@/api/eservice'
 import { CatalogCard, CatalogCardSkeleton } from '@/components/shared/CatalogCard'
@@ -42,7 +42,10 @@ export const EServiceCatalogCard: React.FC<{ eservice: CatalogEService; disabled
 
   const handlePrefetch = () => {
     if (!activeDescriptor) return
-    queryClient.prefetchQuery(EServiceQueries.getDescriptorCatalog(eServiceId, activeDescriptor.id))
+    queryClient.prefetchQuery({
+      ...EServiceQueries.getDescriptorCatalog(eServiceId, activeDescriptor.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
   return (
     <CatalogCard

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeClientsTab/PurposeClientsTableRow.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeClientsTab/PurposeClientsTableRow.tsx
@@ -1,6 +1,7 @@
 import type { Purpose } from '@/api/api.generatedTypes'
 import { AuthHooks } from '@/api/auth'
 import { ClientQueries } from '@/api/client'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { PurposeMutations } from '@/api/purpose'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
 import { ButtonSkeleton } from '@/components/shared/MUI-skeletons'
@@ -42,7 +43,10 @@ export const PurposeClientsTableRow: React.FC<PurposeClientsTableRowProps> = ({
   }
 
   const handlePrefetchClient = () => {
-    queryClient.prefetchQuery(ClientQueries.getSingle(client.id))
+    queryClient.prefetchQuery({
+      ...ClientQueries.getSingle(client.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   return (

--- a/src/pages/ConsumerPurposeTemplateCatalogPage/components/PurposeTemplateCatalogGrid.tsx
+++ b/src/pages/ConsumerPurposeTemplateCatalogPage/components/PurposeTemplateCatalogGrid.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import type { CatalogPurposeTemplate } from '@/api/api.generatedTypes'
 import { useQueryClient } from '@tanstack/react-query'
 import { PurposeTemplateQueries } from '@/api/purposeTemplate/purposeTemplate.queries'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import {
   CatalogCardForPurposeTemplate,
   CatalogCardForPurposeTemplateSkeleton,
@@ -46,7 +47,10 @@ export const PurposeTemplateCatalogCard: React.FC<{
 
   const handlePrefetch = () => {
     if (!purposeTemplate) return
-    queryClient.prefetchQuery(PurposeTemplateQueries.getSingle(purposeTemplateId))
+    queryClient.prefetchQuery({
+      ...PurposeTemplateQueries.getSingle(purposeTemplateId),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
   return (
     <CatalogCardForPurposeTemplate

--- a/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/ConsumerPurposesTableRow.tsx
@@ -1,6 +1,7 @@
 import type { Purpose } from '@/api/api.generatedTypes'
 import { AuthHooks } from '@/api/auth'
 import { PurposeQueries } from '@/api/purpose'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
 import { InfoTooltip } from '@/components/shared/InfoTooltip'
 import { ButtonSkeleton } from '@/components/shared/MUI-skeletons'
@@ -33,7 +34,10 @@ export const ConsumerPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
   )
 
   const handlePrefetch = () => {
-    queryClient.prefetchQuery(PurposeQueries.getSingle(purpose.id))
+    queryClient.prefetchQuery({
+      ...PurposeQueries.getSingle(purpose.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const isDelegator = Boolean(

--- a/src/pages/ProviderAgreementsListPage/components/ProviderAgreementsTableRow.tsx
+++ b/src/pages/ProviderAgreementsListPage/components/ProviderAgreementsTableRow.tsx
@@ -1,4 +1,5 @@
 import { AgreementQueries } from '@/api/agreement'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import type { AgreementListEntry } from '@/api/api.generatedTypes'
 import { AuthHooks } from '@/api/auth'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
@@ -30,7 +31,10 @@ export const ProviderAgreementsTableRow: React.FC<{ agreement: AgreementListEntr
   const descriptor = agreement.descriptor
 
   const handlePrefetch = () => {
-    queryClient.prefetchQuery(AgreementQueries.getSingle(agreement.id))
+    queryClient.prefetchQuery({
+      ...AgreementQueries.getSingle(agreement.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const eserviceCellData = (

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceKeychainsTab/ProviderEServiceKeychainsTab.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceKeychainsTab/ProviderEServiceKeychainsTab.tsx
@@ -10,6 +10,7 @@ import { AddKeychainToEServiceDrawer } from './AddKeychainToEServiceDrawer'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { KeychainQueries } from '@/api/keychain'
 import { KeychainMutations } from '@/api/keychain/keychain.mutations'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import type { CompactProducerKeychain } from '@/api/api.generatedTypes'
 
 export const ProviderEserviceKeychainsTab: React.FC = () => {
@@ -41,12 +42,13 @@ export const ProviderEserviceKeychainsTab: React.FC = () => {
 
   const handlePrefetchKeychainList = () => {
     if (!canAddKeychain) return
-    queryClient.prefetchQuery(
-      KeychainQueries.getKeychainsList({
+    queryClient.prefetchQuery({
+      ...KeychainQueries.getKeychainsList({
         limit: 50,
         offset: 0,
-      })
-    )
+      }),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   return (

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceKeychainsTab/ProviderEServiceKeychainsTableRow.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceKeychainsTab/ProviderEServiceKeychainsTableRow.tsx
@@ -1,6 +1,7 @@
 import type { CompactProducerKeychain } from '@/api/api.generatedTypes'
 import { AuthHooks } from '@/api/auth'
 import { KeychainQueries } from '@/api/keychain'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { KeychainMutations } from '@/api/keychain/keychain.mutations'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
 import { ButtonSkeleton } from '@/components/shared/MUI-skeletons'
@@ -27,7 +28,10 @@ export const ProviderEServiceKeychainsTableRow: React.FC<
   const { mutate: removeKeychainFromEService } = KeychainMutations.useRemoveKeychainFromEService()
 
   const handlePrefetchKeychain = () => {
-    queryClient.prefetchQuery(KeychainQueries.getSingle(keychain.id))
+    queryClient.prefetchQuery({
+      ...KeychainQueries.getSingle(keychain.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const actions: ActionItem[] = [

--- a/src/pages/ProviderEServiceListPage/components/EServiceTableRow.tsx
+++ b/src/pages/ProviderEServiceListPage/components/EServiceTableRow.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from '@/router'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
 import { EServiceQueries } from '@/api/eservice'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { ButtonSkeleton } from '@/components/shared/MUI-skeletons'
 import { useGetProviderEServiceActions } from '@/hooks/useGetProviderEServiceActions'
 import { TableRow } from '@pagopa/interop-fe-commons'
@@ -56,13 +57,17 @@ export const EServiceTableRow: React.FC<EServiceTableRow> = ({ eservice }) => {
 
   const handlePrefetch = () => {
     if (isEServiceEditable) {
-      queryClient.prefetchQuery(EServiceQueries.getSingle(eservice.id))
+      queryClient.prefetchQuery({
+        ...EServiceQueries.getSingle(eservice.id),
+        staleTime: PREFETCH_STALE_TIME,
+      })
       return
     }
     if (!eservice.activeDescriptor) return
-    queryClient.prefetchQuery(
-      EServiceQueries.getDescriptorProvider(eservice.id, eservice.activeDescriptor.id)
-    )
+    queryClient.prefetchQuery({
+      ...EServiceQueries.getDescriptorProvider(eservice.id, eservice.activeDescriptor.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const actions = [

--- a/src/pages/ProviderEServiceTemplatesCatalogPage/components/EServiceTemplateCatalogGrid.tsx
+++ b/src/pages/ProviderEServiceTemplatesCatalogPage/components/EServiceTemplateCatalogGrid.tsx
@@ -5,6 +5,7 @@ import type { CatalogEServiceTemplate } from '@/api/api.generatedTypes'
 import { CatalogCard } from '@/components/shared/CatalogCard'
 import { useQueryClient } from '@tanstack/react-query'
 import { EServiceTemplateQueries } from '@/api/eserviceTemplate'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { AVATAR_BASEPATH } from '@/config/env'
 
 type EServiceTemplateCatalogGridProps = {
@@ -40,9 +41,10 @@ export const EServiceTemplateCatalogCard: React.FC<{
 
   const handlePrefetch = () => {
     if (!eserviceTemplate.publishedVersion.id) return
-    queryClient.prefetchQuery(
-      EServiceTemplateQueries.getSingle(publishedVersion.id, eServiceTemplateVersionId)
-    )
+    queryClient.prefetchQuery({
+      ...EServiceTemplateQueries.getSingle(publishedVersion.id, eServiceTemplateVersionId),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
   return (
     <CatalogCard

--- a/src/pages/ProviderEServiceTemplatesListPage/components/EServiceTemplateTableRow.tsx
+++ b/src/pages/ProviderEServiceTemplatesListPage/components/EServiceTemplateTableRow.tsx
@@ -8,6 +8,7 @@ import { ButtonSkeleton } from '@/components/shared/MUI-skeletons'
 import { TableRow } from '@pagopa/interop-fe-commons'
 import { useQueryClient } from '@tanstack/react-query'
 import { EServiceTemplateQueries } from '@/api/eserviceTemplate'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import type { ProducerEServiceTemplate } from '@/api/api.generatedTypes'
 import { useGetProviderEServiceTemplateActions } from '@/hooks/useGetProviderEServiceTemplateActions'
 import { NotificationBadgeDot } from '@/components/shared/NotificationBadgeDot/NotificationBadgeDot'
@@ -40,9 +41,13 @@ export const EServiceTemplateTableRow: React.FC<EServiceTemplateTableRow> = ({
   )
 
   const handlePrefetch = () => {
-    queryClient.prefetchQuery(
-      EServiceTemplateQueries.getSingle(eserviceTemplate.id, versionIdEserviceTemplate as string)
-    )
+    queryClient.prefetchQuery({
+      ...EServiceTemplateQueries.getSingle(
+        eserviceTemplate.id,
+        versionIdEserviceTemplate as string
+      ),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const hasNotActiveVersionTemplate = !eserviceTemplate.activeVersion

--- a/src/pages/ProviderKeychainDetailsPage/components/KeychainMembersTab/KeychainMembersTab.tsx
+++ b/src/pages/ProviderKeychainDetailsPage/components/KeychainMembersTab/KeychainMembersTab.tsx
@@ -10,6 +10,7 @@ import { KeychainMembersTable, KeychainMembersTableSkeleton } from './KeychainMe
 import { KeychainMutations } from '@/api/keychain/keychain.mutations'
 import { KeychainQueries } from '@/api/keychain/keychain.queries'
 import { TenantQueries } from '@/api/tenant'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { AddUsersToKeychainDrawer } from '@/components/shared/AddUsersToKeychainDrawer'
 
 type KeychainMembersTabProps = {
@@ -40,12 +41,13 @@ export const KeychainMembersTab: React.FC<KeychainMembersTabProps> = ({ keychain
 
   const handlePrefetchUserList = () => {
     if (!canAddMembers) return
-    queryClient.prefetchQuery(
-      TenantQueries.getPartyUsersList({
+    queryClient.prefetchQuery({
+      ...TenantQueries.getPartyUsersList({
         roles: ['admin', 'security'],
         tenantId: jwt?.organizationId as string,
-      })
-    )
+      }),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   return (

--- a/src/pages/ProviderKeychainDetailsPage/components/KeychainMembersTab/KeychainMembersTableRow.tsx
+++ b/src/pages/ProviderKeychainDetailsPage/components/KeychainMembersTab/KeychainMembersTableRow.tsx
@@ -9,6 +9,7 @@ import { AuthHooks } from '@/api/auth'
 import type { CompactUser } from '@/api/api.generatedTypes'
 import { useQueryClient } from '@tanstack/react-query'
 import { SelfcareQueries } from '@/api/selfcare'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { useGetProducerKeychainUserActions } from '../../hooks/useGetProducerKeychainUserActions'
 
 interface KeychainMembersTableRowProps {
@@ -27,7 +28,10 @@ export const KeychainMembersTableRow: React.FC<KeychainMembersTableRowProps> = (
   const { actions } = useGetProducerKeychainUserActions({ keychainId, userId: user.userId })
 
   const handlePrefetchOperator = () => {
-    queryClient.prefetchQuery(SelfcareQueries.getSingleUser(user.userId))
+    queryClient.prefetchQuery({
+      ...SelfcareQueries.getSingleUser(user.userId),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   return (

--- a/src/pages/ProviderKeychainDetailsPage/components/KeychainPublicKeysTab/KeychainPublicKeysTableRow.tsx
+++ b/src/pages/ProviderKeychainDetailsPage/components/KeychainPublicKeysTab/KeychainPublicKeysTableRow.tsx
@@ -1,5 +1,6 @@
 import type { PublicKey } from '@/api/api.generatedTypes'
 import { KeychainQueries } from '@/api/keychain/keychain.queries'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { Box, Skeleton } from '@mui/material'
 import { TableRow } from '@pagopa/interop-fe-commons'
 import { useQueryClient } from '@tanstack/react-query'
@@ -31,12 +32,13 @@ export const KeychainPublicKeysTableRow: React.FC<KeychainPublicKeysTableRowProp
   })
 
   const handlePrefetchKey = () => {
-    queryClient.prefetchQuery(
-      KeychainQueries.getProducerKeychainKey({
+    queryClient.prefetchQuery({
+      ...KeychainQueries.getProducerKeychainKey({
         producerKeychainId: keychainId,
         keyId,
-      })
-    )
+      }),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const color = publicKey.isOrphan ? 'error' : 'primary'

--- a/src/pages/ProviderPurposesListPage/components/ProviderPurposesTableRow.tsx
+++ b/src/pages/ProviderPurposesListPage/components/ProviderPurposesTableRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import type { Purpose } from '@/api/api.generatedTypes'
 import { PurposeQueries } from '@/api/purpose'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { ActionMenu, ActionMenuSkeleton } from '@/components/shared/ActionMenu'
 import { ButtonSkeleton } from '@/components/shared/MUI-skeletons'
 import { StatusChip, StatusChipSkeleton } from '@/components/shared/StatusChip'
@@ -22,7 +23,10 @@ export const ProviderPurposesTableRow: React.FC<{ purpose: Purpose }> = ({ purpo
   const { actions } = useGetProviderPurposesActions(purpose)
 
   const handlePrefetch = () => {
-    queryClient.prefetchQuery(PurposeQueries.getSingle(purpose.id))
+    queryClient.prefetchQuery({
+      ...PurposeQueries.getSingle(purpose.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   const hasWaitingForApprovalVersion = !!(

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/AttributesTableRow.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/AttributesTableRow.tsx
@@ -1,5 +1,6 @@
 import type { CompactAttribute } from '@/api/api.generatedTypes'
 import { AttributeQueries } from '@/api/attribute'
+import { PREFETCH_STALE_TIME } from '@/config/constants'
 import { ButtonSkeleton } from '@/components/shared/MUI-skeletons'
 import { Link } from '@/router'
 import { Skeleton } from '@mui/material'
@@ -18,7 +19,10 @@ export const AttributesTableRow: React.FC<AttributesTableRowProps> = ({ attribut
   const queryClient = useQueryClient()
 
   const handlePrefetch = () => {
-    queryClient.prefetchQuery(AttributeQueries.getSingle(attribute.id))
+    queryClient.prefetchQuery({
+      ...AttributeQueries.getSingle(attribute.id),
+      staleTime: PREFETCH_STALE_TIME,
+    })
   }
 
   return (


### PR DESCRIPTION
## 🔗 Issue

[PIN-10389](https://pagopa.atlassian.net/browse/PIN-10389)

## 📝 Description / Context

Row-detail tables and catalog cards prefetch the detail data on `onPointerEnter`/`onFocusVisible` via `queryClient.prefetchQuery(...)`. The `QueryClient` sets no default `staleTime`, so it falls back to `0`: every query is immediately stale and `prefetchQuery` re-runs the request on every hover, even when the same entity was just fetched. Hovering across rows or returning to already-visited rows therefore fires many redundant network requests. This PR lets the prefetch serve recently-fetched data from cache within a defined time window.

Design decision: `staleTime` is applied only to the `prefetchQuery` call (by spreading the existing query options), not to the shared `getSingle` query options and not as a global default. Putting it on the shared query options would also make the detail page's own query "fresh" for the window, and the app refreshes data after mutations through a global `mutationCache.onSuccess` that calls `refetchQueries({ type: 'active', stale: true })`, which only refetches stale queries. A fresh detail query would be skipped, so the detail view could show stale data right after a mutation. Scoping `staleTime` to the prefetch keeps the detail observer at the default `staleTime: 0`, so post-mutation polling keeps working as before.

## 🛠 List of changes

- Add shared constant `PREFETCH_STALE_TIME = 60_000` in `src/config/constants.ts`.
- Pass `staleTime: PREFETCH_STALE_TIME` to every hover/focus `queryClient.prefetchQuery(...)` call (24 files, 25 call sites) by spreading the existing query options.
- Leave the one-time session-token prefetch in `App.tsx` untouched (bootstrap call, already `staleTime: Infinity` in its own options).

## 🧪 How to test

- Open the browser DevTools Network tab.
- Go to a list with detail links (e.g. Finalità, Richieste di fruizione, Catalogo e-service).
- Hover repeatedly over the same row action: only the first hover within 60s triggers the `GET`; subsequent hovers on the same entity are served from cache (no new request); a different row still prefetches on first hover; returning to an already-visited row within 60s does not refetch.
- Confirm a detail page still refreshes after a mutation (e.g. suspend/activate): post-mutation refresh must be unaffected.

[PIN-10389]: https://pagopa.atlassian.net/browse/PIN-10389
