### PR TITLE
fix: encode query params in API requests (PIN-9370, PIN-10613)

### DIFF
--- a/src/config/__tests__/axios.test.ts
+++ b/src/config/__tests__/axios.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import axiosInstance from '../axios'
+
+describe('axios params serializer', () => {
+  it('URL-encodes reserved characters in query params while preserving comma-separated arrays', () => {
+    const uri = axiosInstance.getUri({
+      url: '/catalog',
+      params: {
+        q: '% & "\'',
+        states: ['PUBLISHED', 'DRAFT'],
+        offset: 0,
+        empty: '',
+        omitted: undefined,
+      },
+    })
+
+    expect(uri).toBe('/catalog?q=%25%20%26%20%22%27&states=PUBLISHED,DRAFT&offset=0&empty=')
+  })
+})

--- a/src/config/__tests__/axios.test.ts
+++ b/src/config/__tests__/axios.test.ts
@@ -7,13 +7,16 @@ describe('axios params serializer', () => {
       url: '/catalog',
       params: {
         q: '% & "\'',
-        states: ['PUBLISHED', 'DRAFT'],
+        states: ['PUBLISHED', undefined, null, 'DRAFT'],
+        eserviceIds: [undefined],
         offset: 0,
         empty: '',
         omitted: undefined,
       },
     })
 
-    expect(uri).toBe('/catalog?q=%25%20%26%20%22%27&states=PUBLISHED,DRAFT&offset=0&empty=')
+    expect(uri).toBe(
+      '/catalog?q=%25%20%26%20%22%27&states=PUBLISHED,DRAFT&eserviceIds=&offset=0&empty='
+    )
   })
 })

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -39,7 +39,10 @@ const serializeParams = (query: Record<string, unknown>) => {
       .filter(([, value]) => value !== undefined && value !== null)
       .map(([key, value]) =>
         Array.isArray(value)
-          ? `${encodeQueryParam(key)}=${value.map(encodeQueryParam).join(',')}`
+          ? `${encodeQueryParam(key)}=${value
+              .filter((arrayValue) => arrayValue !== undefined && arrayValue !== null)
+              .map(encodeQueryParam)
+              .join(',')}`
           : `${encodeQueryParam(key)}=${encodeQueryParam(value)}`
       )
       .join('&')

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -24,6 +24,12 @@ const deepTrim = (object: string | Record<string, unknown>) => {
 }
 
 /** This function helps to serialize correctly arrays in url params  */
+const encodeQueryParam = (value: unknown) =>
+  encodeURIComponent(String(value)).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`
+  )
+
 const serializeParams = (query: Record<string, unknown>) => {
   return (
     Object.entries(query)
@@ -32,7 +38,9 @@ const serializeParams = (query: Record<string, unknown>) => {
       // like 0 or '' are allowed
       .filter(([, value]) => value !== undefined && value !== null)
       .map(([key, value]) =>
-        Array.isArray(value) ? `${key}=${value.join(',')}` : `${key}=${value}`
+        Array.isArray(value)
+          ? `${encodeQueryParam(key)}=${value.map(encodeQueryParam).join(',')}`
+          : `${encodeQueryParam(key)}=${encodeQueryParam(value)}`
       )
       .join('&')
   )


### PR DESCRIPTION
## 🔗 Issue

[PIN-9370](https://pagopa.atlassian.net/browse/PIN-9370)
[PIN-10613](https://pagopa.atlassian.net/browse/PIN-10613)

## 📝 Description / Context

This PR fixes query parameter serialization for API requests. The custom Axios params serializer was building query strings manually, so reserved characters such as `%` and `&` were not encoded and could produce malformed URLs or incorrect filtering behavior.

The fix uses URL encoding for query parameter keys and values. It also keeps a stricter encoding for characters that `encodeURIComponent` normally leaves unescaped, such as `'`, `!`, `(`, `)`, and `*`, so user-provided search text is always treated as parameter content rather than URL syntax.

## 🛠 List of changes

- URL-encode query parameter keys and values in the shared Axios params serializer.
- Keep stricter percent-encoding for additional special characters left unescaped by `encodeURIComponent`.
- Preserve the existing comma-separated format for array query params.
- Add a focused test covering reserved characters and array serialization.

## 🧪 How to test

- Open an e-service search flow and search by name using reserved characters such as `%`, `&`, or `'`; the request URL should contain encoded values and the query should not be split incorrectly.
- Verify list/autocomplete filters that use query params still work with multi-value filters.

[PIN-9370]: https://pagopa.atlassian.net/browse/PIN-9370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PIN-10613]: https://pagopa.atlassian.net/browse/PIN-10613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ