### PR TITLE
fix: hide purpose step first-version alert when editing an e-service (PIN-9970)

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepPurpose/EServiceCreateStepPurpose.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepPurpose/EServiceCreateStepPurpose.tsx
@@ -12,13 +12,16 @@ import { EServiceCreateStepPurposeRiskAnalysis } from './EServiceCreateStepPurpo
 export const EServiceCreateStepPurpose: React.FC = () => {
   const { t } = useTranslation('eservice', { keyPrefix: 'create' })
 
-  const { descriptor, forward, back, riskAnalysisFormState } = useEServiceCreateContext()
+  const { descriptor, forward, back, riskAnalysisFormState, areEServiceGeneralInfoEditable } =
+    useEServiceCreateContext()
 
   return (
     <>
-      <Alert severity="warning" sx={{ mb: 3 }}>
-        {t('stepPurpose.firstVersionOnlyEditableInfoAlert')}
-      </Alert>
+      {areEServiceGeneralInfoEditable && (
+        <Alert severity="warning" sx={{ mb: 3 }}>
+          {t('stepPurpose.firstVersionOnlyEditableInfoAlert')}
+        </Alert>
+      )}
       {!riskAnalysisFormState.isOpen ? (
         <>
           <SectionContainer

--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepPurpose/__tests__/EServiceCreateStepPurpose.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepPurpose/__tests__/EServiceCreateStepPurpose.test.tsx
@@ -1,0 +1,41 @@
+import { vi } from 'vitest'
+import { mockUseEServiceCreateContext } from '@/../__mocks__/data/eservice.mocks'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { EServiceCreateStepPurpose } from '../EServiceCreateStepPurpose'
+import { screen } from '@testing-library/react'
+
+vi.mock('../EServiceCreateStepPurposeAddPurposesTable', () => ({
+  EServiceCreateStepPurposeAddPurposesTable: () => (
+    <div>EServiceCreateStepPurposeAddPurposesTable</div>
+  ),
+}))
+
+vi.mock('../EServiceCreateStepPurposeRiskAnalysis/EServiceCreateStepPurposeRiskAnalysis', () => ({
+  EServiceCreateStepPurposeRiskAnalysis: () => <div>EServiceCreateStepPurposeRiskAnalysis</div>,
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('EServiceCreateStepPurpose', () => {
+  it('shows the first-version editable-info alert when general info is editable', () => {
+    mockUseEServiceCreateContext({ areEServiceGeneralInfoEditable: true })
+    renderWithApplicationContext(<EServiceCreateStepPurpose />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('hides the first-version editable-info alert when general info is not editable', () => {
+    mockUseEServiceCreateContext({ areEServiceGeneralInfoEditable: false })
+    renderWithApplicationContext(<EServiceCreateStepPurpose />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## 🔗 Issue

[PIN-9970](https://pagopa.atlassian.net/browse/PIN-9970)

## 📝 Description / Context

The Purpose ("Finalità") step of the e-service creation wizard (RECEIVE mode) renders a warning alert: "I contenuti di questo passaggio non saranno più modificabili dopo la pubblicazione della prima versione dell'e-service." The alert was shown unconditionally, including when editing an already-published e-service into a new version. In that case it is misleading: it refers to the "first version" while the purposes are already locked. This PR shows the alert only while the first/draft version is still editable, and hides it when creating a new version of a published e-service.

## 🛠 List of changes

- Gate the "first version only editable" warning in `EServiceCreateStepPurpose` on the existing `areEServiceGeneralInfoEditable` context flag, so it renders only when the e-service is new or on its first draft version, and is hidden when editing into a new version. No new logic is introduced: the flag is the same one the rest of the wizard already uses to switch sections to read-only.

## 🧪 How to test

- As a provider, create a new RECEIVE e-service from scratch and go to the Purpose step: the yellow warning is shown.
- Edit an already-published RECEIVE e-service into a new version and go to the Purpose step: the yellow warning is no longer shown.
- Create an e-service instance from a RECEIVE template and go to the Purpose step: the yellow warning is still shown (it is always a first version).
- (Optional) Edit a first version (v1) still in DRAFT: the yellow warning is still shown.

[PIN-9970]: https://pagopa.atlassian.net/browse/PIN-9970
