### PR TITLE
fix: show cancel estimate change request CTA on consumer purpose detail (PIN-9828)

### DIFF
--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsUpdatePlanCard.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsDailyCallsUpdatePlanCard.tsx
@@ -55,24 +55,22 @@ export const ConsumerPurposeDetailsDailyCallsUpdatePlanCard: React.FC<
               {formatThousands(waitingForApprovalVersion.dailyCalls)}
             </Typography>
           </Box>
-          {
-            // if the purpose was created by the delegate and I am the delegator and the delegation is still active
-            purpose.delegation?.delegator.id === jwt?.organizationId && (
-              <Stack gap={2}>
-                <Divider />
-                <IconLink
-                  onClick={handleDeleteDailyCallsUpdate}
-                  component="button"
-                  disabled={isSuspended}
-                  startIcon={<DeleteOutlineIcon />}
-                  alignSelf="start"
-                  color="error"
-                >
-                  {t('removeChangePlanRequestLink.label')}
-                </IconLink>
-              </Stack>
-            )
-          }
+          {purpose.delegation?.delegator.id !== jwt?.organizationId && (
+            <Stack gap={2}>
+              <Divider />
+              <IconLink
+                onClick={handleDeleteDailyCallsUpdate}
+                component="button"
+                disabled={isSuspended}
+                startIcon={<DeleteOutlineIcon />}
+                alignSelf="start"
+                color="error"
+                sx={{ fontWeight: '700' }}
+              >
+                {t('removeChangePlanRequestLink.label')}
+              </IconLink>
+            </Stack>
+          )}
         </Stack>
       </CardContent>
     </Card>

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsDailyCallsUpdatePlanCard.test.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsDailyCallsUpdatePlanCard.test.tsx
@@ -1,0 +1,79 @@
+import { screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ConsumerPurposeDetailsDailyCallsUpdatePlanCard } from '../ConsumerPurposeDetailsDailyCallsUpdatePlanCard'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
+import type { PurposeVersion } from '@/api/api.generatedTypes'
+
+vi.mock('@/api/purpose', () => ({
+  PurposeMutations: {
+    useDeleteVersion: () => ({ mutate: vi.fn() }),
+  },
+}))
+
+const waitingForApprovalVersion: PurposeVersion = {
+  id: 'waiting-for-approval-version-id',
+  state: 'WAITING_FOR_APPROVAL',
+  createdAt: '2023-02-03T07:59:52.458Z',
+  dailyCalls: 20,
+}
+
+describe('ConsumerPurposeDetailsDailyCallsUpdatePlanCard', () => {
+  it('shows the remove change plan request link for admin consumers with a pending request', () => {
+    mockUseJwt()
+    renderWithApplicationContext(
+      <ConsumerPurposeDetailsDailyCallsUpdatePlanCard
+        purpose={createMockPurpose({ waitingForApprovalVersion })}
+      />,
+      { withReactQueryContext: true }
+    )
+    expect(screen.getByText('removeChangePlanRequestLink.label')).toBeInTheDocument()
+  })
+
+  it('hides the remove change plan request link for non-admin users', () => {
+    mockUseJwt({ isAdmin: false })
+    renderWithApplicationContext(
+      <ConsumerPurposeDetailsDailyCallsUpdatePlanCard
+        purpose={createMockPurpose({ waitingForApprovalVersion })}
+      />,
+      { withReactQueryContext: true }
+    )
+    expect(screen.queryByText('removeChangePlanRequestLink.label')).not.toBeInTheDocument()
+  })
+
+  it('hides the remove change plan request link for the delegator of an active delegation', () => {
+    mockUseJwt()
+    renderWithApplicationContext(
+      <ConsumerPurposeDetailsDailyCallsUpdatePlanCard
+        purpose={createMockPurpose({
+          waitingForApprovalVersion,
+          delegation: {
+            id: 'delegation-id',
+            delegator: { id: 'organizationId', name: 'Delegator' },
+            delegate: { id: 'delegate-id', name: 'Delegate' },
+          },
+        })}
+      />,
+      { withReactQueryContext: true }
+    )
+    expect(screen.queryByText('removeChangePlanRequestLink.label')).not.toBeInTheDocument()
+  })
+
+  it('shows the remove change plan request link for the delegate of an active delegation', () => {
+    mockUseJwt()
+    renderWithApplicationContext(
+      <ConsumerPurposeDetailsDailyCallsUpdatePlanCard
+        purpose={createMockPurpose({
+          waitingForApprovalVersion,
+          delegation: {
+            id: 'delegation-id',
+            delegator: { id: 'delegator-id', name: 'Delegator' },
+            delegate: { id: 'organizationId', name: 'Delegate' },
+          },
+        })}
+      />,
+      { withReactQueryContext: true }
+    )
+    expect(screen.getByText('removeChangePlanRequestLink.label')).toBeInTheDocument()
+  })
+})

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsDailyCallsUpdatePlanCard.test.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsDailyCallsUpdatePlanCard.test.tsx
@@ -11,6 +11,8 @@ vi.mock('@/api/purpose', () => ({
   },
 }))
 
+mockUseJwt()
+
 const waitingForApprovalVersion: PurposeVersion = {
   id: 'waiting-for-approval-version-id',
   state: 'WAITING_FOR_APPROVAL',
@@ -20,7 +22,6 @@ const waitingForApprovalVersion: PurposeVersion = {
 
 describe('ConsumerPurposeDetailsDailyCallsUpdatePlanCard', () => {
   it('shows the remove change plan request link for admin consumers with a pending request', () => {
-    mockUseJwt()
     renderWithApplicationContext(
       <ConsumerPurposeDetailsDailyCallsUpdatePlanCard
         purpose={createMockPurpose({ waitingForApprovalVersion })}
@@ -30,19 +31,7 @@ describe('ConsumerPurposeDetailsDailyCallsUpdatePlanCard', () => {
     expect(screen.getByText('removeChangePlanRequestLink.label')).toBeInTheDocument()
   })
 
-  it('hides the remove change plan request link for non-admin users', () => {
-    mockUseJwt({ isAdmin: false })
-    renderWithApplicationContext(
-      <ConsumerPurposeDetailsDailyCallsUpdatePlanCard
-        purpose={createMockPurpose({ waitingForApprovalVersion })}
-      />,
-      { withReactQueryContext: true }
-    )
-    expect(screen.queryByText('removeChangePlanRequestLink.label')).not.toBeInTheDocument()
-  })
-
   it('hides the remove change plan request link for the delegator of an active delegation', () => {
-    mockUseJwt()
     renderWithApplicationContext(
       <ConsumerPurposeDetailsDailyCallsUpdatePlanCard
         purpose={createMockPurpose({
@@ -60,7 +49,6 @@ describe('ConsumerPurposeDetailsDailyCallsUpdatePlanCard', () => {
   })
 
   it('shows the remove change plan request link for the delegate of an active delegation', () => {
-    mockUseJwt()
     renderWithApplicationContext(
       <ConsumerPurposeDetailsDailyCallsUpdatePlanCard
         purpose={createMockPurpose({
@@ -75,5 +63,29 @@ describe('ConsumerPurposeDetailsDailyCallsUpdatePlanCard', () => {
       { withReactQueryContext: true }
     )
     expect(screen.getByText('removeChangePlanRequestLink.label')).toBeInTheDocument()
+  })
+
+  it('shows the remove change plan request link disabled when the current version is suspended', () => {
+    renderWithApplicationContext(
+      <ConsumerPurposeDetailsDailyCallsUpdatePlanCard
+        purpose={createMockPurpose({
+          waitingForApprovalVersion,
+          currentVersion: { state: 'SUSPENDED' },
+        })}
+      />,
+      { withReactQueryContext: true }
+    )
+    expect(screen.getByRole('button', { name: 'removeChangePlanRequestLink.label' })).toBeDisabled()
+  })
+
+  it('hides the remove change plan request link for non-admin users', () => {
+    mockUseJwt({ isAdmin: false })
+    renderWithApplicationContext(
+      <ConsumerPurposeDetailsDailyCallsUpdatePlanCard
+        purpose={createMockPurpose({ waitingForApprovalVersion })}
+      />,
+      { withReactQueryContext: true }
+    )
+    expect(screen.queryByText('removeChangePlanRequestLink.label')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## 🔗 Issue

[PIN-9828](https://pagopa.atlassian.net/browse/PIN-9828)

## 📝 Description / Context

On the consumer purpose detail page (Fruizione > Finalità inoltrate > detail), when an estimate-change request exceeds the total threshold it goes into "waiting for approval" and the consumer must be able to withdraw it via the "Annulla richiesta" CTA under the "Nuova stima richiesta" card. The CTA was not shown to a normal consumer: its visibility was gated to `purpose.delegation?.delegator.id === jwt?.organizationId`, a guard introduced with the consumer-delegation feature. For a consumer without a delegation that condition is always false, so the CTA never rendered. This PR aligns the card with its sibling "Richiedi cambio stima" card: the CTA is shown to everyone except the delegator of an active delegation (i.e. the normal consumer and the delegate see it, the delegator does not). It also matches the Figma weight for the link.

## 🛠 List of changes

- `ConsumerPurposeDetailsDailyCallsUpdatePlanCard`: invert the visibility condition from `=== jwt?.organizationId` to `!== jwt?.organizationId`, mirroring the sibling "Richiedi cambio stima" card so the cancel CTA is shown to the normal consumer and the delegate, and hidden for the delegator of an active delegation. The early return (admin + pending version + current version) and the `disabled` on suspended state are unchanged.
- Add `fontWeight: 700` to the "Annulla richiesta" link to match the Figma spec and the sibling card.
- Remove the now-misleading inline comment on the visibility condition.
- Add a test file covering the four role cases (normal admin consumer: shown, non-admin: hidden, delegator: hidden, delegate: shown).

## 🧪 How to test

- As a consumer admin, on a purpose with a pending over-threshold estimate-change request (use "Richiedi cambio stima" with a value above the total threshold), open the purpose detail: under "Nuova stima richiesta" the red, bold "Annulla richiesta" link appears with a trash icon, and clicking it withdraws the request.
- With an active consumer delegation: the delegate sees the link, the delegator does not.
- When the purpose current version is suspended, the link is shown but disabled.

---

<img width="568" height="554" alt="PIN-9828-cancel-request-cta" src="https://github.com/user-attachments/assets/af95783a-c0f4-4aa4-ba8c-dd7c7b09a047" />


[PIN-9828]: https://pagopa.atlassian.net/browse/PIN-9828
