### PR TITLE
chore/PIN-10498: changed environment banner label

### DIFF
--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -387,7 +387,7 @@
   },
   "environmentBanner": {
     "content": {
-      "uat": "Testing environment. Do not use real data.",
+      "uat": "Testing environment. Configure as if in Production, but use only test data.",
       "att": "Validation environment for private entities: be careful, the data must not be real"
     }
   },

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -387,7 +387,7 @@
   },
   "environmentBanner": {
     "content": {
-      "uat": "Ambiente di collaudo. Non utilizzare dati reali.",
+      "uat": "Ambiente di collaudo. Configura come se fossi in Produzione, ma usa solo dati fittizi.",
       "att": "Ambiente di attestazione per enti privati: attenzione i dati non devono essere reali"
     }
   },


### PR DESCRIPTION
## 🔗 Issue
[PIN-10498](https://pagopa.atlassian.net/browse/PIN-10389)

## 📝 Description / Context
Changed label for the environment banner in both languages

## 🛠 List of changes

- changed environmentBanner.content.uat italian message
- changed environmentBanner.content.uat english message

## 🧪 How to test

1. Navigate to the pdnd-interop-frontend project
2. Verify the English translations in `src/static/locales/en/shared-components.json`:
   - Check `environmentBanner.content.uat` displays correctly
   - Check `environmentBanner.content.att` displays correctly
3. Confirm Italian translations remain unchanged in `src/static/locales/it/shared-components.json`
4. Run the application in UAT/ATT environment and verify banner messages display the correct English text

[PIN-10498]: https://pagopa.atlassian.net/browse/PIN-10498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ