### PR TITLE
fix: update archiving message text and documentation link (PIN-10499)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interop-dashboard-frontend",
-  "version": "2.4.0-RC4",
+  "version": "2.4.1-RC1",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "scripts": {

--- a/src/components/dialogs/DialogArchiveEservice.tsx
+++ b/src/components/dialogs/DialogArchiveEservice.tsx
@@ -1,5 +1,6 @@
 import { EServiceMutations } from '@/api/eservice'
-import { DOCUMENTATION_URL, GRACE_PERIOD_ARCHIVING_ESERVICE_DAYS } from '@/config/env'
+import { GRACE_PERIOD_ARCHIVING_ESERVICE_DAYS } from '@/config/env'
+import { archivingGuideLink } from '@/config/constants'
 import { useDialog } from '@/stores'
 import type { DialogArchiveEserviceProps } from '@/types/dialog.types'
 import { formatDateStringNumeric } from '@/utils/format.utils'
@@ -104,7 +105,7 @@ const DialogArchiveEservice: React.FC<DialogArchiveEserviceProps> = ({ eserviceI
           <Alert severity="info" sx={{ mt: 4 }}>
             <Trans
               components={{
-                1: <Link underline="hover" href={DOCUMENTATION_URL} target="_blank" />,
+                1: <Link underline="hover" href={archivingGuideLink} target="_blank" />,
               }}
             >
               {t('content.alert')}

--- a/src/components/dialogs/DialogArchiveVersion.tsx
+++ b/src/components/dialogs/DialogArchiveVersion.tsx
@@ -1,5 +1,6 @@
 import { EServiceMutations } from '@/api/eservice'
-import { DOCUMENTATION_URL, GRACE_PERIOD_ARCHIVING_ESERVICE_DAYS } from '@/config/env'
+import { GRACE_PERIOD_ARCHIVING_ESERVICE_DAYS } from '@/config/env'
+import { archivingGuideLink } from '@/config/constants'
 import { useDialog } from '@/stores'
 import type { DialogArchiveVersionProps } from '@/types/dialog.types'
 import { calculateArchivableOn } from '@/utils/eservice.utils'
@@ -59,7 +60,7 @@ export const DialogArchiveVersion: React.FC<DialogArchiveVersionProps> = ({
         <Alert severity="info" sx={{ mt: 4 }}>
           <Trans
             components={{
-              1: <Link underline="hover" href={DOCUMENTATION_URL} target="_blank" />,
+              1: <Link underline="hover" href={archivingGuideLink} target="_blank" />,
             }}
           >
             {t('content.alert')}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -44,6 +44,7 @@ export const implementAndManageEServiceTemplateLink = `${DOCUMENTATION_URL}/rife
 export const updateEserviceInstanceLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/template-e-service/relazione-tra-template-e-istanza`
 export const purposeTemplateGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/template-finalita/relazione-tra-template-e-finalita`
 export const archiveEserviceGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/e-service/operazioni-e-ciclo-di-vita`
+export const archivingGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/e-service/archiviazione`
 export const userRolesGuideLink = `${DOCUMENTATION_URL}/per-iniziare/primo-accesso-e-configurazione-iniziale`
 export const notificationGuideLink = `https://developer.pagopa.it/pdnd-interoperabilita/guides/manuale-operativo-pdnd-interoperabilita/v1.0/riferimenti-tecnici/notifiche`
 export const notificationMailChangeLink =

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -315,7 +315,7 @@
           "infoLabel": "Explain why you chose to archive the e-service. If you wish, suggest an alternative e-service. Both information will be shared with users. Minimum 10 characters, maximum 250 characters."
         }
       },
-      "alert": "Actual archiving may require some technical time as users continue to exchange data. See <1>documentation</1> for further details."
+      "alert": "Actual archiving may require additional technical time as users continue to exchange data. See the <1>documentation</1> for further details."
     },
     "actions": {
       "back": "Back",
@@ -334,7 +334,7 @@
     "title": "Archive version",
     "content": {
       "description": "Archiving will occur on <strong>{{date}}</strong>. Before this date, the version will remain active to allow users to adapt. You can only cancel archiving before this date.",
-      "alert": "Actual archiving may require some time as users continue to exchange data. See the <1>documentation</1> for further details."
+      "alert": "Actual archiving may require additional technical time as users continue to exchange data. See the <1>documentation</1> for further details."
     }
   },
   "copyToClipboardButton": {

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -315,7 +315,7 @@
           "infoLabel": "Spiega perché hai scelto di archiviare l’e-service. Se vuoi, suggerisci un e-service alternativo. Entrambe le informazioni saranno condivise con i fruitori. Min 10 caratteri, max 250 caratteri"
         }
       },
-      "alert": "L’archiviazione effettiva potrebbe richiedere un tempo tecnico in cui i fruitori continueranno a scambiare dati. Consulta la <1>documentazione</1> per avere altri dettagli."
+      "alert": "L’archiviazione effettiva potrebbe richiedere un tempo tecnico aggiuntivo in cui i fruitori continueranno a scambiare dati. Consulta la <1>documentazione</1> per avere altri dettagli."
     },
     "actions": {
       "back": "Indietro",
@@ -334,7 +334,7 @@
     "title": "Archivia versione",
     "content": {
       "description": "L’archiviazione avverrà il giorno <strong>{{date}}</strong>. Prima di questa data, la versione resterà attiva per consentire ai fruitori di adeguarsi. Potrai annullare l’archiviazione solo prima di questa data.",
-      "alert": "L’archiviazione effettiva potrebbe richiedere un tempo tecnico in cui i fruitori continueranno a scambiare dati. Consulta la <1>documentazione</1> per avere altri dettagli."
+      "alert": "L’archiviazione effettiva potrebbe richiedere un tempo tecnico aggiuntivo in cui i fruitori continueranno a scambiare dati. Consulta la <1>documentazione</1> per avere altri dettagli."
     }
   },
   "copyToClipboardButton": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10499](https://pagopa.atlassian.net/browse/PIN-10499)

## 📝 Description / Context

The info alert shown in the two manual-archiving dialogs (archive version and archive e-service) needed two corrections: the copy now clarifies that the actual archiving may require _additional_ technical time during which consumers keep exchanging data, and the "documentazione" link now points to the dedicated archiving documentation page instead of the documentation homepage. Both dialogs share the same alert string and link.

## 🛠 List of changes

- Add the word "aggiuntivo" to the IT alert copy in `dialogArchiveEservice.content.alert` and `dialogArchiveVersion.content.alert` (`src/static/locales/it/shared-components.json`), keeping the "Consulta la documentazione" sentence. Mirror the change in EN ("additional technical time") and normalise the two previously divergent EN strings into one consistent wording.
- Add a dedicated `archivingGuideLink` constant in `src/config/constants.ts` pointing to `${DOCUMENTATION_URL}/riferimenti-tecnici/e-service/archiviazione`, following the existing `*GuideLink` pattern. The shared `DOCUMENTATION_URL` base is left untouched, so the other documentation links across the app are unaffected.
- Point the `<1>documentazione</1>` link in `DialogArchiveVersion` and `DialogArchiveEservice` to the new `archivingGuideLink` instead of the generic `DOCUMENTATION_URL`.

## 🧪 How to test

- As a provider, open the "Archivia versione" dialog on an active e-service version: the info alert reads "...un tempo tecnico aggiuntivo in cui i fruitori continueranno a scambiare dati. Consulta la documentazione...", and the "documentazione" link opens `.../riferimenti-tecnici/e-service/archiviazione`.
- Do the same on the "Archivia e-service" dialog (ADVISE step): same corrected copy and link.
- Switch the UI language to EN and verify both alerts read "...additional technical time as users continue to exchange data...".

Note: the target documentation page is not live yet (per the ticket) but will be shortly. The URL is built without the `/it/` locale prefix to match every other documentation link in the app (the site redirects to the localized page).

[PIN-10499]: https://pagopa.atlassian.net/browse/PIN-10499
