### PR TITLE
fix/9794: changed details section helper text

### DIFF
--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -41,7 +41,7 @@
       },
       "detailsSection": {
         "title": "E-service details",
-        "description": "This information has been pre-populated by the template creator and cannot be edited.",
+        "description": "This information cannot be edited.",
         "readOnlyDescription": "The following information is no longer editable.",
         "firstVersionOnlyEditableInfo": "This data will no longer be editable after the first version of the e-service is published.",
         "asyncExchangeField": {

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -41,7 +41,7 @@
       },
       "detailsSection": {
         "title": "Dettagli dell'e-service",
-        "description": "Queste informazioni sono state precompilate da chi ha creato il template e non sono modificabili.",
+        "description": "Queste informazioni non sono modificabili.",
         "readOnlyDescription": "Le seguenti informazioni non sono più modificabili.",
         "firstVersionOnlyEditableInfo": "Questi dati non saranno più modificabili dopo la pubblicazione della prima versione dell’e-service.",
         "asyncExchangeField": {


### PR DESCRIPTION
## 🔗 Issue
[PIN-9794](https://pagopa.atlassian.net/browse/PIN-9794)

## 📝 Description / Context
This PR simplifies the helper text in the e-service Details section to state only that the information is not editable.

## 🛠 List of changes

- Updated EN text: “This information cannot be edited.”
- Updated IT text: “Queste informazioni non sono modificabili.”
- Removed template-specific wording from both locales.

## 🧪 How to test
1. Open the e-service Details section in the UI.
2. Verify the helper text is shown correctly in EN and IT.
3. Confirm no other labels in the section are affected.

[PIN-9794]: https://pagopa.atlassian.net/browse/PIN-9794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ