### PR TITLE
fix: disabled daily calls if user is reviewer (PIN-10457)

### DIFF
--- a/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryGeneralInformationAccordion.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryGeneralInformationAccordion.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { PurposeQueries } from '@/api/purpose'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { useGetPurposeInfoAlert } from '@/hooks/useGetPurposeInfoAlert'
+import { AuthHooks } from '@/api/auth'
 
 type ConsumerPurposeSummaryGeneralInformationAccordionProps = {
   purposeId: string
@@ -15,11 +16,13 @@ type ConsumerPurposeSummaryGeneralInformationAccordionProps = {
 export const ConsumerPurposeSummaryGeneralInformationAccordion: React.FC<
   ConsumerPurposeSummaryGeneralInformationAccordionProps
 > = ({ purposeId }) => {
+  const { isReviewer } = AuthHooks.useJwt()
   const { data: purpose } = useSuspenseQuery(PurposeQueries.getSingle(purposeId))
 
-  const { data: remainingDailyCalls } = useQuery(
-    PurposeQueries.getRemainingDailyCalls({ purposeId })
-  )
+  const { data: remainingDailyCalls } = useQuery({
+    ...PurposeQueries.getRemainingDailyCalls({ purposeId }),
+    enabled: !isReviewer,
+  })
 
   const { t } = useTranslation('purpose', { keyPrefix: 'summary.generalInformationSection' })
 

--- a/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryGeneralInformationAccordion.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryGeneralInformationAccordion.test.tsx
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import { ConsumerPurposeSummaryGeneralInformationAccordion } from '../ConsumerPurposeSummaryGeneralInformationAccordion'
+import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
+import { waitFor } from '@testing-library/react'
+
+const useSuspenseQueryMock = vi.fn()
+const remainingDailyCallsQueryFn = vi.fn().mockResolvedValue({
+  remainingDailyCallsPerConsumer: 5,
+  remainingDailyCallsTotal: 100,
+})
+
+vi.mock('@/router', () => ({
+  Link: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}))
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+
+  return {
+    ...actual,
+    useSuspenseQuery: () => useSuspenseQueryMock(),
+  }
+})
+
+vi.mock('@/api/purpose', () => ({
+  PurposeQueries: {
+    getSingle: (id: string) => ['purpose', id],
+    getRemainingDailyCalls: ({ purposeId }: { purposeId: string }) => ({
+      queryKey: ['remainingDailyCalls', purposeId],
+      queryFn: remainingDailyCallsQueryFn,
+    }),
+  },
+}))
+
+vi.mock('@/hooks/useGetPurposeInfoAlert', () => ({
+  useGetPurposeInfoAlert: () => undefined,
+}))
+
+describe('ConsumerPurposeSummaryGeneralInformationAccordion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    useSuspenseQueryMock.mockReturnValue({
+      data: createMockPurpose(),
+    })
+
+    remainingDailyCallsQueryFn.mockResolvedValue({
+      remainingDailyCallsPerConsumer: 5,
+      remainingDailyCallsTotal: 100,
+    })
+  })
+
+  it('should execute remainingDailyCalls query when user is not reviewer', async () => {
+    mockUseJwt({ isReviewer: false })
+
+    renderWithApplicationContext(
+      <ConsumerPurposeSummaryGeneralInformationAccordion purposeId="purpose-id" />,
+      {
+        withReactQueryContext: true,
+      }
+    )
+
+    await waitFor(() => {
+      expect(remainingDailyCallsQueryFn).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should not execute remainingDailyCalls query when user is reviewer', async () => {
+    mockUseJwt({ isReviewer: true })
+
+    renderWithApplicationContext(
+      <ConsumerPurposeSummaryGeneralInformationAccordion purposeId="purpose-id" />,
+      {
+        withReactQueryContext: true,
+      }
+    )
+
+    await waitFor(() => {
+      expect(remainingDailyCallsQueryFn).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Issue
- [PIN-10457](https://pagopa.atlassian.net/browse/PIN-10457)
## Description / Context / Why
- Disabled getRemainingDailyCalls service if user has reviewer role

[PIN-10457]: https://pagopa.atlassian.net/browse/PIN-10457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ