### PR TITLE
fix/PIN-9877: download type button no submitting

### DIFF
--- a/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepInfoVersion/components/UploadDocumentsSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/EServiceCreateStepInfoVersion/components/UploadDocumentsSection.tsx
@@ -182,6 +182,7 @@ const UploadDocumentsSectionReadonly: React.FC<{
       <IconLink
         fontWeight={600}
         component="button"
+        type="button"
         onClick={() => handleDownloadDocument(doc)}
         endIcon={<DownloadIcon sx={{ ml: 1 }} fontSize="small" />}
       >


### PR DESCRIPTION
## 🔗 Issue
[PIN-9877](https://pagopa.atlassian.net/browse/PIN-9877)

## 📝 Description / Context
This PR fixes an unintended form submission when clicking the document download action in the upload documents section.

The download control was rendered as a button without an explicit type, so inside a form it could behave as submit. The fix sets it explicitly as a non-submit button, ensuring the click only triggers file download.

## 🛠 List of changes

- Added explicit button type for the download action in the readonly documents list.
- Prevented accidental form submit when users click to download a document.
- Preserved existing download behavior and UI.

## 🧪 How to test
1. Open the e-service creation flow and reach the documents section.
2. Ensure at least one document is visible in readonly list mode.
3. Click the download action on a document.
4. Verify the file download starts correctly.
5. Verify no form submission or page step transition is triggered by that click.

[PIN-9877]: https://pagopa.atlassian.net/browse/PIN-9877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ