### PR TITLE
fix/PIN-10037: changed redundant text on update eservice descr and version

### DIFF
--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -929,17 +929,17 @@
       }
     },
     "updateEServiceDescription": {
-      "loading": "Stiamo modificando la descrizione dell'e-service del template",
+      "loading": "Stiamo modificando la descrizione del template e-service",
       "outcome": {
-        "error": "Descrizione dell'e-service del template dell'e-service non aggiornata. Riprovare.",
-        "success": "Descrizione dell'e-service del template dell'e-service aggiornata correttamente"
+        "error": "Descrizione del template e-service non aggiornata. Riprovare.",
+        "success": "Descrizione del template e-service aggiornata correttamente"
       }
     },
     "updateVersion": {
-      "loading": "Stiamo modificando la descrizione della versione dell'e-service del template",
+      "loading": "Stiamo modificando la descrizione della versione del template e-service",
       "outcome": {
-        "error": "Descrizione della versione dell'e-service del template dell'e-service non aggiornata. Riprovare.",
-        "success": "Descrizione della versione dell'e-service del template dell'e-service aggiornata correttamente"
+        "error": "Descrizione della versione del template e-service non aggiornata. Riprovare.",
+        "success": "Descrizione della versione del template e-service aggiornata correttamente"
       }
     },
     "postVersionDraftDocument": {


### PR DESCRIPTION
## 🔗 Issue
[PIN-10037](https://pagopa.atlassian.net/browse/PIN-10037)

## 📝 Description / Context
This PR removes redundant wording in Italian mutation feedback messages related to template e-service description and version updates.

The previous texts repeated "dell'e-service del template dell'e-service".  
The new copy is cleaner and consistent: "del template e-service".

## 🛠 List of changes

- Updated loading/error/success messages for updateEServiceDescription.
- Updated loading/error/success messages for updateVersion.
- Simplified Italian wording by removing duplicated terms.

## 🧪 How to test
1. Open a template e-service flow where description/version update actions are available.
2. Trigger description update and verify loading/success/error feedback text.
3. Trigger version description update and verify loading/success/error feedback text.
4. Confirm messages show the new wording "template e-service" without redundancy.

[PIN-10037]: https://pagopa.atlassian.net/browse/PIN-10037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ