### PR TITLE
fix: eservice template publish button tooltip (PIN-10025)

### DIFF
--- a/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
@@ -102,6 +102,7 @@ const ProviderEServiceTemplateSummaryPage: React.FC = () => {
   const hasMissingFields =
     !eserviceTemplate?.voucherLifespan ||
     !eserviceTemplate?.description ||
+    !eserviceTemplate?.interface ||
     hasMissingAsyncExchangeFields
 
   const canBePublished = () => {

--- a/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/__tests__/ProviderEServiceTemplateSummary.page.test.tsx
@@ -279,6 +279,23 @@ describe('ProviderEServiceTemplateSummaryPage', () => {
     })
   })
 
+  it('shows the missing fields tooltip when interface is missing', async () => {
+    mockUseJwt({ isAdmin: true, isViewer: false })
+    useQueryMock.mockReturnValue({
+      data: createMockEServiceTemplateVersionDetailsNoInterface(),
+      isLoading: false,
+    })
+
+    renderWithApplicationContext(<ProviderEServiceTemplateSummaryPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    const publishButton = screen.getByRole('button', { name: 'publish' })
+    expect(publishButton).toBeDisabled()
+    expect(screen.getByLabelText('missingFieldsTooltip')).toBeInTheDocument()
+  })
+
   expect(screen.queryByRole('button', { name: 'publish' })).not.toBeInTheDocument()
   expect(screen.queryByRole('button', { name: 'deleteDraft' })).not.toBeInTheDocument()
   expect(screen.queryByRole('button', { name: 'editDraft' })).not.toBeInTheDocument()


### PR DESCRIPTION
## Issue
- [PIN-10025](https://pagopa.atlassian.net/browse/PIN-10025)
## Description / Context / Why
- Updated hasMissingFields const in e-service template summary

[PIN-10025]: https://pagopa.atlassian.net/browse/PIN-10025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ