### PR TITLE
fix: enable archiving and align CTAs for template-instance e-services (PIN-10505)

### DIFF
--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -39,7 +39,10 @@ afterAll(() => {
   server.close()
 })
 
-function renderUseGetProviderEServiceTableActionsHook(descriptorMock: ProducerEService) {
+function renderUseGetProviderEServiceTableActionsHook(
+  descriptorMock: ProducerEService,
+  opts: { where?: 'tableRow' | 'detailsPage'; hasPersonalData?: boolean } = {}
+) {
   return renderHookWithApplicationContext(
     () =>
       useGetProviderEServiceActions(
@@ -50,9 +53,11 @@ function renderUseGetProviderEServiceTableActionsHook(descriptorMock: ProducerES
         descriptorMock.draftDescriptor?.id,
         descriptorMock.mode,
         descriptorMock.name,
-        descriptorMock.isTemplateInstance,
         descriptorMock.isNewTemplateVersionAvailable ?? false,
-        descriptorMock.delegation
+        descriptorMock.isTemplateInstance,
+        descriptorMock.delegation,
+        opts.hasPersonalData,
+        opts.where
       ),
     {
       withReactQueryContext: true,
@@ -1390,8 +1395,14 @@ describe('useGetProviderEServiceActions slot split bypass (preserve legacy behav
     expect(result.current.headerInfoActions).toHaveLength(0)
     expect(result.current.menuActions.map((a) => a.label)).toEqual(['viewAllVersions'])
   })
+})
 
-  it('PUBLISHED + template instance: no slot split, template menu preserved', () => {
+describe('useGetProviderEServiceActions slot split — template instance (where=detailsPage, non-delegated)', () => {
+  beforeEach(() => {
+    mockUseJwt({ isAdmin: true })
+  })
+
+  it('PUBLISHED: enters the slot split; suspend+createNewVersion in header, archiveEservice+viewAllVersions in menu, no cloneEservice (S1)', () => {
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
       isTemplateInstance: true,
@@ -1399,7 +1410,232 @@ describe('useGetProviderEServiceActions slot split bypass (preserve legacy behav
     })
     const { result } = renderDetailsPageHook(descriptorMock)
     expect(result.current.primaryAction).toBeUndefined()
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual([
+      'suspendVersion',
+      'createNewVersion',
+    ])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'archiveEservice',
+      'viewAllVersions',
+    ])
+  })
+
+  it('SUSPENDED active single version: archiveEservice now appears in the menu (the reported bug fix) (S5/QA1)', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+      isTemplateInstance: true,
+      delegation: undefined,
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, {
+      isActiveDescriptor: true,
+      hasMultipleVersions: false,
+    })
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual([
+      'reactivateVersion',
+      'createNewVersion',
+    ])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual(['archiveEservice'])
+  })
+
+  it('DEPRECATED: archiveVersion in header, menu keeps createNewVersion+archiveEservice, no cloneEservice (S3/QA2)', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
+      isTemplateInstance: true,
+      delegation: undefined,
+    })
+    const { result } = renderDetailsPageHook(descriptorMock)
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual([
+      'suspendVersion',
+      'archiveVersion',
+    ])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'createNewVersion',
+      'archiveEservice',
+      'viewAllVersions',
+    ])
+  })
+
+  it('SUSPENDED non-active: reactivate+archiveVersion in header (S4/QA3)', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
+      isTemplateInstance: true,
+      delegation: undefined,
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, { isActiveDescriptor: false })
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual([
+      'reactivateVersion',
+      'archiveVersion',
+    ])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'createNewVersion',
+      'archiveEservice',
+      'viewAllVersions',
+    ])
+  })
+
+  it('ARCHIVED with a newer descriptor: viewLatestVersion in header, menu keeps createNewVersion+archiveEservice (S6)', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVED', version: '1' },
+      isTemplateInstance: true,
+      delegation: undefined,
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, { latestDescriptorId: 'newer-id' })
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual(['viewLatestVersion'])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'createNewVersion',
+      'archiveEservice',
+      'viewAllVersions',
+    ])
+  })
+
+  it('ARCHIVING with ESERVICE scope: cancelArchivingEservice primary, reduced menu without cloneEservice (S7)', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVING', version: '1' },
+      isTemplateInstance: true,
+      delegation: undefined,
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, {
+      archivingSchedule: { scope: 'ESERVICE' },
+    })
+    expect(result.current.primaryAction?.label).toBe('cancelArchivingEservice')
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual(['suspendVersion'])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual(['viewAllVersions'])
+  })
+
+  it('archiving-collapsed menus never expose "Aggiorna istanza", even when a new template version is available (S7b)', () => {
+    const eserviceArchiving = renderDetailsPageHook(
+      createMockEServiceProvider({
+        activeDescriptor: { id: 'test-1', state: 'ARCHIVING', version: '1' },
+        isTemplateInstance: true,
+        isNewTemplateVersionAvailable: true,
+        delegation: undefined,
+      }),
+      { archivingSchedule: { scope: 'ESERVICE' } }
+    )
+    expect(eserviceArchiving.result.current.menuActions.map((a) => a.label)).toEqual([
+      'viewAllVersions',
+    ])
+
+    const eserviceBeingArchived = renderDetailsPageHook(
+      createMockEServiceProvider({
+        activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
+        isTemplateInstance: true,
+        isNewTemplateVersionAvailable: true,
+        delegation: undefined,
+      }),
+      { isEServiceBeingArchived: true }
+    )
+    expect(eserviceBeingArchived.result.current.menuActions.map((a) => a.label)).not.toContain(
+      'updateInstance'
+    )
+  })
+
+  it('E10 (ARCHIVING + DESCRIPTOR + isActiveDescriptor=true): still empty (impossible state), same as classic (S11)', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVING', version: '1' },
+      isTemplateInstance: true,
+      delegation: undefined,
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, {
+      archivingSchedule: { scope: 'DESCRIPTOR' },
+      isActiveDescriptor: true,
+    })
+    expect(result.current.primaryAction).toBeUndefined()
     expect(result.current.headerInfoActions).toHaveLength(0)
-    expect(result.current.menuActions.length).toBeGreaterThan(0)
+    expect(result.current.menuActions).toHaveLength(0)
+  })
+
+  it('"Aggiorna istanza" (updateInstance) is in the menu only when a new template version is available (S14)', () => {
+    const withUpgrade = renderDetailsPageHook(
+      createMockEServiceProvider({
+        activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+        isTemplateInstance: true,
+        isNewTemplateVersionAvailable: true,
+        delegation: undefined,
+      })
+    )
+    expect(withUpgrade.result.current.menuActions.map((a) => a.label)).toEqual([
+      'updateInstance',
+      'archiveEservice',
+      'viewAllVersions',
+    ])
+
+    const withoutUpgrade = renderDetailsPageHook(
+      createMockEServiceProvider({
+        activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+        isTemplateInstance: true,
+        isNewTemplateVersionAvailable: false,
+        delegation: undefined,
+      })
+    )
+    expect(withoutUpgrade.result.current.menuActions.map((a) => a.label)).not.toContain(
+      'updateInstance'
+    )
+  })
+
+  it.each(['PUBLISHED', 'DEPRECATED', 'SUSPENDED', 'ARCHIVED'] as const)(
+    'never exposes "Duplica e-service" (cloneEservice) — %s (S13)',
+    (state) => {
+      const descriptorMock = createMockEServiceProvider({
+        activeDescriptor: { id: 'test-1', state, version: '1' },
+        isTemplateInstance: true,
+        delegation: undefined,
+      })
+      const { result } = renderDetailsPageHook(descriptorMock, { latestDescriptorId: 'newer-id' })
+      const labels = [
+        result.current.primaryAction?.label,
+        ...result.current.headerInfoActions.map((a) => a.label),
+        ...result.current.menuActions.map((a) => a.label),
+      ]
+      expect(labels).not.toContain('cloneEservice')
+    }
+  )
+
+  it('operatorAPI (non-delegated) gets the same slot split as admin (S17)', () => {
+    mockUseJwt({ isAdmin: false, isOperatorAPI: true })
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      isTemplateInstance: true,
+      delegation: undefined,
+    })
+    const { result } = renderDetailsPageHook(descriptorMock)
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual([
+      'suspendVersion',
+      'createNewVersion',
+    ])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'archiveEservice',
+      'viewAllVersions',
+    ])
+  })
+
+  it('delegated template instance stays out of the slot split (no archive actions) (S15)', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      isTemplateInstance: true,
+      delegation: createMockDelegationWithCompactTenants({
+        delegator: { id: 'organizationId', name: 'delegator-name' },
+      }),
+    })
+    const { result } = renderDetailsPageHook(descriptorMock)
+    expect(result.current.primaryAction).toBeUndefined()
+    expect(result.current.headerInfoActions).toHaveLength(0)
+    expect(result.current.menuActions.map((a) => a.label)).not.toContain('archiveEservice')
+  })
+
+  it('table-row context stays out of the slot split (flat template menu, no archive) (S16)', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      isTemplateInstance: true,
+      delegation: undefined,
+    })
+    const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock, {
+      where: 'tableRow',
+    })
+    expect(result.current.primaryAction).toBeUndefined()
+    expect(result.current.headerInfoActions).toHaveLength(0)
+    const labels = result.current.menuActions.map((a) => a.label)
+    expect(labels).not.toContain('archiveEservice')
+    expect(labels).not.toContain('archiveVersion')
   })
 })

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -1124,11 +1124,7 @@ export function useGetProviderEServiceActions(
     : availableClassicEServiceAction
 
   const isHappyPathDetailsPage =
-    where === 'detailsPage' &&
-    (isAdmin || isOperatorAPI) &&
-    !isDelegator &&
-    !isDelegate &&
-    !isTemplateInstance
+    where === 'detailsPage' && (isAdmin || isOperatorAPI) && !isDelegator && !isDelegate
 
   if (!isHappyPathDetailsPage) {
     return {
@@ -1152,18 +1148,34 @@ export function useGetProviderEServiceActions(
 
   const newVersionAction = hasVersionDraft ? editDraftAction : createNewDraftAction
 
-  const menuClassic = [cloneAction, archiveEserviceAction, ...viewAllVersionsItems]
-  const menuWithNewVersion = isEServiceBeingArchived
-    ? [cloneAction, ...viewAllVersionsItems]
-    : [newVersionAction, cloneAction, archiveEserviceAction, ...viewAllVersionsItems]
-  const menuEserviceArchiving = [cloneAction, ...viewAllVersionsItems]
-  const menuArchivedEserviceActive = [
-    newVersionAction,
-    cloneAction,
+  const cloneItems: Array<ActionItemButton> = isTemplateInstance ? [] : [cloneAction]
+  const upgradeItems: Array<ActionItemButton> =
+    isTemplateInstance && isNewTemplateVersionAvailable ? [upgradeEServiceAction] : []
+
+  const menuClassic = [
+    ...upgradeItems,
+    ...cloneItems,
     archiveEserviceAction,
     ...viewAllVersionsItems,
   ]
-  const menuArchivedEserviceArchived = [cloneAction, ...viewAllVersionsItems]
+  const menuWithNewVersion = isEServiceBeingArchived
+    ? [...cloneItems, ...viewAllVersionsItems]
+    : [
+        ...upgradeItems,
+        newVersionAction,
+        ...cloneItems,
+        archiveEserviceAction,
+        ...viewAllVersionsItems,
+      ]
+  const menuEserviceArchiving = [...cloneItems, ...viewAllVersionsItems]
+  const menuArchivedEserviceActive = [
+    ...upgradeItems,
+    newVersionAction,
+    ...cloneItems,
+    archiveEserviceAction,
+    ...viewAllVersionsItems,
+  ]
+  const menuArchivedEserviceArchived = [...cloneItems, ...viewAllVersionsItems]
 
   const slots: Slots = match({ state, archivingScope, isActiveDescriptor, isEServiceBeingArchived })
     .with({ state: 'PUBLISHED' }, () => ({


### PR DESCRIPTION
## 🔗 Issue

[PIN-10505](https://pagopa.atlassian.net/browse/PIN-10505)

## 📝 Description / Context

On the provider e-service detail page, an e-service instantiated from a template did not expose the manual archiving actions and kept all its CTAs in a flat three-dot menu, unlike classic (non-template) e-services which use a header/menu split. The archiving endpoints (`scheduleArchive` for descriptor and e-service, plus the cancel variants) already accept template instances on the backend, so this is a FE-only change. This PR routes non-delegated template instances (admin and operatorAPI) on the details page through the same action layout as classic e-services, enabling the full manual archiving lifecycle, with two template-specific differences: "Duplica e-service" is removed, and "Aggiorna istanza" is kept in the menu (shown when a newer template version is available). The layout follows the classic behaviour as the source of truth, since there is no dedicated Figma for template instances yet.

## 🛠 List of changes

- `useGetProviderEServiceActions`: drop the `!isTemplateInstance` guard from the details-page happy-path condition, so non-delegated template instances (admin/operatorAPI) get the header/menu/primary-CTA slot layout, including archive version / archive e-service and the archiving grace-period lifecycle. Delegated template instances and the table-row context are unchanged.
- Make the menu builders template-aware: remove `cloneAction` ("Duplica e-service") for template instances, and prepend `upgradeEServiceAction` ("Aggiorna istanza") when `isNewTemplateVersionAvailable`. For classic e-services the menus are byte-for-byte unchanged.
- Preserve the `emptySlots` handling for the unreachable `{ARCHIVING|ARCHIVING_SUSPENDED, scope=DESCRIPTOR, isActiveDescriptor}` combination (a version can be archived as a single descriptor only when it is not the active one).
- Tests: add template-instance coverage to `useGetProviderEServiceActions.test.ts` (per-state layout, archiving enabled, no "Duplica", conditional "Aggiorna istanza", operatorAPI parity, delegated/table-row regressions); fix a swapped-argument bug in the existing table-actions test helper.

## 🧪 How to test

- As a provider admin, open a template-instance e-service on the details page (e.g. a suspended single version): the three-dot menu now shows "Archivia e-service"; the header shows "Riattiva/Sospendi versione" + "Crea nuova versione"; there is no "Duplica e-service".
- On a deprecated or suspended non-active version: "Archivia versione" appears in the header.
- When a newer template version is available: "Aggiorna istanza" appears in the menu.
- Regression: a classic (non-template) e-service is unchanged; a delegated template instance and the e-service list table row keep their previous (flat, no-archive) behaviour.

<img width="1200" height="886" alt="PIN-10505-template-instance-archive-cta" src="https://github.com/user-attachments/assets/16bd9497-f0f4-4743-83f4-081e4a843079" />


[PIN-10505]: https://pagopa.atlassian.net/browse/PIN-10505
