### PR TITLE
fix: update product updates banner copy (PIN-10419)

### DIFF
--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -400,7 +400,7 @@
   },
   "productUpdatesBanner": {
     "title": "Novità su PDND: archiviazione e nuovi ruoli",
-    "body": "Da adesso, puoi archiviare le versioni obsolete di un e-service o un intero e-service. In più sono disponibili due nuovi ruoli: validatore, per approvare o compilare l’analisi del rischio, e consultatore, per visualizzare le attività di un ente su PDND.",
+    "body": "Da adesso, puoi archiviare le versioni obsolete di un e-service o un intero e-service. In più sono disponibili due nuovi ruoli: valutatore, per approvare o compilare l’analisi del rischio, e consultatore, per visualizzare le attività di un ente su PDND.",
     "action1Label": "Come funziona l’archiviazione",
     "action1AriaLabel": "Come funziona l’archiviazione, apre in una nuova scheda",
     "action2Label": "Come funzionano i nuovi ruoli",


### PR DESCRIPTION
## 🔗 Issue

[PIN-10419](https://pagopa.atlassian.net/browse/PIN-10419)

## 📝 Description / Context

This hotfix aligns the Italian product updates banner copy with the expected wording for the new roles announcement.

## 🛠 List of changes

- Updated the Italian product updates banner body from “validatore” to “valutatore”.

## 🧪 How to test

- Open the application where the product updates banner is displayed.
- Verify that the banner text says “valutatore, per approvare o compilare l’analisi del rischio”.

[PIN-10419]: https://pagopa.atlassian.net/browse/PIN-10419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ