### PR TITLE
feature: fix tooltip not readable from all screen readers (PIN-2665, INT-96)

### DIFF
--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -513,18 +513,11 @@ const ProviderEServiceSummaryPage: React.FC = () => {
             >
               {tCommon('reject')}
             </Button>
-            <Tooltip title={publishTooltipTitle} arrow>
-              <span>
-                <Button
-                  startIcon={<PublishIcon />}
-                  variant="contained"
-                  onClick={handleApproveDelegatedVersionDraft}
-                  disabled={isSupport || isAsyncExchangeValidationLoading || !isPublishable}
-                >
-                  {tCommon('publish')}
-                </Button>
-              </span>
-            </Tooltip>
+            <PublishButton
+              onClick={handleApproveDelegatedVersionDraft}
+              disabled={isSupport || isAsyncExchangeValidationLoading || !isPublishable}
+              tooltipTitle={publishTooltipTitle}
+            />
           </Stack>
         )}
         {requireDelegateCorrections && sortedRejectedReasons && (
@@ -571,7 +564,7 @@ const PublishButton: React.FC<PublishButtonProps> = ({ disabled, onClick, toolti
           tabIndex={0}
           role="button"
           aria-disabled="true"
-          aria-label={tooltipTitle ? `${buttonLabel} - ${tooltipTitle}` : `${buttonLabel}`}
+          aria-label={tooltipTitle ? `${buttonLabel} - ${tooltipTitle}` : buttonLabel}
         >
           <span aria-hidden="true">{button}</span>
         </span>

--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -556,22 +556,30 @@ type PublishButtonProps = {
 
 const PublishButton: React.FC<PublishButtonProps> = ({ disabled, onClick, tooltipTitle }) => {
   const { t: tCommon } = useTranslation('common', { keyPrefix: 'actions' })
+  const buttonLabel = tCommon('publish')
 
-  const Wrapper = disabled
-    ? ({ children }: { children: React.ReactElement }) => (
-        <Tooltip arrow title={tooltipTitle}>
-          <span tabIndex={disabled ? 0 : undefined}>{children}</span>
-        </Tooltip>
-      )
-    : React.Fragment
-
-  return (
-    <Wrapper>
-      <Button disabled={disabled} startIcon={<PublishIcon />} variant="contained" onClick={onClick}>
-        {tCommon('publish')}
-      </Button>
-    </Wrapper>
+  const button = (
+    <Button disabled={disabled} startIcon={<PublishIcon />} variant="contained" onClick={onClick}>
+      {buttonLabel}
+    </Button>
   )
+
+  if (disabled) {
+    return (
+      <Tooltip arrow title={tooltipTitle}>
+        <span
+          tabIndex={0}
+          role="button"
+          aria-disabled="true"
+          aria-label={`${buttonLabel} - ${tooltipTitle}`}
+        >
+          <span aria-hidden="true">{button}</span>
+        </span>
+      </Tooltip>
+    )
+  }
+
+  return button
 }
 
 type PublishTooltipKey =

--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -571,7 +571,7 @@ const PublishButton: React.FC<PublishButtonProps> = ({ disabled, onClick, toolti
           tabIndex={0}
           role="button"
           aria-disabled="true"
-          aria-label={`${buttonLabel} - ${tooltipTitle}`}
+          aria-label={tooltipTitle ? `${buttonLabel} - ${tooltipTitle}` : `${buttonLabel}`}
         >
           <span aria-hidden="true">{button}</span>
         </span>

--- a/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
@@ -240,8 +240,10 @@ describe('ProviderEServiceSummaryPage', () => {
       withRouterContext: true,
     })
 
-    const publishButton = screen.getByRole('button', { name: 'publish' })
-    expect(publishButton).toBeDisabled()
+    const publishButton = screen.getByRole('button', {
+      name: 'publish - summary.notPublishableTooltip.label',
+    })
+    expect(publishButton).toHaveAttribute('aria-disabled', 'true')
   })
 
   it('disables delegated approval when asynchronous mandatory fields are missing', () => {
@@ -263,7 +265,9 @@ describe('ProviderEServiceSummaryPage', () => {
       withRouterContext: true,
     })
 
-    const approveButton = screen.getByRole('button', { name: 'publish' })
+    const approveButton = screen.getByRole('button', {
+      name: 'publish',
+    })
     expect(approveButton).toBeDisabled()
   })
 
@@ -430,8 +434,10 @@ describe('ProviderEServiceSummaryPage', () => {
         withRouterContext: true,
       })
 
-      const publishButton = screen.getByRole('button', { name: 'publish' })
-      expect(publishButton).toBeDisabled()
+      const publishButton = screen.getByRole('button', {
+        name: 'publish - summary.rulesetExpiredTooltip.label',
+      })
+      expect(publishButton).toHaveAttribute('aria-disabled', 'true')
     })
 
     it('should be false when there are other descriptors even if riskAnalysis rulesetExpiration is expired', () => {

--- a/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
@@ -266,7 +266,7 @@ describe('ProviderEServiceSummaryPage', () => {
     })
 
     const approveButton = screen.getByRole('button', {
-      name: 'publish',
+      name: 'publish - summary.notPublishableTooltip.label',
     })
     expect(approveButton).toBeDisabled()
   })

--- a/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
@@ -268,7 +268,7 @@ describe('ProviderEServiceSummaryPage', () => {
     const approveButton = screen.getByRole('button', {
       name: 'publish - summary.notPublishableTooltip.label',
     })
-    expect(approveButton).toBeDisabled()
+    expect(approveButton).toHaveAttribute('aria-disabled', 'true')
   })
 
   it('renders edit button', () => {

--- a/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/__tests__/ProviderEServiceSummary.page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ProviderEServiceSummaryPage from '../ProviderEServiceSummary.page'
 import { mockUseJwt, mockUseParams, renderWithApplicationContext } from '@/utils/testing.utils'
@@ -244,6 +244,11 @@ describe('ProviderEServiceSummaryPage', () => {
       name: 'publish - summary.notPublishableTooltip.label',
     })
     expect(publishButton).toHaveAttribute('aria-disabled', 'true')
+    const innerButton = within(publishButton).getByRole('button', {
+      name: 'publish',
+      hidden: true,
+    })
+    expect(innerButton).toBeDisabled()
   })
 
   it('disables delegated approval when asynchronous mandatory fields are missing', () => {
@@ -269,6 +274,11 @@ describe('ProviderEServiceSummaryPage', () => {
       name: 'publish - summary.notPublishableTooltip.label',
     })
     expect(approveButton).toHaveAttribute('aria-disabled', 'true')
+    const innerButton = within(approveButton).getByRole('button', {
+      name: 'publish',
+      hidden: true,
+    })
+    expect(innerButton).toBeDisabled()
   })
 
   it('renders edit button', () => {
@@ -438,6 +448,11 @@ describe('ProviderEServiceSummaryPage', () => {
         name: 'publish - summary.rulesetExpiredTooltip.label',
       })
       expect(publishButton).toHaveAttribute('aria-disabled', 'true')
+      const innerButton = within(publishButton).getByRole('button', {
+        name: 'publish',
+        hidden: true,
+      })
+      expect(innerButton).toBeDisabled()
     })
 
     it('should be false when there are other descriptors even if riskAnalysis rulesetExpiration is expired', () => {


### PR DESCRIPTION
## 🔗 Issue

[PIN-2665_INT-96](https://pagopa.atlassian.net/browse/A2-2665)

## 📝 Description / Context

NVDA screen reader doesn't announce the tooltip on eservice create summary pusblish button. This PR include a refactor of the button so the tooltip will be visible to all screen readers