### PR TITLE
feat: INT-95 add aria labels for document download in ProviderEServiceDocumentationSection (A2-2664 - A11Y)

### DIFF
--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDocumentationSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDocumentationSection.tsx
@@ -85,6 +85,9 @@ export const ProviderEServiceDocumentationSection: React.FC<
                     component="button"
                     onClick={handleDownloadDocument.bind(null, doc)}
                     startIcon={<AttachFileIcon fontSize="small" />}
+                    aria-label={tCommon('ariaLabels.downloadDocument', {
+                      name: doc.prettyName,
+                    })}
                   >
                     {doc.prettyName}
                   </IconLink>
@@ -105,6 +108,9 @@ export const ProviderEServiceDocumentationSection: React.FC<
                     descriptor.asyncExchangeCallbackInterface
                   )}
                   startIcon={<AttachFileIcon fontSize="small" />}
+                  aria-label={tCommon('ariaLabels.downloadDocument', {
+                    name: descriptor.asyncExchangeCallbackInterface.prettyName,
+                  })}
                 >
                   {descriptor.asyncExchangeCallbackInterface.prettyName}
                 </IconLink>

--- a/src/static/locales/en/common.json
+++ b/src/static/locales/en/common.json
@@ -200,5 +200,8 @@
     "LTE": "Less than or equal to",
     "EQ": "Equal to",
     "NE": "Not equal to"
+  },
+  "ariaLabels": {
+    "downloadDocument": "Download document {{name}}"
   }
 }

--- a/src/static/locales/it/common.json
+++ b/src/static/locales/it/common.json
@@ -200,5 +200,8 @@
     "LTE": "Minore o uguale a",
     "EQ": "Uguale a",
     "NE": "Diverso da"
+  },
+  "ariaLabels": {
+    "downloadDocument": "Scarica il documento {{name}}"
   }
 }


### PR DESCRIPTION
## 🔗 Issue

[A2-2664](https://pagopa.atlassian.net/browse/A2-2664)

## 📝 Description / Context

The download action in ProviderEServiceDocumentationSection was not announced to the screen reader.

## 🛠 List of changes

- Add aria label strings in common.json for download documents (IT/EN)
- Add aria-label in ProviderEServiceDocumentationSection 


[A2-2664]: https://pagopa.atlassian.net/browse/A2-2664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ