### PR TITLE
fix: correct consumer agreement archiving version alerts (PIN-10524)

### DIFF
--- a/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementVersionAlerts.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementVersionAlerts.tsx
@@ -38,7 +38,7 @@ export const ConsumerAgreementVersionAlerts: React.FC<ConsumerAgreementVersionAl
             severity={alert.severity}
             action={
               alert.showSeeDetailsAction ? (
-                <Button color="inherit" size="small" onClick={() => setIsDrawerOpen(true)}>
+                <Button color="primary" size="small" onClick={() => setIsDrawerOpen(true)}>
                   {t('seeDetails')}
                 </Button>
               ) : undefined

--- a/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementVersionAlerts.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementVersionAlerts.tsx
@@ -17,11 +17,15 @@ export const ConsumerAgreementVersionAlerts: React.FC<ConsumerAgreementVersionAl
 
   if (!descriptor) return null
 
+  const activeDescriptor = descriptor.eservice.activeDescriptor
+  const isObsoleteDescriptor = Boolean(activeDescriptor && activeDescriptor.id !== descriptor.id)
+
   const alerts = getConsumerAgreementVersionAlertSpec({
     state: descriptor.state,
     scope: descriptor.archivingSchedule?.scope,
     archivableOn: descriptor.archivingSchedule?.archivableOn,
     archivedAt: descriptor.archivedAt,
+    isObsoleteDescriptor,
     t,
   })
 

--- a/src/pages/ConsumerAgreementDetailsPage/components/__tests__/ConsumerAgreementVersionAlerts.test.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/__tests__/ConsumerAgreementVersionAlerts.test.tsx
@@ -43,9 +43,10 @@ describe('ConsumerAgreementVersionAlerts', () => {
     expect(screen.queryByRole('button', { name: 'seeDetails' })).toBeNull()
   })
 
-  it('renders a warning alert with see-details plus an obsolete-version info alert when state is ARCHIVING + scope ESERVICE', () => {
+  it('renders a warning alert with see-details plus an obsolete-version info alert when state is ARCHIVING + scope ESERVICE and the descriptor is obsolete', () => {
     renderAlerts(
       createMockEServiceDescriptorCatalog({
+        id: 'obsolete-descriptor-id',
         state: 'ARCHIVING',
         archivingSchedule: { scope: 'ESERVICE', archivableOn: '2026-12-01T00:00:00.000Z' },
       })
@@ -54,6 +55,19 @@ describe('ConsumerAgreementVersionAlerts', () => {
     expect(alerts).toHaveLength(2)
     expect(alerts[0]).toHaveClass(/MuiAlert-standardWarning/)
     expect(alerts[1]).toHaveClass(/MuiAlert-standardInfo/)
+    expect(screen.getByRole('button', { name: 'seeDetails' })).toBeInTheDocument()
+  })
+
+  it('renders only the warning alert with see-details when state is ARCHIVING + scope ESERVICE and the descriptor is the active one', () => {
+    renderAlerts(
+      createMockEServiceDescriptorCatalog({
+        state: 'ARCHIVING',
+        archivingSchedule: { scope: 'ESERVICE', archivableOn: '2026-12-01T00:00:00.000Z' },
+      })
+    )
+    const alerts = screen.getAllByRole('alert')
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toHaveClass(/MuiAlert-standardWarning/)
     expect(screen.getByRole('button', { name: 'seeDetails' })).toBeInTheDocument()
   })
 

--- a/src/pages/ConsumerAgreementDetailsPage/components/__tests__/ConsumerAgreementVersionAlerts.test.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/__tests__/ConsumerAgreementVersionAlerts.test.tsx
@@ -43,7 +43,7 @@ describe('ConsumerAgreementVersionAlerts', () => {
     expect(screen.queryByRole('button', { name: 'seeDetails' })).toBeNull()
   })
 
-  it('renders a single warning alert and a see-details button when state is ARCHIVING + scope ESERVICE', () => {
+  it('renders a warning alert with see-details plus an obsolete-version info alert when state is ARCHIVING + scope ESERVICE', () => {
     renderAlerts(
       createMockEServiceDescriptorCatalog({
         state: 'ARCHIVING',
@@ -51,8 +51,9 @@ describe('ConsumerAgreementVersionAlerts', () => {
       })
     )
     const alerts = screen.getAllByRole('alert')
-    expect(alerts).toHaveLength(1)
+    expect(alerts).toHaveLength(2)
     expect(alerts[0]).toHaveClass(/MuiAlert-standardWarning/)
+    expect(alerts[1]).toHaveClass(/MuiAlert-standardInfo/)
     expect(screen.getByRole('button', { name: 'seeDetails' })).toBeInTheDocument()
   })
 
@@ -76,7 +77,7 @@ describe('ConsumerAgreementVersionAlerts', () => {
     expect(alerts[0]).toHaveClass(/MuiAlert-standardError/)
   })
 
-  it('renders an error alert when state is ARCHIVED + scope DESCRIPTOR (default branch)', () => {
+  it('renders the version-archived alert for ARCHIVED + scope DESCRIPTOR', () => {
     renderAlerts(
       createMockEServiceDescriptorCatalog({
         state: 'ARCHIVED',
@@ -87,6 +88,21 @@ describe('ConsumerAgreementVersionAlerts', () => {
     const alerts = screen.getAllByRole('alert')
     expect(alerts).toHaveLength(1)
     expect(alerts[0]).toHaveClass(/MuiAlert-standardError/)
+    expect(alerts[0]).toHaveTextContent('archivedDescriptor')
+  })
+
+  it('renders the whole-e-service archived alert for ARCHIVED + scope ESERVICE', () => {
+    renderAlerts(
+      createMockEServiceDescriptorCatalog({
+        state: 'ARCHIVED',
+        archivingSchedule: { scope: 'ESERVICE' },
+        archivedAt: '2026-12-01T00:00:00.000Z',
+      })
+    )
+    const alerts = screen.getAllByRole('alert')
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toHaveClass(/MuiAlert-standardError/)
+    expect(alerts[0]).toHaveTextContent('archivedEService')
   })
 
   it('opens the drawer when the see-details button is clicked (ARCHIVING_SUSPENDED + ESERVICE)', async () => {

--- a/src/static/locales/en/agreement.json
+++ b/src/static/locales/en/agreement.json
@@ -133,12 +133,13 @@
     "noPurposeAlert": "To access the data <1>create your first purpose</1>.",
     "versionAlert": {
       "deprecatedActive": "This e-service version is obsolete but still active. A new version is available.",
+      "deprecatedActiveShort": "This e-service version is obsolete but still active.",
       "archivingDescriptor": "This e-service version will be archived on {{date}}. After that date, you will only be able to use the new version to exchange data with the e-service.",
       "archivingSuspendedDescriptor": "This e-service version will be archived on {{date}}. It is currently suspended and cannot be used. A new version is available.",
       "suspendedLast": "This e-service version is currently suspended and cannot be used.",
       "suspendedLastNoNewVersion": "This e-service version is currently suspended and cannot be used. No new version is available.",
-      "archivedDescriptor": "This e-service version was archived on {{date}} and can no longer be used. To continue exchanging data with the e-service, switch to the new version. The agreement linked to this version can be archived.",
-      "archivedEService": "This e-service was archived on {{date}} and can no longer be used. The agreement linked to this version can be archived.",
+      "archivedDescriptor": "This e-service version was archived on {{date}} and can no longer be used. To continue exchanging data with the e-service, check whether a new version is available and, if you haven't already, archive the agreement.",
+      "archivedEService": "This e-service was archived on {{date}} and can no longer be used. If you haven't already, archive the agreement.",
       "archivingEService": "This e-service will be archived on {{date}}. After that date, you will no longer be able to exchange data with the e-service.",
       "seeDetails": "See details"
     },

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -309,7 +309,7 @@
         "description": "By archiving the e-service, all versions will be archived and draft versions will be deleted.\nIf you confirm this choice, archiving will occur on <strong>{{date}}</strong>. Before this date, the e-service will remain active to allow users to adapt. You can cancel archiving only before this date."
       },
       "confirm": {
-        "description": "All users will be informed of the notice period and the reason for the archiving.",
+        "description": "All users will be informed of the date and the reason for the archiving.",
         "form": {
           "label": "Archiving reason",
           "infoLabel": "Explain why you chose to archive the e-service. If you wish, suggest an alternative e-service. Both information will be shared with users. Minimum 10 characters, maximum 250 characters."

--- a/src/static/locales/it/agreement.json
+++ b/src/static/locales/it/agreement.json
@@ -133,12 +133,13 @@
     "noPurposeAlert": "Per accedere ai dati <1>crea la tua prima finalità</1>.",
     "versionAlert": {
       "deprecatedActive": "Questa versione dell’e-service è obsoleta, ma è ancora attiva. È disponibile una nuova versione.",
+      "deprecatedActiveShort": "Questa versione dell’e-service è obsoleta, ma è ancora attiva.",
       "archivingDescriptor": "Questa versione dell’e-service sarà archiviata il giorno {{date}}. Dopo questa data potrai utilizzare solo la nuova versione per scambiare dati con l’e-service.",
       "archivingSuspendedDescriptor": "Questa versione dell’e-service sarà archiviata il giorno {{date}}. Al momento è sospesa e non può essere utilizzata. È disponibile una nuova versione.",
       "suspendedLast": "Questa versione dell’e-service è al momento sospesa e non può essere utilizzata.",
       "suspendedLastNoNewVersion": "Questa versione dell’e-service è al momento sospesa e non può essere utilizzata. Non è disponibile una nuova versione.",
-      "archivedDescriptor": "Questa versione dell’e-service è stata archiviata il giorno {{date}} e non può più essere utilizzata. Per continuare a scambiare dati con l’e-service, passa alla nuova versione. La richiesta di fruizione collegata a questa versione può essere archiviata.",
-      "archivedEService": "Questo e-service è stato archiviato il giorno {{date}} e non può più essere utilizzato. La richiesta di fruizione collegata a questa versione può essere archiviata.",
+      "archivedDescriptor": "Questa versione dell’e-service è stata archiviata il giorno {{date}} e non può più essere utilizzata. Per continuare a scambiare i dati con l’e-service, verifica se è disponibile una nuova versione e, se non l’hai già fatto, archivia la richiesta di fruizione.",
+      "archivedEService": "Questo e-service è stato archiviato il giorno {{date}} e non può più essere utilizzato. Se non l’hai già fatto, archivia la richiesta di fruizione.",
       "archivingEService": "Questo e-service sarà archiviato il giorno {{date}}. Dopo questa data non potrai più scambiare dati con l’e-service.",
       "seeDetails": "Vedi dettagli"
     },

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -309,7 +309,7 @@
         "description": "Con l’archiviazione dell’e-service, tutte le sue versioni saranno archiviate e quelle in bozza eliminate.\nSe confermi questa scelta, l’archiviazione avverrà il giorno <strong>{{date}}</strong>. Prima di questa data, l’e-service resterà attivo per consentire ai fruitori di adeguarsi. Potrai annullare l’archiviazione solo prima di questa data."
       },
       "confirm": {
-        "description": "Tutti i fruitori saranno informati sul periodo di preavviso e sul motivo dell’archiviazione.",
+        "description": "Tutti i fruitori saranno informati sulla data e sul motivo dell’archiviazione.",
         "form": {
           "label": "Motivo archiviazione",
           "infoLabel": "Spiega perché hai scelto di archiviare l’e-service. Se vuoi, suggerisci un e-service alternativo. Entrambe le informazioni saranno condivise con i fruitori. Min 10 caratteri, max 250 caratteri"

--- a/src/utils/__tests__/agreement.utils.test.ts
+++ b/src/utils/__tests__/agreement.utils.test.ts
@@ -237,6 +237,7 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     scope: undefined,
     archivableOn: undefined,
     archivedAt: undefined,
+    isObsoleteDescriptor: false,
     t,
   } as const
 
@@ -263,17 +264,31 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     expect(result[0].showSeeDetailsAction).toBeUndefined()
   })
 
-  it('returns warning with see-details + obsolete info alert for ARCHIVING + scope ESERVICE', () => {
+  it('returns warning with see-details + obsolete info alert for ARCHIVING + scope ESERVICE when the descriptor is obsolete', () => {
     const result = getConsumerAgreementVersionAlertSpec({
       ...baseArgs,
       state: 'ARCHIVING',
       scope: 'ESERVICE',
       archivableOn: '2026-12-01T00:00:00.000Z',
+      isObsoleteDescriptor: true,
     })
     expect(result).toHaveLength(2)
     expect(result[0]).toMatchObject({ severity: 'warning', showSeeDetailsAction: true })
     expect(result[0].content).toMatch(/^archivingEService:/)
     expect(result[1]).toEqual({ severity: 'info', content: 'deprecatedActiveShort' })
+  })
+
+  it('returns only the warning with see-details for ARCHIVING + scope ESERVICE when the descriptor is the active one', () => {
+    const result = getConsumerAgreementVersionAlertSpec({
+      ...baseArgs,
+      state: 'ARCHIVING',
+      scope: 'ESERVICE',
+      archivableOn: '2026-12-01T00:00:00.000Z',
+      isObsoleteDescriptor: false,
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ severity: 'warning', showSeeDetailsAction: true })
+    expect(result[0].content).toMatch(/^archivingEService:/)
   })
 
   it('returns single error alert for ARCHIVING_SUSPENDED + scope DESCRIPTOR', () => {

--- a/src/utils/__tests__/agreement.utils.test.ts
+++ b/src/utils/__tests__/agreement.utils.test.ts
@@ -263,16 +263,17 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     expect(result[0].showSeeDetailsAction).toBeUndefined()
   })
 
-  it('returns a single warning alert with see-details for ARCHIVING + scope ESERVICE', () => {
+  it('returns warning with see-details + obsolete info alert for ARCHIVING + scope ESERVICE', () => {
     const result = getConsumerAgreementVersionAlertSpec({
       ...baseArgs,
       state: 'ARCHIVING',
       scope: 'ESERVICE',
       archivableOn: '2026-12-01T00:00:00.000Z',
     })
-    expect(result).toHaveLength(1)
+    expect(result).toHaveLength(2)
     expect(result[0]).toMatchObject({ severity: 'warning', showSeeDetailsAction: true })
     expect(result[0].content).toMatch(/^archivingEService:/)
+    expect(result[1]).toEqual({ severity: 'info', content: 'deprecatedActiveShort' })
   })
 
   it('returns single error alert for ARCHIVING_SUSPENDED + scope DESCRIPTOR', () => {
@@ -284,7 +285,7 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     })
     expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({ severity: 'error' })
-    expect(result[0].content).toMatch(/^archivingSuspendedDescriptor:/)
+    expect(result[0].content).toMatch(/^archivingSuspendedDescriptor:\d{2}\/\d{2}\/\d{4}$/)
   })
 
   it('returns error + warning with see-details for ARCHIVING_SUSPENDED + scope ESERVICE', () => {
@@ -306,7 +307,7 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     ])
   })
 
-  it('returns archivedEService for ARCHIVED + scope ESERVICE', () => {
+  it('returns archivedEService for ARCHIVED + scope ESERVICE (whole e-service archived)', () => {
     const result = getConsumerAgreementVersionAlertSpec({
       ...baseArgs,
       state: 'ARCHIVED',
@@ -315,10 +316,10 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     })
     expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({ severity: 'error' })
-    expect(result[0].content).toMatch(/^archivedEService:/)
+    expect(result[0].content).toMatch(/^archivedEService:\d{2}\/\d{2}\/\d{4}$/)
   })
 
-  it('returns archivedDescriptor for ARCHIVED + scope DESCRIPTOR (default branch)', () => {
+  it('returns archivedDescriptor for ARCHIVED + scope DESCRIPTOR (single version archived)', () => {
     const result = getConsumerAgreementVersionAlertSpec({
       ...baseArgs,
       state: 'ARCHIVED',
@@ -327,7 +328,7 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     })
     expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({ severity: 'error' })
-    expect(result[0].content).toMatch(/^archivedDescriptor:/)
+    expect(result[0].content).toMatch(/^archivedDescriptor:\d{2}\/\d{2}\/\d{4}$/)
   })
 
   it('returns empty array for ARCHIVING without a scope (no matching branch)', () => {

--- a/src/utils/agreement.utils.ts
+++ b/src/utils/agreement.utils.ts
@@ -9,7 +9,7 @@ import type {
 import type { AlertColor } from '@mui/material'
 import type { TFunction } from 'i18next'
 import { match } from 'ts-pattern'
-import { formatDateString } from './format.utils'
+import { formatDateStringNumeric } from './format.utils'
 
 /**
  * Checks if the user has already an agreement draft for the given e-service.
@@ -141,8 +141,8 @@ export function getConsumerAgreementVersionAlertSpec(args: {
   t: TFunction<'agreement', 'consumerRead.versionAlert'>
 }): ConsumerAgreementVersionAlertSpec[] {
   const { state, scope, archivableOn, archivedAt, t } = args
-  const scheduledDate = archivableOn ? formatDateString(archivableOn) : ''
-  const archivedDate = archivedAt ? formatDateString(archivedAt) : ''
+  const scheduledDate = archivableOn ? formatDateStringNumeric(archivableOn) : ''
+  const archivedDate = archivedAt ? formatDateStringNumeric(archivedAt) : ''
 
   return match({ state, scope })
     .returnType<ConsumerAgreementVersionAlertSpec[]>()
@@ -156,6 +156,7 @@ export function getConsumerAgreementVersionAlertSpec(args: {
         content: t('archivingEService', { date: scheduledDate }),
         showSeeDetailsAction: true,
       },
+      { severity: 'info', content: t('deprecatedActiveShort') },
     ])
     .with({ state: 'ARCHIVING_SUSPENDED', scope: 'DESCRIPTOR' }, () => [
       { severity: 'error', content: t('archivingSuspendedDescriptor', { date: scheduledDate }) },

--- a/src/utils/agreement.utils.ts
+++ b/src/utils/agreement.utils.ts
@@ -138,9 +138,10 @@ export function getConsumerAgreementVersionAlertSpec(args: {
   scope: ArchivingScope | undefined
   archivableOn: string | undefined
   archivedAt: string | undefined
+  isObsoleteDescriptor: boolean
   t: TFunction<'agreement', 'consumerRead.versionAlert'>
 }): ConsumerAgreementVersionAlertSpec[] {
-  const { state, scope, archivableOn, archivedAt, t } = args
+  const { state, scope, archivableOn, archivedAt, isObsoleteDescriptor, t } = args
   const scheduledDate = archivableOn ? formatDateStringNumeric(archivableOn) : ''
   const archivedDate = archivedAt ? formatDateStringNumeric(archivedAt) : ''
 
@@ -150,14 +151,19 @@ export function getConsumerAgreementVersionAlertSpec(args: {
     .with({ state: 'ARCHIVING', scope: 'DESCRIPTOR' }, () => [
       { severity: 'warning', content: t('archivingDescriptor', { date: scheduledDate }) },
     ])
-    .with({ state: 'ARCHIVING', scope: 'ESERVICE' }, () => [
-      {
-        severity: 'warning',
-        content: t('archivingEService', { date: scheduledDate }),
-        showSeeDetailsAction: true,
-      },
-      { severity: 'info', content: t('deprecatedActiveShort') },
-    ])
+    .with({ state: 'ARCHIVING', scope: 'ESERVICE' }, () => {
+      const alerts: ConsumerAgreementVersionAlertSpec[] = [
+        {
+          severity: 'warning',
+          content: t('archivingEService', { date: scheduledDate }),
+          showSeeDetailsAction: true,
+        },
+      ]
+      if (isObsoleteDescriptor) {
+        alerts.push({ severity: 'info', content: t('deprecatedActiveShort') })
+      }
+      return alerts
+    })
     .with({ state: 'ARCHIVING_SUSPENDED', scope: 'DESCRIPTOR' }, () => [
       { severity: 'error', content: t('archivingSuspendedDescriptor', { date: scheduledDate }) },
     ])


### PR DESCRIPTION
## 🔗 Issue

- [PIN-10524] — misleading alert on the agreement detail after the version is archived
- [PIN-10540] — misleading alert when the whole e-service is archived
- [PIN-10538] — wrong date format and black "Vedi dettagli" link on the e-service archiving alert
- [PIN-10539] — missing "obsolete but still active" message
- [PIN-10529] — wrong copy in the "Archivia e-service" dialog
- [PIN-10542] — wrong date format on the archiving alert of the suspended version

## 📝 Description / Context

Set of QA-reported issues on the consumer agreement ("richiesta di fruizione") detail page and on the "Archivia e-service" dialog, all under the manual-archiving epic [PIN-5130]. They share the same alert logic and dialog copy, so they are fixed together. Changes are copy-only or presentation-only, plus one missing alert; the ARCHIVED routing keeps relying on `archivingSchedule.scope`, confirmed with the backend team as the reliable discriminator between descriptor-scoped and e-service-scoped archiving. Targets `main`.

## 🛠 List of changes

- [PIN-10524] — reworded `agreement.consumerRead.versionAlert.archivedDescriptor`: dropped the misleading "passa alla nuova versione" and the unconditional archive suggestion, now neutral ("verifica se è disponibile una nuova versione e, se non l'hai già fatto, archivia la richiesta di fruizione").
- [PIN-10540] — reworded `archivedEService` to the neutral wording; shown when `archivingSchedule.scope === 'ESERVICE'`.
- [PIN-10538] — all dates in these alerts are now numeric (`dd/mm/yyyy`, via `formatDateStringNumeric`), and the "Vedi dettagli" button is now blue (`color="primary"`) as per Figma.
- [PIN-10542] — same numeric-date fix, covering the alert of the suspended version being archived (`ARCHIVING_SUSPENDED`).
- [PIN-10539] — the "questa versione è obsoleta, ma è ancora attiva" message (`deprecatedActiveShort`) is now shown alongside the e-service archiving alert (`ARCHIVING` + scope `ESERVICE`).
- [PIN-10529] — fixed the "Archivia e-service" dialog confirm-step copy: "sul periodo di preavviso" → "sulla data".

## 🧪 How to test

On the consumer agreement detail page (Fruizione → Richieste inoltrate → Visualizza), for the version linked to the agreement:

- version archived while the e-service is still alive (scope DESCRIPTOR) → neutral `archivedDescriptor` copy, numeric date ([PIN-10524]);
- whole e-service archived (scope ESERVICE) → dedicated `archivedEService` copy, numeric date ([PIN-10540]);
- e-service being archived (ARCHIVING + scope ESERVICE) → archiving alert with numeric date and blue "Vedi dettagli", plus the "obsolete but still active" info alert ([PIN-10538] + [PIN-10539]);
- suspended version being archived (ARCHIVING_SUSPENDED) → numeric date ([PIN-10542]).

On the provider e-service detail page, open the ⋮ menu → "Archivia e-service" → step "Conferma": the text reads "…sulla data…" ([PIN-10529]).

## 📸 Screenshots

### PIN-10524
<img width="2400" height="3142" alt="PIN-10524-archived-descriptor" src="https://github.com/user-attachments/assets/ba1f4cd0-9eff-4e51-ad7d-511774c0c755" />

### PIN-10540
<img width="2400" height="3096" alt="PIN-10540-archived-eservice" src="https://github.com/user-attachments/assets/b5c26555-9e1f-4cb6-8a1c-05565beed846" />

### PIN-10538
<img width="2400" height="3238" alt="PIN-10538-archiving-date-and-blue-button" src="https://github.com/user-attachments/assets/ead7e858-99c1-42ec-bf6e-fce555c2ae50" />

### PIN-10539
<img width="2400" height="3238" alt="PIN-10539-obsolete-version-message" src="https://github.com/user-attachments/assets/0931717e-71b2-41a5-a558-143e6c706b6b" />

### PIN-10529
<img width="2400" height="1772" alt="PIN-10529-archive-eservice-dialog" src="https://github.com/user-attachments/assets/52937d6a-aaed-45eb-8fbb-3cbdf6d66da8" />

### PIN-10542
<img width="2400" height="3096" alt="PIN-10542-archiving-suspended-date" src="https://github.com/user-attachments/assets/0fe2d709-7725-4862-b136-3040092c1e88" />



[PIN-5130]: https://pagopa.atlassian.net/browse/PIN-5130
[PIN-10524]: https://pagopa.atlassian.net/browse/PIN-10524
[PIN-10540]: https://pagopa.atlassian.net/browse/PIN-10540
[PIN-10538]: https://pagopa.atlassian.net/browse/PIN-10538
[PIN-10539]: https://pagopa.atlassian.net/browse/PIN-10539
[PIN-10529]: https://pagopa.atlassian.net/browse/PIN-10529
[PIN-10542]: https://pagopa.atlassian.net/browse/PIN-10542
