### PR TITLE
feature: create certified discrete attribute (PIN-10106)

### DIFF
--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -2191,6 +2191,17 @@ export interface CertifiedTenantAttributeSeed {
   id: string;
 }
 
+export interface CertifiedDiscreteTenantAttributeSeed {
+  /** @format uuid */
+  id: string;
+  /**
+   * @format int32
+   * @min 1
+   * @max 1000000000
+   */
+  certifiedDiscreteThreshold: number;
+}
+
 export interface DelegationTenant {
   /** @format uuid */
   id: string;
@@ -3926,6 +3937,14 @@ export interface AddCertifiedAttributeParams {
   tenantId: string;
 }
 
+export interface AddCertifiedDiscreteAttributeParams {
+  /**
+   * The internal identifier of the tenant
+   * @format uuid
+   */
+  tenantId: string;
+}
+
 export interface GetProducerPurposesParams {
   q?: string;
   /**
@@ -4516,6 +4535,19 @@ export interface VerifyVerifiedAttributeParams {
 }
 
 export interface RevokeCertifiedAttributeParams {
+  /**
+   * Tenant id which attribute needs to be verified
+   * @format uuid
+   */
+  tenantId: string;
+  /**
+   * Attribute id to be revoked
+   * @format uuid
+   */
+  attributeId: string;
+}
+
+export interface RevokeCertifiedDiscreteAttributeParams {
   /**
    * Tenant id which attribute needs to be verified
    * @format uuid
@@ -6708,6 +6740,27 @@ export namespace Tenants {
   }
 
   /**
+   * @description Add a certified discrete attribute to a Tenant by the requester Tenant
+   * @tags tenants
+   * @name AddCertifiedDiscreteAttribute
+   * @request POST:/tenants/{tenantId}/attributes/certifiedDiscrete
+   * @secure
+   */
+  export namespace AddCertifiedDiscreteAttribute {
+    export type RequestParams = {
+      /**
+       * The internal identifier of the tenant
+       * @format uuid
+       */
+      tenantId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = CertifiedDiscreteTenantAttributeSeed;
+    export type RequestHeaders = {};
+    export type ResponseBody = void;
+  }
+
+  /**
    * @description Adds the declared attribute to the Institution
    * @tags tenants
    * @name AddDeclaredAttribute
@@ -6819,6 +6872,32 @@ export namespace Tenants {
    * @secure
    */
   export namespace RevokeCertifiedAttribute {
+    export type RequestParams = {
+      /**
+       * Tenant id which attribute needs to be verified
+       * @format uuid
+       */
+      tenantId: string;
+      /**
+       * Attribute id to be revoked
+       * @format uuid
+       */
+      attributeId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = void;
+  }
+
+  /**
+   * @description Revoke a certified discrete attribute to a Tenant by the requester Tenant
+   * @tags tenants
+   * @name RevokeCertifiedDiscreteAttribute
+   * @request DELETE:/tenants/{tenantId}/attributes/certifiedDiscrete/{attributeId}
+   * @secure
+   */
+  export namespace RevokeCertifiedDiscreteAttribute {
     export type RequestParams = {
       /**
        * Tenant id which attribute needs to be verified
@@ -10310,6 +10389,24 @@ export namespace CertifiedAttributes {
     export type RequestParams = {};
     export type RequestQuery = {};
     export type RequestBody = CertifiedAttributeSeed;
+    export type RequestHeaders = {};
+    export type ResponseBody = Attribute;
+  }
+}
+
+export namespace CertifiedDiscreteAttributes {
+  /**
+   * @description Creates the certified discrete attribute passed as payload
+   * @tags attributes
+   * @name CreateCertifiedDiscreteAttribute
+   * @summary Creates certified discrete attribute
+   * @request POST:/certifiedDiscreteAttributes
+   * @secure
+   */
+  export namespace CreateCertifiedDiscreteAttribute {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = AttributeSeed;
     export type RequestHeaders = {};
     export type ResponseBody = Attribute;
   }

--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -2199,7 +2199,7 @@ export interface CertifiedDiscreteTenantAttributeSeed {
    * @min 1
    * @max 1000000000
    */
-  certifiedDiscreteThreshold: number;
+  certifiedDiscreteValue: number;
 }
 
 export interface DelegationTenant {
@@ -3028,7 +3028,15 @@ export interface DeleteAgreementParams {
   agreementId: string;
 }
 
-export interface ActivateAgreementParams {
+export interface ApproveAgreementParams {
+  /**
+   * The identifier of the agreement
+   * @format uuid
+   */
+  agreementId: string;
+}
+
+export interface UnsuspendAgreementParams {
   /**
    * The identifier of the agreement
    * @format uuid
@@ -6321,12 +6329,34 @@ export namespace Agreements {
   /**
    * @description returns the updated agreement
    * @tags agreements
-   * @name ActivateAgreement
+   * @name ApproveAgreement
    * @summary Activate an agreement
-   * @request POST:/agreements/{agreementId}/activate
+   * @request POST:/agreements/{agreementId}/approve
    * @secure
    */
-  export namespace ActivateAgreement {
+  export namespace ApproveAgreement {
+    export type RequestParams = {
+      /**
+       * The identifier of the agreement
+       * @format uuid
+       */
+      agreementId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = DelegationRef;
+    export type RequestHeaders = {};
+    export type ResponseBody = Agreement;
+  }
+
+  /**
+   * @description returns the updated agreement
+   * @tags agreements
+   * @name UnsuspendAgreement
+   * @summary Activate a suspended agreement
+   * @request POST:/agreements/{agreementId}/unsuspend
+   * @secure
+   */
+  export namespace UnsuspendAgreement {
     export type RequestParams = {
       /**
        * The identifier of the agreement
@@ -6891,7 +6921,7 @@ export namespace Tenants {
   }
 
   /**
-   * @description Revoke a certified discrete attribute to a Tenant by the requester Tenant
+   * @description Revoke a certified discrete attribute from a Tenant by the requester Tenant
    * @tags tenants
    * @name RevokeCertifiedDiscreteAttribute
    * @request DELETE:/tenants/{tenantId}/attributes/certifiedDiscrete/{attributeId}

--- a/src/api/attribute/attribute.mutations.ts
+++ b/src/api/attribute/attribute.mutations.ts
@@ -4,9 +4,25 @@ import { AttributeServices } from './attribute.services'
 import type { DeclaredTenantAttributeSeed } from '../api.generatedTypes'
 
 function useCreateCertified() {
-  const { t } = useTranslation('mutations-feedback', { keyPrefix: 'attribute.create' })
+  const { t } = useTranslation('mutations-feedback', {
+    keyPrefix: 'attribute.createCertifiedAttribute',
+  })
   return useMutation({
     mutationFn: AttributeServices.createCertified,
+    meta: {
+      errorToastLabel: t('outcome.error'),
+      loadingLabel: t('loading'),
+      successToastLabel: t('outcome.success'),
+    },
+  })
+}
+
+function useCreateCertifiedDiscrete() {
+  const { t } = useTranslation('mutations-feedback', {
+    keyPrefix: 'attribute.createCertifiedAttribute',
+  })
+  return useMutation({
+    mutationFn: AttributeServices.createCertifiedDiscrete,
     meta: {
       errorToastLabel: t('outcome.error'),
       loadingLabel: t('loading'),
@@ -148,6 +164,7 @@ function useRevokeDeclaredPartyAttribute() {
 
 export const AttributeMutations = {
   useCreateCertified,
+  useCreateCertifiedDiscrete,
   useCreateVerified,
   useCreateDeclared,
   useAddCertifiedAttribute,

--- a/src/api/attribute/attribute.services.ts
+++ b/src/api/attribute/attribute.services.ts
@@ -70,6 +70,14 @@ async function createCertified(payload: CertifiedAttributeSeed) {
   return response.data
 }
 
+async function createCertifiedDiscrete(payload: AttributeSeed) {
+  const response = await axiosInstance.post<Attribute>(
+    `${BACKEND_FOR_FRONTEND_URL}/certifiedDiscreteAttributes`,
+    payload
+  )
+  return response.data
+}
+
 async function createVerified(payload: AttributeSeed) {
   const response = await axiosInstance.post<Attribute>(
     `${BACKEND_FOR_FRONTEND_URL}/verifiedAttributes`,
@@ -162,6 +170,7 @@ export const AttributeServices = {
   getPartyVerifiedList,
   getPartyDeclaredList,
   createCertified,
+  createCertifiedDiscrete,
   createVerified,
   createDeclared,
   addCertifiedAttribute,

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
@@ -89,7 +89,7 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
               name="kind"
               options={kindOptions}
               rules={{ required: true }}
-              aria-controls="thresholdTypeField"
+              aria-controls="threshold-type-field"
             />
           </Stack>
           <Stack spacing={3}>
@@ -117,7 +117,7 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
             />
             {selectedKind === 'CERTIFIED_DISCRETE' && (
               <RHFAutocompleteSingle
-                id="thresholdTypeField"
+                id="threshold-type-field"
                 label={t('form.infoFields.thresholdTypeField.label')}
                 name="thresholdType"
                 size="small"

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
@@ -1,11 +1,7 @@
 import type { AttributeKind } from '@/api/api.generatedTypes'
 import { AttributeMutations } from '@/api/attribute'
 import { Drawer } from '@/components/shared/Drawer'
-import {
-  RHFAutocompleteSingle,
-  RHFRadioGroup,
-  RHFTextField,
-} from '@/components/shared/react-hook-form-inputs'
+import { RHFRadioGroup, RHFTextField } from '@/components/shared/react-hook-form-inputs'
 import { Stack, Typography } from '@mui/material'
 import React from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -21,7 +17,6 @@ type CreateNewAttributeFormValues = {
   kind: Extract<AttributeKind, 'CERTIFIED' | 'CERTIFIED_DISCRETE'>
   name: string
   description: string
-  thresholdType: string
 }
 
 export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
@@ -37,12 +32,11 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
       kind: 'CERTIFIED',
       name: '',
       description: '',
-      thresholdType: undefined,
     },
   })
 
   const onSubmit = formMethods.handleSubmit(
-    ({ kind, name, description, thresholdType }: CreateNewAttributeFormValues) => {
+    ({ kind, name, description }: CreateNewAttributeFormValues) => {
       match(kind)
         .with('CERTIFIED', () =>
           createCertifiedAttribute({ name: name, description: description }, { onSuccess: onClose })
@@ -65,8 +59,6 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
     },
   ] as const
 
-  const selectedKind = formMethods.watch('kind')
-
   return (
     <FormProvider {...formMethods}>
       <Drawer
@@ -85,12 +77,7 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
             <Typography fontWeight={600} variant="label">
               {t('form.kindField.label')}
             </Typography>
-            <RHFRadioGroup
-              name="kind"
-              options={kindOptions}
-              rules={{ required: true }}
-              aria-controls="threshold-type-field"
-            />
+            <RHFRadioGroup name="kind" options={kindOptions} rules={{ required: true }} />
           </Stack>
           <Stack spacing={3}>
             <Typography fontWeight={600} variant="label">
@@ -115,21 +102,6 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
               rules={{ required: true, minLength: 10 }}
               infoLabel={t('form.infoFields.descriptionField.infoLabel')}
             />
-            {selectedKind === 'CERTIFIED_DISCRETE' && (
-              <RHFAutocompleteSingle
-                id="threshold-type-field"
-                label={t('form.infoFields.thresholdTypeField.label')}
-                name="thresholdType"
-                size="small"
-                rules={{ required: true }}
-                options={[
-                  {
-                    label: t('form.infoFields.thresholdTypeField.optionNumericLabel'),
-                    value: 'number',
-                  },
-                ]}
-              />
-            )}
           </Stack>
         </Stack>
       </Drawer>

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
@@ -2,6 +2,7 @@ import type { AttributeKind } from '@/api/api.generatedTypes'
 import { AttributeMutations } from '@/api/attribute'
 import { Drawer } from '@/components/shared/Drawer'
 import { RHFRadioGroup, RHFTextField } from '@/components/shared/react-hook-form-inputs'
+import { FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE } from '@/config/env'
 import { Stack, Typography } from '@mui/material'
 import React from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -41,13 +42,10 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
     ({ kind, name, description }: CreateNewAttributeFormValues) => {
       match(kind)
         .with('CERTIFIED', () =>
-          createCertifiedAttribute({ name: name, description: description }, { onSuccess: onClose })
+          createCertifiedAttribute({ name, description }, { onSuccess: onClose })
         )
         .with('CERTIFIED_DISCRETE', () => {
-          createCertifiedDiscreteAttribute(
-            { name: name, description: description },
-            { onSuccess: onClose }
-          )
+          createCertifiedDiscreteAttribute({ name, description }, { onSuccess: onClose })
         })
         .exhaustive()
     }
@@ -62,7 +60,7 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
       label: t('form.kindField.kindRadio.optionCertifiedDiscreteLabel'),
       value: 'CERTIFIED_DISCRETE',
     },
-  ] as const
+  ]
 
   return (
     <FormProvider {...formMethods}>
@@ -77,38 +75,63 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
         onClose={onClose}
         isOpen={isOpen}
       >
-        <Stack component="form" noValidate spacing={5} mb={3}>
-          <Stack spacing={3}>
-            <Typography fontWeight={600} variant="label">
-              {t('form.kindField.label')}
-            </Typography>
-            <RHFRadioGroup name="kind" options={kindOptions} rules={{ required: true }} />
+        {FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE && (
+          <Stack component="form" noValidate spacing={5} mb={3}>
+            (
+            <Stack spacing={3}>
+              <Typography fontWeight={600} variant="label">
+                {t('form.kindField.label')}
+              </Typography>
+              <RHFRadioGroup name="kind" options={kindOptions} rules={{ required: true }} />
+            </Stack>
+            )
+            <Stack spacing={3}>
+              <Typography fontWeight={600} variant="label">
+                {t('form.infoFields.label')}
+              </Typography>
+              <RHFTextField
+                label={t('form.infoFields.nameField.label')}
+                name="name"
+                inputProps={{ maxLength: 160 }}
+                size="small"
+                required
+                rules={{ required: true, minLength: 5 }}
+                infoLabel={t('form.infoFields.nameField.infoLabel')}
+              />
+              <RHFTextField
+                label={t('form.infoFields.descriptionField.label')}
+                multiline
+                name="description"
+                inputProps={{ maxLength: 250 }}
+                size="small"
+                required
+                rules={{ required: true, minLength: 10 }}
+                infoLabel={t('form.infoFields.descriptionField.infoLabel')}
+              />
+            </Stack>
           </Stack>
-          <Stack spacing={3}>
-            <Typography fontWeight={600} variant="label">
-              {t('form.infoFields.label')}
-            </Typography>
+        )}
+        {!FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE && (
+          <Stack component="form" noValidate spacing={3}>
             <RHFTextField
               label={t('form.infoFields.nameField.label')}
+              labelType="external"
               name="name"
               inputProps={{ maxLength: 160 }}
-              size="small"
-              required
               rules={{ required: true, minLength: 5 }}
               infoLabel={t('form.infoFields.nameField.infoLabel')}
             />
             <RHFTextField
               label={t('form.infoFields.descriptionField.label')}
+              labelType="external"
               multiline
               name="description"
               inputProps={{ maxLength: 250 }}
-              size="small"
-              required
               rules={{ required: true, minLength: 10 }}
               infoLabel={t('form.infoFields.descriptionField.infoLabel')}
             />
           </Stack>
-        </Stack>
+        )}
       </Drawer>
     </FormProvider>
   )

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
@@ -26,6 +26,8 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
   const { t } = useTranslation('party', { keyPrefix: 'tenantCertifier.manageTab.drawer' })
 
   const { mutate: createCertifiedAttribute } = AttributeMutations.useCreateCertified()
+  const { mutate: createCertifiedDiscreteAttribute } =
+    AttributeMutations.useCreateCertifiedDiscrete()
 
   const formMethods = useForm<CreateNewAttributeFormValues>({
     defaultValues: {
@@ -42,7 +44,10 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
           createCertifiedAttribute({ name: name, description: description }, { onSuccess: onClose })
         )
         .with('CERTIFIED_DISCRETE', () => {
-          //TODO
+          createCertifiedDiscreteAttribute(
+            { name: name, description: description },
+            { onSuccess: onClose }
+          )
         })
         .exhaustive()
     }

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
@@ -1,10 +1,16 @@
+import type { AttributeKind } from '@/api/api.generatedTypes'
 import { AttributeMutations } from '@/api/attribute'
 import { Drawer } from '@/components/shared/Drawer'
-import { RHFTextField } from '@/components/shared/react-hook-form-inputs'
-import { Stack } from '@mui/material'
+import {
+  RHFAutocompleteSingle,
+  RHFRadioGroup,
+  RHFTextField,
+} from '@/components/shared/react-hook-form-inputs'
+import { Stack, Typography } from '@mui/material'
 import React from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { match } from 'ts-pattern'
 
 type CreateAttributeDrawerProps = {
   isOpen: boolean
@@ -12,8 +18,10 @@ type CreateAttributeDrawerProps = {
 }
 
 type CreateNewAttributeFormValues = {
+  kind: Extract<AttributeKind, 'CERTIFIED' | 'CERTIFIED_DISCRETE'>
   name: string
   description: string
+  thresholdType: string
 }
 
 export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
@@ -26,14 +34,38 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
 
   const formMethods = useForm<CreateNewAttributeFormValues>({
     defaultValues: {
+      kind: 'CERTIFIED',
       name: '',
       description: '',
+      thresholdType: undefined,
     },
   })
 
-  const onSubmit = formMethods.handleSubmit((values: CreateNewAttributeFormValues) => {
-    createCertifiedAttribute(values, { onSuccess: onClose })
-  })
+  const onSubmit = formMethods.handleSubmit(
+    ({ kind, name, description, thresholdType }: CreateNewAttributeFormValues) => {
+      match(kind)
+        .with('CERTIFIED', () =>
+          createCertifiedAttribute({ name: name, description: description }, { onSuccess: onClose })
+        )
+        .with('CERTIFIED_DISCRETE', () => {
+          //TODO
+        })
+        .exhaustive()
+    }
+  )
+
+  const kindOptions: Array<{
+    label: string
+    value: Extract<AttributeKind, 'CERTIFIED' | 'CERTIFIED_DISCRETE'>
+  }> = [
+    { label: t('form.kindField.kindRadio.optionCertifiedLabel'), value: 'CERTIFIED' },
+    {
+      label: t('form.kindField.kindRadio.optionCertifiedDiscreteLabel'),
+      value: 'CERTIFIED_DISCRETE',
+    },
+  ] as const
+
+  const selectedKind = formMethods.watch('kind')
 
   return (
     <FormProvider {...formMethods}>
@@ -48,24 +80,57 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
         onClose={onClose}
         isOpen={isOpen}
       >
-        <Stack component="form" noValidate spacing={3}>
-          <RHFTextField
-            label={t('form.nameField.label')}
-            labelType="external"
-            name="name"
-            inputProps={{ maxLength: 160 }}
-            rules={{ required: true, minLength: 5 }}
-            infoLabel={t('form.nameField.infoLabel')}
-          />
-          <RHFTextField
-            label={t('form.descriptionField.label')}
-            labelType="external"
-            multiline
-            name="description"
-            inputProps={{ maxLength: 250 }}
-            rules={{ required: true, minLength: 10 }}
-            infoLabel={t('form.descriptionField.infoLabel')}
-          />
+        <Stack component="form" noValidate spacing={5} mb={3}>
+          <Stack spacing={3}>
+            <Typography fontWeight={600} variant="label">
+              {t('form.kindField.label')}
+            </Typography>
+            <RHFRadioGroup
+              name="kind"
+              options={kindOptions}
+              rules={{ required: true }}
+              aria-controls="thresholdTypeField"
+            />
+          </Stack>
+          <Stack spacing={3}>
+            <Typography fontWeight={600} variant="label">
+              {t('form.infoFields.label')}
+            </Typography>
+            <RHFTextField
+              label={t('form.infoFields.nameField.label')}
+              name="name"
+              inputProps={{ maxLength: 160 }}
+              size="small"
+              required
+              rules={{ required: true, minLength: 5 }}
+              infoLabel={t('form.infoFields.nameField.infoLabel')}
+            />
+            <RHFTextField
+              label={t('form.infoFields.descriptionField.label')}
+              multiline
+              name="description"
+              inputProps={{ maxLength: 250 }}
+              size="small"
+              required
+              rules={{ required: true, minLength: 10 }}
+              infoLabel={t('form.infoFields.descriptionField.infoLabel')}
+            />
+            {selectedKind === 'CERTIFIED_DISCRETE' && (
+              <RHFAutocompleteSingle
+                id="thresholdTypeField"
+                label={t('form.infoFields.thresholdTypeField.label')}
+                name="thresholdType"
+                size="small"
+                rules={{ required: true }}
+                options={[
+                  {
+                    label: t('form.infoFields.thresholdTypeField.optionNumericLabel'),
+                    value: 'number',
+                  },
+                ]}
+              />
+            )}
+          </Stack>
         </Stack>
       </Drawer>
     </FormProvider>

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
@@ -77,14 +77,13 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
       >
         {FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE && (
           <Stack component="form" noValidate spacing={5} mb={3}>
-            (
             <Stack spacing={3}>
               <Typography fontWeight={600} variant="label">
                 {t('form.kindField.label')}
               </Typography>
               <RHFRadioGroup name="kind" options={kindOptions} rules={{ required: true }} />
             </Stack>
-            )
+
             <Stack spacing={3}>
               <Typography fontWeight={600} variant="label">
                 {t('form.infoFields.label')}

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/__test__/CreateAttributeDrawer.test.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/__test__/CreateAttributeDrawer.test.tsx
@@ -1,0 +1,126 @@
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import React from 'react'
+import { CreateAttributeDrawer } from '../CreateAttributeDrawer'
+import userEvent from '@testing-library/user-event'
+import { waitFor } from '@testing-library/react'
+
+const { mockCreateCertified, mockCreateCertifiedDiscrete } = vi.hoisted(() => {
+  return {
+    mockCreateCertified: vi.fn(),
+    mockCreateCertifiedDiscrete: vi.fn(),
+  }
+})
+
+vi.mock('@/api/attribute/attribute.services', () => ({
+  AttributeServices: {
+    createCertified: mockCreateCertified,
+    createCertifiedDiscrete: mockCreateCertifiedDiscrete,
+  },
+}))
+
+describe('CreateAttributeDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks() // Pulisce i mock tra un test e l'altro
+  })
+  describe('rendering', () => {
+    it('should not render the drawer when isOpen is false', () => {
+      const screen = renderWithApplicationContext(
+        <CreateAttributeDrawer isOpen={false} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      expect(screen.queryByText('title')).not.toBeInTheDocument()
+      expect(screen.queryByText('subtitle')).not.toBeInTheDocument()
+      expect(screen.queryByText('submitBtnLabel')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('form.infoFields.nameField.label')).not.toBeInTheDocument()
+    })
+
+    it('should render the drawer when isOpen is true', () => {
+      const screen = renderWithApplicationContext(
+        <CreateAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      expect(screen.getByText('title')).toBeInTheDocument()
+      expect(screen.getByText('subtitle')).toBeInTheDocument()
+      expect(screen.getByText('submitBtnLabel')).toBeInTheDocument()
+      expect(screen.getByText('form.infoFields.nameField.label')).toBeInTheDocument()
+    })
+  })
+
+  describe('form submission', () => {
+    it('should call createCertifiedAttribute if attribute kind selected is CERTIFIED', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <CreateAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const radioOptionCertified = screen.getByRole('radio', {
+        name: 'form.kindField.kindRadio.optionCertifiedLabel',
+      })
+
+      await user.click(radioOptionCertified)
+
+      const nameField = screen.getByRole('textbox', { name: 'form.infoFields.nameField.label' })
+      const descriptionField = screen.getByRole('textbox', {
+        name: 'form.infoFields.descriptionField.label',
+      })
+
+      await user.type(nameField, 'test name certified')
+      await user.type(descriptionField, 'test description certified')
+
+      const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockCreateCertifiedDiscrete).not.toBeCalled()
+        expect(mockCreateCertified).toBeCalledWith({
+          name: 'test name certified',
+          description: 'test description certified',
+        })
+      })
+    })
+
+    it('should call createCertifiedAttributeDiscrete if attribute kind selected is CERTIFIED_DISCRETE', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <CreateAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const radioOptionCertified = screen.getByRole('radio', {
+        name: 'form.kindField.kindRadio.optionCertifiedDiscreteLabel',
+      })
+
+      await user.click(radioOptionCertified)
+
+      const nameField = screen.getByRole('textbox', { name: 'form.infoFields.nameField.label' })
+      const descriptionField = screen.getByRole('textbox', {
+        name: 'form.infoFields.descriptionField.label',
+      })
+
+      await user.type(nameField, 'test name certified discrete')
+      await user.type(descriptionField, 'test description certified discrete')
+
+      const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockCreateCertified).not.toBeCalled()
+        expect(mockCreateCertifiedDiscrete).toBeCalledWith({
+          name: 'test name certified discrete',
+          description: 'test description certified discrete',
+        })
+      })
+    })
+  })
+})

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/__test__/CreateAttributeDrawer.test.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/__test__/CreateAttributeDrawer.test.tsx
@@ -20,7 +20,7 @@ vi.mock('@/api/attribute/attribute.services', () => ({
 
 describe('CreateAttributeDrawer', () => {
   beforeEach(() => {
-    vi.clearAllMocks() // Pulisce i mock tra un test e l'altro
+    vi.clearAllMocks()
   })
   describe('rendering', () => {
     it('should not render the drawer when isOpen is false', () => {

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -334,6 +334,13 @@
         "success": "The attribute has been created successfully"
       }
     },
+    "createCertifiedAttribute": {
+      "loading": "We are creating the new attribute.",
+      "outcome": {
+        "error": "The certificate attribute could not be created. Check that you have entered the correct information.",
+        "success": "You have created a new certified attribute."
+      }
+    },
     "addCertifiedAttribute": {
       "loading": "Attribute is being assigned",
       "outcome": {

--- a/src/static/locales/en/party.json
+++ b/src/static/locales/en/party.json
@@ -97,10 +97,6 @@
             "descriptionField": {
               "label": "Attribute description",
               "infoLabel": "Min 10 characters, max 250 characters"
-            },
-            "thresholdTypeField": {
-              "label": "Value type",
-              "optionNumericLabel": "Numeric"
             }
           }
         }

--- a/src/static/locales/en/party.json
+++ b/src/static/locales/en/party.json
@@ -81,13 +81,27 @@
         "subtitle": "Once created, you can assign and revoke this attribute to other parties",
         "submitBtnLabel": "Create attribute",
         "form": {
-          "nameField": {
-            "label": "Attribute name",
-            "infoLabel": "Min 5 characters, max 160 characters"
+          "kindField": {
+            "label": "Type",
+            "kindRadio": {
+            "optionCertifiedLabel": "Certified attribute",
+            "optionCertifiedDiscreteLabel": "Certified attribute with a value to be customized"
+            }
           },
-          "descriptionField": {
-            "label": "Attribute description",
-            "infoLabel": "Min 10 characters, max 250 characters"
+          "infoFields": {
+            "label": "Information",
+            "nameField": {
+              "label": "Attribute name",
+              "infoLabel": "Min 5 characters, max 160 characters"
+            },
+            "descriptionField": {
+              "label": "Attribute description",
+              "infoLabel": "Min 10 characters, max 250 characters"
+            },
+            "thresholdTypeField": {
+              "label": "Value type",
+              "optionNumericLabel": "Numeric"
+            }
           }
         }
       }

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -334,6 +334,13 @@
         "success": "L’attributo è stato creato correttamente"
       }
     },
+    "createCertifiedAttribute": {
+      "loading": "Stiamo creando il nuovo attributo",
+      "outcome": {
+        "error": "Non è stato possibile creare l'attributo certificato. Controlla di aver inserito le informazioni corrette.",
+        "success": "Hai creato un nuovo attributo certificato."
+      }
+    },
     "addCertifiedAttribute": {
       "loading": "Stiamo assegnando l'attributo",
       "outcome": {

--- a/src/static/locales/it/party.json
+++ b/src/static/locales/it/party.json
@@ -97,10 +97,6 @@
             "descriptionField": {
               "label": "Descrizione dell’attributo",
               "infoLabel": "Min 10 caratteri, max 250 caratteri"
-            },
-            "thresholdTypeField": {
-              "label": "Tipo di valore",
-              "optionNumericLabel": "Numerico"
             }
           }
         }

--- a/src/static/locales/it/party.json
+++ b/src/static/locales/it/party.json
@@ -81,13 +81,27 @@
         "subtitle": "Una volta creato, potrai assegnare e revocare questo attributo agli altri enti",
         "submitBtnLabel": "Crea attributo",
         "form": {
-          "nameField": {
-            "label": "Nome dell'attributo",
-            "infoLabel": "Min 5 caratteri, max 160 caratteri"
+          "kindField": {
+            "label": "Tipologia",
+            "kindRadio": {
+            "optionCertifiedLabel": "Attributo certificato",
+            "optionCertifiedDiscreteLabel": "Attributo certificato con valore da personalizzare"
+            }
           },
-          "descriptionField": {
-            "label": "Descrizione dell’attributo",
-            "infoLabel": "Min 10 caratteri, max 250 caratteri"
+          "infoFields": {
+            "label": "Informazioni",
+            "nameField": {
+              "label": "Nome dell'attributo",
+              "infoLabel": "Min 5 caratteri, max 160 caratteri"
+            },
+            "descriptionField": {
+              "label": "Descrizione dell’attributo",
+              "infoLabel": "Min 10 caratteri, max 250 caratteri"
+            },
+            "thresholdTypeField": {
+              "label": "Tipo di valore",
+              "optionNumericLabel": "Numerico"
+            }
           }
         }
       }


### PR DESCRIPTION
## 🔗 Issue

[PIN-10106](https://pagopa.atlassian.net/browse/PIN-10106)

## 📝 Description / Context

This PR add the necessary changes to `CreateAttributeDrawer` inside the certificator page that permit to create a certified discrete attribute

## 🛠 List of changes

- redesign of `CreateAttributeDrawer`
- add new strings


[PIN-10106]: https://pagopa.atlassian.net/browse/PIN-10106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ