### PR TITLE
fix: update schema editor copy (PIN-10549)

### DIFF
--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -300,15 +300,15 @@
         "title": "Interface",
         "description": {
           "rest": "Upload the OpenAPI file that describes the API.",
-          "beforePublishing": "Before publishing, you can use these tools to check:",
-          "technicalCompliance": "technical compliance",
+          "beforePublishing": "Before publishing, you can use these tools to:",
+          "technicalCompliance": "check technical compliance",
           "technicalComplianceDescription": "with the ModI guidelines through",
-          "semanticCompliance": "semantic compliance",
-          "semanticComplianceDescription": "with the National Data Catalog annotations through",
+          "semanticCompliance": "verify semantic quality",
+          "semanticComplianceDescription": "of your data schema through the score calculated by",
           "restLinkLabel": "OpenAPI Checker",
           "schemaEditorLinkLabel": "Schema Editor",
           "restForm": "Fill in these fields to automatically generate the OpenAPI file.",
-          "soap": "Upload the WSDL file that describes the API"
+          "soap": "Upload the WSDL file that describes the API."
         },
         "prettyName": "API specification",
         "dropzoneLabel": "Drag the OpenAPI file here or click here to select it from your computer",

--- a/src/static/locales/en/eserviceTemplate.json
+++ b/src/static/locales/en/eserviceTemplate.json
@@ -342,15 +342,15 @@
           "title": "Interface",
           "alert": "You can upload a file without contact data, terms and conditions, and server URLs, as these will be filled in by the implementer in the next phase.",
           "description": {
-            "rest": "Upload a draft of the OpenAPI specification that describes the API.",
-            "beforePublishing": "Before publishing, you can use these tools to check:",
-            "technicalCompliance": "technical compliance",
+            "rest": "Upload the OpenAPI file that describes the API.",
+            "beforePublishing": "Before publishing, you can use these tools to:",
+            "technicalCompliance": "check technical compliance",
             "technicalComplianceDescription": "with the ModI guidelines through",
-            "semanticCompliance": "semantic compliance",
-            "semanticComplianceDescription": "with the National Data Catalog annotations through",
+            "semanticCompliance": "verify semantic quality",
+            "semanticComplianceDescription": "of your data schema through the score calculated by",
             "restLinkLabel": "OpenAPI Checker",
             "schemaEditorLinkLabel": "Schema Editor",
-            "soap": "Upload a draft of the WSDL specification that describes the API"
+            "soap": "Upload the WSDL file that describes the API."
           },
           "prettyName": "API specification"
         },

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -300,15 +300,15 @@
         "title": "Interfaccia",
         "description": {
           "rest": "Carica il file OpenAPI che descrive l'API.",
-          "beforePublishing": "Prima della pubblicazione, puoi usare questi strumenti per controllare:",
-          "technicalCompliance": "la conformità tecnica",
+          "beforePublishing": "Prima della pubblicazione, puoi usare questi strumenti per:",
+          "technicalCompliance": "controllare la conformità tecnica",
           "technicalComplianceDescription": "secondo le linee guida ModI con",
-          "semanticCompliance": "la conformità semantica",
-          "semanticComplianceDescription": "tramite le annotazioni del Catalogo Nazionale Dati con",
+          "semanticCompliance": "verificare la qualità semantica",
+          "semanticComplianceDescription": "del tuo schema dati attraverso lo score calcolato dallo",
           "restLinkLabel": "OpenAPI Checker",
           "schemaEditorLinkLabel": "Schema Editor",
           "restForm": "Compila questi campi per generare automaticamente il file OpenAPI.",
-          "soap": "Carica il file WSDL che descrive l'API"
+          "soap": "Carica il file WSDL che descrive l'API."
         },
         "prettyName": "Specifica API",
         "dropzoneLabel": "Trascina qui il file OpenAPI oppure clicca qui per selezionarlo dal computer",

--- a/src/static/locales/it/eserviceTemplate.json
+++ b/src/static/locales/it/eserviceTemplate.json
@@ -342,15 +342,15 @@
           "title": "Interfaccia",
           "alert": "Puoi caricare un file senza dati di contatto, Termini e Condizioni e indirizzi dei server: queste informazioni saranno inserite in una fase successiva da chi userà il template.",
           "description": {
-            "rest": "Carica una bozza del file OpenAPI che descrive l'API.",
-            "beforePublishing": "Prima della pubblicazione, puoi usare questi strumenti per controllare:",
-            "technicalCompliance": "la conformità tecnica",
+            "rest": "Carica il file OpenAPI che descrive l'API.",
+            "beforePublishing": "Prima della pubblicazione, puoi usare questi strumenti per:",
+            "technicalCompliance": "controllare la conformità tecnica",
             "technicalComplianceDescription": "secondo le linee guida ModI con",
-            "semanticCompliance": "la conformità semantica",
-            "semanticComplianceDescription": "tramite le annotazioni del Catalogo Nazionale Dati con",
+            "semanticCompliance": "verificare la qualità semantica",
+            "semanticComplianceDescription": "del tuo schema dati attraverso lo score calcolato dallo",
             "restLinkLabel": "OpenAPI Checker",
             "schemaEditorLinkLabel": "Schema Editor",
-            "soap": "Carica una bozza del file WSDL che descrive l'API"
+            "soap": "Carica il file WSDL che descrive l'API."
           },
           "prettyName": "Specifica API"
         },


### PR DESCRIPTION
## 🔗 Issue

[PIN-10549](https://pagopa.atlassian.net/browse/PIN-10549)

## 📝 Description / Context

Updates the interface section copy that points users to OpenAPI Checker and Schema Editor, aligning e-service and e-service template creation/update flows with the requested wording.

## 🛠 List of changes

- Updated REST interface description copy for e-service and e-service template technical specs.
- Updated SOAP interface description copy by removing draft wording for templates.
- Kept English locale files aligned with the Italian copy changes.

## 🧪 How to test

- In the producer e-service creation or new version technical specs step, select a REST API and verify the interface description shows the OpenAPI Checker and Schema Editor guidance.
- In the same flow with SOAP, verify the interface description only asks to upload the WSDL file and does not show the external links.
- In the e-service template creation/update technical specs step, verify REST and SOAP copy match the expected wording and the informational alert is still shown.


[PIN-10549]: https://pagopa.atlassian.net/browse/PIN-10549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ