### PR TITLE
chore/PIN-10551: release version validation action w CR

### DIFF
--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -19,10 +19,12 @@ env:
 jobs:
   validate-dev:
     name: Validate PR towards dev
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write
       pull-requests: write
+    steps:
       - name: Check if PR is an align PR
         id: check_align
         env:
@@ -55,12 +57,12 @@ jobs:
         if: steps.check_align.outputs.skip != 'true'
         env:
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
           echo "Checking PR labels for release tag..."
           echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
 
           COMMENT_MARKER='<!-- release-version-validation -->'
-
           get_warning_comment_id() {
             gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
               --paginate \
@@ -82,6 +84,7 @@ jobs:
               gh pr comment "${{ github.event.pull_request.number }}" \
                 --repo "${{ github.repository }}" \
                 --body "$body" >/dev/null || true
+            fi
           }
 
           delete_warning_comment() {
@@ -111,11 +114,18 @@ jobs:
 
           ALLOWED_MAJOR=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f1)
           ALLOWED_MINOR=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f2)
-          ALLOWED_PREVIOUS_MINOR=$((ALLOWED_MINOR - 1))
 
           LABEL_MAJOR=$(echo "$RELEASE" | cut -d. -f1)
           LABEL_MINOR=$(echo "$RELEASE" | cut -d. -f2)
           LABEL_PATCH=$(echo "$RELEASE" | cut -d. -f3)
+
+          PREVIOUS_HOTFIX_ALLOWED=false
+          if [ "$ALLOWED_MINOR" -gt 0 ]; then
+            ALLOWED_PREVIOUS_MINOR=$((ALLOWED_MINOR - 1))
+            if [ "$LABEL_MAJOR" -eq "$ALLOWED_MAJOR" ] && [ "$LABEL_MINOR" -eq "$ALLOWED_PREVIOUS_MINOR" ] && [ "$LABEL_PATCH" -gt 0 ]; then
+              PREVIOUS_HOTFIX_ALLOWED=true
+            fi
+          fi
 
           if [ "$RELEASE" = "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
             echo "Release label '$RELEASE' matches the allowed release. PR is allowed to merge."
@@ -123,12 +133,12 @@ jobs:
             exit 0
           fi
 
-          if [ "$LABEL_MAJOR" -eq "$ALLOWED_MAJOR" ] && [ "$LABEL_MINOR" -eq "$ALLOWED_PREVIOUS_MINOR" ] && [ "$LABEL_PATCH" -gt 0 ]; then
-            echo "Release label '$RELEASE' is a hotfix for the immediately previous minor release. PR is allowed to merge."
+          if [ "$PREVIOUS_HOTFIX_ALLOWED" = "true" ]; then
+            echo "Release label '$RELEASE' is a valid hotfix for the previous release line. PR is allowed to merge."
             delete_warning_comment || true
             exit 0
           fi
 
           echo "::warning::Release label '$RELEASE' is not within the allowed range for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
-          upsert_warning_comment "$(printf '%b' "$COMMENT_MARKER\n⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is not allowed for merge towards \`dev\`.\nAllowed release: \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nAccepted exception: only the immediately previous minor release with patch greater than 0 is allowed as a hotfix.")" || true
+          upsert_warning_comment "$(printf '%b' "$COMMENT_MARKER\n⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is not allowed for merge towards \`dev\`.\nAllowed release: \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nAccepted exception: only the immediately previous minor release in the same major, with patch greater than 0, is allowed as a hotfix.")" || true
           exit 0

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
       pull-requests: write
     steps:
       - name: Check if PR is an align PR
@@ -34,8 +33,8 @@ jobs:
           get_latest_bot_review_state() {
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --paginate \
-              --jq '.[] | select(.user.login == "github-actions[bot]") | .state' \
-              | tail -n1 || true
+              --slurp \
+              --jq 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | .state // empty' || true
           }
 
           approve_review_if_blocking() {
@@ -73,8 +72,8 @@ jobs:
           get_latest_bot_review_state() {
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --paginate \
-              --jq '.[] | select(.user.login == "github-actions[bot]") | .state' \
-              | tail -n1 || true
+              --slurp \
+              --jq 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | .state // empty' || true
           }
 
           request_changes_review() {
@@ -110,17 +109,27 @@ jobs:
           }
 
           if [[ -z "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" || ! "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::warning::Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is not set or is not in x.y.z format; skipping release validation."
-            approve_review_if_blocking || true
+            echo "::warning::Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is not set or is not in x.y.z format; blocking merge until configuration is fixed."
+            request_changes_review "Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is missing or invalid (expected x.y.z)." || true
             exit 0
           fi
-          RELEASE="$( { echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)"
+          mapfile -t SEMVER_RELEASE_LABELS < <(echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true)
+          SEMVER_LABEL_COUNT="${#SEMVER_RELEASE_LABELS[@]}"
 
-          if [ -z "$RELEASE" ]; then
+          if [ "$SEMVER_LABEL_COUNT" -eq 0 ]; then
             echo "::warning::PR does not have a release label (expected format: x.y.z)."
             request_changes_review "No release label found on the PR (expected format: x.y.z)." || true
             exit 0
           fi
+
+          if [ "$SEMVER_LABEL_COUNT" -gt 1 ]; then
+            LABEL_LIST="$(printf '%s, ' "${SEMVER_RELEASE_LABELS[@]}" | sed 's/, $//')"
+            echo "::warning::PR has multiple release labels in x.y.z format: $LABEL_LIST. Exactly one release label is required."
+            request_changes_review "Multiple release labels found ($LABEL_LIST). Exactly one x.y.z release label is required." || true
+            exit 0
+          fi
+
+          RELEASE="${SEMVER_RELEASE_LABELS[0]}"
 
           echo "Found release label: $RELEASE"
 

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -2,7 +2,17 @@ name: Release version validation
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled, edited, ready_for_review]
+    types:
+      [
+        opened,
+        reopened,
+        synchronize,
+        labeled,
+        unlabeled,
+        edited,
+        ready_for_review,
+        converted_to_draft,
+      ]
 
 concurrency:
   group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
@@ -17,7 +27,7 @@ env:
 jobs:
   validate-dev:
     name: Validate PR towards dev
-    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
+    if: github.event.action == 'converted_to_draft' || (github.event.pull_request.state == 'open' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -92,6 +102,13 @@ jobs:
                 || echo "::warning::Failed to dismiss previous blocking review (id: $review_id)."
             done
           }
+
+          # Early exit: if PR converted to draft, dismiss any blocking review
+          if [[ "$PR_ACTION" == "converted_to_draft" ]]; then
+            echo "PR converted to draft. Dismissing any blocking review."
+            dismiss_blocking_review_if_present
+            exit 0
+          fi
 
           # Only validate for dev branch; dismiss review for any other target branch
           if [[ "$CURRENT_BASE_BRANCH" != "dev" ]]; then

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -47,14 +47,18 @@ jobs:
 
           COMMENT_MARKER='<!-- release-version-validation -->'
 
+          get_warning_comment_id() {
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --paginate \
+              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$COMMENT_MARKER\"))) | .id" \
+              | tail -n1
+          }
+
           upsert_warning_comment() {
             local body="$1"
             local comment_id
 
-            comment_id="$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              --paginate \
-              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$COMMENT_MARKER\"))) | .id" \
-              | tail -n1)"
+            comment_id="$(get_warning_comment_id)"
 
             if [ -n "$comment_id" ]; then
               gh api "repos/${{ github.repository }}/issues/comments/$comment_id" \
@@ -64,6 +68,16 @@ jobs:
               gh pr comment "${{ github.event.pull_request.number }}" \
                 --repo "${{ github.repository }}" \
                 --body "$body" >/dev/null
+            fi
+          }
+
+          delete_warning_comment() {
+            local comment_id
+            comment_id="$(get_warning_comment_id)"
+
+            if [ -n "$comment_id" ]; then
+              gh api "repos/${{ github.repository }}/issues/comments/$comment_id" \
+                --method DELETE >/dev/null
             fi
           }
 
@@ -91,18 +105,16 @@ jobs:
 
           if [ "$RELEASE" = "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
             echo "Release label '$RELEASE' matches the allowed release. PR is allowed to merge."
+            delete_warning_comment || true
             exit 0
           fi
 
           if [ "$LABEL_MAJOR" -eq "$ALLOWED_MAJOR" ] && [ "$LABEL_MINOR" -eq "$ALLOWED_PREVIOUS_MINOR" ] && [ "$LABEL_PATCH" -gt 0 ]; then
             echo "Release label '$RELEASE' is a hotfix for the immediately previous minor release. PR is allowed to merge."
+            delete_warning_comment || true
             exit 0
           fi
 
-          if [ "$RELEASE" != "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
-            echo "::warning::Release label '$RELEASE' is not within the allowed range for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
-            upsert_warning_comment "$(printf '%b' "$COMMENT_MARKER\n⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is not allowed for merge towards \`dev\`.\nAllowed release: \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nAccepted exception: only the immediately previous minor release with patch greater than 0 is allowed as a hotfix.")" || true
-            exit 0
-          fi
-
-          echo "Release label '$RELEASE' is within the allowed range. PR is allowed to merge."
+          echo "::warning::Release label '$RELEASE' is not within the allowed range for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
+          upsert_warning_comment "$(printf '%b' "$COMMENT_MARKER\n⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is not allowed for merge towards \`dev\`.\nAllowed release: \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nAccepted exception: only the immediately previous minor release with patch greater than 0 is allowed as a hotfix.")" || true
+          exit 0

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -36,10 +36,14 @@ jobs:
           echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
 
           get_latest_bot_review_state() {
-            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+            local reviews_json
+            if ! reviews_json="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --paginate \
-              --slurp \
-              --jq 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | .state // empty'
+              --slurp)"; then
+              return 1
+            fi
+
+            echo "$reviews_json" | jq -r 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | .state // empty'
           }
 
           request_changes_review() {

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -62,7 +62,6 @@ jobs:
             fi
 
               echo "Posting REQUEST_CHANGES review with current validation reason."
-              dismiss_blocking_review_if_present
               current_head_sha="${{ github.event.pull_request.head.sha }}"
 
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -83,8 +83,7 @@ jobs:
             else
               gh pr comment "${{ github.event.pull_request.number }}" \
                 --repo "${{ github.repository }}" \
-                --body "$body" >/dev/null
-            fi
+                --body "$body" >/dev/null || true
           }
 
           delete_warning_comment() {

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -30,12 +30,14 @@ jobs:
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 
           echo "Checking PR labels for release tag..."
           echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
 
-          get_latest_bot_review_state() {
+          get_latest_bot_review_info() {
             local reviews_json
             if ! reviews_json="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --paginate \
@@ -43,21 +45,12 @@ jobs:
               return 1
             fi
 
-            echo "$reviews_json" | jq -r 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | .state // empty'
+            echo "$reviews_json" | jq -r 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | [(.id // ""), (.state // "")] | @tsv'
           }
 
           request_changes_review() {
             local reason="$1"
-            local latest_state
-            if ! latest_state="$(get_latest_bot_review_state)"; then
-              echo "::error::Failed to fetch latest bot review state before posting REQUEST_CHANGES review."
-              return 1
-            fi
-
-            if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
-              echo "A blocking review from github-actions[bot] already exists."
-              return 0
-            fi
+            echo "Posting REQUEST_CHANGES review with current validation reason."
 
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --method POST \
@@ -66,26 +59,33 @@ jobs:
               -f body="Release version validation failed. $reason" >/dev/null
           }
 
-          approve_review_if_blocking() {
-            local latest_state
-            if ! latest_state="$(get_latest_bot_review_state)"; then
-              echo "::error::Failed to fetch latest bot review state before posting APPROVE review."
+          dismiss_blocking_review_if_present() {
+            local latest_review_info
+            if ! latest_review_info="$(get_latest_bot_review_info)"; then
+              echo "::error::Failed to fetch latest bot review before attempting dismissal."
               return 1
             fi
 
-            if [ "$latest_state" != "CHANGES_REQUESTED" ]; then
+            if [ -z "$latest_review_info" ]; then
               return 0
             fi
 
-            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
-              --method POST \
-              -f event='APPROVE' \
-              -f commit_id='${{ github.event.pull_request.head.sha }}' \
-              -f body='Release version validation passed. Removing previous blocking review.' >/dev/null
+            local review_id review_state
+            review_id="${latest_review_info%%$'\t'*}"
+            review_state="${latest_review_info#*$'\t'}"
+
+            if [ "$review_state" != "CHANGES_REQUESTED" ] || [ -z "$review_id" ]; then
+              return 0
+            fi
+
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/$review_id/dismissals" \
+              --method PUT \
+              -f message='Release version validation passed. Dismissing previous blocking review.' \
+              -f event='DISMISS' >/dev/null
           }
 
           if [[ "$PR_TITLE" =~ ^align/(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-            approve_review_if_blocking
+            dismiss_blocking_review_if_present
             echo "PR title '$PR_TITLE' is an align PR. Skipping release check."
             exit 0
           fi
@@ -138,13 +138,13 @@ jobs:
 
           if [ "$RELEASE" = "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
             echo "Release label '$RELEASE' matches the allowed release. PR is allowed to merge."
-            approve_review_if_blocking
+            dismiss_blocking_review_if_present
             exit 0
           fi
 
           if [ "$PREVIOUS_HOTFIX_ALLOWED" = "true" ]; then
             echo "Release label '$RELEASE' is a valid hotfix for the previous release line. PR is allowed to merge."
-            approve_review_if_blocking
+            dismiss_blocking_review_if_present
             exit 0
           fi
 

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -55,7 +55,8 @@ jobs:
             echo "::warning::PR does not have a release label (expected format: x.y.z)."
             gh pr comment "${{ github.event.pull_request.number }}" \
               --repo "${{ github.repository }}" \
-              --body "$(printf '%b' "⚠️ **Release version validation warning**\n\nNo release label was found on this PR (expected format: \`x.y.z\`).")" 2>/dev/null || true
+              --edit-last \
+              --body "$(printf '%b' "⚠️ **Release version validation warning**\n\nNo release label was found on this PR (expected format: \`x.y.z\`).")" || true
             exit 0
           fi
 

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -47,7 +47,7 @@ jobs:
               return 1
             fi
 
-            echo "$reviews_json" | jq -r 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | [(.id // ""), (.state // ""), (.body // "")] | @tsv'
+            echo "$reviews_json" | jq -r 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null and (.body // "" | startswith("Release version validation failed.")))) | sort_by(.submitted_at) | last | [(.id // ""), (.state // ""), (.body // "")] | @tsv'
           }
 
           request_changes_review() {

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -110,8 +110,8 @@ jobs:
           fi
 
           if [[ -z "$ALLOWED_RELEASE" || ! "$ALLOWED_RELEASE" =~ $SEMVER_REGEX ]]; then
-            echo "::warning::Repository variable ALLOWED_RELEASE is not set or is not in x.y.z format; blocking merge until configuration is fixed."
-            request_changes_review "Repository variable ALLOWED_RELEASE is missing or invalid (expected x.y.z)."
+            echo "::warning::Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is not set or is not in x.y.z format; blocking merge until configuration is fixed."
+            request_changes_review "Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is missing or invalid (expected x.y.z)."
             exit 0
           fi
           mapfile -t SEMVER_RELEASE_LABELS < <(echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -E "$SEMVER_REGEX" || true)

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -45,18 +45,29 @@ jobs:
               return 1
             fi
 
-            echo "$reviews_json" | jq -r 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | [(.id // ""), (.state // "")] | @tsv'
+            echo "$reviews_json" | jq -r 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | [(.id // ""), (.state // ""), (.body // "")] | @tsv'
           }
 
           request_changes_review() {
             local reason="$1"
+            local desired_body="Release version validation failed. $reason"
+            local latest_id latest_state latest_body
+
+            if IFS=$'\t' read -r latest_id latest_state latest_body < <(get_latest_bot_review_info); then
+              if [ "$latest_state" = "CHANGES_REQUESTED" ] && [ "$latest_body" = "$desired_body" ]; then
+                echo "Existing blocking review already matches current validation reason; skipping."
+                return 0
+              fi
+            fi
+
+            dismiss_blocking_review_if_present
             echo "Posting REQUEST_CHANGES review with current validation reason."
 
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --method POST \
               -f event='REQUEST_CHANGES' \
               -f commit_id='${{ github.event.pull_request.head.sha }}' \
-              -f body="Release version validation failed. $reason" >/dev/null
+              -f body="$desired_body" >/dev/null
           }
 
           dismiss_blocking_review_if_present() {

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -88,7 +88,7 @@ jobs:
             for review_id in "${review_ids[@]}"; do
               gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/$review_id/dismissals" \
                 --method PUT \
-                -f message='Release version validation passed. Dismissing previous blocking review.' >/dev/null \
+                -f message='Release version validation updated. Dismissing previous blocking review.' >/dev/null \
                 || echo "::warning::Failed to dismiss previous blocking review (id: $review_id)."
             done
           }

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -48,8 +48,11 @@ jobs:
           RELEASE="$( { echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)"
 
           if [ -z "$RELEASE" ]; then
-            echo "::error::PR does not have a release label (expected format: x.y.z)"
-            exit 1
+            echo "::warning::PR does not have a release label (expected format: x.y.z)."
+            gh pr comment "${{ github.event.pull_request.number }}" \
+              --repo "${{ github.repository }}" \
+              --body "$(printf '%b' "⚠️ **Release version validation warning**\n\nNo release label was found on this PR (expected format: \`x.y.z\`).")" 2>/dev/null || true
+            exit 0
           fi
 
           echo "Found release label: $RELEASE"

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -31,22 +31,30 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          COMMENT_MARKER='<!-- release-version-validation -->'
-
-          delete_warning_comment() {
-            local comment_id
-            comment_id="$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+          get_latest_bot_review_state() {
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --paginate \
-              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$COMMENT_MARKER\"))) | .id" \
-              | tail -n1 || true)"
+              --jq '.[] | select(.user.login == "github-actions[bot]") | .state' \
+              | tail -n1 || true
+          }
 
-            if [ -n "$comment_id" ]; then
-              gh api "repos/${{ github.repository }}/issues/comments/$comment_id" --method DELETE >/dev/null || true
+          approve_review_if_blocking() {
+            local latest_state
+            latest_state="$(get_latest_bot_review_state)"
+
+            if [ "$latest_state" != "CHANGES_REQUESTED" ]; then
+              return 0
             fi
+
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+              --method POST \
+              -f event='APPROVE' \
+              -f commit_id='${{ github.event.pull_request.head.sha }}' \
+              -f body='Release version validation skipped for align PR. Removing previous blocking review.' >/dev/null || true
           }
 
           if [[ "$PR_TITLE" =~ ^align/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            delete_warning_comment
+            approve_review_if_blocking || true
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "PR title '$PR_TITLE' is an align PR. Skipping release check."
           else
@@ -61,41 +69,6 @@ jobs:
         run: |
           echo "Checking PR labels for release tag..."
           echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
-
-          COMMENT_MARKER='<!-- release-version-validation -->'
-          get_warning_comment_id() {
-            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              --paginate \
-              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$COMMENT_MARKER\"))) | .id" \
-              | tail -n1 || true
-          }
-
-          upsert_warning_comment() {
-            local body="$1"
-            local comment_id
-
-            comment_id="$(get_warning_comment_id)"
-
-            if [ -n "$comment_id" ]; then
-              gh api "repos/${{ github.repository }}/issues/comments/$comment_id" \
-                --method PATCH \
-                -f body="$body" >/dev/null || true
-            else
-              gh pr comment "${{ github.event.pull_request.number }}" \
-                --repo "${{ github.repository }}" \
-                --body "$body" >/dev/null || true
-            fi
-          }
-
-          delete_warning_comment() {
-            local comment_id
-            comment_id="$(get_warning_comment_id)"
-
-            if [ -n "$comment_id" ]; then
-              gh api "repos/${{ github.repository }}/issues/comments/$comment_id" \
-                --method DELETE >/dev/null || true
-            fi
-          }
 
           get_latest_bot_review_state() {
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
@@ -138,14 +111,13 @@ jobs:
 
           if [[ -z "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" || ! "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::warning::Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is not set or is not in x.y.z format; skipping release validation."
-            delete_warning_comment || true
+            approve_review_if_blocking || true
             exit 0
           fi
           RELEASE="$( { echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)"
 
           if [ -z "$RELEASE" ]; then
             echo "::warning::PR does not have a release label (expected format: x.y.z)."
-            upsert_warning_comment "$(printf '%b' "$COMMENT_MARKER\n⚠️ **Release version validation warning**\n\nNo release label was found on this PR (expected format: \`x.y.z\`).")" || true
             request_changes_review "No release label found on the PR (expected format: x.y.z)." || true
             exit 0
           fi
@@ -169,19 +141,16 @@ jobs:
 
           if [ "$RELEASE" = "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
             echo "Release label '$RELEASE' matches the allowed release. PR is allowed to merge."
-            delete_warning_comment || true
             approve_review_if_blocking || true
             exit 0
           fi
 
           if [ "$PREVIOUS_HOTFIX_ALLOWED" = "true" ]; then
             echo "Release label '$RELEASE' is a valid hotfix for the previous release line. PR is allowed to merge."
-            delete_warning_comment || true
             approve_review_if_blocking || true
             exit 0
           fi
 
           echo "::warning::Release label '$RELEASE' is not within the allowed range for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
-          upsert_warning_comment "$(printf '%b' "$COMMENT_MARKER\n⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is not allowed for merge towards \`dev\`.\nAllowed release: \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nAccepted exception: only the immediately previous minor release in the same major, with patch greater than 0, is allowed as a hotfix.")" || true
           request_changes_review "Release label '$RELEASE' is not allowed for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'." || true
           exit 0

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -56,8 +56,7 @@ jobs:
         if: steps.check_align.outputs.skip != 'true'
         env:
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           echo "Checking PR labels for release tag..."
           echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
 

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -80,8 +80,8 @@ jobs:
 
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/$review_id/dismissals" \
               --method PUT \
-              -f message='Release version validation passed. Dismissing previous blocking review.' \
-              -f event='DISMISS' >/dev/null
+              -f message='Release version validation passed. Dismissing previous blocking review.' >/dev/null \
+              || echo "::warning::Failed to dismiss previous blocking review (id: $review_id)."
           }
 
           if [[ "$PR_TITLE" =~ ^align/(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -2,17 +2,7 @@ name: Release version validation
 
 on:
   pull_request:
-    types:
-      [
-        opened,
-        reopened,
-        synchronize,
-        labeled,
-        unlabeled,
-        edited,
-        ready_for_review,
-        converted_to_draft,
-      ]
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited, ready_for_review, converted_to_draft]
 
 concurrency:
   group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -1,7 +1,7 @@
 name: Release version validation
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled, edited, ready_for_review]
     branches:
       - 'dev'

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -61,8 +61,9 @@ jobs:
               fi
             fi
 
-            echo "Posting REQUEST_CHANGES review with current validation reason."
-            current_head_sha="${{ github.event.pull_request.head.sha }}"
+              echo "Posting REQUEST_CHANGES review with current validation reason."
+              dismiss_blocking_review_if_present
+              current_head_sha="${{ github.event.pull_request.head.sha }}"
 
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --method POST \

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  ALLOWED_RELEASE_TOWARDS_DEV_BRANCH: '2.21.0'
+  ALLOWED_RELEASE_TOWARDS_DEV_BRANCH: ${{ vars.ALLOWED_RELEASE_TOWARDS_DEV_BRANCH }}
 
 jobs:
   validate-dev:

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -58,8 +58,8 @@ jobs:
 
           echo "Found release label: $RELEASE"
 
-          if [ "$RELEASE" != "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
-            echo "::error::Release label '$RELEASE' does not match the allowed release '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'"
+          if [ "$(printf '%s\n%s\n' "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" "$RELEASE" | sort -V | tail -n1)" != "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
+            echo "::error::Release label '$RELEASE' is higher than the allowed release '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'"
             echo "If you wish to merge this PR in the future, please wait until it is permitted."
             exit 1
           fi

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -79,7 +79,8 @@ jobs:
             echo "::warning::Release label '$RELEASE' is higher than the allowed release '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
             gh pr comment "${{ github.event.pull_request.number }}" \
               --repo "${{ github.repository }}" \
-              --body "$(printf '%b' "⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is higher than the currently allowed release \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nIf you wish to merge this PR, please wait until it is permitted.")" 2>/dev/null || true
+              --edit-last \
+              --body "$(printf '%b' "⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is higher than the currently allowed release \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nIf you wish to merge this PR, please wait until it is permitted.")" || true
             exit 0
           fi
 

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -45,6 +45,10 @@ jobs:
           echo "Checking PR labels for release tag..."
           echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
 
+          if [[ -z "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" || ! "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::warning::Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is not set or is not in x.y.z format; skipping release validation."
+            exit 0
+          fi
           RELEASE="$( { echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)"
 
           if [ -z "$RELEASE" ]; then

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -36,7 +36,7 @@ jobs:
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 
           echo "Checking PR labels for release tag..."
-          echo "Allowed release: $ALLOWED_RELEASE"
+          echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
 
           get_latest_bot_review_info() {
             local reviews_json

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -24,48 +24,14 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Check if PR is an align PR
-        id: check_align
+      - name: Check release label on PR
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          get_latest_bot_review_state() {
-            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
-              --paginate \
-              --slurp \
-              --jq 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | .state // empty' || true
-          }
-
-          approve_review_if_blocking() {
-            local latest_state
-            latest_state="$(get_latest_bot_review_state)"
-
-            if [ "$latest_state" != "CHANGES_REQUESTED" ]; then
-              return 0
-            fi
-
-            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
-              --method POST \
-              -f event='APPROVE' \
-              -f commit_id='${{ github.event.pull_request.head.sha }}' \
-              -f body='Release version validation skipped for align PR. Removing previous blocking review.' >/dev/null || true
-          }
-
-          if [[ "$PR_TITLE" =~ ^align/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            approve_review_if_blocking || true
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "PR title '$PR_TITLE' is an align PR. Skipping release check."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Check release label on PR
-        if: steps.check_align.outputs.skip != 'true'
-        env:
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+
           echo "Checking PR labels for release tag..."
           echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
 
@@ -73,13 +39,16 @@ jobs:
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --paginate \
               --slurp \
-              --jq 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | .state // empty' || true
+              --jq 'flatten | map(select(.user.login == "github-actions[bot]" and .submitted_at != null)) | sort_by(.submitted_at) | last | .state // empty'
           }
 
           request_changes_review() {
             local reason="$1"
             local latest_state
-            latest_state="$(get_latest_bot_review_state)"
+            if ! latest_state="$(get_latest_bot_review_state)"; then
+              echo "::error::Failed to fetch latest bot review state before posting REQUEST_CHANGES review."
+              return 1
+            fi
 
             if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
               echo "A blocking review from github-actions[bot] already exists."
@@ -90,12 +59,15 @@ jobs:
               --method POST \
               -f event='REQUEST_CHANGES' \
               -f commit_id='${{ github.event.pull_request.head.sha }}' \
-              -f body="Release version validation failed. $reason" >/dev/null || true
+              -f body="Release version validation failed. $reason" >/dev/null
           }
 
           approve_review_if_blocking() {
             local latest_state
-            latest_state="$(get_latest_bot_review_state)"
+            if ! latest_state="$(get_latest_bot_review_state)"; then
+              echo "::error::Failed to fetch latest bot review state before posting APPROVE review."
+              return 1
+            fi
 
             if [ "$latest_state" != "CHANGES_REQUESTED" ]; then
               return 0
@@ -105,27 +77,33 @@ jobs:
               --method POST \
               -f event='APPROVE' \
               -f commit_id='${{ github.event.pull_request.head.sha }}' \
-              -f body='Release version validation passed. Removing previous blocking review.' >/dev/null || true
+              -f body='Release version validation passed. Removing previous blocking review.' >/dev/null
           }
 
-          if [[ -z "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" || ! "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::warning::Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is not set or is not in x.y.z format; blocking merge until configuration is fixed."
-            request_changes_review "Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is missing or invalid (expected x.y.z)." || true
+          if [[ "$PR_TITLE" =~ ^align/(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            approve_review_if_blocking
+            echo "PR title '$PR_TITLE' is an align PR. Skipping release check."
             exit 0
           fi
-          mapfile -t SEMVER_RELEASE_LABELS < <(echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true)
+
+          if [[ -z "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" || ! "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" =~ $SEMVER_REGEX ]]; then
+            echo "::warning::Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is not set or is not in x.y.z format; blocking merge until configuration is fixed."
+            request_changes_review "Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is missing or invalid (expected x.y.z)."
+            exit 0
+          fi
+          mapfile -t SEMVER_RELEASE_LABELS < <(echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -E "$SEMVER_REGEX" || true)
           SEMVER_LABEL_COUNT="${#SEMVER_RELEASE_LABELS[@]}"
 
           if [ "$SEMVER_LABEL_COUNT" -eq 0 ]; then
             echo "::warning::PR does not have a release label (expected format: x.y.z)."
-            request_changes_review "No release label found on the PR (expected format: x.y.z)." || true
+            request_changes_review "No release label found on the PR (expected format: x.y.z)."
             exit 0
           fi
 
           if [ "$SEMVER_LABEL_COUNT" -gt 1 ]; then
             LABEL_LIST="$(printf '%s, ' "${SEMVER_RELEASE_LABELS[@]}" | sed 's/, $//')"
             echo "::warning::PR has multiple release labels in x.y.z format: $LABEL_LIST. Exactly one release label is required."
-            request_changes_review "Multiple release labels found ($LABEL_LIST). Exactly one x.y.z release label is required." || true
+            request_changes_review "Multiple release labels found ($LABEL_LIST). Exactly one x.y.z release label is required."
             exit 0
           fi
 
@@ -133,12 +111,18 @@ jobs:
 
           echo "Found release label: $RELEASE"
 
-          ALLOWED_MAJOR=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f1)
-          ALLOWED_MINOR=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f2)
+          ALLOWED_MAJOR_RAW=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f1)
+          ALLOWED_MINOR_RAW=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f2)
 
-          LABEL_MAJOR=$(echo "$RELEASE" | cut -d. -f1)
-          LABEL_MINOR=$(echo "$RELEASE" | cut -d. -f2)
-          LABEL_PATCH=$(echo "$RELEASE" | cut -d. -f3)
+          LABEL_MAJOR_RAW=$(echo "$RELEASE" | cut -d. -f1)
+          LABEL_MINOR_RAW=$(echo "$RELEASE" | cut -d. -f2)
+          LABEL_PATCH_RAW=$(echo "$RELEASE" | cut -d. -f3)
+
+          ALLOWED_MAJOR=$((10#$ALLOWED_MAJOR_RAW))
+          ALLOWED_MINOR=$((10#$ALLOWED_MINOR_RAW))
+          LABEL_MAJOR=$((10#$LABEL_MAJOR_RAW))
+          LABEL_MINOR=$((10#$LABEL_MINOR_RAW))
+          LABEL_PATCH=$((10#$LABEL_PATCH_RAW))
 
           PREVIOUS_HOTFIX_ALLOWED=false
           if [ "$ALLOWED_MINOR" -gt 0 ]; then
@@ -150,16 +134,16 @@ jobs:
 
           if [ "$RELEASE" = "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
             echo "Release label '$RELEASE' matches the allowed release. PR is allowed to merge."
-            approve_review_if_blocking || true
+            approve_review_if_blocking
             exit 0
           fi
 
           if [ "$PREVIOUS_HOTFIX_ALLOWED" = "true" ]; then
             echo "Release label '$RELEASE' is a valid hotfix for the previous release line. PR is allowed to merge."
-            approve_review_if_blocking || true
+            approve_review_if_blocking
             exit 0
           fi
 
           echo "::warning::Release label '$RELEASE' is not within the allowed range for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
-          request_changes_review "Release label '$RELEASE' is not allowed for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'." || true
+          request_changes_review "Release label '$RELEASE' is not allowed for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
           exit 0

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -71,12 +71,7 @@ jobs:
             echo "::warning::Release label '$RELEASE' is higher than the allowed release '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'. This PR cannot be merged yet."
             gh pr comment "${{ github.event.pull_request.number }}" \
               --repo "${{ github.repository }}" \
-              --body-file - 2>/dev/null <<EOF || true
-⚠️ **Release version validation warning**
-
-Release label \`$RELEASE\` is higher than the currently allowed release \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.
-If you wish to merge this PR, please wait until it is permitted.
-EOF
+              --body "$(printf '%b' "⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is higher than the currently allowed release \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nIf you wish to merge this PR, please wait until it is permitted.")" 2>/dev/null || true
           fi
 
           echo "Release label matches. PR is allowed to merge."

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -99,6 +99,7 @@ jobs:
 
           if [[ -z "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" || ! "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::warning::Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is not set or is not in x.y.z format; skipping release validation."
+            delete_warning_comment || true
             exit 0
           fi
           RELEASE="$( { echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)"

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -79,7 +79,7 @@ jobs:
             if [ -n "$comment_id" ]; then
               gh api "repos/${{ github.repository }}/issues/comments/$comment_id" \
                 --method PATCH \
-                -f body="$body" >/dev/null
+                -f body="$body" >/dev/null || true
             else
               gh pr comment "${{ github.event.pull_request.number }}" \
                 --repo "${{ github.repository }}" \

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -39,18 +39,12 @@ jobs:
       - name: Check release label on PR
         if: steps.check_align.outputs.skip != 'true'
         env:
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           echo "Checking PR labels for release tag..."
           echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
 
-          RELEASE=""
-          for LABEL in $PR_LABELS; do
-            if echo "$LABEL" | grep -qP '^\d+\.\d+\.\d+$'; then
-              RELEASE="$LABEL"
-              break
-            fi
-          done
+          RELEASE="$(echo "$PR_LABELS_JSON" | jq -r '.[]' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)"
 
           if [ -z "$RELEASE" ]; then
             echo "::error::PR does not have a release label (expected format: x.y.z)"

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -28,7 +28,6 @@ jobs:
     steps:
       - name: Check release label on PR
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -67,7 +67,7 @@ jobs:
             gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
               --paginate \
               --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$COMMENT_MARKER\"))) | .id" \
-              | tail -n1
+              | tail -n1 || true
           }
 
           upsert_warning_comment() {

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -63,7 +63,7 @@ jobs:
             fi
 
             echo "Posting REQUEST_CHANGES review with current validation reason."
-            current_head_sha="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.head.sha')"
+            current_head_sha="${{ github.event.pull_request.head.sha }}"
 
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --method POST \

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -2,7 +2,7 @@ name: Release version validation
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled, edited]
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited, ready_for_review]
     branches:
       - 'dev'
 
@@ -19,7 +19,9 @@ env:
 jobs:
   validate-dev:
     name: Validate PR towards dev
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -28,8 +28,24 @@ jobs:
         id: check_align
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          GH_TOKEN: ${{ github.token }}
         run: |
+          COMMENT_MARKER='<!-- release-version-validation -->'
+
+          delete_warning_comment() {
+            local comment_id
+            comment_id="$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --paginate \
+              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$COMMENT_MARKER\"))) | .id" \
+              | tail -n1 || true)"
+
+            if [ -n "$comment_id" ]; then
+              gh api "repos/${{ github.repository }}/issues/comments/$comment_id" --method DELETE >/dev/null || true
+            fi
+          }
+
           if [[ "$PR_TITLE" =~ ^align/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            delete_warning_comment
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "PR title '$PR_TITLE' is an align PR. Skipping release check."
           else

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -97,6 +97,45 @@ jobs:
             fi
           }
 
+          get_latest_bot_review_state() {
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+              --paginate \
+              --jq '.[] | select(.user.login == "github-actions[bot]") | .state' \
+              | tail -n1 || true
+          }
+
+          request_changes_review() {
+            local reason="$1"
+            local latest_state
+            latest_state="$(get_latest_bot_review_state)"
+
+            if [ "$latest_state" = "CHANGES_REQUESTED" ]; then
+              echo "A blocking review from github-actions[bot] already exists."
+              return 0
+            fi
+
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+              --method POST \
+              -f event='REQUEST_CHANGES' \
+              -f commit_id='${{ github.event.pull_request.head.sha }}' \
+              -f body="Release version validation failed. $reason" >/dev/null || true
+          }
+
+          approve_review_if_blocking() {
+            local latest_state
+            latest_state="$(get_latest_bot_review_state)"
+
+            if [ "$latest_state" != "CHANGES_REQUESTED" ]; then
+              return 0
+            fi
+
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+              --method POST \
+              -f event='APPROVE' \
+              -f commit_id='${{ github.event.pull_request.head.sha }}' \
+              -f body='Release version validation passed. Removing previous blocking review.' >/dev/null || true
+          }
+
           if [[ -z "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" || ! "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::warning::Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is not set or is not in x.y.z format; skipping release validation."
             delete_warning_comment || true
@@ -107,6 +146,7 @@ jobs:
           if [ -z "$RELEASE" ]; then
             echo "::warning::PR does not have a release label (expected format: x.y.z)."
             upsert_warning_comment "$(printf '%b' "$COMMENT_MARKER\n⚠️ **Release version validation warning**\n\nNo release label was found on this PR (expected format: \`x.y.z\`).")" || true
+            request_changes_review "No release label found on the PR (expected format: x.y.z)." || true
             exit 0
           fi
 
@@ -130,15 +170,18 @@ jobs:
           if [ "$RELEASE" = "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
             echo "Release label '$RELEASE' matches the allowed release. PR is allowed to merge."
             delete_warning_comment || true
+            approve_review_if_blocking || true
             exit 0
           fi
 
           if [ "$PREVIOUS_HOTFIX_ALLOWED" = "true" ]; then
             echo "Release label '$RELEASE' is a valid hotfix for the previous release line. PR is allowed to merge."
             delete_warning_comment || true
+            approve_review_if_blocking || true
             exit 0
           fi
 
           echo "::warning::Release label '$RELEASE' is not within the allowed range for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
           upsert_warning_comment "$(printf '%b' "$COMMENT_MARKER\n⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is not allowed for merge towards \`dev\`.\nAllowed release: \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nAccepted exception: only the immediately previous minor release in the same major, with patch greater than 0, is allowed as a hotfix.")" || true
+          request_changes_review "Release label '$RELEASE' is not allowed for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'." || true
           exit 0

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if echo "$PR_TITLE" | grep -qP '^align/\d+\.\d+\.\d+$'; then
+          if [[ "$PR_TITLE" =~ ^align/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "PR title '$PR_TITLE' is an align PR. Skipping release check."
           else

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -1,0 +1,67 @@
+name: Release version validation
+
+on:
+  pull_request:
+    branches:
+      - 'dev'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ALLOWED_RELEASE_TOWARDS_DEV_BRANCH: '2.21.0'
+
+jobs:
+  validate-dev:
+    name: Validate PR towards dev
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check if PR is an align PR
+        id: check_align
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$PR_TITLE" | grep -qP '^align/\d+\.\d+\.\d+$'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "PR title '$PR_TITLE' is an align PR. Skipping release check."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check release label on PR
+        if: steps.check_align.outputs.skip != 'true'
+        env:
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        run: |
+          echo "Checking PR labels for release tag..."
+          echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
+
+          RELEASE=""
+          for LABEL in $PR_LABELS; do
+            if echo "$LABEL" | grep -qP '^\d+\.\d+\.\d+$'; then
+              RELEASE="$LABEL"
+              break
+            fi
+          done
+
+          if [ -z "$RELEASE" ]; then
+            echo "::error::PR does not have a release label (expected format: x.y.z)"
+            exit 1
+          fi
+
+          echo "Found release label: $RELEASE"
+
+          if [ "$RELEASE" != "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
+            echo "::error::Release label '$RELEASE' does not match the allowed release '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'"
+            echo "If you wish to merge this PR in the future, please wait until it is permitted."
+            exit 1
+          fi
+
+          echo "Release label matches. PR is allowed to merge."

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -63,11 +63,12 @@ jobs:
             fi
 
             echo "Posting REQUEST_CHANGES review with current validation reason."
+            current_head_sha="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.head.sha')"
 
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
               --method POST \
               -f event='REQUEST_CHANGES' \
-              -f commit_id='${{ github.event.pull_request.head.sha }}' \
+              -f commit_id="$current_head_sha" \
               -f body="$desired_body" >/dev/null
           }
 

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -44,7 +44,7 @@ jobs:
           echo "Checking PR labels for release tag..."
           echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
 
-          RELEASE="$(echo "$PR_LABELS_JSON" | jq -r '.[]' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)"
+          RELEASE="$( { echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)"
 
           if [ -z "$RELEASE" ]; then
             echo "::error::PR does not have a release label (expected format: x.y.z)"

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -75,10 +75,11 @@ jobs:
           fi
 
           if [ "$(printf '%s\n%s\n' "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" "$RELEASE" | sort -V | tail -n1)" != "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
-            echo "::warning::Release label '$RELEASE' is higher than the allowed release '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'. This PR cannot be merged yet."
+            echo "::warning::Release label '$RELEASE' is higher than the allowed release '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
             gh pr comment "${{ github.event.pull_request.number }}" \
               --repo "${{ github.repository }}" \
               --body "$(printf '%b' "⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is higher than the currently allowed release \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nIf you wish to merge this PR, please wait until it is permitted.")" 2>/dev/null || true
+            exit 0
           fi
 
-          echo "Release label matches. PR is allowed to merge."
+          echo "Release label '$RELEASE' is within the allowed range. PR is allowed to merge."

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -56,13 +56,14 @@ jobs:
 
           ALLOWED_MAJOR=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f1)
           ALLOWED_MINOR=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f2)
+          ALLOWED_PREVIOUS_MINOR=$((ALLOWED_MINOR - 1))
 
           LABEL_MAJOR=$(echo "$RELEASE" | cut -d. -f1)
           LABEL_MINOR=$(echo "$RELEASE" | cut -d. -f2)
           LABEL_PATCH=$(echo "$RELEASE" | cut -d. -f3)
 
-          if [ "$LABEL_MAJOR" -eq "$ALLOWED_MAJOR" ] && [ "$LABEL_MINOR" -lt "$ALLOWED_MINOR" ] && [ "$LABEL_PATCH" -gt 0 ]; then
-            echo "Release label '$RELEASE' is a hotfix for a previous minor release. PR is allowed to merge."
+          if [ "$LABEL_MAJOR" -eq "$ALLOWED_MAJOR" ] && [ "$LABEL_MINOR" -eq "$ALLOWED_PREVIOUS_MINOR" ] && [ "$LABEL_PATCH" -gt 0 ]; then
+            echo "Release label '$RELEASE' is a hotfix for the immediately previous minor release. PR is allowed to merge."
             exit 0
           fi
 
@@ -70,10 +71,12 @@ jobs:
             echo "::warning::Release label '$RELEASE' is higher than the allowed release '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'. This PR cannot be merged yet."
             gh pr comment "${{ github.event.pull_request.number }}" \
               --repo "${{ github.repository }}" \
-              --body "⚠️ **Release version validation warning**
+              --body-file - 2>/dev/null <<EOF || true
+⚠️ **Release version validation warning**
 
 Release label \`$RELEASE\` is higher than the currently allowed release \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.
-If you wish to merge this PR, please wait until it is permitted." 2>/dev/null || true
+If you wish to merge this PR, please wait until it is permitted.
+EOF
           fi
 
           echo "Release label matches. PR is allowed to merge."

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -93,7 +93,7 @@ jobs:
 
             if [ -n "$comment_id" ]; then
               gh api "repos/${{ github.repository }}/issues/comments/$comment_id" \
-                --method DELETE >/dev/null
+                --method DELETE >/dev/null || true
             fi
           }
 

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -45,6 +45,28 @@ jobs:
           echo "Checking PR labels for release tag..."
           echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
 
+          COMMENT_MARKER='<!-- release-version-validation -->'
+
+          upsert_warning_comment() {
+            local body="$1"
+            local comment_id
+
+            comment_id="$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --paginate \
+              --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$COMMENT_MARKER\"))) | .id" \
+              | tail -n1)"
+
+            if [ -n "$comment_id" ]; then
+              gh api "repos/${{ github.repository }}/issues/comments/$comment_id" \
+                --method PATCH \
+                -f body="$body" >/dev/null
+            else
+              gh pr comment "${{ github.event.pull_request.number }}" \
+                --repo "${{ github.repository }}" \
+                --body "$body" >/dev/null
+            fi
+          }
+
           if [[ -z "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" || ! "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::warning::Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is not set or is not in x.y.z format; skipping release validation."
             exit 0
@@ -53,10 +75,7 @@ jobs:
 
           if [ -z "$RELEASE" ]; then
             echo "::warning::PR does not have a release label (expected format: x.y.z)."
-            gh pr comment "${{ github.event.pull_request.number }}" \
-              --repo "${{ github.repository }}" \
-              --edit-last \
-              --body "$(printf '%b' "⚠️ **Release version validation warning**\n\nNo release label was found on this PR (expected format: \`x.y.z\`).")" || true
+            upsert_warning_comment "$(printf '%b' "$COMMENT_MARKER\n⚠️ **Release version validation warning**\n\nNo release label was found on this PR (expected format: \`x.y.z\`).")" || true
             exit 0
           fi
 
@@ -70,17 +89,19 @@ jobs:
           LABEL_MINOR=$(echo "$RELEASE" | cut -d. -f2)
           LABEL_PATCH=$(echo "$RELEASE" | cut -d. -f3)
 
+          if [ "$RELEASE" = "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
+            echo "Release label '$RELEASE' matches the allowed release. PR is allowed to merge."
+            exit 0
+          fi
+
           if [ "$LABEL_MAJOR" -eq "$ALLOWED_MAJOR" ] && [ "$LABEL_MINOR" -eq "$ALLOWED_PREVIOUS_MINOR" ] && [ "$LABEL_PATCH" -gt 0 ]; then
             echo "Release label '$RELEASE' is a hotfix for the immediately previous minor release. PR is allowed to merge."
             exit 0
           fi
 
-          if [ "$(printf '%s\n%s\n' "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" "$RELEASE" | sort -V | tail -n1)" != "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
-            echo "::warning::Release label '$RELEASE' is higher than the allowed release '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
-            gh pr comment "${{ github.event.pull_request.number }}" \
-              --repo "${{ github.repository }}" \
-              --edit-last \
-              --body "$(printf '%b' "⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is higher than the currently allowed release \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nIf you wish to merge this PR, please wait until it is permitted.")" || true
+          if [ "$RELEASE" != "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
+            echo "::warning::Release label '$RELEASE' is not within the allowed range for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
+            upsert_warning_comment "$(printf '%b' "$COMMENT_MARKER\n⚠️ **Release version validation warning**\n\nRelease label \`$RELEASE\` is not allowed for merge towards \`dev\`.\nAllowed release: \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.\nAccepted exception: only the immediately previous minor release with patch greater than 0 is allowed as a hotfix.")" || true
             exit 0
           fi
 

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -62,7 +62,6 @@ jobs:
               fi
             fi
 
-            dismiss_blocking_review_if_present
             echo "Posting REQUEST_CHANGES review with current validation reason."
 
             gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Check if PR is an align PR
         id: check_align
@@ -40,6 +40,7 @@ jobs:
         if: steps.check_align.outputs.skip != 'true'
         env:
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "Checking PR labels for release tag..."
           echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
@@ -53,10 +54,26 @@ jobs:
 
           echo "Found release label: $RELEASE"
 
+          ALLOWED_MAJOR=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f1)
+          ALLOWED_MINOR=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f2)
+
+          LABEL_MAJOR=$(echo "$RELEASE" | cut -d. -f1)
+          LABEL_MINOR=$(echo "$RELEASE" | cut -d. -f2)
+          LABEL_PATCH=$(echo "$RELEASE" | cut -d. -f3)
+
+          if [ "$LABEL_MAJOR" -eq "$ALLOWED_MAJOR" ] && [ "$LABEL_MINOR" -lt "$ALLOWED_MINOR" ] && [ "$LABEL_PATCH" -gt 0 ]; then
+            echo "Release label '$RELEASE' is a hotfix for a previous minor release. PR is allowed to merge."
+            exit 0
+          fi
+
           if [ "$(printf '%s\n%s\n' "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" "$RELEASE" | sort -V | tail -n1)" != "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
-            echo "::error::Release label '$RELEASE' is higher than the allowed release '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'"
-            echo "If you wish to merge this PR in the future, please wait until it is permitted."
-            exit 1
+            echo "::warning::Release label '$RELEASE' is higher than the allowed release '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'. This PR cannot be merged yet."
+            gh pr comment "${{ github.event.pull_request.number }}" \
+              --repo "${{ github.repository }}" \
+              --body "⚠️ **Release version validation warning**
+
+Release label \`$RELEASE\` is higher than the currently allowed release \`$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH\`.
+If you wish to merge this PR, please wait until it is permitted." 2>/dev/null || true
           fi
 
           echo "Release label matches. PR is allowed to merge."

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -62,8 +62,8 @@ jobs:
           dismiss_blocking_review_if_present() {
             local latest_review_info
             if ! latest_review_info="$(get_latest_bot_review_info)"; then
-              echo "::error::Failed to fetch latest bot review before attempting dismissal."
-              return 1
+              echo "::warning::Failed to fetch latest bot review; skipping dismissal."
+              return 0
             fi
 
             if [ -z "$latest_review_info" ]; then

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -3,8 +3,6 @@ name: Release version validation
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled, edited, ready_for_review]
-    branches:
-      - 'dev'
 
 concurrency:
   group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
@@ -30,13 +28,15 @@ jobs:
         env:
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
           GH_TOKEN: ${{ github.token }}
+          PR_ACTION: ${{ github.event.action }}
+          CURRENT_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
 
           SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 
           echo "Checking PR labels for release tag..."
-          echo "Allowed release: $ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
+          echo "Allowed release: $ALLOWED_RELEASE"
 
           get_latest_bot_review_info() {
             local reviews_json
@@ -93,15 +93,25 @@ jobs:
             done
           }
 
+          # Only validate for dev branch; dismiss review for any other target branch
+          if [[ "$CURRENT_BASE_BRANCH" != "dev" ]]; then
+            dismiss_blocking_review_if_present
+            echo "PR target branch is not dev. Skipping release check."
+            exit 0
+          fi
+
+          ALLOWED_RELEASE="$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH"
+          echo "Validating for dev branch. ALLOWED_RELEASE: $ALLOWED_RELEASE"
+
           if echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -qi '^align$'; then
             dismiss_blocking_review_if_present
             echo "PR has 'align' label. Skipping release check."
             exit 0
           fi
 
-          if [[ -z "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" || ! "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" =~ $SEMVER_REGEX ]]; then
-            echo "::warning::Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is not set or is not in x.y.z format; blocking merge until configuration is fixed."
-            request_changes_review "Repository variable ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is missing or invalid (expected x.y.z)."
+          if [[ -z "$ALLOWED_RELEASE" || ! "$ALLOWED_RELEASE" =~ $SEMVER_REGEX ]]; then
+            echo "::warning::Repository variable ALLOWED_RELEASE is not set or is not in x.y.z format; blocking merge until configuration is fixed."
+            request_changes_review "Repository variable ALLOWED_RELEASE is missing or invalid (expected x.y.z)."
             exit 0
           fi
           mapfile -t SEMVER_RELEASE_LABELS < <(echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -E "$SEMVER_REGEX" || true)
@@ -124,8 +134,8 @@ jobs:
 
           echo "Found release label: $RELEASE"
 
-          ALLOWED_MAJOR_RAW=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f1)
-          ALLOWED_MINOR_RAW=$(echo "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" | cut -d. -f2)
+          ALLOWED_MAJOR_RAW=$(echo "$ALLOWED_RELEASE" | cut -d. -f1)
+          ALLOWED_MINOR_RAW=$(echo "$ALLOWED_RELEASE" | cut -d. -f2)
 
           LABEL_MAJOR_RAW=$(echo "$RELEASE" | cut -d. -f1)
           LABEL_MINOR_RAW=$(echo "$RELEASE" | cut -d. -f2)
@@ -145,7 +155,7 @@ jobs:
             fi
           fi
 
-          if [ "$RELEASE" = "$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH" ]; then
+          if [ "$RELEASE" = "$ALLOWED_RELEASE" ]; then
             echo "Release label '$RELEASE' matches the allowed release. PR is allowed to merge."
             dismiss_blocking_review_if_present
             exit 0
@@ -157,6 +167,6 @@ jobs:
             exit 0
           fi
 
-          echo "::warning::Release label '$RELEASE' is not within the allowed range for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
-          request_changes_review "Release label '$RELEASE' is not allowed for merge towards dev. Allowed release: '$ALLOWED_RELEASE_TOWARDS_DEV_BRANCH'."
+          echo "::warning::Release label '$RELEASE' is not within the allowed range for merge. Allowed release: '$ALLOWED_RELEASE'."
+          request_changes_review "Release label '$RELEASE' is not allowed. Allowed release: '$ALLOWED_RELEASE'."
           exit 0

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -81,8 +81,7 @@ jobs:
               return 0
             fi
 
-            mapfile -t review_ids < <(echo "$reviews_json" | jq -r 'flatten | map(select(.user.login == "github-actions[bot]" and .state == "CHANGES_REQUESTED" and .id != null)) | sort_by(.submitted_at) | .[].id')
-
+            mapfile -t review_ids < <(echo "$reviews_json" | jq -r 'flatten | map(select(.user.login == "github-actions[bot]" and .state == "CHANGES_REQUESTED" and .id != null and (.body // "" | startswith("Release version validation failed.")))) | sort_by(.submitted_at) | .[].id')
             if [ "${#review_ids[@]}" -eq 0 ]; then
               return 0
             fi

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -19,11 +19,10 @@ env:
 jobs:
   validate-dev:
     name: Validate PR towards dev
-    runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write
-    steps:
       - name: Check if PR is an align PR
         id: check_align
         env:

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -2,6 +2,7 @@ name: Release version validation
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited]
     branches:
       - 'dev'
 

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -1,13 +1,13 @@
 name: Release version validation
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, labeled, unlabeled, edited, ready_for_review]
     branches:
       - 'dev'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -60,28 +60,26 @@ jobs:
           }
 
           dismiss_blocking_review_if_present() {
-            local latest_review_info
-            if ! latest_review_info="$(get_latest_bot_review_info)"; then
-              echo "::warning::Failed to fetch latest bot review; skipping dismissal."
+            local reviews_json
+            if ! reviews_json="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+              --paginate \
+              --slurp)"; then
+              echo "::warning::Failed to fetch bot reviews; skipping dismissal."
               return 0
             fi
 
-            if [ -z "$latest_review_info" ]; then
+            mapfile -t review_ids < <(echo "$reviews_json" | jq -r 'flatten | map(select(.user.login == "github-actions[bot]" and .state == "CHANGES_REQUESTED" and .id != null)) | sort_by(.submitted_at) | .[].id')
+
+            if [ "${#review_ids[@]}" -eq 0 ]; then
               return 0
             fi
 
-            local review_id review_state
-            review_id="${latest_review_info%%$'\t'*}"
-            review_state="${latest_review_info#*$'\t'}"
-
-            if [ "$review_state" != "CHANGES_REQUESTED" ] || [ -z "$review_id" ]; then
-              return 0
-            fi
-
-            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/$review_id/dismissals" \
-              --method PUT \
-              -f message='Release version validation passed. Dismissing previous blocking review.' >/dev/null \
-              || echo "::warning::Failed to dismiss previous blocking review (id: $review_id)."
+            for review_id in "${review_ids[@]}"; do
+              gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/$review_id/dismissals" \
+                --method PUT \
+                -f message='Release version validation passed. Dismissing previous blocking review.' >/dev/null \
+                || echo "::warning::Failed to dismiss previous blocking review (id: $review_id)."
+            done
           }
 
           if [[ "$PR_TITLE" =~ ^align/(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then

--- a/.github/workflows/release-version-validation.yml
+++ b/.github/workflows/release-version-validation.yml
@@ -94,9 +94,9 @@ jobs:
             done
           }
 
-          if [[ "$PR_TITLE" =~ ^align/(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+          if echo "$PR_LABELS_JSON" | jq -r '.[]?' | grep -qi '^align$'; then
             dismiss_blocking_review_if_present
-            echo "PR title '$PR_TITLE' is an align PR. Skipping release check."
+            echo "PR has 'align' label. Skipping release check."
             exit 0
           fi
 


### PR DESCRIPTION
## 🔗 Issue

[PIN-10551](https://pagopa.atlassian.net/browse/PIN-10551)

## 📝 Description / Context

To streamline and automate the process, it often happens that we end up with pull requests that are mergeable into dev (for example, because the next release is the one that needs to be promoted to QA) and other PRs that instead need to be put on hold. 

Post a Change Request (CR) when the PR release label is missing, invalid, or outside the allowed range for dev.

Current CR rules (in short):

A CR is posted if no label in x.y.z format is found on the PR.
A CR is posted if the label does not exactly match ALLOWED_RELEASE_TOWARDS_DEV_BRANCH.
ALLOWED_RELEASE_TOWARDS_DEV_BRANCH is a github variable stored in Settings > Secrets and variables > Variables

The only non-exact match accepted (apart from "align") is a hotfix on the immediately previous minor within the same major:
- major = allowed major
- minor = allowed minor - 1
- patch > 0

Any other case triggers a PR, including:
different major
newer minor than allowed
older than previous minor
previous minor with patch = 0
exception: skip validation using label "align"

## 🛠 List of changes

- new release-version-validation.yml file in github/workflows

## 🧪 How to test

change title or labels on the PR accordingly


[PIN-10551]: https://pagopa.atlassian.net/browse/PIN-10551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ