### PR TITLE
feature: assign certified discrete attribute (PIN-10107)

### DIFF
--- a/__mocks__/data/tenant.mocks.ts
+++ b/__mocks__/data/tenant.mocks.ts
@@ -1,0 +1,9 @@
+import type { CompactTenant } from '../../src/api/api.generatedTypes'
+import { createMockFactory } from '../../src/utils/testing.utils'
+
+const createMockCompactTenant = createMockFactory<CompactTenant>({
+  id: 'tenant id',
+  name: 'tenant name',
+})
+
+export { createMockCompactTenant }

--- a/src/api/attribute/attribute.mutations.ts
+++ b/src/api/attribute/attribute.mutations.ts
@@ -67,12 +67,40 @@ function useAddCertifiedAttribute() {
   })
 }
 
+function useAddCertifiedDiscreteAttribute() {
+  const { t } = useTranslation('mutations-feedback', {
+    keyPrefix: 'attribute.addCertifiedAttribute',
+  })
+  return useMutation({
+    mutationFn: AttributeServices.addCertifiedDiscreteAttribute,
+    meta: {
+      errorToastLabel: t('outcome.error'),
+      loadingLabel: t('loading'),
+      successToastLabel: t('outcome.success'),
+    },
+  })
+}
+
 function useRevokeCertifiedAttribute() {
   const { t } = useTranslation('mutations-feedback', {
     keyPrefix: 'attribute.revokeCertifiedAttribute',
   })
   return useMutation({
     mutationFn: AttributeServices.revokeCertifiedAttribute,
+    meta: {
+      errorToastLabel: t('outcome.error'),
+      loadingLabel: t('loading'),
+      successToastLabel: t('outcome.success'),
+    },
+  })
+}
+
+function useRevokeCertifiedDiscreteAttribute() {
+  const { t } = useTranslation('mutations-feedback', {
+    keyPrefix: 'attribute.revokeCertifiedAttribute',
+  })
+  return useMutation({
+    mutationFn: AttributeServices.revokeCertifiedDiscreteAttribute,
     meta: {
       errorToastLabel: t('outcome.error'),
       loadingLabel: t('loading'),
@@ -168,7 +196,9 @@ export const AttributeMutations = {
   useCreateVerified,
   useCreateDeclared,
   useAddCertifiedAttribute,
+  useAddCertifiedDiscreteAttribute,
   useRevokeCertifiedAttribute,
+  useRevokeCertifiedDiscreteAttribute,
   useVerifyPartyAttribute,
   useUpdateVerifiedPartyAttribute,
   useRevokeVerifiedPartyAttribute,

--- a/src/api/attribute/attribute.services.ts
+++ b/src/api/attribute/attribute.services.ts
@@ -6,6 +6,7 @@ import type {
   Attributes,
   CertifiedAttributeSeed,
   CertifiedAttributesResponse,
+  CertifiedDiscreteTenantAttributeSeed,
   CertifiedTenantAttributeSeed,
   DeclaredAttributesResponse,
   DeclaredTenantAttributeSeed,
@@ -104,6 +105,16 @@ async function addCertifiedAttribute({
   )
 }
 
+async function addCertifiedDiscreteAttribute({
+  tenantId,
+  ...payload
+}: { tenantId: string } & CertifiedDiscreteTenantAttributeSeed) {
+  return axiosInstance.post(
+    `${BACKEND_FOR_FRONTEND_URL}/tenants/${tenantId}/attributes/certifiedDiscrete`,
+    payload
+  )
+}
+
 async function revokeCertifiedAttribute({
   tenantId,
   attributeId,
@@ -113,6 +124,18 @@ async function revokeCertifiedAttribute({
 }) {
   return axiosInstance.delete(
     `${BACKEND_FOR_FRONTEND_URL}/tenants/${tenantId}/attributes/certified/${attributeId}`
+  )
+}
+
+async function revokeCertifiedDiscreteAttribute({
+  tenantId,
+  attributeId,
+}: {
+  tenantId: string
+  attributeId: string
+}) {
+  return axiosInstance.delete(
+    `${BACKEND_FOR_FRONTEND_URL}/tenants/${tenantId}/attributes/certifiedDiscrete/${attributeId}`
   )
 }
 
@@ -174,7 +197,9 @@ export const AttributeServices = {
   createVerified,
   createDeclared,
   addCertifiedAttribute,
+  addCertifiedDiscreteAttribute,
   revokeCertifiedAttribute,
+  revokeCertifiedDiscreteAttribute,
   verifyPartyAttribute,
   updateVerifiedPartyAttribute,
   revokeVerifiedPartyAttribute,

--- a/src/components/dialogs/DialogRevokeCertifiedAttribute.tsx
+++ b/src/components/dialogs/DialogRevokeCertifiedAttribute.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/material'
 import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
+import { match } from 'ts-pattern'
 
 export const DialogRevokeCertifiedAttribute: React.FC<DialogRevokeCertifiedAttributeProps> = ({
   attribute,
@@ -41,16 +42,20 @@ export const DialogRevokeCertifiedAttribute: React.FC<DialogRevokeCertifiedAttri
   }
 
   const handleRevoke = () => {
-    if (attribute.kind === 'CERTIFIED') {
-      revokeCertifiedAttribute({ tenantId: attribute.tenantId, attributeId: attribute.attributeId })
-    }
-
-    if (attribute.kind === 'CERTIFIED_DISCRETE') {
-      revokeCertifiedDiscreteAttribute({
-        tenantId: attribute.tenantId,
-        attributeId: attribute.attributeId,
-      })
-    }
+    match(attribute.kind)
+      .with('CERTIFIED', () =>
+        revokeCertifiedAttribute({
+          tenantId: attribute.tenantId,
+          attributeId: attribute.attributeId,
+        })
+      )
+      .with('CERTIFIED_DISCRETE', () =>
+        revokeCertifiedDiscreteAttribute({
+          tenantId: attribute.tenantId,
+          attributeId: attribute.attributeId,
+        })
+      )
+      .run()
 
     closeDialog()
   }

--- a/src/components/dialogs/DialogRevokeCertifiedAttribute.tsx
+++ b/src/components/dialogs/DialogRevokeCertifiedAttribute.tsx
@@ -27,6 +27,8 @@ export const DialogRevokeCertifiedAttribute: React.FC<DialogRevokeCertifiedAttri
   const [isConfirmCheckboxChecked, setIsConfirmCheckboxChecked] = React.useState<boolean>(false)
 
   const { mutate: revokeCertifiedAttribute } = AttributeMutations.useRevokeCertifiedAttribute()
+  const { mutate: revokeCertifiedDiscreteAttribute } =
+    AttributeMutations.useRevokeCertifiedDiscreteAttribute()
 
   const handleCheckBoxChange = () => {
     setIsConfirmCheckboxChecked((prev) => {
@@ -39,7 +41,17 @@ export const DialogRevokeCertifiedAttribute: React.FC<DialogRevokeCertifiedAttri
   }
 
   const handleRevoke = () => {
-    revokeCertifiedAttribute({ tenantId: attribute.tenantId, attributeId: attribute.attributeId })
+    if (attribute.kind === 'CERTIFIED') {
+      revokeCertifiedAttribute({ tenantId: attribute.tenantId, attributeId: attribute.attributeId })
+    }
+
+    if (attribute.kind === 'CERTIFIED_DISCRETE') {
+      revokeCertifiedDiscreteAttribute({
+        tenantId: attribute.tenantId,
+        attributeId: attribute.attributeId,
+      })
+    }
+
     closeDialog()
   }
 

--- a/src/components/dialogs/__tests__/DialogRevokeCertifiedAttribute.test.tsx
+++ b/src/components/dialogs/__tests__/DialogRevokeCertifiedAttribute.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DialogRevokeCertifiedAttribute } from '../DialogRevokeCertifiedAttribute'
+
+const closeDialogMock = vi.fn()
+const revokeCertifiedAttributeMock = vi.fn()
+const revokeCertifiedDiscreteAttributeMock = vi.fn()
+const useRevokeCertifiedAttributeMock = vi.fn()
+const useRevokeCertifiedDiscreteAttributeMock = vi.fn()
+
+vi.mock('@/stores', () => ({
+  useDialog: () => ({
+    closeDialog: closeDialogMock,
+  }),
+}))
+
+vi.mock('@/api/attribute', () => ({
+  AttributeMutations: {
+    useRevokeCertifiedAttribute: () => useRevokeCertifiedAttributeMock(),
+    useRevokeCertifiedDiscreteAttribute: () => useRevokeCertifiedDiscreteAttributeMock(),
+  },
+}))
+
+describe('DialogRevokeCertifiedAttribute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    useRevokeCertifiedAttributeMock.mockReturnValue({
+      mutate: revokeCertifiedAttributeMock,
+      isPending: false,
+    })
+
+    useRevokeCertifiedDiscreteAttributeMock.mockReturnValue({
+      mutate: revokeCertifiedDiscreteAttributeMock,
+      isPending: false,
+    })
+  })
+
+  it('should render dialog informations', () => {
+    render(
+      <DialogRevokeCertifiedAttribute
+        type="revokeCertifiedAttribute"
+        attribute={{
+          tenantId: 'tenant-id',
+          tenantName: 'Tenant Name',
+          attributeId: 'attribute-id',
+          attributeName: 'Attribute Name',
+          kind: 'CERTIFIED',
+        }}
+      />
+    )
+
+    expect(screen.getByText('title')).toBeInTheDocument()
+    expect(screen.getByText('content.checkbox')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'cancel' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'revoke' })).toBeInTheDocument()
+  })
+
+  it('should close dialog when cancel is clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DialogRevokeCertifiedAttribute
+        type="revokeCertifiedAttribute"
+        attribute={{
+          tenantId: 'tenant-id',
+          tenantName: 'Tenant Name',
+          attributeId: 'attribute-id',
+          attributeName: 'Attribute Name',
+          kind: 'CERTIFIED',
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(closeDialogMock).toHaveBeenCalledTimes(1)
+    expect(revokeCertifiedAttributeMock).not.toHaveBeenCalled()
+    expect(revokeCertifiedDiscreteAttributeMock).not.toHaveBeenCalled()
+  })
+
+  it('should keep revoke button disabled until confirmation checkbox is checked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DialogRevokeCertifiedAttribute
+        type="revokeCertifiedAttribute"
+        attribute={{
+          tenantId: 'tenant-id',
+          tenantName: 'Tenant Name',
+          attributeId: 'attribute-id',
+          attributeName: 'Attribute Name',
+          kind: 'CERTIFIED',
+        }}
+      />
+    )
+
+    const revokeButton = screen.getByRole('button', { name: 'revoke' })
+    expect(revokeButton).toBeDisabled()
+
+    await user.click(screen.getByRole('checkbox', { name: 'content.checkbox' }))
+    expect(revokeButton).toBeEnabled()
+  })
+
+  it('should call revokeCertifiedAttribute for CERTIFIED kind and close dialog', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DialogRevokeCertifiedAttribute
+        type="revokeCertifiedAttribute"
+        attribute={{
+          tenantId: 'tenant-id',
+          tenantName: 'Tenant Name',
+          attributeId: 'attribute-id',
+          attributeName: 'Attribute Name',
+          kind: 'CERTIFIED',
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('checkbox', { name: 'content.checkbox' }))
+    await user.click(screen.getByRole('button', { name: 'revoke' }))
+
+    expect(revokeCertifiedAttributeMock).toHaveBeenCalledWith({
+      tenantId: 'tenant-id',
+      attributeId: 'attribute-id',
+    })
+    expect(revokeCertifiedDiscreteAttributeMock).not.toHaveBeenCalled()
+    expect(closeDialogMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call revokeCertifiedDiscreteAttribute for CERTIFIED_DISCRETE kind and close dialog', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DialogRevokeCertifiedAttribute
+        type="revokeCertifiedAttribute"
+        attribute={{
+          tenantId: 'tenant-id-discrete',
+          tenantName: 'Tenant Name Discrete',
+          attributeId: 'attribute-id-discrete',
+          attributeName: 'Attribute Name Discrete',
+          kind: 'CERTIFIED_DISCRETE',
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('checkbox', { name: 'content.checkbox' }))
+    await user.click(screen.getByRole('button', { name: 'revoke' }))
+
+    expect(revokeCertifiedDiscreteAttributeMock).toHaveBeenCalledWith({
+      tenantId: 'tenant-id-discrete',
+      attributeId: 'attribute-id-discrete',
+    })
+    expect(revokeCertifiedAttributeMock).not.toHaveBeenCalled()
+    expect(closeDialogMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
@@ -141,10 +141,6 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
   const isSelectedAttributeCertifiedDiscrete =
     selectedAttribute && selectedAttribute.kind === 'CERTIFIED_DISCRETE'
 
-  React.useEffect(() => {
-    formMethods.resetField('value')
-  }, [formMethods, selectedAttribute])
-
   return (
     <FormProvider {...formMethods}>
       <Drawer
@@ -163,6 +159,7 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
             label={t('form.attributeField.label')}
             size="small"
             onInputChange={(_, value) => setAttributeSearchParam(value)}
+            onValueChange={() => formMethods.resetField('value')}
             sx={{ mb: 0, flex: 1 }}
             options={attributeOptions}
             focusOnMount

--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
@@ -20,7 +20,7 @@ type AssignAttributeDrawerProps = {
 type AssignAttributeFormValues = {
   attribute: CompactAttribute
   tenant: CompactTenant
-  threshold: number
+  value: number
 }
 
 export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
@@ -40,7 +40,7 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
     defaultValues: {
       attribute: undefined,
       tenant: undefined,
-      threshold: undefined,
+      value: undefined,
     },
   })
 
@@ -123,7 +123,7 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
           {
             id: values.attribute.id,
             tenantId: values.tenant.id,
-            certifiedDiscreteThreshold: values.threshold,
+            certifiedDiscreteValue: values.value,
           },
           { onSuccess: onClose }
         )
@@ -137,6 +137,13 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
     setAttributeSearchParam('')
     setTenantSearchParam('')
   }
+
+  const isSelectedAttributeCertifiedDiscrete =
+    selectedAttribute && selectedAttribute.kind === 'CERTIFIED_DISCRETE'
+
+  React.useEffect(() => {
+    formMethods.resetField('value')
+  }, [formMethods, selectedAttribute])
 
   return (
     <FormProvider {...formMethods}>
@@ -160,7 +167,7 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
             options={attributeOptions}
             focusOnMount
             name="attribute"
-            aria-controls="threshold-value-field"
+            aria-controls={isSelectedAttributeCertifiedDiscrete ? 'value-field' : undefined}
           />
           <RHFAutocompleteSingle
             label={t('form.tenantField.label')}
@@ -170,17 +177,17 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
             options={tenantOptions}
             name="tenant"
           />
-          {selectedAttribute && selectedAttribute.kind === 'CERTIFIED_DISCRETE' && (
+          {isSelectedAttributeCertifiedDiscrete && (
             <RHFTextField
-              id="threshold-value-field"
-              label={t('form.thresholdField.label')}
-              name="threshold"
+              id="value-field"
+              label={t('form.valueField.label')}
+              name="value"
               rules={{
                 required: true,
                 min: 1,
                 max: 1000000000,
                 validate: (value) =>
-                  Number.isInteger(Number(value)) || t('form.thresholdField.validation.integer'),
+                  Number.isInteger(Number(value)) || t('form.valueField.validation.integer'),
               }}
               required
               size="small"

--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
@@ -165,6 +165,7 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
             focusOnMount
             name="attribute"
             aria-controls={isSelectedAttributeCertifiedDiscrete ? 'value-field' : undefined}
+            rules={{ required: true }}
           />
           <RHFAutocompleteSingle
             label={t('form.tenantField.label')}
@@ -173,6 +174,7 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
             sx={{ mb: 0, flex: 1 }}
             options={tenantOptions}
             name="tenant"
+            rules={{ required: true }}
           />
           {isSelectedAttributeCertifiedDiscrete && (
             <RHFTextField
@@ -180,7 +182,7 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
               label={t('form.valueField.label')}
               name="value"
               rules={{
-                required: true,
+                required: isSelectedAttributeCertifiedDiscrete ? true : false,
                 min: 1,
                 max: 1000000000,
                 validate: (value) =>

--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
@@ -3,12 +3,14 @@ import { AttributeMutations, AttributeQueries } from '@/api/attribute'
 import { TenantHooks, TenantQueries } from '@/api/tenant'
 import { Drawer } from '@/components/shared/Drawer'
 import { RHFAutocompleteSingle, RHFTextField } from '@/components/shared/react-hook-form-inputs'
+import { FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE } from '@/config/env'
 import { Stack } from '@mui/material'
 import { useAutocompleteTextInput } from '@pagopa/interop-fe-commons'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import React from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { match } from 'ts-pattern'
 
 type AssignAttributeDrawerProps = {
   isOpen: boolean
@@ -68,7 +70,9 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
     ...AttributeQueries.getList({
       limit: 50,
       offset: 0,
-      kinds: ['CERTIFIED', 'CERTIFIED_DISCRETE'],
+      kinds: FEATURE_FLAG_ATTRIBUTE_CERTIFIED_DISCRETE
+        ? ['CERTIFIED', 'CERTIFIED_DISCRETE']
+        : ['CERTIFIED'],
       origin: certifierId,
       q: getAttributeQ(),
     }),
@@ -107,23 +111,24 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
   })
 
   const onSubmit = formMethods.handleSubmit((values: AssignAttributeFormValues) => {
-    if (values.attribute.kind === 'CERTIFIED') {
-      addCertifiedAttribute(
-        { id: values.attribute.id, tenantId: values.tenant.id },
-        { onSuccess: onClose }
+    match(values.attribute.kind)
+      .with('CERTIFIED', () =>
+        addCertifiedAttribute(
+          { id: values.attribute.id, tenantId: values.tenant.id },
+          { onSuccess: onClose }
+        )
       )
-    }
-
-    if (values.attribute.kind === 'CERTIFIED_DISCRETE') {
-      addCertifiedDiscreteAttribute(
-        {
-          id: values.attribute.id,
-          tenantId: values.tenant.id,
-          certifiedDiscreteThreshold: values.threshold,
-        },
-        { onSuccess: onClose }
+      .with('CERTIFIED_DISCRETE', () =>
+        addCertifiedDiscreteAttribute(
+          {
+            id: values.attribute.id,
+            tenantId: values.tenant.id,
+            certifiedDiscreteThreshold: values.threshold,
+          },
+          { onSuccess: onClose }
+        )
       )
-    }
+      .run()
   })
 
   const handleTransitionExited = () => {
@@ -170,7 +175,13 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
               id="threshold-value-field"
               label={t('form.thresholdField.label')}
               name="threshold"
-              rules={{ required: true, min: 0, max: 1000000000 }}
+              rules={{
+                required: true,
+                min: 1,
+                max: 1000000000,
+                validate: (value) =>
+                  Number.isInteger(Number(value)) || t('form.thresholdField.validation.integer'),
+              }}
               required
               size="small"
               type="number"

--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
@@ -2,7 +2,7 @@ import type { CompactAttribute, CompactTenant, TenantFeature } from '@/api/api.g
 import { AttributeMutations, AttributeQueries } from '@/api/attribute'
 import { TenantHooks, TenantQueries } from '@/api/tenant'
 import { Drawer } from '@/components/shared/Drawer'
-import { RHFAutocompleteSingle } from '@/components/shared/react-hook-form-inputs'
+import { RHFAutocompleteSingle, RHFTextField } from '@/components/shared/react-hook-form-inputs'
 import { Stack } from '@mui/material'
 import { useAutocompleteTextInput } from '@pagopa/interop-fe-commons'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
@@ -18,6 +18,7 @@ type AssignAttributeDrawerProps = {
 type AssignAttributeFormValues = {
   attribute: CompactAttribute
   tenant: CompactTenant
+  threshold: number
 }
 
 export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
@@ -27,6 +28,8 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
   const { t } = useTranslation('party', { keyPrefix: 'tenantCertifier.assignTab.drawer' })
 
   const { mutate: addCertifiedAttribute } = AttributeMutations.useAddCertifiedAttribute()
+  const { mutate: addCertifiedDiscreteAttribute } =
+    AttributeMutations.useAddCertifiedDiscreteAttribute()
 
   const [attributeSearchParam, setAttributeSearchParam] = useAutocompleteTextInput()
   const [tenantSearchParam, setTenantSearchParam] = useAutocompleteTextInput()
@@ -35,6 +38,7 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
     defaultValues: {
       attribute: undefined,
       tenant: undefined,
+      threshold: undefined,
     },
   })
 
@@ -64,7 +68,7 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
     ...AttributeQueries.getList({
       limit: 50,
       offset: 0,
-      kinds: ['CERTIFIED'],
+      kinds: ['CERTIFIED', 'CERTIFIED_DISCRETE'],
       origin: certifierId,
       q: getAttributeQ(),
     }),
@@ -103,10 +107,23 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
   })
 
   const onSubmit = formMethods.handleSubmit((values: AssignAttributeFormValues) => {
-    addCertifiedAttribute(
-      { id: values.attribute.id, tenantId: values.tenant.id },
-      { onSuccess: onClose }
-    )
+    if (values.attribute.kind === 'CERTIFIED') {
+      addCertifiedAttribute(
+        { id: values.attribute.id, tenantId: values.tenant.id },
+        { onSuccess: onClose }
+      )
+    }
+
+    if (values.attribute.kind === 'CERTIFIED_DISCRETE') {
+      addCertifiedDiscreteAttribute(
+        {
+          id: values.attribute.id,
+          tenantId: values.tenant.id,
+          certifiedDiscreteThreshold: values.threshold,
+        },
+        { onSuccess: onClose }
+      )
+    }
   })
 
   const handleTransitionExited = () => {
@@ -132,23 +149,33 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
         <Stack component="form" noValidate spacing={3}>
           <RHFAutocompleteSingle
             label={t('form.attributeField.label')}
-            labelType="external"
             size="small"
             onInputChange={(_, value) => setAttributeSearchParam(value)}
             sx={{ mb: 0, flex: 1 }}
             options={attributeOptions}
             focusOnMount
             name="attribute"
+            aria-controls="threshold-value-field"
           />
           <RHFAutocompleteSingle
             label={t('form.tenantField.label')}
-            labelType="external"
             size="small"
             onInputChange={(_, value) => setTenantSearchParam(value)}
             sx={{ mb: 0, flex: 1 }}
             options={tenantOptions}
             name="tenant"
           />
+          {selectedAttribute && selectedAttribute.kind === 'CERTIFIED_DISCRETE' && (
+            <RHFTextField
+              id="threshold-value-field"
+              label={t('form.thresholdField.label')}
+              name="threshold"
+              rules={{ required: true, min: 0, max: 1000000000 }}
+              required
+              size="small"
+              type="number"
+            />
+          )}
         </Stack>
       </Drawer>
     </FormProvider>

--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
@@ -259,6 +259,54 @@ describe('AssignAttributeDrawer', () => {
       expect(addCertifiedDiscreteAttributeRequests).toHaveLength(0)
     })
 
+    it('should reset value when the selected attribute changes', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <AssignAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const attributeAutocomplete = screen.getByRole('combobox', {
+        name: 'form.attributeField.label',
+      })
+
+      await user.click(attributeAutocomplete)
+      await user.click(await screen.findByRole('option', { name: 'test certified discrete' }))
+
+      const valueField = screen.getByRole('spinbutton', {
+        name: 'form.valueField.label',
+      })
+
+      await user.type(valueField, '11')
+      expect(valueField).toHaveValue(11)
+
+      await user.click(attributeAutocomplete)
+      await user.click(await screen.findByRole('option', { name: 'test certified' }))
+
+      await user.click(attributeAutocomplete)
+      await user.click(await screen.findByRole('option', { name: 'test certified discrete' }))
+
+      expect(
+        screen.getByRole('spinbutton', {
+          name: 'form.valueField.label',
+        })
+      ).toHaveValue(null)
+
+      const tenantAutocomplete = screen.getByRole('combobox', {
+        name: 'form.tenantField.label',
+      })
+      await user.click(tenantAutocomplete)
+      await user.click(await screen.findByRole('option', { name: 'test tenant name' }))
+
+      await user.click(screen.getByRole('button', { name: 'submitBtnLabel' }))
+
+      expect(await screen.findByText('validation.mixed.required')).toBeInTheDocument()
+      expect(addCertifiedAttributeRequests).toHaveLength(0)
+      expect(addCertifiedDiscreteAttributeRequests).toHaveLength(0)
+    })
+
     it('should show min error and block submit for CERTIFIED_DISCRETE when value is below 1', async () => {
       const user = userEvent.setup()
       const screen = renderWithApplicationContext(

--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
@@ -155,6 +155,9 @@ describe('AssignAttributeDrawer', () => {
       await user.click(tenantAutocomplete)
       const tenantToSelect = await screen.findByRole('option', { name: 'test tenant name' })
       await user.click(tenantToSelect)
+      await waitFor(() => {
+        expect((tenantAutocomplete as HTMLInputElement).value).toBe('test tenant name')
+      })
 
       const valueField = screen.queryByRole('spinbutton', {
         name: 'form.valueField.label',
@@ -208,6 +211,7 @@ describe('AssignAttributeDrawer', () => {
       })
 
       await user.type(valueField, '11')
+      expect((valueField as HTMLInputElement).value).toBe('11')
 
       const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
       await user.click(submitButton)

--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
@@ -2,21 +2,63 @@ import { renderWithApplicationContext } from '@/utils/testing.utils'
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 import { waitFor } from '@testing-library/react'
-import { vi, describe, it, beforeEach, expect } from 'vitest'
+import { vi, describe, it, beforeEach, beforeAll, afterAll, afterEach, expect } from 'vitest'
 import { AssignAttributeDrawer } from '../AssignAttributeDrawer'
 import { createMockCompactAttribute } from '../../../../../../__mocks__/data/attribute.mocks'
 import { createMockCompactTenant } from '../../../../../../__mocks__/data/tenant.mocks'
 import { TenantServices } from '@/api/tenant'
 import { AttributeServices } from '@/api/attribute'
 import { mockUseGetActiveUserParty } from '@/utils/testing.utils'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
 
-const mockAddCertifiedAttribute = vi.fn()
-const mockAddCertifiedDiscreteAttribute = vi.fn()
+let addCertifiedAttributeRequests: Array<{ tenantId: string; body: { id: string } }> = []
+let addCertifiedDiscreteAttributeRequests: Array<{
+  tenantId: string
+  body: { id: string; certifiedDiscreteValue: number }
+}> = []
 
-vi.spyOn(AttributeServices, 'addCertifiedAttribute').mockImplementation(mockAddCertifiedAttribute)
-vi.spyOn(AttributeServices, 'addCertifiedDiscreteAttribute').mockImplementation(
-  mockAddCertifiedDiscreteAttribute
+const server = setupServer(
+  rest.post(
+    `${BACKEND_FOR_FRONTEND_URL}/tenants/:tenantId/attributes/certified`,
+    async (req, res, ctx) => {
+      const body = await req.json()
+
+      addCertifiedAttributeRequests.push({
+        tenantId: req.params.tenantId as string,
+        body: body as { id: string },
+      })
+
+      return res(ctx.status(200))
+    }
+  ),
+  rest.post(
+    `${BACKEND_FOR_FRONTEND_URL}/tenants/:tenantId/attributes/certifiedDiscrete`,
+    async (req, res, ctx) => {
+      const body = await req.json()
+
+      addCertifiedDiscreteAttributeRequests.push({
+        tenantId: req.params.tenantId as string,
+        body: body as { id: string; certifiedDiscreteValue: number },
+      })
+
+      return res(ctx.status(200))
+    }
+  )
 )
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
 
 vi.spyOn(TenantServices, 'getTenants').mockResolvedValue({
   pagination: { offset: 0, limit: 10, totalCount: 2 },
@@ -42,6 +84,8 @@ vi.spyOn(AttributeServices, 'getList').mockResolvedValue({
 describe('AssignAttributeDrawer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    addCertifiedAttributeRequests = []
+    addCertifiedDiscreteAttributeRequests = []
     mockUseGetActiveUserParty({
       data: {
         features: [
@@ -112,21 +156,25 @@ describe('AssignAttributeDrawer', () => {
       const tenantToSelect = await screen.findByRole('option', { name: 'test tenant name' })
       await user.click(tenantToSelect)
 
-      const thresholdField = screen.queryByRole('spinbutton', {
-        name: 'form.thresholdField.label',
+      const valueField = screen.queryByRole('spinbutton', {
+        name: 'form.valueField.label',
       })
 
-      expect(thresholdField).not.toBeInTheDocument()
+      expect(valueField).not.toBeInTheDocument()
 
       const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
       await user.click(submitButton)
 
       await waitFor(() => {
-        expect(mockAddCertifiedDiscreteAttribute).not.toBeCalled()
-        expect(mockAddCertifiedAttribute).toBeCalledWith({
+        expect(addCertifiedDiscreteAttributeRequests).toHaveLength(0)
+        expect(addCertifiedAttributeRequests).toHaveLength(1)
+      })
+
+      expect(addCertifiedAttributeRequests[0]).toEqual({
+        tenantId: 'test tenant id',
+        body: {
           id: 'testAttributeCertifiedId',
-          tenantId: 'test tenant id',
-        })
+        },
       })
     })
 
@@ -155,23 +203,138 @@ describe('AssignAttributeDrawer', () => {
       const tenantToSelect = await screen.findByRole('option', { name: 'test tenant name' })
       await user.click(tenantToSelect)
 
-      const thresholdField = screen.getByRole('spinbutton', {
-        name: 'form.thresholdField.label',
+      const valueField = screen.getByRole('spinbutton', {
+        name: 'form.valueField.label',
       })
 
-      await user.type(thresholdField, '11')
+      await user.type(valueField, '11')
 
       const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
       await user.click(submitButton)
 
       await waitFor(() => {
-        expect(mockAddCertifiedAttribute).not.toBeCalled()
-        expect(mockAddCertifiedDiscreteAttribute).toBeCalledWith({
-          id: 'testAttributeCertifiedDiscreteId',
-          tenantId: 'test tenant id',
-          certifiedDiscreteThreshold: 11,
-        })
+        expect(addCertifiedAttributeRequests).toHaveLength(0)
+        expect(addCertifiedDiscreteAttributeRequests).toHaveLength(1)
       })
+
+      expect(addCertifiedDiscreteAttributeRequests[0]).toEqual({
+        tenantId: 'test tenant id',
+        body: {
+          id: 'testAttributeCertifiedDiscreteId',
+          certifiedDiscreteValue: 11,
+        },
+      })
+    })
+
+    it('should show required error and block submit for CERTIFIED_DISCRETE when value is missing', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <AssignAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const attributeAutocomplete = screen.getByRole('combobox', {
+        name: 'form.attributeField.label',
+      })
+      await user.click(attributeAutocomplete)
+      const attributeToSelect = await screen.findByRole('option', {
+        name: 'test certified discrete',
+      })
+      await user.click(attributeToSelect)
+
+      const tenantAutocomplete = screen.getByRole('combobox', {
+        name: 'form.tenantField.label',
+      })
+      await user.click(tenantAutocomplete)
+      const tenantToSelect = await screen.findByRole('option', { name: 'test tenant name' })
+      await user.click(tenantToSelect)
+
+      const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
+      await user.click(submitButton)
+
+      expect(await screen.findByText('validation.mixed.required')).toBeInTheDocument()
+      expect(addCertifiedAttributeRequests).toHaveLength(0)
+      expect(addCertifiedDiscreteAttributeRequests).toHaveLength(0)
+    })
+
+    it('should show min error and block submit for CERTIFIED_DISCRETE when value is below 1', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <AssignAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const attributeAutocomplete = screen.getByRole('combobox', {
+        name: 'form.attributeField.label',
+      })
+      await user.click(attributeAutocomplete)
+      const attributeToSelect = await screen.findByRole('option', {
+        name: 'test certified discrete',
+      })
+      await user.click(attributeToSelect)
+
+      const tenantAutocomplete = screen.getByRole('combobox', {
+        name: 'form.tenantField.label',
+      })
+      await user.click(tenantAutocomplete)
+      const tenantToSelect = await screen.findByRole('option', { name: 'test tenant name' })
+      await user.click(tenantToSelect)
+
+      const valueField = screen.getByRole('spinbutton', {
+        name: 'form.valueField.label',
+      })
+
+      await user.type(valueField, '-1')
+
+      const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
+      await user.click(submitButton)
+
+      expect(await screen.findByText('validation.number.min')).toBeInTheDocument()
+      expect(addCertifiedAttributeRequests).toHaveLength(0)
+      expect(addCertifiedDiscreteAttributeRequests).toHaveLength(0)
+    })
+
+    it('should show integer error and block submit for CERTIFIED_DISCRETE when value is decimal', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <AssignAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const attributeAutocomplete = screen.getByRole('combobox', {
+        name: 'form.attributeField.label',
+      })
+      await user.click(attributeAutocomplete)
+      const attributeToSelect = await screen.findByRole('option', {
+        name: 'test certified discrete',
+      })
+      await user.click(attributeToSelect)
+
+      const tenantAutocomplete = screen.getByRole('combobox', {
+        name: 'form.tenantField.label',
+      })
+      await user.click(tenantAutocomplete)
+      const tenantToSelect = await screen.findByRole('option', { name: 'test tenant name' })
+      await user.click(tenantToSelect)
+
+      const valueField = screen.getByRole('spinbutton', {
+        name: 'form.valueField.label',
+      })
+
+      await user.type(valueField, '1.5')
+
+      const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
+      await user.click(submitButton)
+
+      expect(await screen.findByText('form.valueField.validation.integer')).toBeInTheDocument()
+      expect(addCertifiedAttributeRequests).toHaveLength(0)
+      expect(addCertifiedDiscreteAttributeRequests).toHaveLength(0)
     })
   })
 })

--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
@@ -259,54 +259,6 @@ describe('AssignAttributeDrawer', () => {
       expect(addCertifiedDiscreteAttributeRequests).toHaveLength(0)
     })
 
-    it('should reset value when the selected attribute changes', async () => {
-      const user = userEvent.setup()
-      const screen = renderWithApplicationContext(
-        <AssignAttributeDrawer isOpen={true} onClose={vi.fn()} />,
-        {
-          withReactQueryContext: true,
-        }
-      )
-
-      const attributeAutocomplete = screen.getByRole('combobox', {
-        name: 'form.attributeField.label',
-      })
-
-      await user.click(attributeAutocomplete)
-      await user.click(await screen.findByRole('option', { name: 'test certified discrete' }))
-
-      const valueField = screen.getByRole('spinbutton', {
-        name: 'form.valueField.label',
-      })
-
-      await user.type(valueField, '11')
-      expect(valueField).toHaveValue(11)
-
-      await user.click(attributeAutocomplete)
-      await user.click(await screen.findByRole('option', { name: 'test certified' }))
-
-      await user.click(attributeAutocomplete)
-      await user.click(await screen.findByRole('option', { name: 'test certified discrete' }))
-
-      expect(
-        screen.getByRole('spinbutton', {
-          name: 'form.valueField.label',
-        })
-      ).toHaveValue(null)
-
-      const tenantAutocomplete = screen.getByRole('combobox', {
-        name: 'form.tenantField.label',
-      })
-      await user.click(tenantAutocomplete)
-      await user.click(await screen.findByRole('option', { name: 'test tenant name' }))
-
-      await user.click(screen.getByRole('button', { name: 'submitBtnLabel' }))
-
-      expect(await screen.findByText('validation.mixed.required')).toBeInTheDocument()
-      expect(addCertifiedAttributeRequests).toHaveLength(0)
-      expect(addCertifiedDiscreteAttributeRequests).toHaveLength(0)
-    })
-
     it('should show min error and block submit for CERTIFIED_DISCRETE when value is below 1', async () => {
       const user = userEvent.setup()
       const screen = renderWithApplicationContext(
@@ -383,6 +335,55 @@ describe('AssignAttributeDrawer', () => {
       expect(await screen.findByText('form.valueField.validation.integer')).toBeInTheDocument()
       expect(addCertifiedAttributeRequests).toHaveLength(0)
       expect(addCertifiedDiscreteAttributeRequests).toHaveLength(0)
+    })
+
+    it('should reset value to default when selected attribute changes', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <AssignAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const attributeAutocomplete = screen.getByRole('combobox', {
+        name: 'form.attributeField.label',
+      })
+
+      await user.click(attributeAutocomplete)
+      const certifiedDiscreteAttributeToSelect = await screen.findByRole('option', {
+        name: 'test certified discrete',
+      })
+      await user.click(certifiedDiscreteAttributeToSelect)
+
+      const valueField = screen.getByRole('spinbutton', {
+        name: 'form.valueField.label',
+      })
+      await user.type(valueField, '11')
+      expect((valueField as HTMLInputElement).value).toBe('11')
+
+      await user.click(attributeAutocomplete)
+      const certifiedAttributeToSelect = await screen.findByRole('option', {
+        name: 'test certified',
+      })
+      await user.click(certifiedAttributeToSelect)
+
+      expect(
+        screen.queryByRole('spinbutton', {
+          name: 'form.valueField.label',
+        })
+      ).not.toBeInTheDocument()
+
+      await user.click(attributeAutocomplete)
+      const certifiedDiscreteAttributeToSelectAgain = await screen.findByRole('option', {
+        name: 'test certified discrete',
+      })
+      await user.click(certifiedDiscreteAttributeToSelectAgain)
+
+      const valueFieldAfterAttributeChange = screen.getByRole('spinbutton', {
+        name: 'form.valueField.label',
+      })
+      expect((valueFieldAfterAttributeChange as HTMLInputElement).value).toBe('')
     })
   })
 })

--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
@@ -133,6 +133,48 @@ describe('AssignAttributeDrawer', () => {
   })
 
   describe('form submission', () => {
+    it('should show required error and block submit when attribute is missing', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <AssignAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
+      await user.click(submitButton)
+
+      const requiredErrors = await screen.findAllByText('validation.mixed.required')
+      expect(requiredErrors).toHaveLength(2)
+      expect(addCertifiedAttributeRequests).toHaveLength(0)
+      expect(addCertifiedDiscreteAttributeRequests).toHaveLength(0)
+    })
+
+    it('should show required error and block submit when tenant is missing', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <AssignAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const attributeAutocomplete = screen.getByRole('combobox', {
+        name: 'form.attributeField.label',
+      })
+      await user.click(attributeAutocomplete)
+      const attributeToSelect = await screen.findByRole('option', { name: 'test certified' })
+      await user.click(attributeToSelect)
+
+      const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
+      await user.click(submitButton)
+
+      expect(await screen.findByText('validation.mixed.required')).toBeInTheDocument()
+      expect(addCertifiedAttributeRequests).toHaveLength(0)
+      expect(addCertifiedDiscreteAttributeRequests).toHaveLength(0)
+    })
+
     it('should call addCertifiedAttribute if selectedAttribute kind is CERTIFIED', async () => {
       const user = userEvent.setup()
       const screen = renderWithApplicationContext(

--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/__test__/AssignAttributeDrawer.test.tsx
@@ -1,0 +1,177 @@
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import React from 'react'
+import userEvent from '@testing-library/user-event'
+import { waitFor } from '@testing-library/react'
+import { vi, describe, it, beforeEach, expect } from 'vitest'
+import { AssignAttributeDrawer } from '../AssignAttributeDrawer'
+import { createMockCompactAttribute } from '../../../../../../__mocks__/data/attribute.mocks'
+import { createMockCompactTenant } from '../../../../../../__mocks__/data/tenant.mocks'
+import { TenantServices } from '@/api/tenant'
+import { AttributeServices } from '@/api/attribute'
+import { mockUseGetActiveUserParty } from '@/utils/testing.utils'
+
+const mockAddCertifiedAttribute = vi.fn()
+const mockAddCertifiedDiscreteAttribute = vi.fn()
+
+vi.spyOn(AttributeServices, 'addCertifiedAttribute').mockImplementation(mockAddCertifiedAttribute)
+vi.spyOn(AttributeServices, 'addCertifiedDiscreteAttribute').mockImplementation(
+  mockAddCertifiedDiscreteAttribute
+)
+
+vi.spyOn(TenantServices, 'getTenants').mockResolvedValue({
+  pagination: { offset: 0, limit: 10, totalCount: 2 },
+  results: [createMockCompactTenant({ id: 'test tenant id', name: 'test tenant name' })],
+})
+
+vi.spyOn(AttributeServices, 'getList').mockResolvedValue({
+  pagination: { offset: 0, limit: 10, totalCount: 2 },
+  results: [
+    createMockCompactAttribute({
+      id: 'testAttributeCertifiedId',
+      kind: 'CERTIFIED',
+      name: 'test certified',
+    }),
+    createMockCompactAttribute({
+      id: 'testAttributeCertifiedDiscreteId',
+      kind: 'CERTIFIED_DISCRETE',
+      name: 'test certified discrete',
+    }),
+  ],
+})
+
+describe('AssignAttributeDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseGetActiveUserParty({
+      data: {
+        features: [
+          {
+            certifier: {
+              certifierId: 'test-certifier-id',
+            },
+          },
+        ],
+      },
+    })
+  })
+  describe('rendering', () => {
+    it('should not render the drawer when isOpen is false', () => {
+      const screen = renderWithApplicationContext(
+        <AssignAttributeDrawer isOpen={false} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      expect(screen.queryByText('title')).not.toBeInTheDocument()
+      expect(screen.queryByText('subtitle')).not.toBeInTheDocument()
+      expect(screen.queryByText('submitBtnLabel')).not.toBeInTheDocument()
+      expect(screen.queryByText('form.attributeField.label')).not.toBeInTheDocument()
+    })
+
+    it('should render the drawer when isOpen is true', () => {
+      const screen = renderWithApplicationContext(
+        <AssignAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      expect(screen.getByText('title')).toBeInTheDocument()
+      expect(screen.getByText('subtitle')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'submitBtnLabel' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('combobox', {
+          name: 'form.attributeField.label',
+        })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('form submission', () => {
+    it('should call addCertifiedAttribute if selectedAttribute kind is CERTIFIED', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <AssignAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const attributeAutocomplete = screen.getByRole('combobox', {
+        name: 'form.attributeField.label',
+      })
+      await user.click(attributeAutocomplete)
+      const attributeToSelect = await screen.findByRole('option', { name: 'test certified' })
+      await user.click(attributeToSelect)
+
+      const tenantAutocomplete = screen.getByRole('combobox', {
+        name: 'form.tenantField.label',
+      })
+      await user.click(tenantAutocomplete)
+      const tenantToSelect = await screen.findByRole('option', { name: 'test tenant name' })
+      await user.click(tenantToSelect)
+
+      const thresholdField = screen.queryByRole('spinbutton', {
+        name: 'form.thresholdField.label',
+      })
+
+      expect(thresholdField).not.toBeInTheDocument()
+
+      const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockAddCertifiedDiscreteAttribute).not.toBeCalled()
+        expect(mockAddCertifiedAttribute).toBeCalledWith({
+          id: 'testAttributeCertifiedId',
+          tenantId: 'test tenant id',
+        })
+      })
+    })
+
+    it('should call addCertifiedDiscreteAttribute if attribute kind selected is CERTIFIED_DISCRETE', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <AssignAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const attributeAutocomplete = screen.getByRole('combobox', {
+        name: 'form.attributeField.label',
+      })
+      await user.click(attributeAutocomplete)
+      const attributeToSelect = await screen.findByRole('option', {
+        name: 'test certified discrete',
+      })
+      await user.click(attributeToSelect)
+
+      const tenantAutocomplete = screen.getByRole('combobox', {
+        name: 'form.tenantField.label',
+      })
+      await user.click(tenantAutocomplete)
+      const tenantToSelect = await screen.findByRole('option', { name: 'test tenant name' })
+      await user.click(tenantToSelect)
+
+      const thresholdField = screen.getByRole('spinbutton', {
+        name: 'form.thresholdField.label',
+      })
+
+      await user.type(thresholdField, '11')
+
+      const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
+      await user.click(submitButton)
+
+      await waitFor(() => {
+        expect(mockAddCertifiedAttribute).not.toBeCalled()
+        expect(mockAddCertifiedDiscreteAttribute).toBeCalledWith({
+          id: 'testAttributeCertifiedDiscreteId',
+          tenantId: 'test tenant id',
+          certifiedDiscreteThreshold: 11,
+        })
+      })
+    })
+  })
+})

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
@@ -18,6 +18,7 @@ type CreateNewAttributeFormValues = {
   kind: Extract<AttributeKind, 'CERTIFIED' | 'CERTIFIED_DISCRETE'>
   name: string
   description: string
+  thresholdType: string
 }
 
 export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
@@ -35,6 +36,7 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
       kind: 'CERTIFIED',
       name: '',
       description: '',
+      thresholdType: undefined,
     },
   })
 

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
@@ -83,7 +83,6 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
               </Typography>
               <RHFRadioGroup name="kind" options={kindOptions} rules={{ required: true }} />
             </Stack>
-
             <Stack spacing={3}>
               <Typography fontWeight={600} variant="label">
                 {t('form.infoFields.label')}

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/CreateAttributeDrawer.tsx
@@ -18,7 +18,6 @@ type CreateNewAttributeFormValues = {
   kind: Extract<AttributeKind, 'CERTIFIED' | 'CERTIFIED_DISCRETE'>
   name: string
   description: string
-  thresholdType: string
 }
 
 export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
@@ -36,7 +35,6 @@ export const CreateAttributeDrawer: React.FC<CreateAttributeDrawerProps> = ({
       kind: 'CERTIFIED',
       name: '',
       description: '',
-      thresholdType: undefined,
     },
   })
 

--- a/src/pages/TenantCertifierPage/components/ManageAttributesTab/__test__/CreateAttributeDrawer.test.tsx
+++ b/src/pages/TenantCertifierPage/components/ManageAttributesTab/__test__/CreateAttributeDrawer.test.tsx
@@ -3,24 +3,44 @@ import React from 'react'
 import { CreateAttributeDrawer } from '../CreateAttributeDrawer'
 import userEvent from '@testing-library/user-event'
 import { waitFor } from '@testing-library/react'
+import { vi, describe, it, beforeEach, beforeAll, afterAll, afterEach, expect } from 'vitest'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
 
-const { mockCreateCertified, mockCreateCertifiedDiscrete } = vi.hoisted(() => {
-  return {
-    mockCreateCertified: vi.fn(),
-    mockCreateCertifiedDiscrete: vi.fn(),
-  }
+let createCertifiedRequests: Array<{ name: string; description: string }> = []
+let createCertifiedDiscreteRequests: Array<{ name: string; description: string }> = []
+
+const server = setupServer(
+  rest.post(`${BACKEND_FOR_FRONTEND_URL}/certifiedAttributes`, async (req, res, ctx) => {
+    const body = await req.json()
+    createCertifiedRequests.push(body as { name: string; description: string })
+    return res(ctx.status(200))
+  }),
+  rest.post(`${BACKEND_FOR_FRONTEND_URL}/certifiedDiscreteAttributes`, async (req, res, ctx) => {
+    const body = await req.json()
+    createCertifiedDiscreteRequests.push(body as { name: string; description: string })
+    return res(ctx.status(200))
+  })
+)
+
+beforeAll(() => {
+  server.listen()
 })
 
-vi.mock('@/api/attribute/attribute.services', () => ({
-  AttributeServices: {
-    createCertified: mockCreateCertified,
-    createCertifiedDiscrete: mockCreateCertifiedDiscrete,
-  },
-}))
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
 
 describe('CreateAttributeDrawer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    createCertifiedRequests = []
+    createCertifiedDiscreteRequests = []
   })
   describe('rendering', () => {
     it('should not render the drawer when isOpen is false', () => {
@@ -80,11 +100,13 @@ describe('CreateAttributeDrawer', () => {
       await user.click(submitButton)
 
       await waitFor(() => {
-        expect(mockCreateCertifiedDiscrete).not.toBeCalled()
-        expect(mockCreateCertified).toBeCalledWith({
-          name: 'test name certified',
-          description: 'test description certified',
-        })
+        expect(createCertifiedDiscreteRequests).toHaveLength(0)
+        expect(createCertifiedRequests).toHaveLength(1)
+      })
+
+      expect(createCertifiedRequests[0]).toEqual({
+        name: 'test name certified',
+        description: 'test description certified',
       })
     })
 
@@ -115,12 +137,58 @@ describe('CreateAttributeDrawer', () => {
       await user.click(submitButton)
 
       await waitFor(() => {
-        expect(mockCreateCertified).not.toBeCalled()
-        expect(mockCreateCertifiedDiscrete).toBeCalledWith({
-          name: 'test name certified discrete',
-          description: 'test description certified discrete',
-        })
+        expect(createCertifiedRequests).toHaveLength(0)
+        expect(createCertifiedDiscreteRequests).toHaveLength(1)
       })
+
+      expect(createCertifiedDiscreteRequests[0]).toEqual({
+        name: 'test name certified discrete',
+        description: 'test description certified discrete',
+      })
+    })
+
+    it('should show required errors and block submit when required fields are empty', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <CreateAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
+      await user.click(submitButton)
+
+      const requiredErrors = await screen.findAllByText('validation.mixed.required')
+      expect(requiredErrors).toHaveLength(2)
+      expect(createCertifiedRequests).toHaveLength(0)
+      expect(createCertifiedDiscreteRequests).toHaveLength(0)
+    })
+
+    it('should show minLength errors and block submit when fields are too short', async () => {
+      const user = userEvent.setup()
+      const screen = renderWithApplicationContext(
+        <CreateAttributeDrawer isOpen={true} onClose={vi.fn()} />,
+        {
+          withReactQueryContext: true,
+        }
+      )
+
+      const nameField = screen.getByRole('textbox', { name: 'form.infoFields.nameField.label' })
+      const descriptionField = screen.getByRole('textbox', {
+        name: 'form.infoFields.descriptionField.label',
+      })
+
+      await user.type(nameField, 'abc')
+      await user.type(descriptionField, 'short')
+
+      const submitButton = screen.getByRole('button', { name: 'submitBtnLabel' })
+      await user.click(submitButton)
+
+      const minLengthErrors = await screen.findAllByText('validation.string.minLength')
+      expect(minLengthErrors).toHaveLength(2)
+      expect(createCertifiedRequests).toHaveLength(0)
+      expect(createCertifiedDiscreteRequests).toHaveLength(0)
     })
   })
 })

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -344,8 +344,8 @@
     "addCertifiedAttribute": {
       "loading": "Attribute is being assigned",
       "outcome": {
-        "error": "The attribute could not be assigned. Please try again",
-        "success": "The attribute has been assigned successfully"
+        "error": "The certificate attribute could not be assigned. Check that you have entered the correct information.",
+        "success": "You have assigned the certified attribute."
       }
     },
     "revokeCertifiedAttribute": {

--- a/src/static/locales/en/party.json
+++ b/src/static/locales/en/party.json
@@ -116,7 +116,10 @@
             "label": "Assignee party"
           },
           "thresholdField": {
-            "label": "Numerical value"
+            "label": "Numerical value",
+            "validation": {
+              "integer": "Value must be an integer"
+            }
           }
         }
       }

--- a/src/static/locales/en/party.json
+++ b/src/static/locales/en/party.json
@@ -106,7 +106,7 @@
       "assignAttributeBtn": "Assign attribute",
       "drawer": {
         "title": "Assign attribute",
-        "subtitle": "The assignee party will be able to use the selected certified attribute for all e-services on PDND",
+        "subtitle": "The assignee party may use the certified attribute for all e-services on PDND Interoperabilità.",
         "submitBtnLabel": "Assign attribute",
         "form": {
           "attributeField": {
@@ -114,6 +114,9 @@
           },
           "tenantField": {
             "label": "Assignee party"
+          },
+          "thresholdField": {
+            "label": "Numerical value"
           }
         }
       }

--- a/src/static/locales/en/party.json
+++ b/src/static/locales/en/party.json
@@ -115,7 +115,7 @@
           "tenantField": {
             "label": "Assignee party"
           },
-          "thresholdField": {
+          "valueField": {
             "label": "Numerical value",
             "validation": {
               "integer": "Value must be an integer"

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -344,8 +344,8 @@
     "addCertifiedAttribute": {
       "loading": "Stiamo assegnando l'attributo",
       "outcome": {
-        "error": "Non è stato possibile assegnare l’attributo. Per favore, riprova",
-        "success": "L’attributo è stato assegnato correttamente"
+        "error": "Non è stato possibile assegnare l'attributo certificato. Controlla di aver inserito le informazioni corrette.",
+        "success": "Hai assegnato l'attributo certificato."
       }
     },
     "revokeCertifiedAttribute": {

--- a/src/static/locales/it/party.json
+++ b/src/static/locales/it/party.json
@@ -115,7 +115,7 @@
           "tenantField": {
             "label": "Ente assegnatario"
           },
-          "thresholdField": {
+          "valueField": {
             "label": "Valore numerico",
             "validation": {
               "integer": "Il valore deve essere intero"

--- a/src/static/locales/it/party.json
+++ b/src/static/locales/it/party.json
@@ -116,7 +116,10 @@
             "label": "Ente assegnatario"
           },
           "thresholdField": {
-            "label": "Valore numerico"
+            "label": "Valore numerico",
+            "validation": {
+              "integer": "Il valore deve essere intero"
+            }
           }
         }
       }

--- a/src/static/locales/it/party.json
+++ b/src/static/locales/it/party.json
@@ -106,7 +106,7 @@
       "assignAttributeBtn": "Assegna attributo",
       "drawer": {
         "title": "Assegna attributo",
-        "subtitle": "L’ente assegnatario potrà spendere l’attributo certificato selezionato per tutti gli e-service presenti su PDND Interoperabilità",
+        "subtitle": "L'ente assegnatario potrà usare l'attributo certificato per tutti gli e-service su PDND Interoperabilità.",
         "submitBtnLabel": "Assegna attributo",
         "form": {
           "attributeField": {
@@ -114,6 +114,9 @@
           },
           "tenantField": {
             "label": "Ente assegnatario"
+          },
+          "thresholdField": {
+            "label": "Valore numerico"
           }
         }
       }


### PR DESCRIPTION
[Merge after #2101]

## 🔗 Issue

[PIN-10107](https://pagopa.atlassian.net/browse/PIN-10107)

## 📝 Description / Context

This PR add the necessary changes to `AssignAttributeDrawer` and `DialogRevokeCertifiedAttribute` inside the certificator page that permit to assign and revoke a certified discrete attribute

## 🛠 List of changes

- implement new assign and revoke certified discrete services and mutations
- redesign of `AssignAttributeDrawer`
- add new revoke service to `DialogRevokeCertifiedAttribute`
- add new strings


[PIN-10107]: https://pagopa.atlassian.net/browse/PIN-10107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ