### PR TITLE
fix: prevent unchanged attributes update (PIN-10046)

### DIFF
--- a/src/components/shared/UpdateAttributesDrawer.tsx
+++ b/src/components/shared/UpdateAttributesDrawer.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/utils/attribute.utils'
 import { useParams } from '@/router'
 import { EServiceTemplateMutations } from '@/api/eserviceTemplate'
+import isEqual from 'lodash/isEqual'
 
 type UpdateAttributesDrawerProps = {
   isOpen: boolean
@@ -103,6 +104,11 @@ export const UpdateAttributesDrawer: React.FC<UpdateAttributesDrawerProps> = ({
   }
 
   const handleSubmit = () => {
+    if (isEqual(selectedAttributes, formModelAttributes)) {
+      onClose()
+      return
+    }
+
     if (kind === 'ESERVICE') {
       updateEserviceAttributes(
         {

--- a/src/components/shared/__tests__/UpdateAttributesDrawer.test.tsx
+++ b/src/components/shared/__tests__/UpdateAttributesDrawer.test.tsx
@@ -32,8 +32,6 @@ vi.mock('@/components/shared/AttributeAutocomplete', () => ({
         onAddAttribute({
           id: 'attr-3',
           name: 'Attribute 3',
-          description: 'desc 3',
-          explicitAttributeVerification: false,
           kind: 'CERTIFIED',
         })
       }

--- a/src/components/shared/__tests__/UpdateAttributesDrawer.test.tsx
+++ b/src/components/shared/__tests__/UpdateAttributesDrawer.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { UpdateAttributesDrawer } from '../UpdateAttributesDrawer'
+import type { FormDescriptorAttribute } from '@/types/attribute.types'
 
 vi.mock('@/components/layout/containers', () => {
   type Attribute = { id: string; name: string }
@@ -20,7 +21,24 @@ vi.mock('@/components/layout/containers', () => {
 })
 
 vi.mock('@/components/shared/AttributeAutocomplete', () => ({
-  AttributeAutocomplete: () => <div data-testid="attribute-autocomplete" />,
+  AttributeAutocomplete: ({
+    onAddAttribute,
+  }: {
+    onAddAttribute: (attribute: FormDescriptorAttribute) => void
+  }) => (
+    <button
+      data-testid="attribute-autocomplete"
+      onClick={() =>
+        onAddAttribute({
+          id: 'attr-3',
+          name: 'Attribute 3',
+          description: 'desc 3',
+          explicitAttributeVerification: false,
+          kind: 'CERTIFIED',
+        })
+      }
+    />
+  ),
 }))
 
 const useUpdateAttributes = vi.fn()
@@ -163,15 +181,43 @@ describe('UpdateAttributesDrawer', () => {
     expect(screen.getByText('group.or')).toBeInTheDocument()
   })
 
-  it('calls updateEserviceTemplateAttributes when kind is ESERVICE_TEMPLATE', () => {
-    render(<UpdateAttributesDrawer {...defaultProps} kind="ESERVICE_TEMPLATE" />)
+  it('closes without calling updateEserviceTemplateAttributes when kind is ESERVICE_TEMPLATE and attributes are unchanged', () => {
+    const onClose = vi.fn()
+
+    render(<UpdateAttributesDrawer {...defaultProps} kind="ESERVICE_TEMPLATE" onClose={onClose} />)
     fireEvent.click(screen.getByText('actions.saveEdits'))
+
+    expect(useUpdateAttributes).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('closes without calling updateEserviceAttributes when kind is ESERVICE and attributes are unchanged', () => {
+    const onClose = vi.fn()
+
+    render(<UpdateAttributesDrawer {...defaultProps} kind="ESERVICE" onClose={onClose} />)
+    fireEvent.click(screen.getByText('actions.saveEdits'))
+
+    expect(useUpdateDescriptorAttributes).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls updateEserviceTemplateAttributes when kind is ESERVICE_TEMPLATE and attributes changed', () => {
+    render(<UpdateAttributesDrawer {...defaultProps} kind="ESERVICE_TEMPLATE" />)
+
+    fireEvent.click(screen.getAllByText('group.addAnotherBtn')[0])
+    fireEvent.click(screen.getByTestId('attribute-autocomplete'))
+    fireEvent.click(screen.getByText('actions.saveEdits'))
+
     expect(useUpdateAttributes).toHaveBeenCalled()
   })
 
-  it('calls updateEserviceAttributes when kind is ESERVICE', () => {
+  it('calls updateEserviceAttributes when kind is ESERVICE and attributes changed', () => {
     render(<UpdateAttributesDrawer {...defaultProps} kind="ESERVICE" />)
+
+    fireEvent.click(screen.getAllByText('group.addAnotherBtn')[0])
+    fireEvent.click(screen.getByTestId('attribute-autocomplete'))
     fireEvent.click(screen.getByText('actions.saveEdits'))
+
     expect(useUpdateDescriptorAttributes).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## 🔗 Issue

[PIN-10046](https://pagopa.atlassian.net/browse/PIN-10046)

## 📝 Description / Context

This PR fixes an issue in the provider e-service and e-service template details pages where saving the attributes drawer without making any actual change triggered the update mutation and could show a technical error toast.

The chosen behavior is to treat unchanged attributes as a no-op: the drawer closes without calling the backend and without showing a success toast. This keeps the flow aligned with existing multi-field/no-op patterns in the codebase and avoids showing a misleading success notification for an update that was not performed.

## 🛠 List of changes

- Added an unchanged-state guard in `UpdateAttributesDrawer`.
- Prevented e-service and e-service template attribute update mutations when the selected attributes match the initial drawer state.
- Added focused tests for unchanged attributes and for the changed-attributes path.

## 🧪 How to test

- Open a provider e-service details page with existing certified, verified, or declared attributes.
- In the “Thresholds and attributes” section, open the attributes drawer.
- Click “Save changes” without adding any attribute: the drawer should close, no error toast should appear, and no backend update should be triggered.
- Reopen the drawer, add an attribute to an existing group, then save: the update should still be submitted normally.
- Repeat the unchanged-save scenario from an e-service template details page.

[PIN-10046]: https://pagopa.atlassian.net/browse/PIN-10046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ