### PR TITLE
feature: fix copy and link in eservice attributes section (PIN-10560)

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -19,6 +19,7 @@ export const pagoPaLink = {
 }
 export const assistanceLink = `https://selfcare.pagopa.it/assistenza?productId=${SELFCARE_PRODUCT_ID}`
 export const attributesHelpLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/attributi`
+export const certifiedAttributesHelpLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/attributi/gli-attributi-piu-utilizzati`
 export const verifyVoucherGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/utilizzare-i-voucher`
 export const manageEServiceGuideLink = `${DOCUMENTATION_URL}/tutorial/tutorial-per-lerogatore/come-integrare-unapi`
 export const importExportEServiceGuideLink = `${DOCUMENTATION_URL}/riferimenti-tecnici/e-service/e-service`

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAttributesSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceAttributesSection.tsx
@@ -8,7 +8,7 @@ import { Box, Link, Tab, Typography } from '@mui/material'
 import { Trans, useTranslation } from 'react-i18next'
 import { useFormContext } from 'react-hook-form'
 
-import { attributesHelpLink } from '@/config/constants'
+import { attributesHelpLink, certifiedAttributesHelpLink } from '@/config/constants'
 
 type EServiceAttributesSectionProps = {
   isEServiceCreatedFromTemplate: boolean
@@ -74,7 +74,7 @@ export const EServiceAttributesSection: React.FC<EServiceAttributesSectionProps>
                 ns="eservice"
                 i18nKey="create.step3.certifiedDescription"
                 components={{
-                  1: <Link underline="hover" href={attributesHelpLink} target="_blank" />,
+                  1: <Link underline="hover" href={certifiedAttributesHelpLink} target="_blank" />,
                 }}
               />
             </Typography>

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepThresholdsAndAttributes/EServiceTemplateCreateStepThresholdsAndAttributes.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepThresholdsAndAttributes/EServiceTemplateCreateStepThresholdsAndAttributes.tsx
@@ -17,7 +17,7 @@ import type {
   DescriptorAttributes,
   UpdateEServiceTemplateVersionSeed,
 } from '@/api/api.generatedTypes'
-import { attributesHelpLink } from '@/config/constants'
+import { attributesHelpLink, certifiedAttributesHelpLink } from '@/config/constants'
 import { TabContext, TabList, TabPanel } from '@mui/lab'
 import { useActiveTab } from '@/hooks/useActiveTab'
 import { AddAttributesToForm } from '@/components/shared/AddAttributesToForm'
@@ -233,7 +233,13 @@ export const EServiceTemplateCreateStepThresholdsAndAttributes: React.FC<ActiveS
                     ns="eserviceTemplate"
                     i18nKey="create.step2.thresholdsAndAttributes.accessRequirements.tabs.certifiedDescription"
                     components={{
-                      1: <Link underline="hover" href={attributesHelpLink} target="_blank" />,
+                      1: (
+                        <Link
+                          underline="hover"
+                          href={certifiedAttributesHelpLink}
+                          target="_blank"
+                        />
+                      ),
                     }}
                   />
                 </Typography>

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -242,7 +242,7 @@
       "attributesTitle": "Access requirements",
       "attributesDescription": "Define who can access this e-service. Create one or more requirements and associate the required attributes to each. The consumer must meet all the indicated requirements and possess at least one of the attributes in each requirement. <1>Learn more about attributes</1>",
       "attributesDescriptionFromTemplate": "You cannot create or delete requirements or add new attributes. The consumer must meet all the indicated requirements and possess at least one of the attributes in each requirement. <1>Learn more about attributes</1>",
-      "certifiedDescription": "These are attributes certified by a <1>recognized authoritative source.</1>",
+      "certifiedDescription": "These are attributes recognized by certified sources such as IPA. Among the most commonly used, for example, are Municipalities and their Consortia and Associations, Provinces and their Consortia and Associations, and Public Service Managers. <1>Learn more about which attributes to use</1>.",
       "verifiedDescription": "These are attributes verified <1>by other organizations</1>, with the possibility of requesting a verification from the provider.",
       "declaredDescription": "These are attributes declared by the consumer during the service request. No verification from the provider is required.",
       "attributesAddBtn": "Create requirement",

--- a/src/static/locales/en/eserviceTemplate.json
+++ b/src/static/locales/en/eserviceTemplate.json
@@ -329,7 +329,7 @@
             "certified": "Certified Attributes",
             "verified": "Verified Attributes",
             "declared": "Declared Attributes",
-            "certifiedDescription": "These are attributes certified by a <1>recognized authoritative source.</1>",
+            "certifiedDescription": "These are attributes recognized by certified sources such as IPA. Among the most commonly used, for example, are Municipalities and their Consortia and Associations, Provinces and their Consortia and Associations, and Public Service Managers. <1>Learn more about which attributes to use</1>.",
             "verifiedDescription": "These are attributes verified <1>by other organizations</1>, with the possibility of requesting a verification from the provider.",
             "declaredDescription": "These are attributes declared by the consumer during the service request. No verification from the provider is required."
           }

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -242,7 +242,7 @@
       "attributesTitle": "Requisiti di accesso",
       "attributesDescription": "Definisci chi può accedere a questo e-service. Crea uno o più requisiti e associa a ciascuno gli attributi richiesti. Il fruitore dovrà soddisfare tutti i requisiti indicati e possedere almeno uno degli attributi in ogni requisito. <1>Scopri di più sugli attributi</1>",
       "attributesDescriptionFromTemplate": "Non puoi creare o eliminare i requisiti né aggiungere altri attributi. Il fruitore dovrà soddisfare tutti i requisiti indicati e possedere almeno uno degli attributi in ogni requisito. <1>Scopri di più sugli attributi</1>",
-      "certifiedDescription": "Sono attributi certificati da una <1>fonte autoritativa riconosciuta.</1>",
+      "certifiedDescription": "Sono attributi riconosciuti da fonti certificate come IPA. Tra i più usati, per esempio, ci sono Comuni e loro Consorzi e Associazioni, Province e loro Consorzi e Associazioni, Gestori di Pubblici Servizi. <1>Scopri di più su quali attributi usare</1>.",
       "verifiedDescription": "Sono attributi verificati <1>da altre organizzazioni</1>, con la possibilità di richiedere una verifica dall'erogatore.",
       "declaredDescription": "Sono attributi dichiarati dal fruitore stesso durante la richiesta di fruizione. Non è necessaria una verifica dell'erogatore.",
       "attributesAddBtn": "Crea requisito",

--- a/src/static/locales/it/eserviceTemplate.json
+++ b/src/static/locales/it/eserviceTemplate.json
@@ -329,7 +329,7 @@
             "certified": "Attributi Certificati",
             "verified": "Attributi Verificati",
             "declared": "Attributi Dichiarati",
-            "certifiedDescription": "Sono attributi certificati da una <1>fonte autoritativa riconosciuta.</1>",
+            "certifiedDescription": "Sono attributi riconosciuti da fonti certificate come IPA. Tra i più usati, per esempio, ci sono Comuni e loro Consorzi e Associazioni, Province e loro Consorzi e Associazioni, Gestori di Pubblici Servizi. <1>Scopri di più su quali attributi usare</1>.",
             "verifiedDescription": "Sono attributi verificati <1>da altre organizzazioni</1>, con la possibilità di richiedere una verifica dall'erogatore.",
             "declaredDescription": "Sono attributi dichiarati dal fruitore stesso durante la richiesta di fruizione. Non è necessaria una verifica dell'erogatore."
           }


### PR DESCRIPTION
## Jira Issue
[PIN-10560](https://pagopa.atlassian.net/browse/PIN-10560)

## Context/Why
**E-Service/ Template E-Service creation/edit**

## Key Changes
 - Add link in `constant.ts` for most used certified attributes documentation
 - Replace link in certified attributes tab description 

## Screenshoots

- E-Service
  
<img width="1021" height="838" alt="Screenshot 2026-07-08 at 16 18 10" src="https://github.com/user-attachments/assets/57e9b6fd-194b-45c5-ae63-419bd8c39c88" />

- Template E-service

<img width="1188" height="843" alt="Screenshot 2026-07-08 at 16 17 50" src="https://github.com/user-attachments/assets/17eaae3e-36aa-409d-8278-9513ff218bcb" />


[PIN-10560]: https://pagopa.atlassian.net/browse/PIN-10560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ