### PR TITLE
feat: add generic product updates banner (PIN-9979)

### DIFF
--- a/src/api/productUpdates/__tests__/productUpdates.services.test.ts
+++ b/src/api/productUpdates/__tests__/productUpdates.services.test.ts
@@ -42,6 +42,8 @@ describe('ProductUpdatesServices.getProductUpdatesJson', () => {
         date: '2028-05-25',
         time: '12:47',
       },
+      title: 'Novita su PDND',
+      description: 'Sono disponibili nuovi aggiornamenti di piattaforma.',
     })
     expect(axios.get).not.toHaveBeenCalled()
   })
@@ -56,6 +58,8 @@ describe('ProductUpdatesServices.getProductUpdatesJson', () => {
         date: '2026-06-12',
         time: '23:59',
       },
+      title: 'Novita piattaforma',
+      description: 'E disponibile una nuova funzionalita.',
     }
     vi.mocked(axios.get).mockResolvedValueOnce({ data: bannerData })
     const ProductUpdatesServices = await importProductUpdatesServices()
@@ -63,8 +67,99 @@ describe('ProductUpdatesServices.getProductUpdatesJson', () => {
     const result = await ProductUpdatesServices.getProductUpdatesJson()
 
     expect(axios.get).toHaveBeenCalledWith(
-      'https://interop-resources.example.com/banner-info-window/data.json'
+      'https://interop-resources.example.com/banner-info-window/it/data.json'
     )
     expect(result).toEqual(bannerData)
+  })
+
+  it('fetches the product updates banner data for the current language', async () => {
+    const bannerData = {
+      start: { date: '2026-06-11', time: '00:00' },
+      end: { date: '2026-06-12', time: '23:59' },
+      title: 'Platform news',
+      description: 'A new feature is available.',
+      firstLink: {
+        link: 'https://docs.example.com/feature',
+        label: 'Read the guide',
+      },
+    }
+    vi.mocked(axios.get).mockResolvedValueOnce({ data: bannerData })
+    const ProductUpdatesServices = await importProductUpdatesServices()
+
+    const result = await ProductUpdatesServices.getProductUpdatesJson('en')
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://interop-resources.example.com/banner-info-window/en/data.json'
+    )
+    expect(result).toEqual(bannerData)
+  })
+
+  it('falls back to the Italian banner when the current language file cannot be loaded', async () => {
+    const italianBannerData = {
+      start: { date: '2026-06-11', time: '00:00' },
+      end: { date: '2026-06-12', time: '23:59' },
+      title: 'Novita piattaforma',
+      description: 'E disponibile una nuova funzionalita.',
+    }
+    vi.mocked(axios.get)
+      .mockRejectedValueOnce(new Error('Not found'))
+      .mockResolvedValueOnce({ data: italianBannerData })
+    const ProductUpdatesServices = await importProductUpdatesServices()
+
+    const result = await ProductUpdatesServices.getProductUpdatesJson('en')
+
+    expect(axios.get).toHaveBeenNthCalledWith(
+      1,
+      'https://interop-resources.example.com/banner-info-window/en/data.json'
+    )
+    expect(axios.get).toHaveBeenNthCalledWith(
+      2,
+      'https://interop-resources.example.com/banner-info-window/it/data.json'
+    )
+    expect(result).toEqual(italianBannerData)
+  })
+
+  it('rejects invalid product updates banner data', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: {
+        start: { date: '2026-06-11', time: '00:00' },
+        end: { date: '2026-06-12', time: '23:59' },
+        title: 'Novita piattaforma',
+      },
+    })
+    const ProductUpdatesServices = await importProductUpdatesServices()
+
+    await expect(ProductUpdatesServices.getProductUpdatesJson()).rejects.toThrow()
+  })
+
+  it('falls back to the Italian banner when the current language file has invalid data', async () => {
+    const italianBannerData = {
+      start: { date: '2026-06-11', time: '00:00' },
+      end: { date: '2026-06-12', time: '23:59' },
+      title: 'Novita piattaforma',
+      description: 'E disponibile una nuova funzionalita.',
+    }
+    vi.mocked(axios.get)
+      .mockResolvedValueOnce({
+        data: {
+          start: { date: '2026-06-11', time: '00:00' },
+          end: { date: '2026-06-12', time: '23:59' },
+          title: 'Platform news',
+        },
+      })
+      .mockResolvedValueOnce({ data: italianBannerData })
+    const ProductUpdatesServices = await importProductUpdatesServices()
+
+    const result = await ProductUpdatesServices.getProductUpdatesJson('en')
+
+    expect(axios.get).toHaveBeenNthCalledWith(
+      1,
+      'https://interop-resources.example.com/banner-info-window/en/data.json'
+    )
+    expect(axios.get).toHaveBeenNthCalledWith(
+      2,
+      'https://interop-resources.example.com/banner-info-window/it/data.json'
+    )
+    expect(result).toEqual(italianBannerData)
   })
 })

--- a/src/api/productUpdates/__tests__/productUpdates.services.test.ts
+++ b/src/api/productUpdates/__tests__/productUpdates.services.test.ts
@@ -132,6 +132,24 @@ describe('ProductUpdatesServices.getProductUpdatesJson', () => {
     await expect(ProductUpdatesServices.getProductUpdatesJson()).rejects.toThrow()
   })
 
+  it('rejects banner links that do not use HTTP or HTTPS', async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: {
+        start: { date: '2026-06-11', time: '00:00' },
+        end: { date: '2026-06-12', time: '23:59' },
+        title: 'Novita piattaforma',
+        description: 'E disponibile una nuova funzionalita.',
+        firstLink: {
+          link: 'javascript:alert(document.domain)',
+          label: 'Read the guide',
+        },
+      },
+    })
+    const ProductUpdatesServices = await importProductUpdatesServices()
+
+    await expect(ProductUpdatesServices.getProductUpdatesJson()).rejects.toThrow()
+  })
+
   it('falls back to the Italian banner when the current language file has invalid data', async () => {
     const italianBannerData = {
       start: { date: '2026-06-11', time: '00:00' },

--- a/src/api/productUpdates/productUpdates.queries.ts
+++ b/src/api/productUpdates/productUpdates.queries.ts
@@ -1,10 +1,10 @@
 import { queryOptions } from '@tanstack/react-query'
 import { ProductUpdatesServices } from './productUpdates.services'
 
-function getProductUpdatesJson() {
+function getProductUpdatesJson(language: string) {
   return queryOptions({
-    queryKey: ['GetProductUpdatesJson'],
-    queryFn: ProductUpdatesServices.getProductUpdatesJson,
+    queryKey: ['GetProductUpdatesJson', language],
+    queryFn: () => ProductUpdatesServices.getProductUpdatesJson(language),
     throwOnError: false,
     retry: false,
     staleTime: Infinity,

--- a/src/api/productUpdates/productUpdates.services.ts
+++ b/src/api/productUpdates/productUpdates.services.ts
@@ -1,8 +1,42 @@
 import { APP_MODE, INTEROP_RESOURCES_BASE_URL } from '@/config/env'
 import type { BannerData } from '@/types/banner.types'
 import axios from 'axios'
+import { z } from 'zod'
 
-async function getProductUpdatesJson() {
+const DEFAULT_BANNER_LANGUAGE = 'it'
+
+const productUpdatesBannerLinkSchema = z.object({
+  link: z.string().url(),
+  label: z.string().min(1),
+})
+
+const productUpdatesBannerDataSchema = z.object({
+  start: z.object({
+    date: z.string().min(1),
+    time: z.string().min(1),
+  }),
+  end: z.object({
+    date: z.string().min(1),
+    time: z.string().min(1),
+  }),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  firstLink: productUpdatesBannerLinkSchema.optional(),
+  secondLink: productUpdatesBannerLinkSchema.optional(),
+})
+
+function getBannerLanguage(language: string) {
+  return language.startsWith('en') ? 'en' : DEFAULT_BANNER_LANGUAGE
+}
+
+async function fetchProductUpdatesJson(language: string) {
+  const response = await axios.get<unknown>(
+    `${INTEROP_RESOURCES_BASE_URL}/banner-info-window/${language}/data.json`
+  )
+  return productUpdatesBannerDataSchema.parse(response.data) satisfies BannerData
+}
+
+async function getProductUpdatesJson(language = DEFAULT_BANNER_LANGUAGE) {
   // Mock data in development to avoid CORS issues with S3
   if (APP_MODE === 'development') {
     const bannerData: BannerData = {
@@ -14,15 +48,24 @@ async function getProductUpdatesJson() {
         date: '2028-05-25',
         time: '12:47',
       },
+      title: 'Novita su PDND',
+      description: 'Sono disponibili nuovi aggiornamenti di piattaforma.',
     }
 
     return bannerData
   }
 
-  const response = await axios.get<BannerData>(
-    `${INTEROP_RESOURCES_BASE_URL}/banner-info-window/data.json`
-  )
-  return response.data
+  const bannerLanguage = getBannerLanguage(language)
+
+  try {
+    return await fetchProductUpdatesJson(bannerLanguage)
+  } catch (error) {
+    if (bannerLanguage === DEFAULT_BANNER_LANGUAGE) {
+      throw error
+    }
+
+    return fetchProductUpdatesJson(DEFAULT_BANNER_LANGUAGE)
+  }
 }
 
 export const ProductUpdatesServices = {

--- a/src/api/productUpdates/productUpdates.services.ts
+++ b/src/api/productUpdates/productUpdates.services.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 const DEFAULT_BANNER_LANGUAGE = 'it'
 
 const productUpdatesBannerLinkSchema = z.object({
-  link: z.string().url(),
+  link: z.url({ protocol: /^https?$/ }),
   label: z.string().min(1),
 })
 

--- a/src/components/shared/__tests__/ProductUpdatesBanner.test.tsx
+++ b/src/components/shared/__tests__/ProductUpdatesBanner.test.tsx
@@ -9,10 +9,14 @@ import { renderWithApplicationContext } from '@/utils/testing.utils'
 const mockProductUpdatesBanner = {
   title: 'This is a notification message',
   text: 'This is the notification context',
-  action1Label: 'Action 1',
-  action2Label: 'Action 2',
-  action1AriaLabel: 'Action 1, opens in a new tab',
-  action2AriaLabel: 'Action 2, opens in a new tab',
+  firstLink: {
+    label: 'Action 1',
+    link: 'https://docs.example.com/first',
+  },
+  secondLink: {
+    label: 'Action 2',
+    link: 'https://docs.example.com/second',
+  },
   isOpen: true,
   closeBanner: vi.fn(),
 }
@@ -36,14 +40,33 @@ describe('Checks product updates banner alert', () => {
     expect(getByText(mockProductUpdatesBanner.title)).toBeInTheDocument()
     expect(getByText(mockProductUpdatesBanner.text)).toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: mockProductUpdatesBanner.action1AriaLabel })
-    ).not.toBeInTheDocument()
+      screen.getByRole('link', { name: mockProductUpdatesBanner.firstLink.label })
+    ).toHaveAttribute('href', mockProductUpdatesBanner.firstLink.link)
     expect(
-      screen.queryByRole('button', { name: mockProductUpdatesBanner.action2AriaLabel })
-    ).not.toBeInTheDocument()
+      screen.getByRole('link', { name: mockProductUpdatesBanner.secondLink.label })
+    ).toHaveAttribute('href', mockProductUpdatesBanner.secondLink.link)
 
     const closeButton = getByTestId('CloseIcon')
     await user.click(closeButton)
     expect(mockProductUpdatesBanner.closeBanner).toHaveBeenCalled()
+  })
+
+  it('does not render optional links when they are not configured', () => {
+    vi.spyOn(useProductUpdatesBannerModule, 'useProductUpdatesBanner').mockReturnValue({
+      ...mockProductUpdatesBanner,
+      firstLink: undefined,
+      secondLink: undefined,
+    })
+
+    renderWithApplicationContext(<ProductUpdatesBanner />, {
+      withRouterContext: true,
+    })
+
+    expect(
+      screen.queryByRole('link', { name: mockProductUpdatesBanner.firstLink.label })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: mockProductUpdatesBanner.secondLink.label })
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/components/shared/__tests__/ProductUpdatesBanner.test.tsx
+++ b/src/components/shared/__tests__/ProductUpdatesBanner.test.tsx
@@ -6,6 +6,12 @@ import { vi } from 'vitest'
 import * as useProductUpdatesBannerModule from '@/hooks/bannerHooks/useProductUpdatesBanner'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, { label }: { label: string }) => `${label}, opens in a new tab`,
+  }),
+}))
+
 const mockProductUpdatesBanner = {
   title: 'This is a notification message',
   text: 'This is the notification context',
@@ -40,10 +46,14 @@ describe('Checks product updates banner alert', () => {
     expect(getByText(mockProductUpdatesBanner.title)).toBeInTheDocument()
     expect(getByText(mockProductUpdatesBanner.text)).toBeInTheDocument()
     expect(
-      screen.getByRole('link', { name: mockProductUpdatesBanner.firstLink.label })
+      screen.getByRole('link', {
+        name: `${mockProductUpdatesBanner.firstLink.label}, opens in a new tab`,
+      })
     ).toHaveAttribute('href', mockProductUpdatesBanner.firstLink.link)
     expect(
-      screen.getByRole('link', { name: mockProductUpdatesBanner.secondLink.label })
+      screen.getByRole('link', {
+        name: `${mockProductUpdatesBanner.secondLink.label}, opens in a new tab`,
+      })
     ).toHaveAttribute('href', mockProductUpdatesBanner.secondLink.link)
 
     const closeButton = getByTestId('CloseIcon')

--- a/src/components/shared/banners/ProductUpdatesBanner.tsx
+++ b/src/components/shared/banners/ProductUpdatesBanner.tsx
@@ -3,8 +3,10 @@ import { useProductUpdatesBanner } from '@/hooks/bannerHooks/useProductUpdatesBa
 import { Banner } from './Banner'
 import { Button } from '@mui/material'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import { useTranslation } from 'react-i18next'
 
 export const ProductUpdatesBanner: React.FC = () => {
+  const { t } = useTranslation('shared-components', { keyPrefix: 'productUpdatesBanner' })
   const { title, text, firstLink, secondLink, isOpen, closeBanner } = useProductUpdatesBanner()
 
   return (
@@ -23,6 +25,7 @@ export const ProductUpdatesBanner: React.FC = () => {
             href={firstLink.link}
             target="_blank"
             rel="noreferrer"
+            aria-label={t('linkAriaLabel', { label: firstLink.label })}
           >
             {firstLink.label}
           </Button>
@@ -38,6 +41,7 @@ export const ProductUpdatesBanner: React.FC = () => {
             href={secondLink.link}
             target="_blank"
             rel="noreferrer"
+            aria-label={t('linkAriaLabel', { label: secondLink.label })}
           >
             {secondLink.label}
           </Button>

--- a/src/components/shared/banners/ProductUpdatesBanner.tsx
+++ b/src/components/shared/banners/ProductUpdatesBanner.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { useProductUpdatesBanner } from '@/hooks/bannerHooks/useProductUpdatesBanner'
 import { Banner } from './Banner'
+import { Button } from '@mui/material'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 export const ProductUpdatesBanner: React.FC = () => {
-  const { title, text, isOpen, closeBanner } = useProductUpdatesBanner()
+  const { title, text, firstLink, secondLink, isOpen, closeBanner } = useProductUpdatesBanner()
 
   return (
     <Banner
@@ -11,30 +13,36 @@ export const ProductUpdatesBanner: React.FC = () => {
       content={text}
       isOpen={isOpen}
       setIsOpen={closeBanner}
-      // action1={
-      //   <Button
-      //     size="small"
-      //     color="inherit"
-      //     endIcon={<OpenInNewIcon />}
-      //     key="action1"
-      //     onClick={() => window.open(archiveEserviceGuideLink, '_blank')}
-      //     aria-label={action1AriaLabel}
-      //   >
-      //     {action1Label}
-      //   </Button>
-      // }
-      // action2={
-      //   <Button
-      //     size="small"
-      //     color="inherit"
-      //     endIcon={<OpenInNewIcon />}
-      //     key="action2"
-      //     onClick={() => window.open(userRolesGuideLink, '_blank')}
-      //     aria-label={action2AriaLabel}
-      //   >
-      //     {action2Label}
-      //   </Button>
-      // }
+      action1={
+        firstLink && (
+          <Button
+            size="small"
+            color="inherit"
+            endIcon={<OpenInNewIcon />}
+            key="action1"
+            href={firstLink.link}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {firstLink.label}
+          </Button>
+        )
+      }
+      action2={
+        secondLink && (
+          <Button
+            size="small"
+            color="inherit"
+            endIcon={<OpenInNewIcon />}
+            key="action2"
+            href={secondLink.link}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {secondLink.label}
+          </Button>
+        )
+      }
     />
   )
 }

--- a/src/hooks/__tests__/useProductUpdatesBanner.test.ts
+++ b/src/hooks/__tests__/useProductUpdatesBanner.test.ts
@@ -21,6 +21,16 @@ vi.mock('../bannerHooks/useBaseBanner', () => ({
 const bannerData = {
   start: { date: '2026-06-11', time: '00:00' },
   end: { date: '2026-06-12', time: '23:59' },
+  title: 'Platform news',
+  description: 'A new feature is available.',
+  firstLink: {
+    link: 'https://docs.example.com/feature',
+    label: 'Read the guide',
+  },
+  secondLink: {
+    link: 'https://docs.example.com/roles',
+    label: 'Discover roles',
+  },
 }
 
 describe('useProductUpdatesBanner', () => {
@@ -50,12 +60,16 @@ describe('useProductUpdatesBanner', () => {
     })
 
     expect(result.current).toMatchObject({
-      title: 'title',
-      text: 'body',
-      action1Label: 'action1Label',
-      action2Label: 'action2Label',
-      action1AriaLabel: 'action1AriaLabel',
-      action2AriaLabel: 'action2AriaLabel',
+      title: 'Platform news',
+      text: 'A new feature is available.',
+      firstLink: {
+        link: 'https://docs.example.com/feature',
+        label: 'Read the guide',
+      },
+      secondLink: {
+        link: 'https://docs.example.com/roles',
+        label: 'Discover roles',
+      },
       isOpen: true,
     })
     expect(useBaseBanner).toHaveBeenCalledWith({

--- a/src/hooks/bannerHooks/useProductUpdatesBanner.ts
+++ b/src/hooks/bannerHooks/useProductUpdatesBanner.ts
@@ -6,8 +6,8 @@ import { useTranslation } from 'react-i18next'
 const STORAGE_KEY = 'productUpdatesBannerDismissedUntil'
 
 export function useProductUpdatesBanner() {
-  const { t } = useTranslation('shared-components', { keyPrefix: 'productUpdatesBanner' })
-  const { data } = useQuery(ProductUpdatesQueries.getProductUpdatesJson())
+  const { i18n } = useTranslation()
+  const { data } = useQuery(ProductUpdatesQueries.getProductUpdatesJson(i18n.language))
 
   const { isOpen, closeBanner } = useBaseBanner({
     data,
@@ -16,20 +16,11 @@ export function useProductUpdatesBanner() {
     priority: 2, // lower than maintenance banner
   })
 
-  const text = t('body')
-  const title = t('title')
-  const action1Label = t('action1Label')
-  const action2Label = t('action2Label')
-  const action1AriaLabel = t('action1AriaLabel')
-  const action2AriaLabel = t('action2AriaLabel')
-
   return {
-    title,
-    text,
-    action1Label,
-    action2Label,
-    action1AriaLabel,
-    action2AriaLabel,
+    title: data?.title ?? '',
+    text: data?.description ?? '',
+    firstLink: data?.firstLink,
+    secondLink: data?.secondLink,
     isOpen,
     closeBanner,
   }

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/__tests__/VoucherInstructionsGeneralForm.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/__tests__/VoucherInstructionsGeneralForm.test.tsx
@@ -22,11 +22,12 @@ vi.mock('../VoucherInstructionsGeneralFormCurrentIdsDrawer', () => ({
 }))
 
 vi.mock('@/api/client/client.services', () => ({
-  getList: vi.fn().mockResolvedValue({
-    data: {
-      content: [],
-    },
-  }),
+  ClientServices: {
+    getList: vi.fn().mockResolvedValue({
+      results: [],
+      pagination: { offset: 0, limit: 50, totalCount: 0 },
+    }),
+  },
 }))
 
 describe('VoucherInstructionsGeneralForm', () => {

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -399,12 +399,6 @@
     "bodyMultipleDay": "PDND Interoperabilità will undergo scheduled maintenance from {{maintenanceStartHour}} on {{maintenanceStartDay}} to {{maintenanceEndHour}} on {{maintenanceEndDay}}. We apologize for any inconvenience caused."
   },
   "productUpdatesBanner": {
-    "title": "What's new on PDND: archiving and new roles",
-    "body": "You can now archive obsolete versions of an e-service or an entire e-service. Two new roles are also available: Validator, to approve or fill in the risk analysis, and Viewer, to view an organization's activities on PDND.",
-    "action1Label": "How archiving works",
-    "action1AriaLabel": "How archiving works, opens in a new tab",
-    "action2Label": "How the new roles work",
-    "action2AriaLabel": "How the new roles work, opens in a new tab",
     "linkAriaLabel": "{{label}}, opens in a new tab"
   },
   "attributeContainer": {

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -404,7 +404,8 @@
     "action1Label": "How archiving works",
     "action1AriaLabel": "How archiving works, opens in a new tab",
     "action2Label": "How the new roles work",
-    "action2AriaLabel": "How the new roles work, opens in a new tab"
+    "action2AriaLabel": "How the new roles work, opens in a new tab",
+    "linkAriaLabel": "{{label}}, opens in a new tab"
   },
   "attributeContainer": {
     "descriptionLabel": "Description",

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -399,12 +399,6 @@
     "bodyMultipleDay": "Interoperabilità PDND sarà sottoposto a manutenzione programmata dalle {{maintenanceStartHour}} del {{maintenanceStartDay}} alle {{maintenanceEndHour}} del {{maintenanceEndDay}}. Ci scusiamo per gli eventuali disservizi causati."
   },
   "productUpdatesBanner": {
-    "title": "Novità su PDND: archiviazione e nuovi ruoli",
-    "body": "Da adesso, puoi archiviare le versioni obsolete di un e-service o un intero e-service. In più sono disponibili due nuovi ruoli: validatore, per approvare o compilare l’analisi del rischio, e consultatore, per visualizzare le attività di un ente su PDND.",
-    "action1Label": "Come funziona l’archiviazione",
-    "action1AriaLabel": "Come funziona l’archiviazione, apre in una nuova scheda",
-    "action2Label": "Come funzionano i nuovi ruoli",
-    "action2AriaLabel": "Come funzionano i nuovi ruoli, apre in una nuova scheda",
     "linkAriaLabel": "{{label}}, apre in una nuova scheda"
   },
   "attributeContainer": {

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -404,7 +404,8 @@
     "action1Label": "Come funziona l’archiviazione",
     "action1AriaLabel": "Come funziona l’archiviazione, apre in una nuova scheda",
     "action2Label": "Come funzionano i nuovi ruoli",
-    "action2AriaLabel": "Come funzionano i nuovi ruoli, apre in una nuova scheda"
+    "action2AriaLabel": "Come funzionano i nuovi ruoli, apre in una nuova scheda",
+    "linkAriaLabel": "{{label}}, apre in una nuova scheda"
   },
   "attributeContainer": {
     "descriptionLabel": "Descrizione",

--- a/src/types/banner.types.ts
+++ b/src/types/banner.types.ts
@@ -1,4 +1,13 @@
+export type BannerLink = {
+  link: string
+  label: string
+}
+
 export type BannerData = {
   start: { date: string; time: string }
   end: { date: string; time: string }
+  title?: string
+  description?: string
+  firstLink?: BannerLink
+  secondLink?: BannerLink
 }


### PR DESCRIPTION
## 🔗 Issue

[PIN-9979](https://pagopa.atlassian.net/browse/PIN-9979)

## 📝 Description / Context

This PR updates the product updates banner to support a generic, S3-driven configuration with localized JSON files. The banner content is now read from the current language path, with Italian as fallback, and validated at runtime before being rendered.

## 🛠 List of changes

- Read product updates banner data from `/banner-info-window/{it|en}/data.json`
- Add Italian fallback when the current language file is missing or invalid
- Render dynamic title, description, and up to two optional documentation links
- Add Zod validation for the S3 JSON payload
- Update service, hook, and component tests for localized paths, fallback, validation, and optional links

## 🧪 How to test

- Open the e-service catalog page with language set to Italian and verify the banner uses the `/it/data.json` content.
- Switch to English and verify the banner uses `/en/data.json`; if the English file is unavailable or invalid, verify it falls back to the Italian content.
- Configure `firstLink` and/or `secondLink` in the JSON and verify only configured links are shown and open in a new tab.


[PIN-9979]: https://pagopa.atlassian.net/browse/PIN-9979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ