### PR TITLE
fix: encoded axios params (PIN-9578)

### DIFF
--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -32,7 +32,9 @@ const serializeParams = (query: Record<string, unknown>) => {
       // like 0 or '' are allowed
       .filter(([, value]) => value !== undefined && value !== null)
       .map(([key, value]) =>
-        Array.isArray(value) ? `${key}=${value.join(',')}` : `${key}=${value}`
+        Array.isArray(value)
+          ? `${key}=${value.map((v) => encodeURIComponent(String(v))).join(',')}`
+          : `${key}=${encodeURIComponent(String(value))}`
       )
       .join('&')
   )


### PR DESCRIPTION
## Issue
- [PIN-9578](https://pagopa.atlassian.net/browse/PIN-9578)
## Description / Context / Why
- Modified serializeParams method to encode params (encodeURIComponent)

[PIN-9578]: https://pagopa.atlassian.net/browse/PIN-9578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ