### PR TITLE
feat:  INT 54 52 51 element not associated correctly (A2-2626 A2-2624 A2-2623)

### DIFF
--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisCheckboxGroup.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisCheckboxGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useId } from 'react'
 import { FormControlLabel, FormGroup, Checkbox } from '@mui/material'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import type { InputOption } from '@/types/common.types'
@@ -53,10 +53,13 @@ export const RiskAnalysisCheckboxGroup: React.FC<RiskAnalysisCheckboxGroupProps>
       ? { validate: () => true }
       : mapValidationErrorMessages(rules, t)
 
+  const labelId = useId()
+
   return (
     <RiskAnalysisInputWrapper
       isInputGroup
       label={label}
+      labelId={labelId}
       infoLabel={infoLabel}
       helperText={helperText}
       error={error}

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisCheckboxGroup.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisCheckboxGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from 'react'
+import React from 'react'
 import { FormControlLabel, FormGroup, Checkbox } from '@mui/material'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import type { InputOption } from '@/types/common.types'
@@ -53,13 +53,10 @@ export const RiskAnalysisCheckboxGroup: React.FC<RiskAnalysisCheckboxGroupProps>
       ? { validate: () => true }
       : mapValidationErrorMessages(rules, t)
 
-  const labelId = useId()
-
   return (
     <RiskAnalysisInputWrapper
       isInputGroup
       label={label}
-      labelId={labelId}
       infoLabel={infoLabel}
       helperText={helperText}
       error={error}

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisInputWrapper.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisInputWrapper.tsx
@@ -60,7 +60,7 @@ const RiskAnalysisInputWrapper: React.FC<RiskAnalysisInputWrapperProps> = ({
   const labelId = externalLabelId || internalLabelId
 
   return (
-    <SectionContainer>
+    <SectionContainer component={isInputGroup ? 'fieldset' : 'div'}>
       <SectionContainer
         innerSection
         {...(isFromPurposeTemplate ? { sx: { border: 1, borderColor: 'lightgrey', p: 3 } } : {})}

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisInputWrapper.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisInputWrapper.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-import React from 'react'
+import React, { useId } from 'react'
 import { RiskAnalysisAnswerComponent } from '@/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepRiskAnalysis/RiskAnalysisForm/RiskAnalysisAnswerComponent'
 import { RiskAnalysisReadAnnotationsComponent } from '@/pages/ConsumerPurposeFromTemplateEditPage/components/PurposeFromTemplateEditStepRiskAnalysis/RiskAnalysisReadAnnotationsComponent'
 import { useTranslation } from 'react-i18next'
@@ -40,7 +40,7 @@ const RiskAnalysisInputWrapper: React.FC<RiskAnalysisInputWrapperProps> = ({
   infoLabel,
   helperText,
   helperTextId,
-  labelId,
+  labelId: externalLabelId,
   infoLabelId,
   error,
   errorId,
@@ -55,19 +55,28 @@ const RiskAnalysisInputWrapper: React.FC<RiskAnalysisInputWrapperProps> = ({
   const { t: tShared } = useTranslation('shared-components', {
     keyPrefix: 'purposeTemplateRiskAnalysisInfoSummary',
   })
+
+  const internalLabelId = useId()
+  const labelId = externalLabelId || internalLabelId
+
   return (
-    <SectionContainer component={isInputGroup ? 'fieldset' : 'div'}>
+    <SectionContainer>
       <SectionContainer
         innerSection
         {...(isFromPurposeTemplate ? { sx: { border: 1, borderColor: 'lightgrey', p: 3 } } : {})}
       >
-        <FormControl fullWidth error={!!error}>
+        <FormControl
+          fullWidth
+          error={!!error}
+          role={isInputGroup ? 'group' : undefined}
+          aria-labelledby={isInputGroup ? labelId : undefined}
+        >
           <Stack spacing={1} sx={{ mb: 4 }}>
             <Box display="flex" justifyContent="space-between" alignItems="flex-start" gap={2}>
               <Box sx={{ flex: 1, minWidth: 0 }}>
                 <FormLabel
-                  htmlFor={name}
-                  component={isInputGroup ? 'legend' : name ? 'label' : 'div'}
+                  htmlFor={isInputGroup ? undefined : name}
+                  component={isInputGroup ? 'div' : name ? 'label' : 'div'}
                   id={labelId}
                   sx={{ fontWeight: 600 }}
                 >

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisInputWrapper.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisInputWrapper.tsx
@@ -76,7 +76,7 @@ const RiskAnalysisInputWrapper: React.FC<RiskAnalysisInputWrapperProps> = ({
               <Box sx={{ flex: 1, minWidth: 0 }}>
                 <FormLabel
                   htmlFor={isInputGroup ? undefined : name}
-                  component={isInputGroup ? 'div' : name ? 'label' : 'div'}
+                  component={isInputGroup ? 'legend' : name ? 'label' : 'div'}
                   id={labelId}
                   sx={{ fontWeight: 600 }}
                 >

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisSelect.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisSelect.tsx
@@ -56,6 +56,13 @@ export const RiskAnalysisSelect: React.FC<RiskAnalysisSelectProps> = ({
       ? { required: false }
       : mapValidationErrorMessages(rules, t)
 
+  const mergedAriaDescribedBy = [
+    props.SelectDisplayProps?.['aria-describedby'],
+    accessibilityProps['aria-describedby'],
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   return (
     <RiskAnalysisInputWrapper
       name={name}
@@ -76,6 +83,7 @@ export const RiskAnalysisSelect: React.FC<RiskAnalysisSelectProps> = ({
           <MUISelect
             {...props}
             {...fieldProps}
+            {...accessibilityProps}
             id={name}
             labelId={ids.labelId}
             value={value ?? ''}
@@ -83,7 +91,8 @@ export const RiskAnalysisSelect: React.FC<RiskAnalysisSelectProps> = ({
               ...props.inputProps,
             }}
             SelectDisplayProps={{
-              'aria-describedby': accessibilityProps['aria-describedby'],
+              ...props.SelectDisplayProps,
+              'aria-describedby': mergedAriaDescribedBy || undefined,
             }}
             onChange={(e) => {
               onChange(e)

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisSelect.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisSelect.tsx
@@ -58,6 +58,7 @@ export const RiskAnalysisSelect: React.FC<RiskAnalysisSelectProps> = ({
 
   return (
     <RiskAnalysisInputWrapper
+      name={name}
       label={label}
       infoLabel={infoLabel}
       error={error}
@@ -75,10 +76,14 @@ export const RiskAnalysisSelect: React.FC<RiskAnalysisSelectProps> = ({
           <MUISelect
             {...props}
             {...fieldProps}
+            id={name}
+            labelId={ids.labelId}
             value={value ?? ''}
             inputProps={{
               ...props.inputProps,
-              ...accessibilityProps,
+            }}
+            SelectDisplayProps={{
+              'aria-describedby': accessibilityProps['aria-describedby'],
             }}
             onChange={(e) => {
               onChange(e)

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisSwitch.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisSwitch.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FormLabel, Switch as MUISwitch, Typography, Stack } from '@mui/material'
+import { Switch as MUISwitch, Typography, Stack, Box } from '@mui/material'
 import type { SwitchProps as MUISwitchProps } from '@mui/material'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import { getAriaAccessibilityInputProps, mapValidationErrorMessages } from '@/utils/form.utils'
@@ -56,6 +56,7 @@ export const RiskAnalysisSwitch: React.FC<RiskAnalysisSwitchProps> = ({
 
   return (
     <RiskAnalysisInputWrapper
+      name={name}
       label={label}
       error={error}
       infoLabel={infoLabel}
@@ -66,7 +67,11 @@ export const RiskAnalysisSwitch: React.FC<RiskAnalysisSwitchProps> = ({
       type={type}
       isAssignedToTemplateUsersSwitch={isAssignedToTemplateUsersSwitch}
     >
-      <FormLabel sx={{ color: 'text.primary' }}>
+      <Box
+        component="label"
+        htmlFor={name}
+        sx={{ color: 'text.primary', display: 'flex', cursor: 'pointer' }}
+      >
         <Stack sx={{ mt: 2, mb: 1 }} direction="row" alignItems="center" spacing={1}>
           <Controller
             name={name}
@@ -77,6 +82,8 @@ export const RiskAnalysisSwitch: React.FC<RiskAnalysisSwitchProps> = ({
                 {...fieldProps}
                 inputProps={{
                   ...switchProps.inputProps,
+                  id: name,
+                  'aria-labelledby': ids.labelId,
                   'aria-describedby': accessibilityProps['aria-describedby'],
                 }}
                 onChange={(e) => {
@@ -98,7 +105,7 @@ export const RiskAnalysisSwitch: React.FC<RiskAnalysisSwitchProps> = ({
             </Typography>
           )}
         </Stack>
-      </FormLabel>
+      </Box>
     </RiskAnalysisInputWrapper>
   )
 }

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisSwitch.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisSwitch.tsx
@@ -67,11 +67,7 @@ export const RiskAnalysisSwitch: React.FC<RiskAnalysisSwitchProps> = ({
       type={type}
       isAssignedToTemplateUsersSwitch={isAssignedToTemplateUsersSwitch}
     >
-      <Box
-        component="label"
-        htmlFor={name}
-        sx={{ color: 'text.primary', display: 'flex', cursor: 'pointer' }}
-      >
+      <Box sx={{ color: 'text.primary', display: 'flex', cursor: 'pointer' }}>
         <Stack sx={{ mt: 2, mb: 1 }} direction="row" alignItems="center" spacing={1}>
           <Controller
             name={name}

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisSwitch.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisSwitch.tsx
@@ -82,9 +82,8 @@ export const RiskAnalysisSwitch: React.FC<RiskAnalysisSwitchProps> = ({
                 {...fieldProps}
                 inputProps={{
                   ...switchProps.inputProps,
+                  ...accessibilityProps,
                   id: name,
-                  'aria-labelledby': ids.labelId,
-                  'aria-describedby': accessibilityProps['aria-describedby'],
                 }}
                 onChange={(e) => {
                   onChange(e.target.checked ? 'true' : 'false')

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisTextField.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisTextField.tsx
@@ -149,6 +149,11 @@ export const RiskAnalysisTextField: React.FC<RiskAnalysisTextFieldProps> = ({
             label={t('suggestedAnswersLabel')}
             options={suggestedValues.map((value) => ({ label: value, value }))}
             rules={{ required: true }}
+            id={`select-${suggestedValueConsumerName}`}
+            inputProps={{
+              'aria-label': label,
+              id: `input-${suggestedValueConsumerName}`,
+            }}
           />
         ) : type === 'consumer' ? (
           // Show textArea for consumer if editable or no suggestedValues

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisTextField.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisTextField.tsx
@@ -79,7 +79,12 @@ export const RiskAnalysisTextField: React.FC<RiskAnalysisTextFieldProps> = ({
 
   const displayError = getDisplayError(error)
 
-  const { accessibilityProps, ids } = getAriaAccessibilityInputProps(name, {
+  const isConsumerReadOnlySuggestedValues =
+    isFromPurposeTemplate && type === 'consumer' && suggestedValues.length > 0 && !isEditable
+
+  const currentFieldName = isConsumerReadOnlySuggestedValues ? suggestedValueConsumerName : name
+
+  const { accessibilityProps, ids } = getAriaAccessibilityInputProps(currentFieldName, {
     label,
     infoLabel,
     error: displayError,
@@ -131,7 +136,7 @@ export const RiskAnalysisTextField: React.FC<RiskAnalysisTextFieldProps> = ({
   if (isFromPurposeTemplate) {
     return (
       <RiskAnalysisInputWrapper
-        name={name}
+        name={currentFieldName}
         label={label}
         infoLabel={infoLabel}
         error={displayError}
@@ -142,18 +147,13 @@ export const RiskAnalysisTextField: React.FC<RiskAnalysisTextFieldProps> = ({
         type={type}
         isAssignedToTemplateUsersSwitch={true}
       >
-        {type === 'consumer' && suggestedValues.length > 0 && !isEditable ? (
+        {isConsumerReadOnlySuggestedValues ? (
           // Show select only if there are suggestedValues AND question is not editable
           <RHFSelect
             name={suggestedValueConsumerName}
             label={t('suggestedAnswersLabel')}
             options={suggestedValues.map((value) => ({ label: value, value }))}
             rules={{ required: true }}
-            id={`select-${suggestedValueConsumerName}`}
-            inputProps={{
-              'aria-label': label,
-              id: `input-${suggestedValueConsumerName}`,
-            }}
           />
         ) : type === 'consumer' ? (
           // Show textArea for consumer if editable or no suggestedValues

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisTextField.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisTextField.tsx
@@ -163,6 +163,7 @@ export const RiskAnalysisTextField: React.FC<RiskAnalysisTextFieldProps> = ({
             render={({ field: { ref, onChange, ...fieldProps } }) => (
               <OutlinedInput
                 {...props}
+                id={currentFieldName}
                 inputProps={{ ...props.inputProps, ...accessibilityProps }}
                 multiline={multiline}
                 rows={multiline ? 6 : undefined}

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisTextField.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisTextField.tsx
@@ -258,6 +258,7 @@ export const RiskAnalysisTextField: React.FC<RiskAnalysisTextFieldProps> = ({
         render={({ field: { ref, onChange, ...fieldProps } }) => (
           <OutlinedInput
             {...props}
+            id={currentFieldName}
             inputProps={{ ...props.inputProps, ...accessibilityProps }}
             multiline={multiline}
             rows={multiline ? 6 : undefined}


### PR DESCRIPTION
## 🔗 Issue

[A2-2623](https://pagopa.atlassian.net/browse/A2-2623)
[A2-2624](https://pagopa.atlassian.net/browse/A2-2624)
[A2-2626](https://pagopa.atlassian.net/browse/A2-2626)

## 📝 Description / Context
This pull request focuses on improving accessibility and consistency for the shared risk analysis form components. The main changes include adding and wiring up unique label and input IDs, updating ARIA attributes, and refactoring label handling to ensure correct associations for assistive technologies.



[A2-2623]: https://pagopa.atlassian.net/browse/A2-2623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[A2-2624]: https://pagopa.atlassian.net/browse/A2-2624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[A2-2626]: https://pagopa.atlassian.net/browse/A2-2626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ