### PR TITLE
fix: error on update eservice template version (PIN-10569)

### DIFF
--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
@@ -61,7 +61,7 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
   const formMethods = useForm({ defaultValues })
 
   const onSubmit = (formValues: EServiceTemplateCreateStepGeneralFormValues) => {
-    // If we are editing an existing e-service eserviceTemplateVersion, we update the draft
+    // If we are editing an existing e-service eserviceTemplateVersion, we proceed to the next step because there aren't editable fields in this step
     if (eserviceTemplateVersion) {
       forward()
       return

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
@@ -8,7 +8,6 @@ import { RHFSwitch, RHFTextField } from '@/components/shared/react-hook-form-inp
 import { StepActions } from '@/components/shared/StepActions'
 import { useNavigate } from '@/router'
 import type { EServiceMode, EServiceTechnology } from '@/api/api.generatedTypes'
-import { compareObjects } from '@/utils/common.utils'
 import SaveIcon from '@mui/icons-material/Save'
 import { IconLink } from '@/components/shared/IconLink'
 import { useEServiceTemplateCreateContext } from '../ProviderEServiceTemplateContext'
@@ -44,7 +43,6 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
     onEserviceTemplateModeChange,
   } = useEServiceTemplateCreateContext()
 
-  const { mutate: updateDraft } = EServiceTemplateMutations.useUpdateDraft()
   const { mutate: createDraft } = EServiceTemplateMutations.useCreateDraft()
 
   const defaultValues: EServiceTemplateCreateStepGeneralFormValues = {
@@ -65,19 +63,7 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
   const onSubmit = (formValues: EServiceTemplateCreateStepGeneralFormValues) => {
     // If we are editing an existing e-service eserviceTemplateVersion, we update the draft
     if (eserviceTemplateVersion) {
-      // If nothing has changed skip the update call
-      const isEServiceTemplateTheSame = compareObjects(
-        formValues,
-        eserviceTemplateVersion.eserviceTemplate
-      )
-
-      if (!isEServiceTemplateTheSame)
-        updateDraft(
-          { eServiceTemplateId: eserviceTemplateVersion.eserviceTemplate.id, ...formValues },
-          { onSuccess: forward }
-        )
-      else forward()
-
+      forward()
       return
     }
 

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import {
@@ -7,17 +7,22 @@ import {
   EServiceTemplateCreateStepGeneralSkeleton,
 } from '../EServiceTemplateCreateStepGeneral'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
-import { mockUseEServiceTemplateCreateContext } from '@/../__mocks__/data/eserviceTemplate.mocks'
+import {
+  createMockEServiceTemplateVersionDetails,
+  mockUseEServiceTemplateCreateContext,
+} from '@/../__mocks__/data/eserviceTemplate.mocks'
+
+const createDraftMutateMock = vi.fn()
 
 vi.mock('@/api/eserviceTemplate', () => ({
   EServiceTemplateMutations: {
-    useUpdateDraft: () => ({ mutate: vi.fn() }),
-    useCreateDraft: () => ({ mutate: vi.fn() }),
+    useCreateDraft: () => ({ mutate: createDraftMutateMock }),
   },
 }))
 
 afterEach(() => {
   vi.clearAllMocks()
+  createDraftMutateMock.mockReset()
 })
 
 describe('EServiceTemplateCreateStepGeneral', () => {
@@ -142,6 +147,78 @@ describe('EServiceTemplateCreateStepGeneral', () => {
       withRouterContext: true,
     })
     expect(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ })).toBeInTheDocument()
+  })
+
+  it('on submit in edit flow forwards without creating a draft', async () => {
+    const user = userEvent.setup()
+    const forward = vi.fn()
+
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetails(),
+      areEServiceTemplateGeneralInfoEditable: false,
+      forward,
+    })
+
+    renderWithApplicationContext(<EServiceTemplateCreateStepGeneral />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.click(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ }))
+
+    expect(forward).toHaveBeenCalledTimes(1)
+    expect(createDraftMutateMock).not.toHaveBeenCalled()
+  })
+
+  it('on submit in create flow creates draft and forwards only after success', async () => {
+    const user = userEvent.setup()
+    const forward = vi.fn()
+
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: undefined,
+      forward,
+    })
+
+    renderWithApplicationContext(<EServiceTemplateCreateStepGeneral />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.type(
+      screen.getByLabelText(/create.step1.eserviceTemplateNameField.label/),
+      'Valid template name'
+    )
+    await user.type(
+      screen.getByLabelText(/create.step1.intendedTargetField.label/),
+      'Valid intended target value'
+    )
+    await user.type(
+      screen.getByLabelText(/create.step1.eserviceDescriptionField.label/),
+      'Valid template description'
+    )
+    await user.click(screen.getByLabelText('personalDataField.DELIVER.options.false'))
+
+    expect(screen.getByLabelText(/create.step1.eserviceTemplateNameField.label/)).toHaveValue(
+      'Valid template name'
+    )
+    expect(screen.getByLabelText(/create.step1.intendedTargetField.label/)).toHaveValue(
+      'Valid intended target value'
+    )
+    expect(screen.getByLabelText(/create.step1.eserviceDescriptionField.label/)).toHaveValue(
+      'Valid template description'
+    )
+
+    await user.click(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ }))
+
+    await waitFor(() => {
+      expect(createDraftMutateMock).toHaveBeenCalledTimes(1)
+    })
+    expect(forward).not.toHaveBeenCalled()
+
+    const createDraftOptions = createDraftMutateMock.mock.calls[0][1]
+    createDraftOptions.onSuccess({ id: 'template-id', versionId: 'version-id' })
+
+    expect(forward).toHaveBeenCalledTimes(1)
   })
 })
 


### PR DESCRIPTION
## 🔗 Issue

[PIN-10569](https://pagopa.atlassian.net/browse/PIN-10569)

## 📝 Description / Context

This pull request simplifies the logic in the `EServiceTemplateCreateStepGeneral` component by removing the check for unchanged form values when updating an existing e-service template. Now, the form always proceeds to the next step without conditionally calling the update draft mutation.

## 🛠 List of changes

- Removed the import and usage of the `compareObjects` utility and the `updateDraft` mutation



[PIN-10569]: https://pagopa.atlassian.net/browse/PIN-10569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ