### PR TITLE
fix: update draft submission logic for first version of e-service template (PIN-10569)

### DIFF
--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
@@ -64,7 +64,8 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
 
   const onSubmit = (formValues: EServiceTemplateCreateStepGeneralFormValues) => {
     if (eserviceTemplateVersion) {
-      //if we are editing the first version of an existing draft of the eservice template, we update the draft
+      //if we are editing the first version of an existing draft of the e-service template,
+      // we update the draft
       if (areEServiceTemplateGeneralInfoEditable) {
         // If nothing has changed skip the update call
         const isEServiceTemplateTheSame = compareObjects(
@@ -80,7 +81,8 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
           return
         }
       }
-      //if the version is not the first one or the state is not DRAFT, we just forward to the next step because there aren't editable fields in this step
+      //if the version is not the first one or the state is not DRAFT,
+      // we just forward to the next step because there aren't editable fields in this step
       forward()
       return
     }

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
@@ -72,11 +72,13 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
           eserviceTemplateVersion.eserviceTemplate
         )
 
-        if (!isEServiceTemplateTheSame)
+        if (!isEServiceTemplateTheSame) {
           updateDraft(
             { eServiceTemplateId: eserviceTemplateVersion.eserviceTemplate.id, ...formValues },
             { onSuccess: forward }
           )
+          return
+        }
       }
       //if the version is not the first one or the state is not DRAFT, we just forward to the next step because there aren't editable fields in this step
       forward()

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
@@ -65,7 +65,7 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
   const onSubmit = (formValues: EServiceTemplateCreateStepGeneralFormValues) => {
     if (eserviceTemplateVersion) {
       //if we are editing the first version of an existing draft of the eservice template, we update the draft
-      if (eserviceTemplateVersion.version === 1 && eserviceTemplateVersion.state === 'DRAFT') {
+      if (areEServiceTemplateGeneralInfoEditable) {
         // If nothing has changed skip the update call
         const isEServiceTemplateTheSame = compareObjects(
           formValues,

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/EServiceTemplateCreateStepGeneral.tsx
@@ -8,7 +8,6 @@ import { RHFSwitch, RHFTextField } from '@/components/shared/react-hook-form-inp
 import { StepActions } from '@/components/shared/StepActions'
 import { useNavigate } from '@/router'
 import type { EServiceMode, EServiceTechnology } from '@/api/api.generatedTypes'
-import { compareObjects } from '@/utils/common.utils'
 import SaveIcon from '@mui/icons-material/Save'
 import { IconLink } from '@/components/shared/IconLink'
 import { useEServiceTemplateCreateContext } from '../ProviderEServiceTemplateContext'
@@ -20,6 +19,7 @@ import {
 } from '@/config/constants'
 import { EServiceTemplateDetailsSection } from '@/pages/ProviderEServiceCreatePage/components/sections/EServiceTemplateDetailsSection'
 import { EServiceDetailsSectionBase } from '@/pages/ProviderEServiceCreatePage/components/sections/EServiceDetailsSectionBase'
+import { compareObjects } from '@/utils/common.utils'
 
 export type EServiceTemplateCreateStepGeneralFormValues = {
   name: string
@@ -44,8 +44,8 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
     onEserviceTemplateModeChange,
   } = useEServiceTemplateCreateContext()
 
-  const { mutate: updateDraft } = EServiceTemplateMutations.useUpdateDraft()
   const { mutate: createDraft } = EServiceTemplateMutations.useCreateDraft()
+  const { mutate: updateDraft } = EServiceTemplateMutations.useUpdateDraft()
 
   const defaultValues: EServiceTemplateCreateStepGeneralFormValues = {
     name: eserviceTemplateVersion?.eserviceTemplate.name ?? '',
@@ -63,21 +63,23 @@ export const EServiceTemplateCreateStepGeneral: React.FC = () => {
   const formMethods = useForm({ defaultValues })
 
   const onSubmit = (formValues: EServiceTemplateCreateStepGeneralFormValues) => {
-    // If we are editing an existing e-service eserviceTemplateVersion, we update the draft
     if (eserviceTemplateVersion) {
-      // If nothing has changed skip the update call
-      const isEServiceTemplateTheSame = compareObjects(
-        formValues,
-        eserviceTemplateVersion.eserviceTemplate
-      )
-
-      if (!isEServiceTemplateTheSame)
-        updateDraft(
-          { eServiceTemplateId: eserviceTemplateVersion.eserviceTemplate.id, ...formValues },
-          { onSuccess: forward }
+      //if we are editing the first version of an existing draft of the eservice template, we update the draft
+      if (eserviceTemplateVersion.version === 1 && eserviceTemplateVersion.state === 'DRAFT') {
+        // If nothing has changed skip the update call
+        const isEServiceTemplateTheSame = compareObjects(
+          formValues,
+          eserviceTemplateVersion.eserviceTemplate
         )
-      else forward()
 
+        if (!isEServiceTemplateTheSame)
+          updateDraft(
+            { eServiceTemplateId: eserviceTemplateVersion.eserviceTemplate.id, ...formValues },
+            { onSuccess: forward }
+          )
+      }
+      //if the version is not the first one or the state is not DRAFT, we just forward to the next step because there aren't editable fields in this step
+      forward()
       return
     }
 

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
@@ -152,7 +152,7 @@ describe('EServiceTemplateCreateStepGeneral', () => {
     expect(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ })).toBeInTheDocument()
   })
 
-  it('submits without update when existing first draft is unchanged', async () => {
+  it.only('submits without update when existing first draft is unchanged', async () => {
     const user = userEvent.setup()
     const forwardMock = vi.fn()
 
@@ -174,9 +174,11 @@ describe('EServiceTemplateCreateStepGeneral', () => {
 
   it('updates draft when existing first draft data changes', async () => {
     const user = userEvent.setup()
+    const forwardMock = vi.fn()
 
     mockUseEServiceTemplateCreateContext({
       eserviceTemplateVersion: createMockEServiceTemplateVersionDetails(),
+      forward: forwardMock,
     })
 
     renderWithApplicationContext(<EServiceTemplateCreateStepGeneral />, {
@@ -191,16 +193,10 @@ describe('EServiceTemplateCreateStepGeneral', () => {
     )
     await user.click(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ }))
 
-    expect(updateDraftMock).toHaveBeenCalledTimes(1)
-    expect(updateDraftMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        eServiceTemplateId: 'template-id-001',
-        name: 'Updated Template Name',
-      }),
-      expect.objectContaining({
-        onSuccess: expect.any(Function),
-      })
-    )
+    const [, options] = updateDraftMock.mock.calls[0]
+    expect(forwardMock).not.toHaveBeenCalled()
+    options.onSuccess()
+    expect(forwardMock).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
@@ -152,7 +152,7 @@ describe('EServiceTemplateCreateStepGeneral', () => {
     expect(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ })).toBeInTheDocument()
   })
 
-  it.only('submits without update when existing first draft is unchanged', async () => {
+  it('submits without update when existing first draft is unchanged', async () => {
     const user = userEvent.setup()
     const forwardMock = vi.fn()
 
@@ -193,10 +193,10 @@ describe('EServiceTemplateCreateStepGeneral', () => {
     )
     await user.click(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ }))
 
-    const [, options] = updateDraftMock.mock.calls[0]
+    expect(updateDraftMock).toHaveBeenCalledTimes(1)
+    const [, { onSuccess }] = updateDraftMock.mock.calls[0]
     expect(forwardMock).not.toHaveBeenCalled()
-    options.onSuccess()
-    expect(forwardMock).toHaveBeenCalledTimes(1)
+    onSuccess()
   })
 })
 

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
@@ -152,6 +152,31 @@ describe('EServiceTemplateCreateStepGeneral', () => {
     expect(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ })).toBeInTheDocument()
   })
 
+  it('submits without update when existing version is not editable', async () => {
+    const user = userEvent.setup()
+    const forwardMock = vi.fn()
+
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetails({
+        version: 2,
+        state: 'PUBLISHED',
+      }),
+      areEServiceTemplateGeneralInfoEditable: false,
+      forward: forwardMock,
+    })
+
+    renderWithApplicationContext(<EServiceTemplateCreateStepGeneral />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.click(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ }))
+
+    expect(updateDraftMock).not.toHaveBeenCalled()
+    expect(createDraftMock).not.toHaveBeenCalled()
+    expect(forwardMock).toHaveBeenCalledTimes(1)
+  })
+
   it('submits without update when existing first draft is unchanged', async () => {
     const user = userEvent.setup()
     const forwardMock = vi.fn()
@@ -197,6 +222,7 @@ describe('EServiceTemplateCreateStepGeneral', () => {
     const [, { onSuccess }] = updateDraftMock.mock.calls[0]
     expect(forwardMock).not.toHaveBeenCalled()
     onSuccess()
+    expect(forwardMock).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepGeneral/__tests__/EServiceTemplateCreateStepGeneral.test.tsx
@@ -7,12 +7,20 @@ import {
   EServiceTemplateCreateStepGeneralSkeleton,
 } from '../EServiceTemplateCreateStepGeneral'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
-import { mockUseEServiceTemplateCreateContext } from '@/../__mocks__/data/eserviceTemplate.mocks'
+import {
+  createMockEServiceTemplateVersionDetails,
+  mockUseEServiceTemplateCreateContext,
+} from '@/../__mocks__/data/eserviceTemplate.mocks'
+
+const { updateDraftMock, createDraftMock } = vi.hoisted(() => ({
+  updateDraftMock: vi.fn(),
+  createDraftMock: vi.fn(),
+}))
 
 vi.mock('@/api/eserviceTemplate', () => ({
   EServiceTemplateMutations: {
-    useUpdateDraft: () => ({ mutate: vi.fn() }),
-    useCreateDraft: () => ({ mutate: vi.fn() }),
+    useUpdateDraft: () => ({ mutate: updateDraftMock }),
+    useCreateDraft: () => ({ mutate: createDraftMock }),
   },
 }))
 
@@ -142,6 +150,57 @@ describe('EServiceTemplateCreateStepGeneral', () => {
       withRouterContext: true,
     })
     expect(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ })).toBeInTheDocument()
+  })
+
+  it('submits without update when existing first draft is unchanged', async () => {
+    const user = userEvent.setup()
+    const forwardMock = vi.fn()
+
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetails(),
+      forward: forwardMock,
+    })
+
+    renderWithApplicationContext(<EServiceTemplateCreateStepGeneral />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.click(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ }))
+
+    expect(updateDraftMock).not.toHaveBeenCalled()
+    expect(forwardMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates draft when existing first draft data changes', async () => {
+    const user = userEvent.setup()
+
+    mockUseEServiceTemplateCreateContext({
+      eserviceTemplateVersion: createMockEServiceTemplateVersionDetails(),
+    })
+
+    renderWithApplicationContext(<EServiceTemplateCreateStepGeneral />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    await user.clear(screen.getByLabelText(/create.step1.eserviceTemplateNameField.label/))
+    await user.type(
+      screen.getByLabelText(/create.step1.eserviceTemplateNameField.label/),
+      'Updated Template Name'
+    )
+    await user.click(screen.getByRole('button', { name: /create.forwardWithSaveBtn/ }))
+
+    expect(updateDraftMock).toHaveBeenCalledTimes(1)
+    expect(updateDraftMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eServiceTemplateId: 'template-id-001',
+        name: 'Updated Template Name',
+      }),
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+      })
+    )
   })
 })
 


### PR DESCRIPTION
## 🔗 Issue

[PIN-10569](https://pagopa.atlassian.net/browse/PIN-10569)

## 📝 Description / Context
This pull request refines the logic for updating e-service template drafts and adds tests to ensure correct behavior. The main changes improve how the component decides when to update an existing draft versus simply proceeding to the next step, and introduces new tests to cover these scenarios.

## 🛠 List of changes

- The `onSubmit` handler in `EServiceTemplateCreateStepGeneral.tsx` now only calls `updateDraft` if the user is editing the first draft version and there are actual changes; otherwise, it skips the update and moves forward. For other versions or non-draft states, it always proceeds without attempting an update because there are no editable fields.



[PIN-10569]: https://pagopa.atlassian.net/browse/PIN-10569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ