### PR TITLE
feat: hide facilitated purpose section for receiver eservice (PIN-10582)

### DIFF
--- a/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
@@ -11,7 +11,7 @@ import type {
 import { PurposeMutations, PurposeQueries } from '@/api/purpose'
 import { SectionContainer } from '@/components/layout/containers'
 import { Alert, Box, Button, Divider, Stack } from '@mui/material'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { PurposeCreateEServiceAutocomplete } from './PurposeCreateEServiceAutocomplete'
@@ -119,7 +119,7 @@ export const PurposeCreateForm: React.FC<PurposeCreateFormProps> = ({ purposeTem
     !isLoadingPurposeTemplates &&
     purposeTemplates?.results &&
     purposeTemplates.results.length > 0 &&
-    selectedEServiceMode !== 'RECEIVE'
+    selectedEServiceMode === 'DELIVER'
 
   // const isSubmitBtnDisabled = !!(useTemplate && purposeId && !purpose)
 
@@ -215,6 +215,13 @@ export const PurposeCreateForm: React.FC<PurposeCreateFormProps> = ({ purposeTem
       })
     }
   }
+
+  useEffect(() => {
+    if (selectedEServiceMode === 'RECEIVE') {
+      formMethods.setValue('templateId', null)
+      formMethods.setValue('usePurposeTemplate', false)
+    }
+  }, [selectedEServiceMode, formMethods])
 
   return (
     <FormProvider {...formMethods}>

--- a/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
@@ -119,7 +119,7 @@ export const PurposeCreateForm: React.FC<PurposeCreateFormProps> = ({ purposeTem
     !isLoadingPurposeTemplates &&
     purposeTemplates?.results &&
     purposeTemplates.results.length > 0 &&
-    selectedEServiceMode === 'DELIVER'
+    selectedEServiceMode !== 'RECEIVE'
 
   // const isSubmitBtnDisabled = !!(useTemplate && purposeId && !purpose)
 

--- a/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
@@ -116,7 +116,10 @@ export const PurposeCreateForm: React.FC<PurposeCreateFormProps> = ({ purposeTem
 
   const selectedEServiceMode = selectedEServiceDescriptor?.eservice.mode
   const isPurposeTemplateCreateSectionVisible =
-    !isLoadingPurposeTemplates && purposeTemplates?.results && purposeTemplates.results.length > 0
+    !isLoadingPurposeTemplates &&
+    purposeTemplates?.results &&
+    purposeTemplates.results.length > 0 &&
+    selectedEServiceMode === 'DELIVER'
 
   // const isSubmitBtnDisabled = !!(useTemplate && purposeId && !purpose)
 

--- a/src/pages/ConsumerPurposeCreatePage/components/__tests__/PurposeCreateForm.test.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/__tests__/PurposeCreateForm.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 import { useFormContext } from 'react-hook-form'
 import { PurposeCreateForm } from '../PurposeCreateForm'
 import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import { createMockEServiceDescriptorCatalog } from '@/../__mocks__/data/eservice.mocks'
 
 vi.mock('@/router', () => ({
   useNavigate: () => vi.fn(),
@@ -24,13 +25,19 @@ vi.mock('@/api/purpose', () => ({
 vi.mock('@/api/eservice', () => ({
   EServiceQueries: {
     getAllCatalogEServices: () => ({ queryKey: ['eservices'], queryFn: vi.fn() }),
-    getDescriptorCatalog: () => ({ queryKey: ['descriptor'], queryFn: vi.fn() }),
+    getDescriptorCatalog: () => ({
+      queryKey: ['descriptor'],
+      queryFn: createMockEServiceDescriptorCatalog(),
+    }),
   },
 }))
 
 vi.mock('@/api/purposeTemplate/purposeTemplate.queries', () => ({
   PurposeTemplateQueries: {
-    getCatalogPurposeTemplates: () => ({ queryKey: ['purpose-templates'], queryFn: vi.fn() }),
+    getCatalogPurposeTemplates: () => ({
+      queryKey: ['purpose-templates'],
+      queryFn: () => ({ results: [{ id: 'tpl-1' }], totalCount: 1 }),
+    }),
   },
 }))
 
@@ -43,6 +50,12 @@ vi.mock('@tanstack/react-query', async () => {
       if (queryKey?.[0] === 'purpose-templates') {
         return {
           data: { results: [{ id: 'tpl-1' }], totalCount: 1 },
+          isLoading: false,
+        }
+      }
+      if (queryKey?.[0] === 'descriptor') {
+        return {
+          data: createMockEServiceDescriptorCatalog(),
           isLoading: false,
         }
       }


### PR DESCRIPTION
## Jira Issue
[PIN-10582](https://pagopa.atlassian.net/browse/PIN-10582)

## Context/Why
**Purpose Creation for Receiver EService**

## Key Changes
 - Add check on EService Mode in `PurposeCreateForm` component 

[PIN-10582]: https://pagopa.atlassian.net/browse/PIN-10582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ