### PR TITLE
fix: prevent decimal values in eservice thresholds (PIN-9642)

### DIFF
--- a/src/components/shared/react-hook-form-inputs/RHFTextField.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFTextField.tsx
@@ -25,10 +25,12 @@ export type RHFTextFieldProps = Omit<MUITextFieldProps, 'type' | 'label'> & {
 } & (
     | {
         type?: 'text' | 'email'
+        integerOnly?: never
         onValueChange?: (value: string) => void
       }
     | {
         type?: 'number'
+        integerOnly?: boolean
         onValueChange?: (value: number) => void
       }
   )
@@ -41,6 +43,7 @@ export const RHFTextField: React.FC<RHFTextFieldProps> = ({
   infoLabel,
   focusOnMount,
   multiline,
+  integerOnly = false,
   onValueChange,
   rules,
   size = 'small',
@@ -104,7 +107,8 @@ export const RHFTextField: React.FC<RHFTextFieldProps> = ({
                 ? (e) => {
                     if (e.key.length !== 1 || e.ctrlKey || e.metaKey) return
                     const isEmpty = (e.target as HTMLInputElement).value === ''
-                    if (!/[1-9.\-]/.test(e.key) && !(e.key === '0' && !isEmpty)) {
+                    const allowedCharacters = integerOnly ? /[1-9\-]/ : /[1-9.\-]/
+                    if (!allowedCharacters.test(e.key) && !(e.key === '0' && !isEmpty)) {
                       e.preventDefault()
                     }
                   }

--- a/src/pages/ProviderEServiceCreatePage/components/sections/EServiceThresholdSection.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/EServiceThresholdSection.tsx
@@ -32,7 +32,8 @@ export const EServiceThresholdSection: React.FC<EServiceThresholdSectionProps> =
             label={t('dailyCallsPerConsumerField.label')}
             infoLabel={t('dailyCallsPerConsumerField.infoLabel')}
             type="number"
-            inputProps={{ min: '1' }}
+            integerOnly
+            inputProps={{ min: '1', step: '1' }}
             required
             rules={{
               required: true,
@@ -47,7 +48,8 @@ export const EServiceThresholdSection: React.FC<EServiceThresholdSectionProps> =
             label={t('dailyCallsTotalField.label')}
             infoLabel={t('dailyCallsTotalField.infoLabel')}
             type="number"
-            inputProps={{ min: '1' }}
+            integerOnly
+            inputProps={{ min: '1', step: '1' }}
             sx={{ my: 0, flex: 1 }}
             required
             rules={{

--- a/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceThresholdSection.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/sections/__tests__/EServiceThresholdSection.test.tsx
@@ -1,6 +1,7 @@
 import { ReactHookFormWrapper, renderWithApplicationContext } from '@/utils/testing.utils'
 import { EServiceThresholdSection } from '../EServiceThresholdSection'
 import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 const renderComponent = (isEServiceCreatedFromTemplate?: boolean) => {
   return renderWithApplicationContext(
@@ -34,6 +35,19 @@ describe('EServiceThresholdSection', () => {
     expect(screen.getAllByText('dailyCallsPerConsumerField.label').length).toBeGreaterThan(0)
     expect(screen.getAllByText('dailyCallsTotalField.label').length).toBeGreaterThan(0)
   })
+
+  it.each(['dailyCallsPerConsumerField.label', 'dailyCallsTotalField.label'])(
+    'should prevent decimal values in the %s field',
+    async (label) => {
+      const user = userEvent.setup()
+      renderComponent()
+
+      const input = screen.getByRole('spinbutton', { name: label })
+      await user.type(input, '1.5')
+
+      expect(input).toHaveValue(15)
+    }
+  )
 
   it('should render alert with suggested values', () => {
     renderComponent(true)


### PR DESCRIPTION
## 🔗 Issue

[PIN-9642](https://pagopa.atlassian.net/browse/PIN-9642)

## 📝 Description / Context

Prevent decimal values from being entered in the expected API calls threshold fields during eservice creation. This avoids sending floating-point values to APIs that only accept integers and prevents the resulting generic error.

## 🛠 List of changes

- Added an `integerOnly` mode to the shared React Hook Form numeric field.
- Enabled integer-only input for the per-consumer and total daily calls thresholds.
- Set the input step to `1` for both threshold fields.
- Added regression tests covering decimal input in both fields.

## 🧪 How to test

- Start the eservice creation flow and navigate to the thresholds and attributes step.
- Try entering a decimal value, such as `1.5` or `1,5`, in both “API calls/day per consumer” and “Total API calls/day”.
- Verify that decimal separators cannot be entered.
- Enter valid integer values and verify that the step can be saved successfully.

[PIN-9642]: https://pagopa.atlassian.net/browse/PIN-9642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ