### PR TITLE
fix/PIN-10597: changed freeOfChargeReasonField labels

### DIFF
--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -88,8 +88,8 @@
         "label": "I am entitled to use the e-service free of charge"
       },
       "freeOfChargeReasonField": {
-        "label": "Specify the legal basis or reason that allows free access (required)",
-        "infoLabel": "Specify whether this is based on a legal exemption or exclusion, or on another reason. Min 10, max 250 characters"
+        "label": "Explain why you can use the e-service free of charge (required)",
+        "infoLabel": "Indicate whether you are doing so on the basis of a legal exemption or exclusion, or for another reason. Min 10, max 250 characters"
       }
     },
     "stepAssignment": {

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -88,8 +88,8 @@
         "label": "Ho diritto all'utilizzo dell'e-service a titolo gratuito"
       },
       "freeOfChargeReasonField": {
-        "label": "Indica la base giuridica o il motivo che consente l'accesso gratuito (richiesto)",
-        "infoLabel": "Specifica se lo fai in base a un’esenzione o a un’esclusione prevista dalla legge, oppure per un altro motivo. Min 10, max 250 caratteri"
+        "label": "Spiega perché puoi usare l’e-service a titolo gratuito (richiesto)",
+        "infoLabel": "Indica se lo fai in base a un’esenzione o a un’esclusione prevista dalla legge, oppure per un altro motivo. Min 10, max 250 caratteri"
       }
     },
     "stepAssignment": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10597](https://pagopa.atlassian.net/browse/PIN-10597)

## 📝 Description / Context

fix text field and helper text copy labels

## 🛠 List of changes

- it/purpose.json -> freeOfChargeReasonField
- en/purpose.json -> freeOfChargeReasonField

## 🧪 How to test

"Fruizione" in the left side menu. -> "Crea nuovo" button at the top right -> select "Comune" and e-service -> "Create bozza"


[PIN-10597]: https://pagopa.atlassian.net/browse/PIN-10597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ