### PR TITLE
fix: update agreement activation endpoints (PIN-10618, PIN-10619)

### DIFF
--- a/src/api/agreement/__tests__/agreement.services.test.ts
+++ b/src/api/agreement/__tests__/agreement.services.test.ts
@@ -1,0 +1,39 @@
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
+import axiosInstance from '@/config/axios'
+import { AgreementServices } from '../agreement.services'
+
+vi.mock('@/config/axios', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}))
+
+describe('AgreementServices', () => {
+  it('should approve a pending agreement', async () => {
+    vi.mocked(axiosInstance.post).mockResolvedValueOnce({ data: {} })
+
+    await AgreementServices.approve({
+      agreementId: 'agreement-id',
+      delegationId: 'delegation-id',
+    })
+
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      `${BACKEND_FOR_FRONTEND_URL}/agreements/agreement-id/approve`,
+      { delegationId: 'delegation-id' }
+    )
+  })
+
+  it('should unsuspend a suspended agreement', async () => {
+    vi.mocked(axiosInstance.post).mockResolvedValueOnce({ data: {} })
+
+    await AgreementServices.unsuspend({
+      agreementId: 'agreement-id',
+      delegationId: 'delegation-id',
+    })
+
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      `${BACKEND_FOR_FRONTEND_URL}/agreements/agreement-id/unsuspend`,
+      { delegationId: 'delegation-id' }
+    )
+  })
+})

--- a/src/api/agreement/agreement.mutations.ts
+++ b/src/api/agreement/agreement.mutations.ts
@@ -187,10 +187,10 @@ function useDeleteDraftDocument() {
   })
 }
 
-function useActivate() {
+function useActivate(mutationFn: typeof AgreementServices.approve) {
   const { t } = useTranslation('mutations-feedback', { keyPrefix: 'agreement.activate' })
   return useMutation({
-    mutationFn: AgreementServices.activate,
+    mutationFn,
     meta: {
       successToastLabel: t('outcome.success'),
       errorToastLabel: t('outcome.error'),
@@ -201,6 +201,14 @@ function useActivate() {
       },
     },
   })
+}
+
+function useApprove() {
+  return useActivate(AgreementServices.approve)
+}
+
+function useUnsuspend() {
+  return useActivate(AgreementServices.unsuspend)
 }
 
 function useReject() {
@@ -282,7 +290,8 @@ export const AgreementMutations = {
   useUpdateDraft,
   useUploadDraftDocument,
   useDeleteDraftDocument,
-  useActivate,
+  useApprove,
+  useUnsuspend,
   useReject,
   useSuspend,
   useArchive,

--- a/src/api/agreement/agreement.services.ts
+++ b/src/api/agreement/agreement.services.ts
@@ -161,9 +161,17 @@ function deleteDraftDocument({
   )
 }
 
-async function activate({ agreementId, delegationId }: { agreementId: string } & DelegationRef) {
+async function approve({ agreementId, delegationId }: { agreementId: string } & DelegationRef) {
   const response = await axiosInstance.post<Agreement>(
-    `${BACKEND_FOR_FRONTEND_URL}/agreements/${agreementId}/activate`,
+    `${BACKEND_FOR_FRONTEND_URL}/agreements/${agreementId}/approve`,
+    { delegationId }
+  )
+  return response.data
+}
+
+async function unsuspend({ agreementId, delegationId }: { agreementId: string } & DelegationRef) {
+  const response = await axiosInstance.post<Agreement>(
+    `${BACKEND_FOR_FRONTEND_URL}/agreements/${agreementId}/unsuspend`,
     { delegationId }
   )
   return response.data
@@ -241,7 +249,8 @@ export const AgreementServices = {
   downloadDraftDocument,
   uploadDraftDocument,
   deleteDraftDocument,
-  activate,
+  approve,
+  unsuspend,
   reject,
   suspend,
   archive,

--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -3017,7 +3017,15 @@ export interface DeleteAgreementParams {
   agreementId: string;
 }
 
-export interface ActivateAgreementParams {
+export interface ApproveAgreementParams {
+  /**
+   * The identifier of the agreement
+   * @format uuid
+   */
+  agreementId: string;
+}
+
+export interface UnsuspendAgreementParams {
   /**
    * The identifier of the agreement
    * @format uuid
@@ -6289,12 +6297,34 @@ export namespace Agreements {
   /**
    * @description returns the updated agreement
    * @tags agreements
-   * @name ActivateAgreement
+   * @name ApproveAgreement
    * @summary Activate an agreement
-   * @request POST:/agreements/{agreementId}/activate
+   * @request POST:/agreements/{agreementId}/approve
    * @secure
    */
-  export namespace ActivateAgreement {
+  export namespace ApproveAgreement {
+    export type RequestParams = {
+      /**
+       * The identifier of the agreement
+       * @format uuid
+       */
+      agreementId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = DelegationRef;
+    export type RequestHeaders = {};
+    export type ResponseBody = Agreement;
+  }
+
+  /**
+   * @description returns the updated agreement
+   * @tags agreements
+   * @name UnsuspendAgreement
+   * @summary Activate a suspended agreement
+   * @request POST:/agreements/{agreementId}/unsuspend
+   * @secure
+   */
+  export namespace UnsuspendAgreement {
     export type RequestParams = {
       /**
        * The identifier of the agreement

--- a/src/hooks/__tests__/useGetAgreementsActions.test.ts
+++ b/src/hooks/__tests__/useGetAgreementsActions.test.ts
@@ -406,6 +406,59 @@ describe('check if useGetAgreementsActions returns the correct actions based on 
   })
 })
 
+describe('check if agreement activation actions call the correct endpoint', () => {
+  it('should unsuspend an agreement suspended by the producer', async () => {
+    const unsuspendHandler = vi.fn((_, res, ctx) => res(ctx.json({})))
+    server.use(
+      rest.post(
+        `${BACKEND_FOR_FRONTEND_URL}/agreements/e8a8153e-9ab2-4aeb-a14c-96aebd4fa049/unsuspend`,
+        unsuspendHandler
+      )
+    )
+    const agreement = createMockAgreement({ state: 'SUSPENDED', suspendedByProducer: true })
+    const { result } = renderUseGetAgreementsActionsHook(agreement, 'provider')
+
+    act(() => result.current.actions[0].action())
+    fireEvent.click(screen.getByRole('button', { name: 'confirm' }))
+
+    await waitFor(() => expect(unsuspendHandler).toHaveBeenCalledOnce())
+  })
+
+  it('should unsuspend an agreement suspended by the consumer', async () => {
+    const unsuspendHandler = vi.fn((_, res, ctx) => res(ctx.json({})))
+    server.use(
+      rest.post(
+        `${BACKEND_FOR_FRONTEND_URL}/agreements/e8a8153e-9ab2-4aeb-a14c-96aebd4fa049/unsuspend`,
+        unsuspendHandler
+      )
+    )
+    const agreement = createMockAgreement({ state: 'SUSPENDED', suspendedByConsumer: true })
+    const { result } = renderUseGetAgreementsActionsHook(agreement, 'consumer')
+
+    act(() => result.current.actions[1].action())
+    fireEvent.click(screen.getByRole('button', { name: 'confirm' }))
+
+    await waitFor(() => expect(unsuspendHandler).toHaveBeenCalledOnce())
+  })
+
+  it('should approve a pending agreement', async () => {
+    const approveHandler = vi.fn((_, res, ctx) => res(ctx.json({})))
+    server.use(
+      rest.post(
+        `${BACKEND_FOR_FRONTEND_URL}/agreements/e8a8153e-9ab2-4aeb-a14c-96aebd4fa049/approve`,
+        approveHandler
+      )
+    )
+    const agreement = createMockAgreement({ state: 'PENDING' })
+    const { result } = renderUseGetAgreementsActionsHook(agreement, 'provider')
+
+    act(() => result.current.actions[1].action())
+    fireEvent.click(screen.getByRole('button', { name: 'confirm' }))
+
+    await waitFor(() => expect(approveHandler).toHaveBeenCalledOnce())
+  })
+})
+
 describe('check if the onSuccess callbacks are called correclty after the clone and delete actions', () => {
   it('should navigate to SUBSCRIBE_AGREEMENT_EDIT route with the returned agreementId after the clone action', async () => {
     const agreement = createMockAgreement({

--- a/src/hooks/useGetAgreementsActions.ts
+++ b/src/hooks/useGetAgreementsActions.ts
@@ -26,7 +26,8 @@ function useGetAgreementsActions(
   const { openDialog } = useDialog()
   const navigate = useNavigate()
 
-  const { mutate: activateAgreement } = AgreementMutations.useActivate()
+  const { mutate: approveAgreement } = AgreementMutations.useApprove()
+  const { mutate: unsuspendAgreement } = AgreementMutations.useUnsuspend()
   const { mutate: suspendAgreement } = AgreementMutations.useSuspend()
   const { mutate: deleteAgreement } = AgreementMutations.useDeleteDraft()
   const { mutate: cloneAgreement } = AgreementMutations.useClone()
@@ -58,6 +59,8 @@ function useGetAgreementsActions(
   if (!agreement || mode === null || !isAdmin || isDelegator) return { actions: [] }
 
   const handleActivate = () => {
+    const activateAgreement = agreement.state === 'PENDING' ? approveAgreement : unsuspendAgreement
+
     if (from === 'CONSUMER' && isDelegationMine) {
       activateAgreement({ agreementId: agreement.id, delegationId: agreement.delegation?.id })
     } else if (from === 'PRODUCER' && isThereProducerDelegation) {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10618](https://pagopa.atlassian.net/browse/PIN-10618)  
[PIN-10619](https://pagopa.atlassian.net/browse/PIN-10619)

## 📝 Description / Context

Agreement activation actions were still calling the removed `/activate` endpoint, causing 404 responses for both suspended and pending agreements.

This change aligns the frontend with the updated BFF contract by using `/unsuspend` to reactivate suspended agreements and `/approve` to approve pending agreements.

## 🛠 List of changes

- Use `/agreements/{agreementId}/unsuspend` for suspended agreements
- Use `/agreements/{agreementId}/approve` for pending agreements
- Update the generated API types from the current BFF OpenAPI specification
- Add service-level coverage for both endpoints
- Add action-level coverage for producer and consumer reactivation flows
- Cover the producer approval flow for pending agreements

## 🧪 How to test

- As a consumer, reactivate an agreement previously suspended by the consumer and verify that the operation succeeds
- As a producer, reactivate an agreement previously suspended by the producer and verify that the operation succeeds
- As a producer, open a pending agreement for an e-service with manual approval and approve it; the agreement should be activated successfully

[PIN-10618]: https://pagopa.atlassian.net/browse/PIN-10618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-10619]: https://pagopa.atlassian.net/browse/PIN-10619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ