### PR TITLE
fix: update DPoP M2M guidance copy (PIN-10624)

### DIFF
--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsSecondDPoPProofStep.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/VoucherInstructionsSecondDPoPProofStep.tsx
@@ -39,6 +39,7 @@ export const VoucherInstructionsSecondDPoPProofStep: React.FC = () => {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
   const clientKind = useClientKind()
+  const guidanceKind = clientKind === 'API' ? 'pdnd' : 'eservice'
 
   const purposeId = searchParams.get('purposeId') || ''
   const memberType = (searchParams.get('memberType') as MemberType) || ''
@@ -103,7 +104,9 @@ export const VoucherInstructionsSecondDPoPProofStep: React.FC = () => {
                   <RHFSelect
                     name="htm"
                     label={t('secondDPoPProofStep.assertionPayload.htmField.label')}
-                    infoLabel={t('secondDPoPProofStep.assertionPayload.htmField.description')}
+                    infoLabel={t(
+                      `secondDPoPProofStep.assertionPayload.htmField.description.${guidanceKind}`
+                    )}
                     options={HTM_OPTIONS.map((value) => ({ label: value, value }))}
                   />
                 </FormControl>
@@ -113,14 +116,16 @@ export const VoucherInstructionsSecondDPoPProofStep: React.FC = () => {
                   <RHFTextField
                     name="htu"
                     label={t('secondDPoPProofStep.assertionPayload.htuField.label')}
-                    infoLabel={t('secondDPoPProofStep.assertionPayload.htuField.description')}
+                    infoLabel={t(
+                      `secondDPoPProofStep.assertionPayload.htuField.description.${guidanceKind}`
+                    )}
                   />
                 </FormControl>
               </Grid>
             </FormProvider>
             <Grid item xs={12} md={12} sx={{ display: 'flex', alignItems: 'center' }}>
               <Alert severity="info" variant="outlined" sx={{ width: '100%', mb: 1.5 }}>
-                {t('secondDPoPProofStep.assertionPayload.alert')}
+                {t(`secondDPoPProofStep.assertionPayload.alert.${guidanceKind}`)}
               </Alert>
             </Grid>
             <VerticalInformationContainer

--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsSecondDPoPProofStep.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/steps/__tests__/VoucherInstructionsSecondDPoPProofStep.test.tsx
@@ -93,6 +93,46 @@ describe('VoucherInstructionsSecondDPoPProofStep', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders PDND M2M guidance for API clients', async () => {
+    useClientKindMock.mockReturnValue('API')
+
+    renderWithApplicationContext(
+      <MemoryRouter>
+        <VoucherInstructionsSecondDPoPProofStep />
+      </MemoryRouter>,
+      { withReactQueryContext: true }
+    )
+
+    expect(
+      screen.getByText('secondDPoPProofStep.assertionPayload.htmField.description.pdnd')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('secondDPoPProofStep.assertionPayload.htuField.description.pdnd')
+    ).toBeInTheDocument()
+    expect(screen.getByText('secondDPoPProofStep.assertionPayload.alert.pdnd')).toBeInTheDocument()
+  })
+
+  it('renders eservice guidance for consumer clients', async () => {
+    useClientKindMock.mockReturnValue('CONSUMER')
+
+    renderWithApplicationContext(
+      <MemoryRouter>
+        <VoucherInstructionsSecondDPoPProofStep />
+      </MemoryRouter>,
+      { withReactQueryContext: true }
+    )
+
+    expect(
+      screen.getByText('secondDPoPProofStep.assertionPayload.htmField.description.eservice')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('secondDPoPProofStep.assertionPayload.htuField.description.eservice')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('secondDPoPProofStep.assertionPayload.alert.eservice')
+    ).toBeInTheDocument()
+  })
+
   it('renders interoperability section for API clients only', async () => {
     useClientKindMock.mockReturnValue('API')
 

--- a/src/static/locales/en/voucher.json
+++ b/src/static/locales/en/voucher.json
@@ -253,13 +253,22 @@
       "title": "Payload",
       "htmField": {
         "label": "HTM",
-        "description": "Indicates the HTTP method you want to invoke against the resource"
+        "description": {
+          "eservice": "Indicates the HTTP method you want to invoke against the resource",
+          "pdnd": "The HTTP method of the PDND M2M API operation you want to invoke."
+        }
       },
       "htuField": {
         "label": "HTU",
-        "description": "The URL of the resource you want to invoke"
+        "description": {
+          "eservice": "The URL of the resource you want to invoke",
+          "pdnd": "The full URL, without query parameters, of the PDND M2M API operation you want to invoke."
+        }
       },
-      "alert": "You can find information about the HTM and HTU parameters within the e-service's OpenAPI interface.",
+      "alert": {
+        "eservice": "You can find information about the HTM and HTU parameters within the e-service's OpenAPI interface.",
+        "pdnd": "You can find the HTM and HTU values in the PDND M2M v3 OpenAPI specification."
+      },
       "athField": {
         "label": "ATH",
         "description": "The hash of the voucher released by PDND in the previous step.",

--- a/src/static/locales/it/voucher.json
+++ b/src/static/locales/it/voucher.json
@@ -253,13 +253,22 @@
       "title": "Payload",
       "htmField": {
         "label": "HTM",
-        "description": "Indica il metodo HTTP che si vuole invocare verso la risorsa"
+        "description": {
+          "eservice": "Indica il metodo HTTP che si vuole invocare verso la risorsa",
+          "pdnd": "Il metodo HTTP dell’operazione API M2M PDND che vuoi invocare."
+        }
       },
       "htuField": {
         "label": "HTU",
-        "description": "L'URL della risorsa che si vuole invocare"
+        "description": {
+          "eservice": "L'URL della risorsa che si vuole invocare",
+          "pdnd": "L’URL completo, senza parametri di query, dell’operazione API M2M PDND che vuoi invocare."
+        }
       },
-      "alert": "Trovi le informazioni sui parametri HTM e HTU all’interno dell’interfaccia OpenAPI dell’e-service.",
+      "alert": {
+        "eservice": "Trovi le informazioni sui parametri HTM e HTU all’interno dell’interfaccia OpenAPI dell’e-service.",
+        "pdnd": "Trovi i valori di HTM e HTU nella specifica OpenAPI M2M v3 di PDND."
+      },
       "athField": {
         "label": "ATH",
         "description": "L’hash del voucher rilasciato da PDND nello step precedente.",


### PR DESCRIPTION
## 🔗 Issue

[PIN-10624](https://pagopa.atlassian.net/browse/PIN-10624)

## 📝 Description / Context

The second DPoP step displayed guidance referring to an e-service OpenAPI specification even when simulating a voucher for PDND M2M APIs.

The guidance is now tailored to the selected client type, while preserving the existing copy for e-service clients.

## 🛠 List of changes

- Added specific HTM and HTU guidance for PDND M2M API clients.
- Updated the Italian and English locale files.
- Preserved the existing OpenAPI guidance for e-service clients.
- Added tests covering both API and e-service client scenarios.

## 🧪 How to test

- Open **Developer tools** and start the voucher simulation for an API Interoperability client.
- Reach the second DPoP step and verify that the HTM and HTU helpers refer to the PDND M2M API operation.
- Verify that the alert refers to the PDND M2M v3 OpenAPI specification.
- Repeat the flow for an e-service client and verify that the existing e-service OpenAPI guidance is still displayed.


[PIN-10624]: https://pagopa.atlassian.net/browse/PIN-10624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ