### PR TITLE
fix/PIN-9971: i18n label soglie rimanenti strong text

### DIFF
--- a/src/components/shared/ProviderThresholdsInfoAlert.tsx
+++ b/src/components/shared/ProviderThresholdsInfoAlert.tsx
@@ -1,5 +1,5 @@
 import { AlertTitle, Stack, Typography } from '@mui/material'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { GreyAlert } from '@/components/shared/GreyAlert'
 
 type ProviderThresholdsInfoAlertProps = {
@@ -30,20 +30,27 @@ export function ProviderThresholdsInfoAlert({
       >
         <Stack direction="row" spacing={2} alignItems="center">
           <Typography>{t('dailyCallsPerConsumer.label')}</Typography>
-          <Typography fontWeight={600}>
-            {t('dailyCallsPerConsumer.value', {
-              min: remainingDailyCallsPerConsumer ?? t('na'),
-              max: dailyCallsPerConsumer,
-            })}
+          <Typography>
+            <Trans
+              ns="purpose"
+              i18nKey="edit.loadEstimationSection.providerThresholdsInfo.dailyCallsPerConsumer.value"
+              values={{
+                min: remainingDailyCallsPerConsumer ?? t('na'),
+                max: dailyCallsPerConsumer,
+              }}
+              components={{ strong: <strong /> }}
+            />
           </Typography>
         </Stack>
         <Stack direction="row" spacing={2} alignItems="center">
           <Typography>{t('dailyCallsTotal.label')}</Typography>
-          <Typography fontWeight={600}>
-            {t('dailyCallsTotal.value', {
-              min: remainingDailyCallsTotal ?? t('na'),
-              max: dailyCallsTotal,
-            })}
+          <Typography>
+            <Trans
+              ns="purpose"
+              i18nKey="edit.loadEstimationSection.providerThresholdsInfo.dailyCallsTotal.value"
+              values={{ min: remainingDailyCallsTotal ?? t('na'), max: dailyCallsTotal }}
+              components={{ strong: <strong /> }}
+            />
           </Typography>
         </Stack>
       </Stack>

--- a/src/components/shared/ProviderThresholdsInfoAlert.tsx
+++ b/src/components/shared/ProviderThresholdsInfoAlert.tsx
@@ -32,8 +32,8 @@ export function ProviderThresholdsInfoAlert({
           <Typography>{t('dailyCallsPerConsumer.label')}</Typography>
           <Typography>
             <Trans
-              ns="purpose"
-              i18nKey="edit.loadEstimationSection.providerThresholdsInfo.dailyCallsPerConsumer.value"
+              t={t}
+              i18nKey="dailyCallsPerConsumer.value"
               values={{
                 min: remainingDailyCallsPerConsumer ?? t('na'),
                 max: dailyCallsPerConsumer,

--- a/src/components/shared/ProviderThresholdsInfoAlert.tsx
+++ b/src/components/shared/ProviderThresholdsInfoAlert.tsx
@@ -46,8 +46,8 @@ export function ProviderThresholdsInfoAlert({
           <Typography>{t('dailyCallsTotal.label')}</Typography>
           <Typography>
             <Trans
-              ns="purpose"
-              i18nKey="edit.loadEstimationSection.providerThresholdsInfo.dailyCallsTotal.value"
+              t={t}
+              i18nKey="dailyCallsTotal.value"
               values={{ min: remainingDailyCallsTotal ?? t('na'), max: dailyCallsTotal }}
               components={{ strong: <strong /> }}
             />

--- a/src/components/shared/__tests__/ProviderThresholdsInfoAlert.test.tsx
+++ b/src/components/shared/__tests__/ProviderThresholdsInfoAlert.test.tsx
@@ -10,13 +10,13 @@ describe('ProviderThresholdsInfoAlert', () => {
   it('renders the daily calls per consumer label and value', () => {
     render(<ProviderThresholdsInfoAlert dailyCallsPerConsumer={100} dailyCallsTotal={1000} />)
     expect(screen.getByText('dailyCallsPerConsumer.label')).toBeInTheDocument()
-    expect(screen.getByText('dailyCallsPerConsumer.value')).toBeInTheDocument()
+    expect(screen.getByText(/dailyCallsPerConsumer\.value/)).toBeInTheDocument()
   })
 
   it('renders the daily calls total label and value', () => {
     render(<ProviderThresholdsInfoAlert dailyCallsPerConsumer={100} dailyCallsTotal={1000} />)
     expect(screen.getByText('dailyCallsTotal.label')).toBeInTheDocument()
-    expect(screen.getByText('dailyCallsTotal.value')).toBeInTheDocument()
+    expect(screen.getByText(/dailyCallsTotal\.value/)).toBeInTheDocument()
   })
 
   it('renders the description', () => {

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -142,11 +142,11 @@
         "na": "n/a",
         "dailyCallsPerConsumer": {
           "label": "Per consumer",
-          "value": "{{min}} available calls out of {{max}}"
+          "value": "<strong>{{min}}</strong> available calls out of <strong>{{max}}</strong>"
         },
         "dailyCallsTotal": {
           "label": "Total",
-          "value": "{{min}} available calls out of {{max}}"
+          "value": "<strong>{{min}}</strong> available calls out of <strong>{{max}}</strong>"
         }
       },
       "alerts": {
@@ -541,11 +541,11 @@
             "na": "n/a",
             "dailyCallsPerConsumer": {
               "label": "Per consumer",
-              "value": "{{min}} available calls out of {{max}}"
+              "value": "<strong>{{min}}</strong> available calls out of <strong>{{max}}</strong>"
             },
             "dailyCallsTotal": {
               "label": "Total",
-              "value": "{{min}} available calls out of {{max}}"
+              "value": "<strong>{{min}}</strong> available calls out of <strong>{{max}}</strong>"
             }
           },
           "riskAnalysisSection": {

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -142,11 +142,11 @@
         "na": "n/a",
         "dailyCallsPerConsumer": {
           "label": "Per fruitore",
-          "value": "{{min}} chiamate disponibili su {{max}}"
+          "value": "<strong>{{min}}</strong> chiamate disponibili su <strong>{{max}}</strong>"
         },
         "dailyCallsTotal": {
           "label": "Totali",
-          "value": "{{min}} chiamate disponibili su {{max}}"
+          "value": "<strong>{{min}}</strong> chiamate disponibili su <strong>{{max}}</strong>"
         }
       },
       "alerts": {
@@ -541,11 +541,11 @@
             "na": "n/a",
             "dailyCallsPerConsumer": {
               "label": "Per fruitore",
-              "value": "{{min}} chiamate disponibili su {{max}}"
+              "value": "<strong>{{min}}</strong> chiamate disponibili su <strong>{{max}}</strong>"
             },
             "dailyCallsTotal": {
               "label": "Totali",
-              "value": "{{min}} chiamate disponibili su {{max}}"
+              "value": "<strong>{{min}}</strong> chiamate disponibili su <strong>{{max}}</strong>"
             }
           },
           "riskAnalysisSection": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-9971](https://pagopa.atlassian.net/browse/PIN-9971)

## 📝 Description / Context

Part of the string shouldn't be bold

## 🛠 List of changes

- used tag strong inside i18n label instead of making the entire string bold on the component

## 🧪 How to test

Finalità -> Crea Nuovo -> Crea bozza


[PIN-9971]: https://pagopa.atlassian.net/browse/PIN-9971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ