### PR TITLE
feat: move agreement id from body to query (PIN-10630)

### DIFF
--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -3017,7 +3017,15 @@ export interface DeleteAgreementParams {
   agreementId: string;
 }
 
-export interface ActivateAgreementParams {
+export interface ApproveAgreementParams {
+  /**
+   * The identifier of the agreement
+   * @format uuid
+   */
+  agreementId: string;
+}
+
+export interface UnsuspendAgreementParams {
   /**
    * The identifier of the agreement
    * @format uuid
@@ -4541,12 +4549,12 @@ export interface UpdateVerifiedAttributeParams {
   attributeId: string;
 }
 
-export interface RevokeVerifiedAttributePayload {
-  /** @format uuid */
-  agreementId: string;
-}
-
 export interface RevokeVerifiedAttributeParams {
+  /**
+   * Agreement id related to the Verified attribute revocation
+   * @format uuid
+   */
+  agreementId: string;
   /**
    * Tenant id which attribute needs to be verified
    * @format uuid
@@ -6289,12 +6297,34 @@ export namespace Agreements {
   /**
    * @description returns the updated agreement
    * @tags agreements
-   * @name ActivateAgreement
+   * @name ApproveAgreement
    * @summary Activate an agreement
-   * @request POST:/agreements/{agreementId}/activate
+   * @request POST:/agreements/{agreementId}/approve
    * @secure
    */
-  export namespace ActivateAgreement {
+  export namespace ApproveAgreement {
+    export type RequestParams = {
+      /**
+       * The identifier of the agreement
+       * @format uuid
+       */
+      agreementId: string;
+    };
+    export type RequestQuery = {};
+    export type RequestBody = DelegationRef;
+    export type RequestHeaders = {};
+    export type ResponseBody = Agreement;
+  }
+
+  /**
+   * @description returns the updated agreement
+   * @tags agreements
+   * @name UnsuspendAgreement
+   * @summary Activate a suspended agreement
+   * @request POST:/agreements/{agreementId}/unsuspend
+   * @secure
+   */
+  export namespace UnsuspendAgreement {
     export type RequestParams = {
       /**
        * The identifier of the agreement
@@ -6884,8 +6914,14 @@ export namespace Tenants {
        */
       attributeId: string;
     };
-    export type RequestQuery = {};
-    export type RequestBody = RevokeVerifiedAttributePayload;
+    export type RequestQuery = {
+      /**
+       * Agreement id related to the Verified attribute revocation
+       * @format uuid
+       */
+      agreementId: string;
+    };
+    export type RequestBody = never;
     export type RequestHeaders = {};
     export type ResponseBody = void;
   }

--- a/src/api/attribute/__tests__/attribute.services.test.ts
+++ b/src/api/attribute/__tests__/attribute.services.test.ts
@@ -1,0 +1,31 @@
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
+import axiosInstance from '@/config/axios'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AttributeServices } from '../attribute.services'
+
+vi.mock('@/config/axios', () => ({
+  default: {
+    delete: vi.fn().mockResolvedValue({ data: {} }),
+  },
+}))
+
+describe('AttributeServices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('revokeVerifiedPartyAttribute', () => {
+    it('sends the agreement id as a query parameter without a request body', async () => {
+      const partyId: string = 'party-id'
+      const attributeId: string = 'attribute-id'
+      const agreementId: string = 'agreement-id'
+
+      await AttributeServices.revokeVerifiedPartyAttribute({ partyId, attributeId, agreementId })
+
+      expect(axiosInstance.delete).toHaveBeenCalledWith(
+        `${BACKEND_FOR_FRONTEND_URL}/tenants/${partyId}/attributes/verified/${attributeId}`,
+        { params: { agreementId } }
+      )
+    })
+  })
+})

--- a/src/api/attribute/attribute.services.ts
+++ b/src/api/attribute/attribute.services.ts
@@ -140,7 +140,7 @@ async function revokeVerifiedPartyAttribute({
 }) {
   return axiosInstance.delete<Attribute>(
     `${BACKEND_FOR_FRONTEND_URL}/tenants/${partyId}/attributes/verified/${attributeId}`,
-    { data: { agreementId } }
+    { params: { agreementId } }
   )
 }
 


### PR DESCRIPTION
## 🔗 Issue
[PIN-10630](https://pagopa.atlassian.net/browse/PIN-10630)

## 📝 Description / Context
The BFF changed the contract for the verified attribute revocation endpoint: `agreementId` is now expected as a query parameter instead of a request body. `DELETE` requests with a body are unreliable and the new contract drops it entirely, so the frontend must align or the revocation fails.

The regenerated API types also pick up the split of the agreement activation endpoint into `approve` (`POST /agreements/{agreementId}/approve`) and `unsuspend` (`POST /agreements/{agreementId}/unsuspend`), replacing the previous single `activate` endpoint.

## 🛠 List of changes
- `revokeVerifiedPartyAttribute` now sends `agreementId` via `params` instead of `data`, so it travels as a query parameter with no request body
- Regenerated API types: `RevokeVerifiedAttributePayload` removed, `agreementId` moved into `RevokeVerifiedAttributeParams` and the request body is now `never`
- Regenerated API types: `ActivateAgreementParams` split into `ApproveAgreementParams` and `UnsuspendAgreementParams`, with the `ActivateAgreement` namespace replaced by `ApproveAgreement` and `UnsuspendAgreement`
- Added unit test covering that the revocation sends the agreement id as a query parameter without a body

## 🧪 How to test
- Log in as a provider and open the details page of an agreement that has verified attributes
- Open the verified attributes drawer and revoke a verified attribute
- In the network tab, check the `DELETE /tenants/{partyId}/attributes/verified/{attributeId}` request: `agreementId` must appear in the query string and the request must have no body
- Verify the revocation completes successfully and the attribute state updates in the UI

[PIN-10630]: https://pagopa.atlassian.net/browse/PIN-10630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ