### PR TITLE
feat: enhance accessibility for stepper component (A2-2657 - INT-88)

### DIFF
--- a/src/components/shared/Stepper.tsx
+++ b/src/components/shared/Stepper.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Stepper as MUIStepper, Step, StepLabel, Box } from '@mui/material'
+import { visuallyHidden } from '@mui/utils'
 import type { StepperStep } from '@/types/common.types'
+import { useTranslation } from 'react-i18next'
 
 type StepperProps = {
   steps: Array<StepperStep>
@@ -8,14 +10,32 @@ type StepperProps = {
 }
 
 export function Stepper({ steps, activeIndex }: StepperProps) {
+  const { t } = useTranslation('shared-components', { keyPrefix: 'stepper' })
+
   return (
     <Box sx={{ py: 3 }}>
       <MUIStepper activeStep={activeIndex} alternativeLabel>
-        {steps.map(({ label }) => (
-          <Step key={label}>
-            <StepLabel>{label}</StepLabel>
-          </Step>
-        ))}
+        {steps.map(({ label }, index) => {
+          const isCompleted = index < activeIndex
+          const isCurrent = index === activeIndex
+
+          let statusText = ''
+          if (isCompleted) statusText = t('completeLabel') + ': '
+          else if (isCurrent) statusText = t('currentStepLabel') + ': '
+
+          return (
+            <Step key={label}>
+              {/* force the non-interactive label into the tab order to improve accessibility */}
+              <StepLabel tabIndex={0}>
+                <span style={visuallyHidden}>
+                  {statusText}
+                  {t('stepperLabel', { currentStep: index + 1, totalSteps: steps.length })}:
+                </span>
+                {label}
+              </StepLabel>
+            </Step>
+          )
+        })}
       </MUIStepper>
     </Box>
   )

--- a/src/components/shared/Stepper.tsx
+++ b/src/components/shared/Stepper.tsx
@@ -29,7 +29,7 @@ export function Stepper({ steps, activeIndex }: StepperProps) {
               <StepLabel tabIndex={0}>
                 <span style={visuallyHidden}>
                   {statusText}
-                  {t('stepperLabel', { currentStep: index + 1, totalSteps: steps.length })}:
+                  {t('stepperLabel', { currentStep: index + 1, totalSteps: steps.length }) + ': '}
                 </span>
                 {label}
               </StepLabel>

--- a/src/components/shared/Stepper.tsx
+++ b/src/components/shared/Stepper.tsx
@@ -24,7 +24,7 @@ export function Stepper({ steps, activeIndex }: StepperProps) {
           else if (isCurrent) statusText = t('currentStepLabel')
 
           return (
-            <Step key={index}>
+            <Step key={label}>
               {/* force the non-interactive label into the tab order to improve accessibility */}
               <StepLabel tabIndex={0}>
                 <span style={visuallyHidden}>

--- a/src/components/shared/Stepper.tsx
+++ b/src/components/shared/Stepper.tsx
@@ -28,7 +28,7 @@ export function Stepper({ steps, activeIndex }: StepperProps) {
               {/* force the non-interactive label into the tab order to improve accessibility */}
               <StepLabel tabIndex={0}>
                 <span style={visuallyHidden}>
-                  {statusText}
+                  {statusText}{' '}
                   {t('stepperLabel', { currentStep: index + 1, totalSteps: steps.length })}
                 </span>
                 {label}

--- a/src/components/shared/Stepper.tsx
+++ b/src/components/shared/Stepper.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Stepper as MUIStepper, Step, StepLabel, Box } from '@mui/material'
-import { visuallyHidden } from '@mui/utils'
+import { Box } from '@mui/material'
 import type { StepperStep } from '@/types/common.types'
 import { useTranslation } from 'react-i18next'
+import { MIStepper } from '@pagopa/mui-italia'
 
 type StepperProps = {
   steps: Array<StepperStep>
@@ -10,33 +10,9 @@ type StepperProps = {
 }
 
 export function Stepper({ steps, activeIndex }: StepperProps) {
-  const { t } = useTranslation('shared-components', { keyPrefix: 'stepper' })
-
   return (
     <Box sx={{ py: 3 }}>
-      <MUIStepper activeStep={activeIndex} alternativeLabel>
-        {steps.map(({ label }, index) => {
-          const isCompleted = index < activeIndex
-          const isCurrent = index === activeIndex
-
-          let statusText = ''
-          if (isCompleted) statusText = t('completeLabel')
-          else if (isCurrent) statusText = t('currentStepLabel')
-
-          return (
-            <Step key={label}>
-              {/* force the non-interactive label into the tab order to improve accessibility */}
-              <StepLabel tabIndex={0}>
-                <span style={visuallyHidden}>
-                  {statusText}{' '}
-                  {t('stepperLabel', { currentStep: index + 1, totalSteps: steps.length })}
-                </span>
-                {label}
-              </StepLabel>
-            </Step>
-          )
-        })}
-      </MUIStepper>
+      <MIStepper activeStep={activeIndex} steps={steps} />
     </Box>
   )
 }

--- a/src/components/shared/Stepper.tsx
+++ b/src/components/shared/Stepper.tsx
@@ -24,12 +24,12 @@ export function Stepper({ steps, activeIndex }: StepperProps) {
           else if (isCurrent) statusText = t('currentStepLabel') + ': '
 
           return (
-            <Step key={label}>
+            <Step key={index}>
               {/* force the non-interactive label into the tab order to improve accessibility */}
               <StepLabel tabIndex={0}>
                 <span style={visuallyHidden}>
                   {statusText}
-                  {t('stepperLabel', { currentStep: index + 1, totalSteps: steps.length }) + ': '}
+                  {t('stepperLabel', { currentStep: index + 1, totalSteps: steps.length })}
                 </span>
                 {label}
               </StepLabel>

--- a/src/components/shared/Stepper.tsx
+++ b/src/components/shared/Stepper.tsx
@@ -20,8 +20,8 @@ export function Stepper({ steps, activeIndex }: StepperProps) {
           const isCurrent = index === activeIndex
 
           let statusText = ''
-          if (isCompleted) statusText = t('completeLabel') + ': '
-          else if (isCurrent) statusText = t('currentStepLabel') + ': '
+          if (isCompleted) statusText = t('completeLabel')
+          else if (isCurrent) statusText = t('currentStepLabel')
 
           return (
             <Step key={index}>

--- a/src/components/shared/__tests__/Stepper.test.tsx
+++ b/src/components/shared/__tests__/Stepper.test.tsx
@@ -27,10 +27,10 @@ describe('Stepper', () => {
     const thirdLabel = screen.getByText('Step three').closest('.MuiStepLabel-root')
 
     expect(firstLabel).toHaveTextContent(
-      'shared-components.stepper.completeLabel: shared-components.stepper.stepperLabel'
+      'shared-components.stepper.completeLabelshared-components.stepper.stepperLabel'
     )
     expect(secondLabel).toHaveTextContent(
-      'shared-components.stepper.currentStepLabel: shared-components.stepper.stepperLabel'
+      'shared-components.stepper.currentStepLabelshared-components.stepper.stepperLabel'
     )
     expect(thirdLabel).toHaveTextContent('shared-components.stepper.stepperLabel')
     expect(thirdLabel).not.toHaveTextContent('shared-components.stepper.completeLabel')

--- a/src/components/shared/__tests__/Stepper.test.tsx
+++ b/src/components/shared/__tests__/Stepper.test.tsx
@@ -4,12 +4,18 @@ import { renderWithApplicationContext } from '@/utils/testing.utils'
 import { Stepper } from '../Stepper'
 import { screen } from '@testing-library/react'
 
-const DummyStep = () => null
+const mockReactI18next = vi.hoisted(async () => {
+  const { createMockReactI18next } = await import('@/utils/__mocks__/react-i18next-helper')
+  return createMockReactI18next('en')
+})
+vi.mock('react-i18next', () => mockReactI18next)
+
+const mockStep = () => null
 
 const steps: Array<StepperStep> = [
-  { label: 'Step one', component: DummyStep },
-  { label: 'Step two', component: DummyStep },
-  { label: 'Step three', component: DummyStep },
+  { label: 'Step one', component: mockStep },
+  { label: 'Step two', component: mockStep },
+  { label: 'Step three', component: mockStep },
 ]
 
 describe('Stepper', () => {
@@ -20,11 +26,15 @@ describe('Stepper', () => {
     const secondLabel = screen.getByText('Step two').closest('.MuiStepLabel-root')
     const thirdLabel = screen.getByText('Step three').closest('.MuiStepLabel-root')
 
-    expect(firstLabel).toHaveTextContent('completeLabel: stepperLabel')
-    expect(secondLabel).toHaveTextContent('currentStepLabel: stepperLabel')
-    expect(thirdLabel).toHaveTextContent('stepperLabel')
-    expect(thirdLabel).not.toHaveTextContent('completeLabel')
-    expect(thirdLabel).not.toHaveTextContent('currentStepLabel')
+    expect(firstLabel).toHaveTextContent(
+      'shared-components.stepper.completeLabel: shared-components.stepper.stepperLabel'
+    )
+    expect(secondLabel).toHaveTextContent(
+      'shared-components.stepper.currentStepLabel: shared-components.stepper.stepperLabel'
+    )
+    expect(thirdLabel).toHaveTextContent('shared-components.stepper.stepperLabel')
+    expect(thirdLabel).not.toHaveTextContent('shared-components.stepper.completeLabel')
+    expect(thirdLabel).not.toHaveTextContent('shared-components.stepper.currentStepLabel')
   })
 
   it('makes each step label focusable and keeps labels visible', () => {

--- a/src/components/shared/__tests__/Stepper.test.tsx
+++ b/src/components/shared/__tests__/Stepper.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import type { StepperStep } from '@/types/common.types'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { Stepper } from '../Stepper'
+import { screen } from '@testing-library/react'
+
+const DummyStep = () => null
+
+const steps: Array<StepperStep> = [
+  { label: 'Step one', component: DummyStep },
+  { label: 'Step two', component: DummyStep },
+  { label: 'Step three', component: DummyStep },
+]
+
+describe('Stepper', () => {
+  it('renders SR-only status text for completed and current steps', () => {
+    renderWithApplicationContext(<Stepper steps={steps} activeIndex={1} />, {})
+
+    const firstLabel = screen.getByText('Step one').closest('.MuiStepLabel-root')
+    const secondLabel = screen.getByText('Step two').closest('.MuiStepLabel-root')
+    const thirdLabel = screen.getByText('Step three').closest('.MuiStepLabel-root')
+
+    expect(firstLabel).toHaveTextContent('completeLabel: stepperLabel')
+    expect(secondLabel).toHaveTextContent('currentStepLabel: stepperLabel')
+    expect(thirdLabel).toHaveTextContent('stepperLabel')
+    expect(thirdLabel).not.toHaveTextContent('completeLabel')
+    expect(thirdLabel).not.toHaveTextContent('currentStepLabel')
+  })
+
+  it('makes each step label focusable and keeps labels visible', () => {
+    renderWithApplicationContext(<Stepper steps={steps} activeIndex={1} />, {})
+
+    const stepOne = screen.getByText('Step one').closest('.MuiStepLabel-root')
+    const stepTwo = screen.getByText('Step two').closest('.MuiStepLabel-root')
+    const stepThree = screen.getByText('Step three').closest('.MuiStepLabel-root')
+
+    expect(stepOne).toHaveAttribute('tabindex', '0')
+    expect(stepTwo).toHaveAttribute('tabindex', '0')
+    expect(stepThree).toHaveAttribute('tabindex', '0')
+
+    expect(screen.getByText('Step one')).toBeVisible()
+    expect(screen.getByText('Step two')).toBeVisible()
+    expect(screen.getByText('Step three')).toBeVisible()
+  })
+})

--- a/src/components/shared/__tests__/Stepper.test.tsx
+++ b/src/components/shared/__tests__/Stepper.test.tsx
@@ -22,9 +22,9 @@ describe('Stepper', () => {
   it('renders SR-only status text for completed and current steps', () => {
     renderWithApplicationContext(<Stepper steps={steps} activeIndex={1} />, {})
 
-    const firstLabel = screen.getByText('Step one').closest('.MuiStepLabel-root')
-    const secondLabel = screen.getByText('Step two').closest('.MuiStepLabel-root')
-    const thirdLabel = screen.getByText('Step three').closest('.MuiStepLabel-root')
+    const firstLabel = screen.getByText('Step one').closest('[tabindex="0"]')
+    const secondLabel = screen.getByText('Step two').closest('[tabindex="0"]')
+    const thirdLabel = screen.getByText('Step three').closest('[tabindex="0"]')
 
     expect(firstLabel).toHaveTextContent(
       'shared-components.stepper.completeLabel shared-components.stepper.stepperLabel'
@@ -40,9 +40,9 @@ describe('Stepper', () => {
   it('makes each step label focusable and keeps labels visible', () => {
     renderWithApplicationContext(<Stepper steps={steps} activeIndex={1} />, {})
 
-    const stepOne = screen.getByText('Step one').closest('.MuiStepLabel-root')
-    const stepTwo = screen.getByText('Step two').closest('.MuiStepLabel-root')
-    const stepThree = screen.getByText('Step three').closest('.MuiStepLabel-root')
+    const stepOne = screen.getByText('Step one').closest('[tabindex="0"]')
+    const stepTwo = screen.getByText('Step two').closest('[tabindex="0"]')
+    const stepThree = screen.getByText('Step three').closest('[tabindex="0"]')
 
     expect(stepOne).toHaveAttribute('tabindex', '0')
     expect(stepTwo).toHaveAttribute('tabindex', '0')

--- a/src/components/shared/__tests__/Stepper.test.tsx
+++ b/src/components/shared/__tests__/Stepper.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { StepperStep } from '@/types/common.types'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import { Stepper } from '../Stepper'

--- a/src/components/shared/__tests__/Stepper.test.tsx
+++ b/src/components/shared/__tests__/Stepper.test.tsx
@@ -27,10 +27,10 @@ describe('Stepper', () => {
     const thirdLabel = screen.getByText('Step three').closest('.MuiStepLabel-root')
 
     expect(firstLabel).toHaveTextContent(
-      'shared-components.stepper.completeLabelshared-components.stepper.stepperLabel'
+      'shared-components.stepper.completeLabel shared-components.stepper.stepperLabel'
     )
     expect(secondLabel).toHaveTextContent(
-      'shared-components.stepper.currentStepLabelshared-components.stepper.stepperLabel'
+      'shared-components.stepper.currentStepLabel shared-components.stepper.stepperLabel'
     )
     expect(thirdLabel).toHaveTextContent('shared-components.stepper.stepperLabel')
     expect(thirdLabel).not.toHaveTextContent('shared-components.stepper.completeLabel')

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -419,7 +419,6 @@
       "inspectAttributeDetails": "Attribute details",
       "modifyCertifiedDiscreteAttribute": "Modify attribute"
     },
-
     "na": "n/a"
   },
   "attributeGroupContainer": {
@@ -561,7 +560,15 @@
   "documents": {
     "notAvailableYet": "The document will be available soon"
   },
+
   "requiredLabel": "*Required fields.",
+
+  "stepper": {
+    "stepperLabel": "Step {{currentStep}} of {{totalSteps}}",
+    "completeLabel": "Step completed",
+    "currentStepLabel": "Current Step"
+  },
+
   "routeLabels": {
     "LOGOUT": "Logout",
     "TOS": "Terms of Service",

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -563,12 +563,6 @@
 
   "requiredLabel": "*Required fields.",
 
-  "stepper": {
-    "stepperLabel": "Step {{currentStep}} of {{totalSteps}}",
-    "completeLabel": "Step completed",
-    "currentStepLabel": "Current step"
-  },
-
   "routeLabels": {
     "LOGOUT": "Logout",
     "TOS": "Terms of Service",

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -566,7 +566,7 @@
   "stepper": {
     "stepperLabel": "Step {{currentStep}} of {{totalSteps}}",
     "completeLabel": "Step completed",
-    "currentStepLabel": "Current Step"
+    "currentStepLabel": "Current step"
   },
 
   "routeLabels": {

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -563,6 +563,12 @@
 
   "requiredLabel": "*Campi obbligatori",
 
+  "stepper": {
+    "stepperLabel": "Step {{currentStep}} di {{totalSteps}}",
+    "completeLabel": "Step completato",
+    "currentStepLabel": "Step corrente"
+  },
+
   "routeLabels": {
     "LOGOUT": "Logout",
     "TOS": "Termini di servizio",

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -563,12 +563,6 @@
 
   "requiredLabel": "*Campi obbligatori",
 
-  "stepper": {
-    "stepperLabel": "Step {{currentStep}} di {{totalSteps}}",
-    "completeLabel": "Step completato",
-    "currentStepLabel": "Step corrente"
-  },
-
   "routeLabels": {
     "LOGOUT": "Logout",
     "TOS": "Termini di servizio",


### PR DESCRIPTION
## 🔗 Issue

[A2-2657](https://pagopa.atlassian.net/browse/A2-2657)

## 📝 Description / Context

This pull request enhances the `Stepper` component by adding accessibility improvements and localization support for step labels. It also introduces new translation keys for both English and Italian to support these features.




[A2-2657]: https://pagopa.atlassian.net/browse/A2-2657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ