### PR TITLE
fix: correct interface data success message (PIN-10628)

### DIFF
--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -283,7 +283,7 @@
       "loading": "Stiamo modificando i dati di interfaccia dell e-service",
       "outcome": {
         "error": "Non è stato possibile salvare i dati di interfaccia. Assicurati di aver inserito le informazioni corrette.",
-        "success": "Dati di interfaccia sono stati salvati corettamente"
+        "success": "Dati di interfaccia sono stati salvati correttamente"
       }
     },
     "deleteAndUpgradeEService": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10628](https://pagopa.atlassian.net/browse/PIN-10628)

## 📝 Description / Context

Fixes a typo in the success message displayed after saving interface data for an eservice template instance.

## 🛠 List of changes

- Replaced `corettamente` with `correttamente` in the Italian success message.

## 🧪 How to test

- Navigate to **Erogazione → Template e-service**.
- Open an available template and select **Usa template**.
- Complete the required information up to the **Specifiche tecniche** step.
- Enter valid interface data and select **Salva dati di interfaccia**.
- Verify that the success message is: **“Dati di interfaccia sono stati salvati correttamente”**.

[PIN-10628]: https://pagopa.atlassian.net/browse/PIN-10628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ