### PR TITLE
test: stabilize voucher client services mock

### DIFF
--- a/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/__tests__/VoucherInstructionsGeneralForm.test.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/components/VoucherInstructions/VoucherInstructionsGeneralForm/__tests__/VoucherInstructionsGeneralForm.test.tsx
@@ -22,11 +22,14 @@ vi.mock('../VoucherInstructionsGeneralFormCurrentIdsDrawer', () => ({
 }))
 
 vi.mock('@/api/client/client.services', () => ({
-  getList: vi.fn().mockResolvedValue({
-    data: {
-      content: [],
-    },
-  }),
+  ClientServices: {
+    getList: vi.fn().mockResolvedValue({
+      results: [],
+      pagination: { offset: 0, limit: 50, totalCount: 0 },
+    }),
+    getSingle: vi.fn().mockResolvedValue({ purposes: [] }),
+    getAllKeysList: vi.fn().mockResolvedValue([]),
+  },
 }))
 
 describe('VoucherInstructionsGeneralForm', () => {


### PR DESCRIPTION
## 📝 Description / Context

The `VoucherInstructionsGeneralForm` test suite used an incorrectly shaped mock for the client services module.

Production code accesses methods through the exported `ClientServices` object, while the test exported `getList` directly. Since React Query executes queries asynchronously, this could pass in isolated runs but fail during the full test suite depending on scheduling.

## 🛠 List of changes

- Align the client services mock with the module's exported `ClientServices` object
- Return the current paginated response shape from `getList`
- Mock `getSingle` and `getAllKeysList` for render states containing a selected client