### PR TITLE
feat: add archive eservice dialog guidance (PIN-10659)

### DIFF
--- a/src/components/dialogs/DialogArchiveEservice.tsx
+++ b/src/components/dialogs/DialogArchiveEservice.tsx
@@ -79,7 +79,7 @@ const DialogArchiveEservice: React.FC<DialogArchiveEserviceProps> = ({ eserviceI
               <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>
                 {t('content.advice.description')}
               </Typography>
-              <GracePeriodField />
+              <GracePeriodField description={t('content.advice.gracePeriodDescription')} />
             </Stack>
           )}
 

--- a/src/components/dialogs/__tests__/DialogArchiveEservice.test.tsx
+++ b/src/components/dialogs/__tests__/DialogArchiveEservice.test.tsx
@@ -44,6 +44,7 @@ describe('DialogArchiveEservice', () => {
     renderDialog()
 
     expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('content.advice.gracePeriodDescription')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'cancel' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'actions.forward' })).toBeInTheDocument()
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument()

--- a/src/components/shared/GracePeriodField.tsx
+++ b/src/components/shared/GracePeriodField.tsx
@@ -8,7 +8,11 @@ import { useWatch } from 'react-hook-form'
 import { Trans, useTranslation } from 'react-i18next'
 import { RHFRadioGroup } from './react-hook-form-inputs'
 
-export const GracePeriodField: React.FC = () => {
+type GracePeriodFieldProps = {
+  description?: string
+}
+
+export const GracePeriodField: React.FC<GracePeriodFieldProps> = ({ description }) => {
   const { t } = useTranslation('shared-components', { keyPrefix: 'archiveGracePeriod' })
 
   const selectedGracePeriodDays = Number(
@@ -26,7 +30,24 @@ export const GracePeriodField: React.FC = () => {
 
   return (
     <Stack spacing={3}>
-      <RHFRadioGroup name="gracePeriodDays" label={t('label')} options={options} />
+      <RHFRadioGroup
+        name="gracePeriodDays"
+        label={
+          description ? (
+            <Stack component="span">
+              <Typography component="span" variant="inherit">
+                {t('label')}
+              </Typography>
+              <Typography component="span" variant="body2" fontWeight={400}>
+                {description}
+              </Typography>
+            </Stack>
+          ) : (
+            t('label')
+          )
+        }
+        options={options}
+      />
       <Typography variant="body2">
         <Trans
           components={{

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -306,7 +306,8 @@
     "title": "Archive e-service",
     "content": {
       "advice": {
-        "description": "By archiving the e-service, all versions will be archived and draft versions will be deleted.\nIf you confirm this choice, a notice period will begin during which the e-service will remain active to allow users to adapt."
+        "description": "By archiving the e-service, all versions will be archived and draft versions will be deleted.\nIf you confirm this choice, a notice period will begin during which the e-service will remain active to allow users to adapt.",
+        "gracePeriodDescription": "If a version is already being archived, you can archive the entire e-service only after the scheduled archiving date for that version."
       },
       "confirm": {
         "description": "All users will be informed of the date and the reason for the archiving.",

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -306,7 +306,8 @@
     "title": "Archivia e-service",
     "content": {
       "advice": {
-        "description": "Con l’archiviazione dell’e-service, tutte le sue versioni saranno archiviate e quelle in bozza eliminate.\nSe confermi questa scelta, inizierà un periodo di preavviso in cui l’e-service resterà attivo per consentire ai fruitori di adeguarsi."
+        "description": "Con l’archiviazione dell’e-service, tutte le sue versioni saranno archiviate e quelle in bozza eliminate.\nSe confermi questa scelta, inizierà un periodo di preavviso in cui l’e-service resterà attivo per consentire ai fruitori di adeguarsi.",
+        "gracePeriodDescription": "Se una versione è già in fase di archiviazione, puoi archiviare l’intero e-service solo dopo la data di archiviazione prevista per quella versione."
       },
       "confirm": {
         "description": "Tutti i fruitori saranno informati sulla data e sul motivo dell’archiviazione.",


### PR DESCRIPTION
## 🔗 Issue

[PIN-10659](https://pagopa.atlassian.net/browse/PIN-10659)

## 📝 Description / Context

Add guidance to the e-service archiving dialog to clarify the constraint applied when one of its versions is already being archived.

## 🛠 List of changes

- Add the guidance below the notice period selection in the e-service archiving dialog.
- Add Italian and English translations.
- Keep the version archiving dialog unchanged.
- Add focused test coverage for the new guidance.

## 🧪 How to test

- Open an active e-service from the producer's “My e-services” area and select “Archive e-service”.
- Verify that the notice period section explains that, when a version is already being archived, the entire e-service can only be archived after that version's scheduled archiving date.
- Open the archive dialog for a single version and verify that this additional guidance is not displayed.

[PIN-10659]: https://pagopa.atlassian.net/browse/PIN-10659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ