### PR TITLE
hotfix: allow consumer client manage admin actions to admin user only (PIN-10673)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interop-dashboard-frontend",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "scripts": {

--- a/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
+++ b/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
@@ -19,6 +19,7 @@ import { useDrawerState } from '@/hooks/useDrawerState'
 import { SetClientAdminDrawer } from './components/SetClientAdminDrawer/SetClientAdminDrawer'
 import type { ActionItemButton } from '@/types/common.types'
 import { useSearchParams } from 'react-router-dom'
+import { AuthHooks } from '@/api/auth'
 
 const ConsumerClientManagePage: React.FC = () => {
   const { t } = useTranslation('client', { keyPrefix: 'edit' })
@@ -29,6 +30,7 @@ const ConsumerClientManagePage: React.FC = () => {
   const clientKind = useClientKind()
   const { activeTab, updateActiveTab } = useActiveTab('clientOperators')
   const navigate = useNavigate()
+  const { isAdmin } = AuthHooks.useJwt()
 
   const { data: client, isLoading: isLoadingClient } = useQuery(ClientQueries.getSingle(clientId))
 
@@ -77,31 +79,35 @@ const ConsumerClientManagePage: React.FC = () => {
               description={t('adminSection.description')}
               sx={{ mb: 3 }}
             >
-              {client?.admin ? (
-                <Stack direction="row" justifyContent="space-between" alignItems={'center'}>
-                  <InformationContainer
-                    label={t('adminSection.adminLabel')}
-                    content={`${client.admin.name} ${client.admin.familyName}`}
-                    direction="column"
-                  />
-                  <Stack direction="row" spacing={2}>
-                    <Button variant="outlined" startIcon={<SyncIcon />} onClick={openDrawer}>
-                      {t('adminSection.actions.substituteAdminLabel')}
+              {isAdmin && (
+                <>
+                  {client?.admin ? (
+                    <Stack direction="row" justifyContent="space-between" alignItems={'center'}>
+                      <InformationContainer
+                        label={t('adminSection.adminLabel')}
+                        content={`${client.admin.name} ${client.admin.familyName}`}
+                        direction="column"
+                      />
+                      <Stack direction="row" spacing={2}>
+                        <Button variant="outlined" startIcon={<SyncIcon />} onClick={openDrawer}>
+                          {t('adminSection.actions.substituteAdminLabel')}
+                        </Button>
+                        <Button
+                          variant="outlined"
+                          color="error"
+                          startIcon={<DeleteIcon />}
+                          onClick={handleRemoveClientAdmin}
+                        >
+                          {t('adminSection.actions.removeAdminLabel')}
+                        </Button>
+                      </Stack>
+                    </Stack>
+                  ) : (
+                    <Button variant="outlined" onClick={openDrawer}>
+                      {t('adminSection.actions.selectAdminLabel')}
                     </Button>
-                    <Button
-                      variant="outlined"
-                      color="error"
-                      startIcon={<DeleteIcon />}
-                      onClick={handleRemoveClientAdmin}
-                    >
-                      {t('adminSection.actions.removeAdminLabel')}
-                    </Button>
-                  </Stack>
-                </Stack>
-              ) : (
-                <Button variant="outlined" onClick={openDrawer}>
-                  {t('adminSection.actions.selectAdminLabel')}
-                </Button>
+                  )}
+                </>
               )}
             </SectionContainer>
           </Grid>
@@ -121,7 +127,7 @@ const ConsumerClientManagePage: React.FC = () => {
           <ClientPublicKeys clientId={clientId} />
         </TabPanel>
       </TabContext>
-      {clientKind === 'API' && (
+      {clientKind === 'API' && isAdmin && (
         <SetClientAdminDrawer
           isOpen={isOpen}
           onClose={closeDrawer}

--- a/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
+++ b/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
@@ -79,36 +79,34 @@ const ConsumerClientManagePage: React.FC = () => {
               description={t('adminSection.description')}
               sx={{ mb: 3 }}
             >
-              {isAdmin && (
-                <>
-                  {client?.admin ? (
-                    <Stack direction="row" justifyContent="space-between" alignItems={'center'}>
-                      <InformationContainer
-                        label={t('adminSection.adminLabel')}
-                        content={`${client.admin.name} ${client.admin.familyName}`}
-                        direction="column"
-                      />
-                      <Stack direction="row" spacing={2}>
-                        <Button variant="outlined" startIcon={<SyncIcon />} onClick={openDrawer}>
-                          {t('adminSection.actions.substituteAdminLabel')}
-                        </Button>
-                        <Button
-                          variant="outlined"
-                          color="error"
-                          startIcon={<DeleteIcon />}
-                          onClick={handleRemoveClientAdmin}
-                        >
-                          {t('adminSection.actions.removeAdminLabel')}
-                        </Button>
-                      </Stack>
+              {client?.admin ? (
+                <Stack direction="row" justifyContent="space-between" alignItems={'center'}>
+                  <InformationContainer
+                    label={t('adminSection.adminLabel')}
+                    content={`${client.admin.name} ${client.admin.familyName}`}
+                    direction="column"
+                  />
+                  {isAdmin && (
+                    <Stack direction="row" spacing={2}>
+                      <Button variant="outlined" startIcon={<SyncIcon />} onClick={openDrawer}>
+                        {t('adminSection.actions.substituteAdminLabel')}
+                      </Button>
+                      <Button
+                        variant="outlined"
+                        color="error"
+                        startIcon={<DeleteIcon />}
+                        onClick={handleRemoveClientAdmin}
+                      >
+                        {t('adminSection.actions.removeAdminLabel')}
+                      </Button>
                     </Stack>
-                  ) : (
-                    <Button variant="outlined" onClick={openDrawer}>
-                      {t('adminSection.actions.selectAdminLabel')}
-                    </Button>
                   )}
-                </>
-              )}
+                </Stack>
+              ) : isAdmin ? (
+                <Button variant="outlined" onClick={openDrawer}>
+                  {t('adminSection.actions.selectAdminLabel')}
+                </Button>
+              ) : null}
             </SectionContainer>
           </Grid>
         </Grid>

--- a/src/pages/ConsumerClientManagePage/__tests__/ConsumerClientManage.page.test.tsx
+++ b/src/pages/ConsumerClientManagePage/__tests__/ConsumerClientManage.page.test.tsx
@@ -325,4 +325,86 @@ describe('ConsumerClientManagePage', () => {
       'closed-client-id-no-admin'
     )
   })
+
+  it('does not render SetClientAdminDrawer if the user is not an admin', async () => {
+    useJwtSpy.mockReturnValue({
+      jwt: createMockJwtUser(),
+      currentRoles: [],
+      isAdmin: false,
+      userEmail: 'test@email.com',
+      isOperatorAPI: false,
+      isOperatorSecurity: true,
+      isOrganizationAllowedToProduce: false,
+      isReviewer: false,
+      isSupport: false,
+      isViewer: false,
+    })
+
+    renderWithApplicationContext(<ConsumerClientManagePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.queryByTestId('set-client-admin-drawer')).not.toBeInTheDocument()
+  })
+
+  it('does not render sobstitute/remove admin actions if the user is not an admin and client admin is selected', async () => {
+    useJwtSpy.mockReturnValue({
+      jwt: createMockJwtUser(),
+      currentRoles: [],
+      isAdmin: false,
+      userEmail: 'test@email.com',
+      isOperatorAPI: false,
+      isOperatorSecurity: true,
+      isOrganizationAllowedToProduce: false,
+      isReviewer: false,
+      isSupport: false,
+      isViewer: false,
+    })
+
+    renderWithApplicationContext(<ConsumerClientManagePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.queryByText('edit.adminSection.adminLabel')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'edit.adminSection.actions.removeAdminLabel' })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('button', { name: 'edit.adminSection.actions.substituteAdminLabel' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not render select admin actions if the user is not an admin and client admin is not selected', async () => {
+    useJwtSpy.mockReturnValue({
+      jwt: createMockJwtUser(),
+      currentRoles: [],
+      isAdmin: false,
+      userEmail: 'test@email.com',
+      isOperatorAPI: false,
+      isOperatorSecurity: true,
+      isOrganizationAllowedToProduce: false,
+      isReviewer: false,
+      isSupport: false,
+      isViewer: false,
+    })
+
+    state.client = {
+      id: 'client-id',
+      name: 'Client Name',
+      description: 'Client Description',
+      admin: undefined,
+    }
+
+    renderWithApplicationContext(<ConsumerClientManagePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(
+      screen.queryByRole('button', { name: 'edit.adminSection.actions.selectAdminLabel' })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/src/pages/ConsumerClientManagePage/__tests__/ConsumerClientManage.page.test.tsx
+++ b/src/pages/ConsumerClientManagePage/__tests__/ConsumerClientManage.page.test.tsx
@@ -367,7 +367,7 @@ describe('ConsumerClientManagePage', () => {
       withRouterContext: true,
     })
 
-    expect(screen.queryByText('edit.adminSection.adminLabel')).not.toBeInTheDocument()
+    expect(screen.queryByText('edit.adminSection.adminLabel')).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'edit.adminSection.actions.removeAdminLabel' })
     ).not.toBeInTheDocument()

--- a/src/pages/ConsumerClientManagePage/__tests__/ConsumerClientManage.page.test.tsx
+++ b/src/pages/ConsumerClientManagePage/__tests__/ConsumerClientManage.page.test.tsx
@@ -4,6 +4,10 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import ConsumerClientManagePage from '../ConsumerClientManage.page'
+import { AuthHooks } from '@/api/auth'
+import { createMockJwtUser } from '@/../__mocks__/data/user.mocks'
+
+const useJwtSpy = vi.spyOn(AuthHooks, 'useJwt')
 
 const {
   mockedNavigate,
@@ -204,6 +208,18 @@ describe('ConsumerClientManagePage', () => {
     }
 
     mockedGetSingle.mockReturnValue({ queryKey: ['ClientGetSingle'] })
+    useJwtSpy.mockReturnValue({
+      jwt: createMockJwtUser(),
+      currentRoles: [],
+      isAdmin: true,
+      userEmail: 'test@email.com',
+      isOperatorAPI: false,
+      isOperatorSecurity: false,
+      isOrganizationAllowedToProduce: false,
+      isReviewer: false,
+      isSupport: false,
+      isViewer: false,
+    })
   })
 
   it('renders API admin section, tabs, and marks notifications as read', () => {

--- a/src/pages/ConsumerClientManagePage/components/SetClientAdminDrawer/SetClientAdminDrawer.tsx
+++ b/src/pages/ConsumerClientManagePage/components/SetClientAdminDrawer/SetClientAdminDrawer.tsx
@@ -29,7 +29,7 @@ export const SetClientAdminDrawer: React.FC<SetClientAdminDrawerProps> = ({
 }) => {
   const { t } = useTranslation('client', { keyPrefix: 'edit.setClientAdminDrawer' })
   const { t: tCommon } = useTranslation('common')
-  const { jwt } = AuthHooks.useJwt()
+  const { jwt, isAdmin } = AuthHooks.useJwt()
 
   const { mutate: setClientAdmin } = ClientMutations.useSetClientAdmin()
 
@@ -45,6 +45,7 @@ export const SetClientAdminDrawer: React.FC<SetClientAdminDrawerProps> = ({
       roles: ['admin'],
     }),
     select: (results) => results ?? [],
+    enabled: isAdmin,
   })
 
   const handleCloseDrawer = () => {


### PR DESCRIPTION
## Jira Issue
[PIN-10673](https://pagopa.atlassian.net/browse/PIN-10673)

## Context/Why
**Admin Section Interop API manage client page**

## Key Changes
 - Disable `getPartyUsersList` for not Admin users
 - Remove `SetClientAdminDrawer` for not Admin users
 - Remove actions from admin section for not Admin users

[PIN-10673]: https://pagopa.atlassian.net/browse/PIN-10673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ