### PR TITLE
feat: use a lightweight endpoint for e-service select listings (PIN-10664)

### DIFF
--- a/__mocks__/data/eservice.mocks.ts
+++ b/__mocks__/data/eservice.mocks.ts
@@ -2,6 +2,7 @@ import type {
   CatalogDescriptorEService,
   CatalogEService,
   CatalogEServiceDescriptor,
+  CompactCatalogEService,
   ProducerEService,
   ProducerEServiceDescriptor,
   ProducerEServiceDetails,
@@ -42,6 +43,21 @@ const createMockEServiceCatalog = createMockFactory<CatalogEService>({
     name: "Agenzia per L'Italia Digitale",
   },
   asyncExchange: false,
+})
+
+const createMockCompactEServiceCatalog = createMockFactory<CompactCatalogEService>({
+  activeDescriptor: {
+    id: 'e9762e42-129a-4b07-9b2e-9614998ef9b8',
+    state: 'PUBLISHED',
+    version: '1',
+    audience: [],
+  },
+  name: '!! -- CAMMELLO -- Test 18/10 [1]',
+  id: 'ad474d35-7939-4bee-bde9-4e469cca1030',
+  producer: {
+    id: '62c6cf7f-f279-41b1-bd76-27982e6491df',
+    name: "Agenzia per L'Italia Digitale",
+  },
 })
 
 const createMockEServiceDescriptorCatalog = createMockFactory<CatalogEServiceDescriptor>({
@@ -519,6 +535,7 @@ function mockUseEServiceCreateContext(
 export {
   createMockEServiceProvider,
   createMockEServiceCatalog,
+  createMockCompactEServiceCatalog,
   createMockEServiceRead,
   createMockEServiceDescriptorCatalog,
   createMockEServiceDescriptorCatalogAsync,

--- a/src/api/eservice/eservice.queries.ts
+++ b/src/api/eservice/eservice.queries.ts
@@ -1,6 +1,7 @@
 import { queryOptions } from '@tanstack/react-query'
 import { EServiceServices } from './eservice.services'
 import type {
+  GetCompactCatalogEServicesParams,
   GetConsumersParams,
   GetEServicesCatalogParams,
   GetProducerEServicesParams,
@@ -18,6 +19,13 @@ function getAllCatalogEServices(params: Omit<GetEServicesCatalogParams, 'offset'
   return queryOptions({
     queryKey: ['EServiceGetAllCatalogList', params],
     queryFn: () => EServiceServices.getAllCatalogEServices(params),
+  })
+}
+
+function getCompactCatalogList(params: GetCompactCatalogEServicesParams) {
+  return queryOptions({
+    queryKey: ['EServiceGetCompactCatalogList', params],
+    queryFn: () => EServiceServices.getCompactCatalogList(params),
   })
 }
 
@@ -84,6 +92,7 @@ function getIsEServiceNameAvailable(eserviceName: string) {
 export const EServiceQueries = {
   getCatalogList,
   getAllCatalogEServices,
+  getCompactCatalogList,
   getProviderList,
   getDescriptorCatalog,
   getDescriptorProvider,

--- a/src/api/eservice/eservice.services.ts
+++ b/src/api/eservice/eservice.services.ts
@@ -3,6 +3,7 @@ import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
 import type {
   CatalogEServiceDescriptor,
   CatalogEServices,
+  CompactCatalogEServices,
   CompactOrganizations,
   CreatedEServiceDescriptor,
   CreatedResource,
@@ -15,6 +16,7 @@ import type {
   EServiceRiskAnalysisSeed,
   EServiceSeed,
   FileResource,
+  GetCompactCatalogEServicesParams,
   GetConsumersParams,
   GetEServicesCatalogParams,
   GetProducerEServicesParams,
@@ -52,6 +54,14 @@ async function getCatalogList(params: GetEServicesCatalogParams) {
 
 async function getAllCatalogEServices(params: Omit<GetEServicesCatalogParams, 'limit' | 'offset'>) {
   return await getAllFromPaginated((offset, limit) => getCatalogList({ ...params, limit, offset }))
+}
+
+async function getCompactCatalogList(params: GetCompactCatalogEServicesParams) {
+  const response = await axiosInstance.get<CompactCatalogEServices>(
+    `${BACKEND_FOR_FRONTEND_URL}/catalog/eservices`,
+    { params }
+  )
+  return response.data
 }
 
 async function getProviderList(params: GetProducerEServicesParams) {
@@ -676,6 +686,7 @@ async function updateEServiceDelegationFlagsAfterPublication({
 export const EServiceServices = {
   getCatalogList,
   getAllCatalogEServices,
+  getCompactCatalogList,
   getProviderList,
   getSingle,
   getDescriptorCatalog,

--- a/src/components/dialogs/DialogClonePurpose/DialogClonePurposeEServiceAutocomplete.tsx
+++ b/src/components/dialogs/DialogClonePurpose/DialogClonePurposeEServiceAutocomplete.tsx
@@ -4,7 +4,7 @@ import { RHFAutocompleteSingle } from '@/components/shared/react-hook-form-input
 import { useTranslation } from 'react-i18next'
 import { useFormContext } from 'react-hook-form'
 import { useAutocompleteTextInput } from '@pagopa/interop-fe-commons'
-import type { CatalogEService, CompactPurposeEService } from '@/api/api.generatedTypes'
+import type { CompactCatalogEService, CompactPurposeEService } from '@/api/api.generatedTypes'
 import { useQuery } from '@tanstack/react-query'
 
 type DialogClonePurposeEServiceAutocompleteProps = {
@@ -18,13 +18,13 @@ export const DialogClonePurposeEServiceAutocomplete: React.FC<
   const { t } = useTranslation('shared-components', {
     keyPrefix: 'dialogClonePurpose',
   })
-  const selectedEServiceRef = React.useRef<CatalogEService | CompactPurposeEService | undefined>(
-    preselectedEservice
-  )
+  const selectedEServiceRef = React.useRef<
+    CompactCatalogEService | CompactPurposeEService | undefined
+  >(preselectedEservice)
   const hasSetFirstEService = React.useRef(true)
 
   const formatAutocompleteOptionLabel = React.useCallback(
-    (eservice: CatalogEService | CompactPurposeEService) => {
+    (eservice: CompactCatalogEService | CompactPurposeEService) => {
       return `${eservice.name} ${t('eserviceField.eserviceProvider')} ${eservice.producer.name}`
     },
     [t]
@@ -53,7 +53,7 @@ export const DialogClonePurposeEServiceAutocomplete: React.FC<
   }
 
   const { data, isLoading } = useQuery(
-    EServiceQueries.getCatalogList({
+    EServiceQueries.getCompactCatalogList({
       q: getQ(),
       agreementStates: ['ACTIVE'],
       // e-service might also be on 'DEPRECATED' state

--- a/src/components/dialogs/DialogClonePurpose/__tests__/DialogClonePurposeEServiceAutocomplete.test.tsx
+++ b/src/components/dialogs/DialogClonePurpose/__tests__/DialogClonePurposeEServiceAutocomplete.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { FormProvider, useForm } from 'react-hook-form'
+import type { CompactPurposeEService } from '@/api/api.generatedTypes'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { DialogClonePurposeEServiceAutocomplete } from '../DialogClonePurposeEServiceAutocomplete'
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useQuery: vi.fn((options: { queryKey?: unknown[]; select?: (data: unknown) => unknown }) => {
+      const key = Array.isArray(options?.queryKey) ? options.queryKey[0] : undefined
+      const eservices = {
+        results: [{ id: 'e-1', name: 'E-service 1', producer: { id: 'p-1', name: 'Org 1' } }],
+        pagination: { offset: 0, limit: 50, totalCount: 1 },
+      }
+      const empty = { results: [], pagination: { offset: 0, limit: 50, totalCount: 0 } }
+      const raw = key === 'EServiceGetCompactCatalogList' ? eservices : empty
+      const data = typeof options?.select === 'function' ? options.select(raw) : raw
+      return { data, isLoading: false, isFetching: false, isSuccess: true, isError: false }
+    }),
+  }
+})
+
+vi.mock('@pagopa/interop-fe-commons', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useAutocompleteTextInput: (initial?: string) => [initial ?? '', vi.fn()],
+  }
+})
+
+vi.mock('@/components/shared/react-hook-form-inputs', () => ({
+  RHFAutocompleteSingle: ({ options }: { options: Array<{ label: string; value: string }> }) => (
+    <ul data-testid="rhf-autocomplete">
+      {options.map((opt, idx) => (
+        <li key={idx} data-testid={`option-${idx}`}>
+          {opt.label}
+        </li>
+      ))}
+    </ul>
+  ),
+}))
+
+const preselectedEservice: CompactPurposeEService = {
+  id: 'pe-1',
+  name: 'Preselected',
+  producer: { id: 'p-0', name: 'Org 0' },
+  descriptor: { id: 'd-0', state: 'PUBLISHED', version: '1', audience: [] },
+  mode: 'DELIVER',
+  personalData: false,
+}
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const methods = useForm({ defaultValues: { eserviceId: '' } })
+  return <FormProvider {...methods}>{children}</FormProvider>
+}
+
+describe('DialogClonePurposeEServiceAutocomplete', () => {
+  it('maps e-services from the compact catalog endpoint into autocomplete options', () => {
+    renderWithApplicationContext(
+      <Wrapper>
+        <DialogClonePurposeEServiceAutocomplete
+          preselectedEservice={preselectedEservice}
+          onEServiceChange={vi.fn()}
+        />
+      </Wrapper>,
+      { withReactQueryContext: true }
+    )
+
+    expect(screen.getByTestId('rhf-autocomplete')).toBeInTheDocument()
+    expect(screen.getByTestId('option-0')).toBeInTheDocument()
+  })
+})

--- a/src/components/shared/ResourceAutoComplete.tsx
+++ b/src/components/shared/ResourceAutoComplete.tsx
@@ -62,7 +62,7 @@ export const ResourceAutoComplete: React.FC<ResourceAutoCompleteProps> = ({
     selectedResource && searchParam === formatResourceLabel(selectedResource) ? '' : searchParam
 
   const { data: eservicesData } = useQuery(
-    EServiceQueries.getCatalogList({
+    EServiceQueries.getCompactCatalogList({
       q,
       states: ['PUBLISHED'],
       limit: 50,

--- a/src/components/shared/__tests__/ResourceAutoComplete.test.tsx
+++ b/src/components/shared/__tests__/ResourceAutoComplete.test.tsx
@@ -4,10 +4,10 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type * as ReactHookForm from 'react-hook-form'
 import { useQuery } from '@tanstack/react-query'
-import type { CatalogEService, CatalogEServiceTemplate } from '@/api/api.generatedTypes'
+import type { CatalogEServiceTemplate, CompactCatalogEService } from '@/api/api.generatedTypes'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import { ResourceAutoComplete } from '../ResourceAutoComplete'
-import { createMockEServiceCatalog } from '../../../../__mocks__/data/eservice.mocks'
+import { createMockCompactEServiceCatalog } from '../../../../__mocks__/data/eservice.mocks'
 import { createMockCatalogEServiceTemplate } from '../../../../__mocks__/data/eserviceTemplate.mocks'
 import { createMockPurposeTemplate } from '../../../../__mocks__/data/purposeTemplate.mocks'
 
@@ -19,8 +19,8 @@ vi.mock('@tanstack/react-query', async () => {
   }
 })
 
-const { mockedGetCatalogList, mockedGetTemplatesCatalog } = vi.hoisted(() => ({
-  mockedGetCatalogList: vi.fn((_params?: unknown) => ({
+const { mockedGetCompactCatalogList, mockedGetTemplatesCatalog } = vi.hoisted(() => ({
+  mockedGetCompactCatalogList: vi.fn((_params?: unknown) => ({
     queryKey: ['eservice-catalog'],
     queryFn: vi.fn(),
   })),
@@ -32,7 +32,7 @@ const { mockedGetCatalogList, mockedGetTemplatesCatalog } = vi.hoisted(() => ({
 
 vi.mock('@/api/eservice', () => ({
   EServiceQueries: {
-    getCatalogList: mockedGetCatalogList,
+    getCompactCatalogList: mockedGetCompactCatalogList,
   },
 }))
 
@@ -95,7 +95,7 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
-function setQueryData(eservices: CatalogEService[], templates: CatalogEServiceTemplate[]) {
+function setQueryData(eservices: CompactCatalogEService[], templates: CatalogEServiceTemplate[]) {
   vi.mocked(useQuery)
     .mockReturnValueOnce({
       data: {
@@ -118,7 +118,7 @@ describe('ResourceAutoComplete', () => {
   })
 
   it('renders option labels with discriminated suffix for both kinds', () => {
-    const eservice = createMockEServiceCatalog({
+    const eservice = createMockCompactEServiceCatalog({
       id: 'es-1',
       name: 'Eservice A',
       producer: { id: 'p-1', name: 'Org1' },
@@ -145,7 +145,7 @@ describe('ResourceAutoComplete', () => {
   })
 
   it('filters out resources already linked via composite kind+id key', () => {
-    const eservice = createMockEServiceCatalog({
+    const eservice = createMockCompactEServiceCatalog({
       id: 'shared-id',
       name: 'Eservice A',
       producer: { id: 'p-1', name: 'Org1' },
@@ -183,7 +183,7 @@ describe('ResourceAutoComplete', () => {
       { withReactQueryContext: true }
     )
 
-    expect(mockedGetCatalogList).toHaveBeenCalledWith(
+    expect(mockedGetCompactCatalogList).toHaveBeenCalledWith(
       expect.objectContaining({ personalData: 'TRUE' })
     )
     expect(mockedGetTemplatesCatalog).toHaveBeenCalledWith(
@@ -203,7 +203,7 @@ describe('ResourceAutoComplete', () => {
       { withReactQueryContext: true }
     )
 
-    expect(mockedGetCatalogList).toHaveBeenCalledWith(
+    expect(mockedGetCompactCatalogList).toHaveBeenCalledWith(
       expect.objectContaining({ personalData: 'FALSE' })
     )
     expect(mockedGetTemplatesCatalog).toHaveBeenCalledWith(
@@ -212,7 +212,7 @@ describe('ResourceAutoComplete', () => {
   })
 
   it('dedupe: excludes e-service that is instance of an active template (mergeLinkableCandidates wiring)', () => {
-    const eserviceInstance = createMockEServiceCatalog({
+    const eserviceInstance = createMockCompactEServiceCatalog({
       id: 'es-instance',
       name: 'Eservice Instance',
       producer: { id: 'p-1', name: 'Org1' },

--- a/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateEServiceAutocomplete.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateEServiceAutocomplete.tsx
@@ -4,7 +4,7 @@ import { RHFAutocompleteSingle } from '@/components/shared/react-hook-form-input
 import { useTranslation } from 'react-i18next'
 import { useFormContext } from 'react-hook-form'
 import { useAutocompleteTextInput } from '@pagopa/interop-fe-commons'
-import type { CatalogEService, CompactEService } from '@/api/api.generatedTypes'
+import type { CompactCatalogEService, CompactEService } from '@/api/api.generatedTypes'
 import type { PurposeCreateFormValues } from './PurposeCreateForm'
 import { useQuery } from '@tanstack/react-query'
 import { DelegationQueries } from '@/api/delegation'
@@ -17,7 +17,9 @@ import { tenantKindForPurposeTemplate } from '@/utils/tenant.utils'
 
 export const PurposeCreateEServiceAutocomplete: React.FC = () => {
   const { t } = useTranslation('purpose')
-  const selectedEServiceRef = React.useRef<CatalogEService | CompactEService | undefined>(undefined)
+  const selectedEServiceRef = React.useRef<CompactCatalogEService | CompactEService | undefined>(
+    undefined
+  )
 
   const { jwt } = AuthHooks.useJwt()
 
@@ -26,7 +28,7 @@ export const PurposeCreateEServiceAutocomplete: React.FC = () => {
     useAutocompleteTextInput()
 
   const formatAutocompleteOptionLabel = React.useCallback(
-    (eservice: CatalogEService | CompactEService) => {
+    (eservice: CompactCatalogEService | CompactEService) => {
       return `${eservice.name} ${t('edit.eserviceProvider')} ${eservice.producer.name}`
     },
     [t]
@@ -62,7 +64,7 @@ export const PurposeCreateEServiceAutocomplete: React.FC = () => {
   }
 
   const { data: eservices = [], isLoading: isEServiceLoading } = useQuery({
-    ...EServiceQueries.getCatalogList({
+    ...EServiceQueries.getCompactCatalogList({
       q: getQ(),
       agreementStates: ['ACTIVE'],
       // e-service might also be on 'DEPRECATED' state

--- a/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/PurposeCreateForm.tsx
@@ -1,5 +1,5 @@
 import type {
-  CatalogEService,
+  CompactCatalogEService,
   CompactEService,
   GetCatalogPurposeTemplatesParams,
   PurposeEServiceSeed,
@@ -28,7 +28,7 @@ import { PurposeTemplateQueries } from '@/api/purposeTemplate/purposeTemplate.qu
 
 export type PurposeCreateFormValues = {
   consumerId: string
-  eservice: CatalogEService | CompactEService | undefined
+  eservice: CompactCatalogEService | CompactEService | undefined
   useTemplate: boolean
   templateId: string | null
   providerRiskAnalysisId: string | null

--- a/src/pages/ConsumerPurposeCreatePage/components/__tests__/PurposeCreateEServiceAutocomplete.test.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/components/__tests__/PurposeCreateEServiceAutocomplete.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { FormProvider, useForm } from 'react-hook-form'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import { PurposeCreateEServiceAutocomplete } from '../PurposeCreateEServiceAutocomplete'
+
+mockUseJwt()
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useQuery: vi.fn((options: { queryKey?: unknown[]; select?: (data: unknown) => unknown }) => {
+      const key = Array.isArray(options?.queryKey) ? options.queryKey[0] : undefined
+      const eservices = {
+        results: [{ id: 'e-1', name: 'E-service 1', producer: { id: 'p-1', name: 'Org 1' } }],
+        pagination: { offset: 0, limit: 50, totalCount: 1 },
+      }
+      const empty = { results: [], pagination: { offset: 0, limit: 50, totalCount: 0 } }
+      const raw = key === 'EServiceGetCompactCatalogList' ? eservices : empty
+      const data = typeof options?.select === 'function' ? options.select(raw) : raw
+      return { data, isLoading: false, isFetching: false, isSuccess: true, isError: false }
+    }),
+  }
+})
+
+vi.mock('@pagopa/interop-fe-commons', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useAutocompleteTextInput: () => ['', vi.fn()],
+  }
+})
+
+vi.mock('@/components/shared/react-hook-form-inputs', () => ({
+  RHFAutocompleteSingle: ({ options }: { options: Array<{ label: string; value: unknown }> }) => (
+    <ul data-testid="rhf-autocomplete">
+      {options.map((opt, idx) => (
+        <li key={idx} data-testid={`option-${idx}`}>
+          {opt.label}
+        </li>
+      ))}
+    </ul>
+  ),
+}))
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const methods = useForm({ defaultValues: { consumerId: '' } })
+  return <FormProvider {...methods}>{children}</FormProvider>
+}
+
+describe('PurposeCreateEServiceAutocomplete', () => {
+  it('maps e-services from the compact catalog endpoint into autocomplete options', () => {
+    renderWithApplicationContext(
+      <Wrapper>
+        <PurposeCreateEServiceAutocomplete />
+      </Wrapper>,
+      { withReactQueryContext: true }
+    )
+
+    expect(screen.getByTestId('rhf-autocomplete')).toBeInTheDocument()
+    expect(screen.getByTestId('option-0')).toBeInTheDocument()
+  })
+})

--- a/src/pages/ConsumerPurposeTemplateCatalogPage/ConsumerPurposeTemplateCatalog.page.tsx
+++ b/src/pages/ConsumerPurposeTemplateCatalogPage/ConsumerPurposeTemplateCatalog.page.tsx
@@ -8,7 +8,10 @@ import {
   useFilters,
   usePagination,
 } from '@pagopa/interop-fe-commons'
-import type { CatalogEService, GetCatalogPurposeTemplatesParams } from '@/api/api.generatedTypes'
+import type {
+  CompactCatalogEService,
+  GetCatalogPurposeTemplatesParams,
+} from '@/api/api.generatedTypes'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { PurposeTemplateQueries } from '@/api/purposeTemplate/purposeTemplate.queries'
 import {
@@ -41,7 +44,7 @@ const ConsumerPurposeTemplateCatalogPage: React.FC = () => {
   })
 
   const { data: eservicesOptions = [] } = useQuery({
-    ...EServiceQueries.getCatalogList({
+    ...EServiceQueries.getCompactCatalogList({
       q: eservicesAutocompleteInput,
       states: ['PUBLISHED'],
       limit: 50,
@@ -49,7 +52,7 @@ const ConsumerPurposeTemplateCatalogPage: React.FC = () => {
     }),
     placeholderData: keepPreviousData,
     select: ({ results }) =>
-      results.map((eservice: CatalogEService) => ({
+      results.map((eservice: CompactCatalogEService) => ({
         label: eservice.name,
         value: eservice.id,
       })),

--- a/src/pages/ConsumerPurposeTemplateCatalogPage/__tests__/ConsumerPurposeTemplateCatalog.page.test.tsx
+++ b/src/pages/ConsumerPurposeTemplateCatalogPage/__tests__/ConsumerPurposeTemplateCatalog.page.test.tsx
@@ -1,0 +1,61 @@
+import { screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import ConsumerPurposeTemplateCatalogPage from '../ConsumerPurposeTemplateCatalog.page'
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useQuery: vi.fn((options: { queryKey?: unknown[]; select?: (data: unknown) => unknown }) => {
+      const key = Array.isArray(options?.queryKey) ? options.queryKey[0] : undefined
+      const eservices = {
+        results: [{ id: 'e-1', name: 'E-service 1', producer: { id: 'p-1', name: 'Org 1' } }],
+        pagination: { offset: 0, limit: 50, totalCount: 1 },
+      }
+      const empty = {
+        results: [],
+        pagination: { offset: 0, limit: 50, totalCount: 0 },
+        data: { results: [] },
+      }
+      const raw = key === 'EServiceGetCompactCatalogList' ? eservices : empty
+      const data = typeof options?.select === 'function' ? options.select(raw) : raw
+      return { data, isLoading: false, isFetching: false, isSuccess: true, isError: false }
+    }),
+  }
+})
+
+vi.mock('@pagopa/interop-fe-commons', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    Filters: () => <div data-testid="filters" />,
+    Pagination: () => <div data-testid="pagination" />,
+    useAutocompleteTextInput: () => ['', vi.fn()],
+    useFilters: () => ({ filtersParams: {} }),
+    usePagination: () => ({
+      paginationParams: { offset: 0, limit: 12 },
+      paginationProps: {},
+      getTotalPageCount: () => 1,
+    }),
+  }
+})
+
+vi.mock('../components/PurposeTemplateCatalogGrid', () => ({
+  PurposeTemplateCatalogGrid: () => <div data-testid="purpose-template-catalog-grid" />,
+  PurposeTemplateCatalogGridSkeleton: () => (
+    <div data-testid="purpose-template-catalog-grid-skeleton" />
+  ),
+}))
+
+describe('ConsumerPurposeTemplateCatalogPage', () => {
+  it('renders filters and the catalog grid, mapping e-service options from the compact catalog endpoint', () => {
+    renderWithApplicationContext(<ConsumerPurposeTemplateCatalogPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByTestId('filters')).toBeInTheDocument()
+    expect(screen.getByTestId('purpose-template-catalog-grid')).toBeInTheDocument()
+  })
+})

--- a/src/pages/ConsumerPurposeTemplateListPage/ConsumerPurposeTemplateList.page.tsx
+++ b/src/pages/ConsumerPurposeTemplateListPage/ConsumerPurposeTemplateList.page.tsx
@@ -91,7 +91,7 @@ const ConsumerPurposeTemplateListPage: React.FC = () => {
   ]
 
   const { data: eservicesOptions = [] } = useQuery({
-    ...EServiceQueries.getCatalogList({
+    ...EServiceQueries.getCompactCatalogList({
       q: eservicesAutocompleteInput,
       states: ['PUBLISHED'],
       limit: 50,

--- a/src/pages/ConsumerPurposeTemplateListPage/__tests__/ConsumerPurposeTemplateList.page.test.tsx
+++ b/src/pages/ConsumerPurposeTemplateListPage/__tests__/ConsumerPurposeTemplateList.page.test.tsx
@@ -1,0 +1,64 @@
+import { screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import ConsumerPurposeTemplateListPage from '../ConsumerPurposeTemplateList.page'
+
+mockUseJwt()
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useQuery: vi.fn((options: { queryKey?: unknown[]; select?: (data: unknown) => unknown }) => {
+      const key = Array.isArray(options?.queryKey) ? options.queryKey[0] : undefined
+      const eservices = {
+        results: [{ id: 'e-1', name: 'E-service 1', producer: { id: 'p-1', name: 'Org 1' } }],
+        pagination: { offset: 0, limit: 50, totalCount: 1 },
+      }
+      const empty = {
+        results: [],
+        pagination: { offset: 0, limit: 50, totalCount: 0 },
+        data: { results: [] },
+      }
+      const raw = key === 'EServiceGetCompactCatalogList' ? eservices : empty
+      const data = typeof options?.select === 'function' ? options.select(raw) : raw
+      return { data, isLoading: false, isFetching: false, isSuccess: true, isError: false }
+    }),
+  }
+})
+
+vi.mock('@pagopa/interop-fe-commons', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    Filters: () => <div data-testid="filters" />,
+    Pagination: () => <div data-testid="pagination" />,
+    useAutocompleteTextInput: () => ['', vi.fn()],
+    useFilters: () => ({ filtersParams: {} }),
+    usePagination: () => ({
+      paginationParams: { offset: 0, limit: 10 },
+      paginationProps: {},
+      getTotalPageCount: () => 1,
+      rowPerPageOptions: [10],
+    }),
+  }
+})
+
+vi.mock('../components/ConsumerPurposeTemplateTable', () => ({
+  ConsumerPurposeTemplateTable: () => <div data-testid="consumer-purpose-template-table" />,
+  ConsumerPurposeTemplateTableSkeleton: () => (
+    <div data-testid="consumer-purpose-template-table-skeleton" />
+  ),
+}))
+
+describe('ConsumerPurposeTemplateListPage', () => {
+  it('renders filters and the template table, mapping e-service options from the compact catalog endpoint', () => {
+    renderWithApplicationContext(<ConsumerPurposeTemplateListPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByTestId('filters')).toBeInTheDocument()
+    expect(screen.getByTestId('consumer-purpose-template-table')).toBeInTheDocument()
+  })
+})

--- a/src/pages/ConsumerPurposesListPage/ConsumerPurposesList.page.tsx
+++ b/src/pages/ConsumerPurposesListPage/ConsumerPurposesList.page.tsx
@@ -42,7 +42,7 @@ const ConsumerPurposesListPage: React.FC = () => {
   })
 
   const { data: eservicesOptions = [] } = useQuery({
-    ...EServiceQueries.getCatalogList({ offset: 0, limit: 50, q: eserviceAutocompleteText }),
+    ...EServiceQueries.getCompactCatalogList({ offset: 0, limit: 50, q: eserviceAutocompleteText }),
     placeholderData: keepPreviousData,
     select: ({ results }) =>
       results.map((o) => ({
@@ -95,7 +95,7 @@ const ConsumerPurposesListPage: React.FC = () => {
   }
 
   const { data: hasActiveEServices } = useQuery({
-    ...EServiceQueries.getCatalogList({
+    ...EServiceQueries.getCompactCatalogList({
       agreementStates: ['ACTIVE'],
       states: ['PUBLISHED'],
       limit: 1,

--- a/src/pages/ConsumerPurposesListPage/__tests__/ConsumerPurposesList.page.test.tsx
+++ b/src/pages/ConsumerPurposesListPage/__tests__/ConsumerPurposesList.page.test.tsx
@@ -1,0 +1,62 @@
+import { screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import ConsumerPurposesListPage from '../ConsumerPurposesList.page'
+
+mockUseJwt()
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useQuery: vi.fn((options: { queryKey?: unknown[]; select?: (data: unknown) => unknown }) => {
+      const key = Array.isArray(options?.queryKey) ? options.queryKey[0] : undefined
+      const eservices = {
+        results: [{ id: 'e-1', name: 'E-service 1', producer: { id: 'p-1', name: 'Org 1' } }],
+        pagination: { offset: 0, limit: 50, totalCount: 1 },
+      }
+      const empty = {
+        results: [],
+        pagination: { offset: 0, limit: 50, totalCount: 0 },
+        data: { results: [] },
+      }
+      const raw = key === 'EServiceGetCompactCatalogList' ? eservices : empty
+      const data = typeof options?.select === 'function' ? options.select(raw) : raw
+      return { data, isLoading: false, isFetching: false, isSuccess: true, isError: false }
+    }),
+  }
+})
+
+vi.mock('@pagopa/interop-fe-commons', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    Filters: () => <div data-testid="filters" />,
+    Pagination: () => <div data-testid="pagination" />,
+    useAutocompleteTextInput: () => ['', vi.fn()],
+    useFilters: () => ({ filtersParams: {} }),
+    usePagination: () => ({
+      paginationParams: { offset: 0, limit: 10 },
+      paginationProps: {},
+      getTotalPageCount: () => 1,
+      rowPerPageOptions: [10],
+    }),
+  }
+})
+
+vi.mock('../components', () => ({
+  ConsumerPurposesTable: () => <div data-testid="consumer-purposes-table" />,
+  ConsumerPurposesTableSkeleton: () => <div data-testid="consumer-purposes-table-skeleton" />,
+}))
+
+describe('ConsumerPurposesListPage', () => {
+  it('renders filters and the purposes table, mapping e-service options from the compact catalog endpoint', () => {
+    renderWithApplicationContext(<ConsumerPurposesListPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByTestId('filters')).toBeInTheDocument()
+    expect(screen.getByTestId('consumer-purposes-table')).toBeInTheDocument()
+  })
+})

--- a/src/pages/DelegationCreatePage/components/DelegationCreateEServiceAutocomplete.tsx
+++ b/src/pages/DelegationCreatePage/components/DelegationCreateEServiceAutocomplete.tsx
@@ -1,6 +1,6 @@
 import type {
-  CatalogEService,
   CatalogEServiceTemplate,
+  CompactCatalogEService,
   DelegationKind,
   ProducerEService,
 } from '@/api/api.generatedTypes'
@@ -20,7 +20,7 @@ export const DelegationCreateEServiceAutocomplete: React.FC<
   DelegationCreateEServiceAutocompleteProps
 > = ({ delegationKind }) => {
   const { t } = useTranslation('party')
-  const selectedEServiceRef = React.useRef<CatalogEService | ProducerEService | undefined>(
+  const selectedEServiceRef = React.useRef<CompactCatalogEService | ProducerEService | undefined>(
     undefined
   )
 
@@ -28,7 +28,7 @@ export const DelegationCreateEServiceAutocomplete: React.FC<
     useAutocompleteTextInput()
 
   const formatAutocompleteOptionLabel = React.useCallback(
-    (eservice: CatalogEService | ProducerEService | CatalogEServiceTemplate) => {
+    (eservice: CompactCatalogEService | ProducerEService | CatalogEServiceTemplate) => {
       return match(delegationKind)
         .with('DELEGATED_CONSUMER', () => {
           if (!('producer' in eservice)) return eservice.name
@@ -73,7 +73,7 @@ export const DelegationCreateEServiceAutocomplete: React.FC<
   })
 
   const { data: catalogEservices = [], isLoading: isLoadingCatalogEservices } = useQuery({
-    ...EServiceQueries.getCatalogList({
+    ...EServiceQueries.getCompactCatalogList({
       q: getQ(),
       // e-service might also be on 'DEPRECATED' state
       states: ['PUBLISHED'],

--- a/src/pages/DelegationCreatePage/components/__tests__/DelegationCreateEServiceAutocomplete.test.tsx
+++ b/src/pages/DelegationCreatePage/components/__tests__/DelegationCreateEServiceAutocomplete.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { FormProvider, useForm } from 'react-hook-form'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { DelegationCreateEServiceAutocomplete } from '../DelegationCreateEServiceAutocomplete'
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useQuery: vi.fn((options: { queryKey?: unknown[]; select?: (data: unknown) => unknown }) => {
+      const key = Array.isArray(options?.queryKey) ? options.queryKey[0] : undefined
+      const eservices = {
+        results: [{ id: 'e-1', name: 'E-service 1', producer: { id: 'p-1', name: 'Org 1' } }],
+        pagination: { offset: 0, limit: 50, totalCount: 1 },
+      }
+      const empty = { results: [], pagination: { offset: 0, limit: 50, totalCount: 0 } }
+      const raw = key === 'EServiceGetCompactCatalogList' ? eservices : empty
+      const data = typeof options?.select === 'function' ? options.select(raw) : raw
+      return { data, isLoading: false, isFetching: false, isSuccess: true, isError: false }
+    }),
+  }
+})
+
+vi.mock('@pagopa/interop-fe-commons', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useAutocompleteTextInput: () => ['', vi.fn()],
+  }
+})
+
+vi.mock('@/components/shared/react-hook-form-inputs', () => ({
+  RHFAutocompleteSingle: ({ options }: { options: Array<{ label: string; value: string }> }) => (
+    <ul data-testid="rhf-autocomplete">
+      {options.map((opt, idx) => (
+        <li key={idx} data-testid={`option-${idx}`}>
+          {opt.label}
+        </li>
+      ))}
+    </ul>
+  ),
+}))
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const methods = useForm({ defaultValues: { eserviceId: '' } })
+  return <FormProvider {...methods}>{children}</FormProvider>
+}
+
+describe('DelegationCreateEServiceAutocomplete', () => {
+  it('maps consumer e-services from the compact catalog endpoint into autocomplete options', () => {
+    renderWithApplicationContext(
+      <Wrapper>
+        <DelegationCreateEServiceAutocomplete delegationKind="DELEGATED_CONSUMER" />
+      </Wrapper>,
+      { withReactQueryContext: true }
+    )
+
+    expect(screen.getByTestId('rhf-autocomplete')).toBeInTheDocument()
+    expect(screen.getByTestId('option-0')).toBeInTheDocument()
+  })
+})

--- a/src/pages/RiskAnalysisListPage/RiskAnalysisList.page.tsx
+++ b/src/pages/RiskAnalysisListPage/RiskAnalysisList.page.tsx
@@ -22,7 +22,7 @@ const RiskAnalysisListPage: React.FC = () => {
     useAutocompleteTextInput('')
 
   const { data: eservicesOptions = [] } = useQuery({
-    ...EServiceQueries.getCatalogList({ offset: 0, limit: 50, q: eserviceAutocompleteText }),
+    ...EServiceQueries.getCompactCatalogList({ offset: 0, limit: 50, q: eserviceAutocompleteText }),
     placeholderData: keepPreviousData,
     select: ({ results }) =>
       results.map((o) => ({

--- a/src/pages/RiskAnalysisListPage/__tests__/RiskAnalysisList.page.test.tsx
+++ b/src/pages/RiskAnalysisListPage/__tests__/RiskAnalysisList.page.test.tsx
@@ -1,0 +1,62 @@
+import { screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import RiskAnalysisListPage from '../RiskAnalysisList.page'
+
+// Feed the query layer with canned data and run each query's `select`, so that the
+// option-mapping branch (including the migrated getCompactCatalogList call) executes.
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useQuery: vi.fn((options: { queryKey?: unknown[]; select?: (data: unknown) => unknown }) => {
+      const key = Array.isArray(options?.queryKey) ? options.queryKey[0] : undefined
+      const eservices = {
+        results: [{ id: 'e-1', name: 'E-service 1', producer: { id: 'p-1', name: 'Org 1' } }],
+        pagination: { offset: 0, limit: 50, totalCount: 1 },
+      }
+      const empty = {
+        results: [],
+        pagination: { offset: 0, limit: 50, totalCount: 0 },
+        data: { results: [] },
+      }
+      const raw = key === 'EServiceGetCompactCatalogList' ? eservices : empty
+      const data = typeof options?.select === 'function' ? options.select(raw) : raw
+      return { data, isLoading: false, isFetching: false, isSuccess: true, isError: false }
+    }),
+  }
+})
+
+vi.mock('@pagopa/interop-fe-commons', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    Filters: () => <div data-testid="filters" />,
+    Pagination: () => <div data-testid="pagination" />,
+    useAutocompleteTextInput: () => ['', vi.fn()],
+    useFilters: () => ({ filtersParams: { eservicesIds: ['e-1'] } }),
+    usePagination: () => ({
+      paginationParams: { offset: 0, limit: 10 },
+      paginationProps: {},
+      getTotalPageCount: () => 1,
+      rowPerPageOptions: [10],
+    }),
+  }
+})
+
+vi.mock('../components/RiskAnalysisTable', () => ({
+  RiskAnalysisTable: () => <div data-testid="risk-analysis-table" />,
+  RiskAnalysisTableSkeleton: () => <div data-testid="risk-analysis-table-skeleton" />,
+}))
+
+describe('RiskAnalysisListPage', () => {
+  it('renders filters and the risk analysis table, mapping e-service options from the compact catalog endpoint', () => {
+    renderWithApplicationContext(<RiskAnalysisListPage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByTestId('filters')).toBeInTheDocument()
+    expect(screen.getByTestId('risk-analysis-table')).toBeInTheDocument()
+  })
+})

--- a/src/utils/purposeTemplate.utils.ts
+++ b/src/utils/purposeTemplate.utils.ts
@@ -1,7 +1,7 @@
 import { match } from 'ts-pattern'
 import type {
-  CatalogEService,
   CatalogEServiceTemplate,
+  CompactCatalogEService,
   EServiceDoc,
   LinkableResource,
   LinkableResourceRequest,
@@ -12,7 +12,7 @@ import type {
 } from '@/api/api.generatedTypes'
 
 export type LinkableCandidate =
-  | { resourceKind: 'ESERVICE'; value: CatalogEService }
+  | { resourceKind: 'ESERVICE'; value: CompactCatalogEService }
   | { resourceKind: 'ESERVICE_TEMPLATE'; value: CatalogEServiceTemplate }
 
 export type LinkableResourceView = {
@@ -23,7 +23,7 @@ export type LinkableResourceView = {
 }
 
 export function mergeLinkableCandidates(
-  eservices: CatalogEService[],
+  eservices: CompactCatalogEService[],
   templates: CatalogEServiceTemplate[]
 ): LinkableCandidate[] {
   const standaloneEServices = eservices.filter(


### PR DESCRIPTION
## 🔗 Issue
[PIN-10664](https://pagopa.atlassian.net/browse/PIN-10664)

## 📝 Description / Context
E-service selects, autocompletes and table filters were populated by reusing the catalog listing endpoint (`GET /catalog`, `EServiceQueries.getCatalogList`), whose pagination limit had been temporarily raised to 200 as a workaround. That endpoint performs heavy per-page work (a `getTenant` call per producer, an unread-notifications
lookup) and returns fields none of these selects use.

This PR moves every select/filter to the new dedicated lightweight BFF endpoint `GET /catalog/eservices` (`EServiceQueries.getCompactCatalogList`, response `CompactCatalogEService`), decoupling them from the catalog listing, and restores the `GET /catalog` max limit to 50. The full catalog page keeps using `GET /catalog`.

## 🛠 List of changes
- Add `EServiceServices.getCompactCatalogList` (`GET /catalog/eservices`) and the matching `EServiceQueries.getCompactCatalogList` query.
- Migrate all 9 select/filter call sites off `getCatalogList`:
  - `ResourceAutoComplete`, `DialogClonePurposeEServiceAutocomplete`, `PurposeCreateEServiceAutocomplete` (keeps `limit: 200`), `DelegationCreateEServiceAutocomplete`.
  - Table filters in `ConsumerPurposesList`, `RiskAnalysisList`, `ConsumerPurposeTemplateList`, `ConsumerPurposeTemplateCatalog`, plus the `hasActiveEServices` existence check.
- Keep `getCatalogList` only for the catalog page (`ConsumerEServiceCatalog`) and `getAllCatalogEServices` in `PurposeCreateForm` (out of scope).
- Retype `LinkableCandidate` / `mergeLinkableCandidates`, the autocomplete refs and `PurposeCreateFormValues.eservice` on `CompactCatalogEService`.
- Add `createMockCompactEServiceCatalog` mock factory.
- Restore the `GET /catalog` max limit to 50 (revert of the temporary workaround).
- Add unit tests for the migrated autocompletes and list/catalog pages.

## 🧪 How to test
- Create purpose: the e-service autocomplete populates and filters by name (incl. the >50 same-name case).
- Clone purpose: the e-service is preselected and the personal-data alert behaves as before.
- Create delegation (both consumer and producer): the autocomplete populates for each kind.
- Link resources on a purpose template: template-derived e-services stay excluded from the options.
- E-service filters in the tables: forwarded purposes, risk analysis, purpose templates (list and catalog).
- E-service catalog page: no regression, pagination within the new max of 50.
- Run the unit tests: `pnpm test`.

[PIN-10664]: https://pagopa.atlassian.net/browse/PIN-10664