### PR TITLE
fix: fix function for last version and add tests (PIN-10548)

### DIFF
--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -59,7 +59,7 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
   const isDelegator = delegations.length > 0
 
   const viewLatestVersionTargetId = React.useMemo(
-    () => getViewLatestVersionTargetId(descriptor?.eservice.descriptors, descriptorId),
+    () => getViewLatestVersionTargetId(descriptor?.eservice.descriptors, descriptorId, 'consumer'),
     [descriptor?.eservice.descriptors, descriptorId]
   )
 

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -52,7 +52,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
   const isEserviceFromTemplate = Boolean(descriptor?.templateRef)
 
   const viewLatestVersionTargetId = React.useMemo(
-    () => getViewLatestVersionTargetId(descriptor?.eservice.descriptors, descriptorId),
+    () => getViewLatestVersionTargetId(descriptor?.eservice.descriptors, descriptorId, 'provider'),
     [descriptor?.eservice.descriptors, descriptorId]
   )
 

--- a/src/utils/__tests__/eservice.utils.test.ts
+++ b/src/utils/__tests__/eservice.utils.test.ts
@@ -53,7 +53,8 @@ describe('getViewLatestVersionTargetId utility function testing', () => {
         { id: 'test-id-1', state: 'DEPRECATED', version: '1', audience: ['test-audience'] },
         { id: 'test-id-2', state: 'PUBLISHED', version: '2', audience: ['test-audience'] },
       ],
-      'test-id-1'
+      'test-id-1',
+      'consumer'
     )
 
     expect(result).toEqual('test-id-2')
@@ -65,13 +66,14 @@ describe('getViewLatestVersionTargetId utility function testing', () => {
         { id: 'test-id-1', state: 'DEPRECATED', version: '1', audience: ['test-audience'] },
         { id: 'test-id-2', state: 'PUBLISHED', version: '2', audience: ['test-audience'] },
       ],
-      'test-id-2'
+      'test-id-2',
+      'consumer'
     )
 
     expect(result).toBeUndefined()
   })
 
-  it('should ignore DRAFT, WAITING_FOR_APPROVAL and ARCHIVED descriptors when computing latest', () => {
+  it('should ignore DRAFT, WAITING_FOR_APPROVAL and ARCHIVED descriptors for consumer', () => {
     const result = getViewLatestVersionTargetId(
       [
         { id: 'test-id-1', state: 'DEPRECATED', version: '1', audience: ['test-audience'] },
@@ -85,22 +87,97 @@ describe('getViewLatestVersionTargetId utility function testing', () => {
         },
         { id: 'test-id-5', state: 'ARCHIVED', version: '5', audience: ['test-audience'] },
       ],
-      'test-id-1'
+      'test-id-1',
+      'consumer'
     )
 
     expect(result).toEqual('test-id-2')
   })
 
-  it('should return undefined when all non-current descriptors are filtered out', () => {
+  it('should return undefined for consumer when all non-current descriptors are filtered out', () => {
     const result = getViewLatestVersionTargetId(
       [
         { id: 'test-id-1', state: 'ARCHIVED', version: '1', audience: ['test-audience'] },
         { id: 'test-id-2', state: 'ARCHIVED', version: '2', audience: ['test-audience'] },
       ],
-      'test-id-1'
+      'test-id-1',
+      'consumer'
     )
 
     expect(result).toBeUndefined()
+  })
+
+  it('should return the latest descriptor id when the current is not the latest for provider', () => {
+    const result = getViewLatestVersionTargetId(
+      [
+        { id: 'test-id-1', state: 'DEPRECATED', version: '1', audience: ['test-audience'] },
+        { id: 'test-id-2', state: 'PUBLISHED', version: '2', audience: ['test-audience'] },
+      ],
+      'test-id-1',
+      'provider'
+    )
+
+    expect(result).toEqual('test-id-2')
+  })
+
+  it('should return undefined when the current descriptor is already the latest for provider', () => {
+    const result = getViewLatestVersionTargetId(
+      [
+        { id: 'test-id-1', state: 'DEPRECATED', version: '1', audience: ['test-audience'] },
+        { id: 'test-id-2', state: 'PUBLISHED', version: '2', audience: ['test-audience'] },
+      ],
+      'test-id-2',
+      'provider'
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should ignore DRAFT and WAITING_FOR_APPROVAL but keep ARCHIVED descriptors for provider', () => {
+    const result = getViewLatestVersionTargetId(
+      [
+        { id: 'test-id-1', state: 'DEPRECATED', version: '1', audience: ['test-audience'] },
+        { id: 'test-id-2', state: 'PUBLISHED', version: '2', audience: ['test-audience'] },
+        { id: 'test-id-3', state: 'DRAFT', version: '3', audience: ['test-audience'] },
+        {
+          id: 'test-id-4',
+          state: 'WAITING_FOR_APPROVAL',
+          version: '4',
+          audience: ['test-audience'],
+        },
+        { id: 'test-id-5', state: 'ARCHIVED', version: '5', audience: ['test-audience'] },
+      ],
+      'test-id-1',
+      'provider'
+    )
+
+    expect(result).toEqual('test-id-5')
+  })
+
+  it('should return latest ARCHIVED descriptor for provider when all descriptors are ARCHIVED', () => {
+    const result = getViewLatestVersionTargetId(
+      [
+        { id: 'test-id-1', state: 'ARCHIVED', version: '1', audience: ['test-audience'] },
+        { id: 'test-id-2', state: 'ARCHIVED', version: '2', audience: ['test-audience'] },
+      ],
+      'test-id-1',
+      'provider'
+    )
+
+    expect(result).toEqual('test-id-2')
+  })
+
+  it('should keep ARCHIVED descriptors for provider when computing latest', () => {
+    const result = getViewLatestVersionTargetId(
+      [
+        { id: 'test-id-1', state: 'PUBLISHED', version: '1', audience: ['test-audience'] },
+        { id: 'test-id-2', state: 'ARCHIVED', version: '2', audience: ['test-audience'] },
+      ],
+      'test-id-1',
+      'provider'
+    )
+
+    expect(result).toEqual('test-id-2')
   })
 })
 

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -61,10 +61,10 @@ export function getActiveDescriptor(descriptors: Array<CompactDescriptor> | unde
 export function getViewLatestVersionTargetId(
   descriptors: Array<CompactDescriptor> | undefined,
   currentDescriptorId: string | undefined,
-  isProviderOrConsumer: 'provider' | 'consumer'
+  providerOrConsumer: 'provider' | 'consumer'
 ) {
   const excludedStates: Array<EServiceDescriptorState> =
-    isProviderOrConsumer === 'provider'
+    providerOrConsumer === 'provider'
       ? ['DRAFT', 'WAITING_FOR_APPROVAL']
       : ['DRAFT', 'WAITING_FOR_APPROVAL', 'ARCHIVED']
 

--- a/src/utils/eservice.utils.ts
+++ b/src/utils/eservice.utils.ts
@@ -60,12 +60,16 @@ export function getActiveDescriptor(descriptors: Array<CompactDescriptor> | unde
 
 export function getViewLatestVersionTargetId(
   descriptors: Array<CompactDescriptor> | undefined,
-  currentDescriptorId: string | undefined
+  currentDescriptorId: string | undefined,
+  isProviderOrConsumer: 'provider' | 'consumer'
 ) {
+  const excludedStates: Array<EServiceDescriptorState> =
+    isProviderOrConsumer === 'provider'
+      ? ['DRAFT', 'WAITING_FOR_APPROVAL']
+      : ['DRAFT', 'WAITING_FOR_APPROVAL', 'ARCHIVED']
+
   const latestId = getLastDescriptor(
-    descriptors?.filter(
-      (d) => d.state !== 'DRAFT' && d.state !== 'WAITING_FOR_APPROVAL' && d.state !== 'ARCHIVED'
-    )
+    descriptors?.filter((d) => !excludedStates.includes(d.state))
   )?.id
   return latestId && latestId !== currentDescriptorId ? latestId : undefined
 }


### PR DESCRIPTION
## 🔗 Issue

[PIN-10548](https://pagopa.atlassian.net/browse/PIN-10548)

## 📝 Description / Context

This PR fix the function so a provider can go to the last version even if the versions are archived.

## 🛠 List of changes

- add `isProviderOrConsumer` prop in the function `getViewLatestVersionTargetId` so the version states are different from provider and consumer
- add tests


[PIN-10548]: https://pagopa.atlassian.net/browse/PIN-10548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ