### PR TITLE
feat: update breadcrumbs and wizard navigation (PIN-10713)

### DIFF
--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -1,85 +1,138 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Breadcrumbs as _Breadcrumbs, useCurrentRoute } from '@/router'
+import { Breadcrumbs as MUIBreadcrumbs, Link as MUILink, Typography } from '@mui/material'
+import {
+  generatePath,
+  Link as RouterLink,
+  useParams as useReactRouterParams,
+} from 'react-router-dom'
+import { getParentRoutes, routes, type RouteKey } from '@/router'
+import { useCurrentRoute } from '@/router/hooks/useCurrentRoute'
 import type sharedComponentsNs from '@/static/locales/en/shared-components.json'
 
+const macrosectionRouteKeys = new Set<RouteKey>([
+  'SUBSCRIBE',
+  'PROVIDE',
+  'TENANT',
+  'CLIENT_MANAGEMENT',
+])
+
 export function Breadcrumbs() {
-  const { t } = useTranslation('shared-components')
+  const { t, i18n } = useTranslation('shared-components')
   const routeLabels = t('routeLabels', {
     returnObjects: true,
   }) as typeof sharedComponentsNs.routeLabels
   const { routeKey } = useCurrentRoute()
+  const params = useReactRouterParams()
+
+  const labels: Record<RouteKey, string | false> = {
+    ...routeLabels,
+
+    /*
+     * The PROVIDE_ESERVICE_MANAGE breadcrumb segment must not be visible in the PROVIDE_ESERVICE_EDIT and PROVIDE_ESERVICE_SUMMARY routes
+     */
+    PROVIDE_ESERVICE_MANAGE: ['PROVIDE_ESERVICE_SUMMARY', 'PROVIDE_ESERVICE_EDIT'].includes(
+      routeKey
+    )
+      ? false
+      : routeLabels.PROVIDE_ESERVICE_MANAGE,
+
+    /*
+     * The PROVIDE_ESERVICE_TEMPLATE_DETAILS breadcrumb segment must not be visible in edit and summary routes
+     */
+    PROVIDE_ESERVICE_TEMPLATE_DETAILS: [
+      'PROVIDE_ESERVICE_TEMPLATE_SUMMARY',
+      'PROVIDE_ESERVICE_TEMPLATE_EDIT',
+    ].includes(routeKey)
+      ? false
+      : routeLabels.PROVIDE_ESERVICE_TEMPLATE_DETAILS,
+
+    /*
+     * The SUBSCRIBE_AGREEMENT_READ breadcrumb segment must not be visible in the SUBSCRIBE_AGREEMENT_EDIT route
+     */
+    SUBSCRIBE_AGREEMENT_READ:
+      routeKey === 'SUBSCRIBE_AGREEMENT_EDIT' ? false : routeLabels.SUBSCRIBE_AGREEMENT_READ,
+
+    /*
+     * The SUBSCRIBE_PURPOSE_DETAILS breadcrumb segment must not be visible in edit and summary routes
+     */
+    SUBSCRIBE_PURPOSE_DETAILS: [
+      'SUBSCRIBE_PURPOSE_EDIT',
+      'SUBSCRIBE_PURPOSE_SUMMARY',
+      'SUBSCRIBE_PURPOSE_FROM_TEMPLATE_EDIT',
+    ].includes(routeKey)
+      ? false
+      : routeLabels.SUBSCRIBE_PURPOSE_DETAILS,
+
+    SUBSCRIBE_PURPOSE_TEMPLATE_DETAILS: [
+      'SUBSCRIBE_PURPOSE_TEMPLATE_SUMMARY',
+      'SUBSCRIBE_PURPOSE_TEMPLATE_EDIT',
+    ].includes(routeKey)
+      ? false
+      : routeLabels.SUBSCRIBE_PURPOSE_TEMPLATE_DETAILS,
+
+    SUBSCRIBE_PURPOSE_FROM_TEMPLATE_EDIT:
+      (routeLabels as Record<string, string | false>).SUBSCRIBE_PURPOSE_FROM_TEMPLATE_EDIT ?? false,
+
+    SUBSCRIBE_PURPOSE_CREATE_FROM_TEMPLATE:
+      (routeLabels as Record<string, string | false>).SUBSCRIBE_PURPOSE_CREATE_FROM_TEMPLATE ??
+      false,
+
+    DEFAULT: false,
+    ASSISTENCE_PARTY_SELECTION: false,
+    PROVIDE_ESERVICE_TEMPLATE_PUBLISH_THANK_YOU: false,
+    PROVIDE_ESERVICE_PUBLISH_THANK_YOU: false,
+    SUBSCRIBE_PURPOSE_PUBLISH_THANK_YOU: false,
+    SUBSCRIBE_RISK_ANALYSIS_LIST:
+      routeKey === 'SUBSCRIBE_RISK_ANALYSIS_LIST'
+        ? false
+        : routeLabels.SUBSCRIBE_RISK_ANALYSIS_LIST,
+    SUBSCRIBE_RISK_ANALYSIS_INFO_COMPILE:
+      routeKey === 'SUBSCRIBE_RISK_ANALYSIS_APPROVAL'
+        ? false
+        : routeLabels.SUBSCRIBE_RISK_ANALYSIS_INFO_COMPILE,
+  }
+
+  const routeKeys = [...getParentRoutes(routeKey), routeKey].filter((key) => labels[key] !== false)
+
+  if (routeKeys.length < 2) return null
+
+  const getPath = (key: RouteKey) => {
+    const routePath = routes[key].path
+    const normalizedPath = routePath.startsWith('/') ? routePath : `/${routePath}`
+    return `/${i18n.language}${generatePath(normalizedPath, params)}`
+  }
 
   return (
-    <_Breadcrumbs
-      routeLabels={{
-        ...routeLabels,
+    <MUIBreadcrumbs sx={{ mb: 1 }}>
+      {routeKeys.map((key, index) => {
+        const label = labels[key]
+        const isCurrentRoute = index === routeKeys.length - 1
 
-        /*
-         * The PROVIDE_ESERVICE_MANAGE breadcrumb segment must not be visible in the PROVIDE_ESERVICE_EDIT and PROVIDE_ESERVICE_SUMMARY routes
-         */
-        PROVIDE_ESERVICE_MANAGE: ['PROVIDE_ESERVICE_SUMMARY', 'PROVIDE_ESERVICE_EDIT'].includes(
-          routeKey
+        if (isCurrentRoute) {
+          return <span key={key}>{label}</span>
+        }
+
+        if (macrosectionRouteKeys.has(key)) {
+          return (
+            <Typography key={key} component="span" color="text.secondary">
+              {label}
+            </Typography>
+          )
+        }
+
+        return (
+          <MUILink
+            key={key}
+            component={RouterLink}
+            to={getPath(key)}
+            sx={{ fontWeight: 700 }}
+            color="inherit"
+          >
+            {label}
+          </MUILink>
         )
-          ? false
-          : routeLabels.PROVIDE_ESERVICE_MANAGE,
-
-        /*
-         * The PROVIDE_ESERVICE_MANAGE breadcrumb segment must not be visible in the PROVIDE_ESERVICE_EDIT and PROVIDE_ESERVICE_SUMMARY routes
-         */
-        PROVIDE_ESERVICE_TEMPLATE_DETAILS: [
-          'PROVIDE_ESERVICE_TEMPLATE_SUMMARY',
-          'PROVIDE_ESERVICE_TEMPLATE_EDIT',
-        ].includes(routeKey)
-          ? false
-          : routeLabels.PROVIDE_ESERVICE_TEMPLATE_DETAILS,
-
-        /*
-         * The SUBSCRIBE_AGREEMENT_READ breadcrumb segment must not be visible in the SUBSCRIBE_AGREEMENT_EDIT route
-         */
-        SUBSCRIBE_AGREEMENT_READ:
-          routeKey === 'SUBSCRIBE_AGREEMENT_EDIT' ? false : routeLabels.SUBSCRIBE_AGREEMENT_READ,
-
-        /*
-         * The SUBSCRIBE_PURPOSE_DETAILS breadcrumb segment must not be visible in the SUBSCRIBE_PURPOSE_EDIT, SUBSCRIBE_PURPOSE_SUMMARY, and SUBSCRIBE_PURPOSE_FROM_TEMPLATE_EDIT routes
-         */
-        SUBSCRIBE_PURPOSE_DETAILS: [
-          'SUBSCRIBE_PURPOSE_EDIT',
-          'SUBSCRIBE_PURPOSE_SUMMARY',
-          'SUBSCRIBE_PURPOSE_FROM_TEMPLATE_EDIT',
-        ].includes(routeKey)
-          ? false
-          : routeLabels.SUBSCRIBE_PURPOSE_DETAILS,
-
-        SUBSCRIBE_PURPOSE_TEMPLATE_DETAILS: [
-          'SUBSCRIBE_PURPOSE_TEMPLATE_SUMMARY',
-          'SUBSCRIBE_PURPOSE_TEMPLATE_EDIT',
-        ].includes(routeKey)
-          ? false
-          : routeLabels.SUBSCRIBE_PURPOSE_TEMPLATE_DETAILS,
-
-        SUBSCRIBE_PURPOSE_FROM_TEMPLATE_EDIT:
-          (routeLabels as Record<string, string | false>).SUBSCRIBE_PURPOSE_FROM_TEMPLATE_EDIT ??
-          false,
-
-        SUBSCRIBE_PURPOSE_CREATE_FROM_TEMPLATE:
-          (routeLabels as Record<string, string | false>).SUBSCRIBE_PURPOSE_CREATE_FROM_TEMPLATE ??
-          false,
-
-        DEFAULT: false,
-        ASSISTENCE_PARTY_SELECTION: false,
-        PROVIDE_ESERVICE_TEMPLATE_PUBLISH_THANK_YOU: false,
-        PROVIDE_ESERVICE_PUBLISH_THANK_YOU: false,
-        SUBSCRIBE_PURPOSE_PUBLISH_THANK_YOU: false,
-        SUBSCRIBE_RISK_ANALYSIS_LIST:
-          routeKey === 'SUBSCRIBE_RISK_ANALYSIS_LIST'
-            ? false
-            : routeLabels.SUBSCRIBE_RISK_ANALYSIS_LIST,
-        SUBSCRIBE_RISK_ANALYSIS_INFO_COMPILE:
-          routeKey === 'SUBSCRIBE_RISK_ANALYSIS_APPROVAL'
-            ? false
-            : routeLabels.SUBSCRIBE_RISK_ANALYSIS_INFO_COMPILE,
-      }}
-    />
+      })}
+    </MUIBreadcrumbs>
   )
 }

--- a/src/components/layout/__tests__/Breadcrumbs.test.tsx
+++ b/src/components/layout/__tests__/Breadcrumbs.test.tsx
@@ -1,0 +1,40 @@
+import { screen } from '@testing-library/react'
+import { createMemoryHistory } from 'history'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { Breadcrumbs } from '../Breadcrumbs'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: () => ({
+      SUBSCRIBE: 'Fruizione',
+      SUBSCRIBE_PURPOSE_LIST: 'Finalità inoltrate',
+      SUBSCRIBE_PURPOSE_DETAILS: 'Dettaglio finalità',
+    }),
+    i18n: {
+      language: 'it',
+    },
+  }),
+}))
+
+vi.mock('@/router/hooks/useCurrentRoute', () => ({
+  useCurrentRoute: () => ({
+    routeKey: 'SUBSCRIBE_PURPOSE_DETAILS',
+  }),
+}))
+
+describe('Breadcrumbs', () => {
+  it('shows the macrosection without making it clickable', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/it/fruizione/finalita/purpose-id'],
+    })
+
+    renderWithApplicationContext(<Breadcrumbs />, { withRouterContext: true }, history)
+
+    expect(screen.getByText('Fruizione').closest('a')).toBeNull()
+    expect(screen.getByRole('link', { name: 'Finalità inoltrate' })).toHaveAttribute(
+      'href',
+      '/it/fruizione/finalita'
+    )
+    expect(screen.getByText('Dettaglio finalità').closest('a')).toBeNull()
+  })
+})

--- a/src/components/layout/containers/NewPageContainer.tsx
+++ b/src/components/layout/containers/NewPageContainer.tsx
@@ -2,25 +2,15 @@ import React from 'react'
 import type { SxProps } from '@mui/material'
 import { Box, Button, Skeleton, Stack, Tooltip, Typography } from '@mui/material'
 import type { ActionItemButton } from '@/types/common.types'
-import { Breadcrumbs } from '../Breadcrumbs'
 import { StatusChip } from '@/components/shared/StatusChip'
 import type { useParams } from '@/router'
 import { Link, type RouteKey } from '@/router'
-import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { ActionMenu } from '@/components/shared/ActionMenu'
 import { ArchivingScheduleBadge } from '@/components/shared/ArchivingScheduleBadge'
 import type { ArchivingScope } from '@/api/api.generatedTypes'
+import { PageNavigation, type PageNavigationProps } from './PageNavigation'
 
 type RouteParams<TRouteKey extends RouteKey> = ReturnType<typeof useParams<TRouteKey>>
-
-export type PageBackToAction = {
-  [K in RouteKey]: {
-    label: string
-    to: K // the specified route
-    params?: RouteParams<K> // params corresponding to that route
-    urlParams?: Record<string, string>
-  }
-}[RouteKey]
 
 type ActionsSectionProps = {
   primaryAction?: ActionItemButton
@@ -28,8 +18,8 @@ type ActionsSectionProps = {
   menuActions?: Array<ActionItemButton>
 }
 
-type BreadcrumbsSectionProps = {
-  backToAction?: PageBackToAction
+type NavigationSectionProps = {
+  navigation?: PageNavigationProps
 }
 
 type ShortCutProps =
@@ -70,12 +60,12 @@ export type PageContainerProps = {
   isLoading?: boolean
   sx?: SxProps
   children: React.ReactNode
-} & BreadcrumbsSectionProps &
+} & NavigationSectionProps &
   IntroProps
 
 type PageContainerSkeletonProps = {
   children?: React.ReactNode
-  backToAction?: PageBackToAction
+  navigation?: PageNavigationProps
 }
 
 type SubtitleProps = {
@@ -89,7 +79,7 @@ export const NewPageContainer: React.FC<PageContainerProps> = ({
 }) => {
   return (
     <Stack direction="column" spacing={3}>
-      <BreadcrumbsSection {...props} />
+      <NavigationSection {...props} />
       {isLoading ? <IntroSkeleton /> : <Intro {...props} />}
       <Box>{children}</Box>
     </Stack>
@@ -98,11 +88,11 @@ export const NewPageContainer: React.FC<PageContainerProps> = ({
 
 export const PageContainerSkeleton: React.FC<PageContainerSkeletonProps> = ({
   children,
-  backToAction,
+  navigation,
 }) => {
   return (
     <Box>
-      <BreadcrumbsSection backToAction={backToAction} />
+      <NavigationSection navigation={navigation} />
       <IntroSkeleton />
       <Box sx={{ mt: 1 }}>{children}</Box>
     </Box>
@@ -152,26 +142,9 @@ const Subtitle: React.FC<SubtitleProps> = ({ description }) => {
     description
   )
 }
-const BreadcrumbsSection: React.FC<BreadcrumbsSectionProps> = ({ backToAction }) => {
-  return (
-    <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 1 }}>
-      {backToAction && (
-        <Link
-          to={backToAction.to}
-          params={backToAction.params}
-          options={backToAction.urlParams ? { urlParams: backToAction.urlParams } : undefined}
-          as="button"
-          startIcon={<ArrowBackIcon />}
-          size="small"
-          variant="naked"
-        >
-          {backToAction.label}
-        </Link>
-      )}
-      <Breadcrumbs />
-    </Stack>
-  )
-}
+const NavigationSection: React.FC<NavigationSectionProps> = ({ navigation }) => (
+  <PageNavigation {...(navigation ?? {})} />
+)
 
 const ActionsSection: React.FC<ActionsSectionProps> = ({
   primaryAction,

--- a/src/components/layout/containers/PageContainer.tsx
+++ b/src/components/layout/containers/PageContainer.tsx
@@ -2,25 +2,16 @@ import React from 'react'
 import type { SxProps } from '@mui/material'
 import { Box, Button, Skeleton, Stack, Tooltip, Typography } from '@mui/material'
 import type { ActionItemButton } from '@/types/common.types'
-import { Breadcrumbs } from '../Breadcrumbs'
 import { StatusChip } from '@/components/shared/StatusChip'
-import { Link, type RouteKey } from '@/router'
-import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-
-export type PageBackToAction = {
-  label: string
-  to: RouteKey
-  params?: Record<string, string>
-  urlParams?: Record<string, string>
-}
+import { PageNavigation, type PageNavigationProps } from './PageNavigation'
 
 type PageContainerActionsProps = {
   statusChip?: React.ComponentProps<typeof StatusChip>
   topSideActions?: Array<ActionItemButton>
 }
 
-type PageContainerBreadcrumbsProps = {
-  backToAction?: PageBackToAction
+type PageContainerNavigationProps = {
+  navigation?: PageNavigationProps
 }
 
 type PageContainerIntroProps = {
@@ -33,32 +24,51 @@ type PageContainerProps = {
   sx?: SxProps
   children: React.ReactNode
 } & PageContainerActionsProps &
-  PageContainerBreadcrumbsProps &
+  PageContainerNavigationProps &
   PageContainerIntroProps
 
 type PageContainerSkeletonProps = {
   children?: React.ReactNode
-  backToAction?: PageBackToAction
+  navigation?: PageNavigationProps
 }
 
 export const PageContainer: React.FC<PageContainerProps> = ({ children, isLoading, ...props }) => {
+  const [hasUnsavedChanges, setHasUnsavedChanges] = React.useState(false)
+  const wizardStepKey = props.navigation?.mode === 'wizard' ? props.navigation.stepKey : undefined
+
+  React.useEffect(() => {
+    setHasUnsavedChanges(false)
+  }, [wizardStepKey])
+
+  const navigation =
+    props.navigation?.mode === 'wizard'
+      ? { ...props.navigation, hasUnsavedChanges }
+      : props.navigation
+
   return (
     <Box>
-      <PageContainerBreadcrumbs {...props} />
+      <PageContainerNavigation navigation={navigation} />
       {isLoading ? <PageContainerIntroSkeleton /> : <PageContainerIntro {...props} />}
       {!isLoading && <PageContainerActions {...props} />}
-      <Box sx={{ mt: 1 }}>{children}</Box>
+      <Box
+        sx={{ mt: 1 }}
+        onChangeCapture={
+          props.navigation?.mode === 'wizard' ? () => setHasUnsavedChanges(true) : undefined
+        }
+      >
+        {children}
+      </Box>
     </Box>
   )
 }
 
 export const PageContainerSkeleton: React.FC<PageContainerSkeletonProps> = ({
   children,
-  backToAction,
+  navigation,
 }) => {
   return (
     <Box>
-      <PageContainerBreadcrumbs backToAction={backToAction} />
+      <PageContainerNavigation navigation={navigation} />
       <PageContainerIntroSkeleton />
       <Box sx={{ mt: 1 }}>{children}</Box>
     </Box>
@@ -95,30 +105,9 @@ const PageContainerSubtitle: React.FC<PageContainerSubtitle> = ({ description })
     description
   )
 }
-const PageContainerBreadcrumbs: React.FC<PageContainerBreadcrumbsProps> = ({ backToAction }) => {
-  return (
-    <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 1 }}>
-      {backToAction && (
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        <Link
-          to={backToAction.to}
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          params={backToAction.params}
-          options={backToAction.urlParams ? { urlParams: backToAction.urlParams } : undefined}
-          as="button"
-          startIcon={<ArrowBackIcon />}
-          size="small"
-          variant="naked"
-        >
-          {backToAction.label}
-        </Link>
-      )}
-      <Breadcrumbs />
-    </Stack>
-  )
-}
+const PageContainerNavigation: React.FC<PageContainerNavigationProps> = ({ navigation }) => (
+  <PageNavigation {...(navigation ?? {})} />
+)
 
 const PageContainerActions: React.FC<PageContainerActionsProps> = ({
   statusChip,

--- a/src/components/layout/containers/PageContainer.tsx
+++ b/src/components/layout/containers/PageContainer.tsx
@@ -42,7 +42,10 @@ export const PageContainer: React.FC<PageContainerProps> = ({ children, isLoadin
 
   const navigation =
     props.navigation?.mode === 'wizard'
-      ? { ...props.navigation, hasUnsavedChanges }
+      ? {
+          ...props.navigation,
+          hasUnsavedChanges: props.navigation.hasUnsavedChanges ?? hasUnsavedChanges,
+        }
       : props.navigation
 
   return (

--- a/src/components/layout/containers/PageNavigation.tsx
+++ b/src/components/layout/containers/PageNavigation.tsx
@@ -1,0 +1,117 @@
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import CloseIcon from '@mui/icons-material/Close'
+import { Button, Stack } from '@mui/material'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { useParams } from '@/router'
+import { Link, type RouteKey } from '@/router'
+import { useDialog } from '@/stores'
+import { Breadcrumbs } from '../Breadcrumbs'
+
+type RouteParams<TRouteKey extends RouteKey> = ReturnType<typeof useParams<TRouteKey>>
+
+export type PageExitAction = {
+  [K in RouteKey]: {
+    to: K
+    params?: RouteParams<K>
+    urlParams?: Record<string, string>
+  }
+}[RouteKey]
+
+export type PageNavigationProps =
+  | {
+      mode?: 'breadcrumbs'
+      showBackButton?: boolean
+      exitAction?: never
+      hasUnsavedChanges?: never
+      stepKey?: never
+    }
+  | {
+      mode: 'back'
+      showBackButton?: never
+      exitAction?: never
+      hasUnsavedChanges?: never
+      stepKey?: never
+    }
+  | {
+      mode: 'wizard'
+      exitAction: PageExitAction
+      showBackButton?: never
+      hasUnsavedChanges?: boolean
+      stepKey?: string | number
+    }
+
+export const PageNavigation: React.FC<PageNavigationProps> = (props) => {
+  const { t } = useTranslation('shared-components', {
+    keyPrefix: 'pageNavigation',
+  })
+  const navigate = useNavigate()
+  const { openDialog } = useDialog()
+
+  if (props.mode === 'wizard') {
+    const { exitAction, hasUnsavedChanges = false } = props
+    const handleExit = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!hasUnsavedChanges) return
+      if (!(event.target instanceof Element)) return
+
+      const exitLink = event.target.closest('a')
+      if (!exitLink) return
+
+      event.preventDefault()
+      const exitPath = exitLink.getAttribute('href')
+
+      if (!exitPath) return
+
+      openDialog({
+        type: 'basic',
+        title: t('exitDialog.title'),
+        description: t('exitDialog.description'),
+        proceedLabel: t('exitDialog.confirmButton'),
+        onProceed: () => navigate(exitPath),
+      })
+    }
+
+    return (
+      <Stack alignItems="flex-start" sx={{ mb: 1 }} onClickCapture={handleExit}>
+        <Link
+          to={exitAction.to}
+          params={exitAction.params}
+          options={exitAction.urlParams ? { urlParams: exitAction.urlParams } : undefined}
+          as="button"
+          size="small"
+          startIcon={<CloseIcon />}
+          variant="naked"
+        >
+          {t('exitButton')}
+        </Link>
+      </Stack>
+    )
+  }
+
+  const backButton = (
+    <Button
+      type="button"
+      onClick={() => navigate(-1)}
+      startIcon={<ArrowBackIcon />}
+      size="small"
+      variant="naked"
+    >
+      {t('backButton')}
+    </Button>
+  )
+
+  if (props.mode === 'back') {
+    return (
+      <Stack alignItems="flex-start" sx={{ mb: 1 }}>
+        {backButton}
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack direction="column" alignItems="flex-start" spacing={1} sx={{ mb: 1 }}>
+      {props.showBackButton && backButton}
+      <Breadcrumbs />
+    </Stack>
+  )
+}

--- a/src/components/layout/containers/__tests__/NewPageContainer.test.tsx
+++ b/src/components/layout/containers/__tests__/NewPageContainer.test.tsx
@@ -1,23 +1,27 @@
 import userEvent from '@testing-library/user-event'
+import { createMemoryHistory, type MemoryHistory } from 'history'
 import { NewPageContainer, type PageContainerProps } from '../NewPageContainer'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import type { ActionItemButton } from '@/types/common.types'
 
-const renderComponent = ({
-  children,
-  title,
-  backToAction,
-  statusChip,
-  primaryAction,
-  secondaryAction,
-  menuActions,
-  description,
-  infoSection,
-}: PageContainerProps) => {
+const renderComponent = (
+  {
+    children,
+    title,
+    navigation,
+    statusChip,
+    primaryAction,
+    secondaryAction,
+    menuActions,
+    description,
+    infoSection,
+  }: PageContainerProps,
+  history?: MemoryHistory
+) => {
   return renderWithApplicationContext(
     <NewPageContainer
       title={title}
-      backToAction={backToAction}
+      navigation={navigation}
       statusChip={statusChip}
       primaryAction={primaryAction}
       secondaryAction={secondaryAction}
@@ -27,7 +31,8 @@ const renderComponent = ({
     >
       {children}
     </NewPageContainer>,
-    { withRouterContext: true }
+    { withRouterContext: true },
+    history
   )
 }
 
@@ -65,25 +70,31 @@ describe('NewPageContainer', () => {
     expect(statusChip).toBeInTheDocument()
   })
 
-  it('should correctly render the backToAction link that navigate to the DEFAULT route passed', async () => {
-    const { history, ...screen } = renderComponent({
-      children: 'Test children',
-      title: 'Test title',
-      backToAction: {
-        label: 'test backToAction',
-        to: 'DEFAULT',
-      },
+  it('should correctly render the browser back button', async () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/it/termini-di-servizio', '/it/privacy-policy'],
+      initialIndex: 1,
     })
+    const screen = renderComponent(
+      {
+        children: 'Test children',
+        title: 'Test title',
+        navigation: {
+          showBackButton: true,
+        },
+      },
+      history
+    )
 
     const user = userEvent.setup()
 
-    const backToActionButton = screen.getByRole('link', { name: 'test backToAction' })
+    const backButton = screen.getByRole('button', { name: 'backButton' })
 
-    expect(backToActionButton).toBeInTheDocument()
+    expect(backButton).toBeInTheDocument()
 
-    await user.click(backToActionButton)
+    await user.click(backButton)
 
-    expect(history.location.pathname).toEqual('/it/')
+    expect(history.location.pathname).toEqual('/it/termini-di-servizio')
   })
 
   it('should correctly render the description', () => {

--- a/src/components/layout/containers/__tests__/PageContainer.test.tsx
+++ b/src/components/layout/containers/__tests__/PageContainer.test.tsx
@@ -1,0 +1,32 @@
+import userEvent from '@testing-library/user-event'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { PageContainer } from '../PageContainer'
+
+describe('PageContainer', () => {
+  it('marks a wizard as having unsaved changes when a form field changes', async () => {
+    const screen = renderWithApplicationContext(
+      <PageContainer
+        navigation={{
+          mode: 'wizard',
+          exitAction: { to: 'DEFAULT' },
+        }}
+      >
+        <label htmlFor="wizard-field">Wizard field</label>
+        <input id="wizard-field" />
+      </PageContainer>,
+      {
+        withRouterContext: true,
+        withDialogContext: true,
+      }
+    )
+
+    await userEvent.type(screen.getByLabelText('Wizard field'), 'Changed value')
+    await userEvent.click(screen.getByRole('link', { name: 'exitButton' }))
+
+    expect(
+      screen.getByRole('dialog', {
+        name: 'exitDialog.title',
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/layout/containers/__tests__/PageContainer.test.tsx
+++ b/src/components/layout/containers/__tests__/PageContainer.test.tsx
@@ -1,8 +1,43 @@
+import React from 'react'
 import userEvent from '@testing-library/user-event'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import { PageContainer } from '../PageContainer'
 
 describe('PageContainer', () => {
+  it('honors externally controlled unsaved changes for programmatic form updates', async () => {
+    const ControlledWizard = () => {
+      const [hasUnsavedChanges, setHasUnsavedChanges] = React.useState(false)
+
+      return (
+        <PageContainer
+          navigation={{
+            mode: 'wizard',
+            exitAction: { to: 'DEFAULT' },
+            hasUnsavedChanges,
+          }}
+        >
+          <button type="button" onClick={() => setHasUnsavedChanges(true)}>
+            Programmatic change
+          </button>
+        </PageContainer>
+      )
+    }
+
+    const screen = renderWithApplicationContext(<ControlledWizard />, {
+      withRouterContext: true,
+      withDialogContext: true,
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Programmatic change' }))
+    await userEvent.click(screen.getByRole('link', { name: 'exitButton' }))
+
+    expect(
+      screen.getByRole('dialog', {
+        name: 'exitDialog.title',
+      })
+    ).toBeInTheDocument()
+  })
+
   it('marks a wizard as having unsaved changes when a form field changes', async () => {
     const screen = renderWithApplicationContext(
       <PageContainer

--- a/src/components/layout/containers/__tests__/PageNavigation.test.tsx
+++ b/src/components/layout/containers/__tests__/PageNavigation.test.tsx
@@ -1,0 +1,124 @@
+import userEvent from '@testing-library/user-event'
+import { createMemoryHistory } from 'history'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { PageNavigation } from '../PageNavigation'
+
+vi.mock('../../Breadcrumbs', () => ({
+  Breadcrumbs: () => <div data-testid="breadcrumbs" />,
+}))
+
+describe('PageNavigation', () => {
+  it('shows breadcrumbs by default', () => {
+    const screen = renderWithApplicationContext(<PageNavigation />, {
+      withRouterContext: true,
+    })
+
+    expect(screen.getByTestId('breadcrumbs')).toBeInTheDocument()
+  })
+
+  it('navigates to the previous browser history entry from the back button', async () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/previous', '/test'],
+      initialIndex: 1,
+    })
+    const screen = renderWithApplicationContext(
+      <PageNavigation showBackButton />,
+      { withRouterContext: true },
+      history
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'backButton',
+      })
+    )
+
+    expect(history.location.pathname).toBe('/previous')
+    expect(screen.getByTestId('breadcrumbs')).toBeInTheDocument()
+  })
+
+  it('shows only the back button in back mode', () => {
+    const screen = renderWithApplicationContext(<PageNavigation mode="back" />, {
+      withRouterContext: true,
+    })
+
+    expect(
+      screen.getByRole('button', {
+        name: 'backButton',
+      })
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('breadcrumbs')).not.toBeInTheDocument()
+  })
+
+  it('leaves a wizard immediately when there are no unsaved changes', async () => {
+    const screen = renderWithApplicationContext(
+      <PageNavigation
+        mode="wizard"
+        exitAction={{
+          to: 'DEFAULT',
+        }}
+      />,
+      { withRouterContext: true, withDialogContext: true }
+    )
+
+    await userEvent.click(
+      screen.getByRole('link', {
+        name: 'exitButton',
+      })
+    )
+
+    expect(screen.history.location.pathname).toBe('/it/')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('asks for confirmation before leaving a wizard with unsaved changes', async () => {
+    const screen = renderWithApplicationContext(
+      <PageNavigation
+        mode="wizard"
+        hasUnsavedChanges
+        exitAction={{
+          to: 'DEFAULT',
+        }}
+      />,
+      { withRouterContext: true, withDialogContext: true }
+    )
+
+    expect(screen.queryByTestId('breadcrumbs')).not.toBeInTheDocument()
+    expect(screen.getByTestId('CloseIcon')).toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole('link', {
+        name: 'exitButton',
+      })
+    )
+
+    expect(screen.history.location.pathname).not.toBe('/it/')
+    expect(
+      screen.getByRole('dialog', {
+        name: 'exitDialog.title',
+      })
+    ).toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'cancel',
+      })
+    )
+
+    expect(screen.history.location.pathname).not.toBe('/it/')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole('link', {
+        name: 'exitButton',
+      })
+    )
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'exitDialog.confirmButton',
+      })
+    )
+
+    expect(screen.history.location.pathname).toBe('/it/')
+  })
+})

--- a/src/pages/ConsumerAgreementCreatePage/ConsumerAgreementCreate.page.tsx
+++ b/src/pages/ConsumerAgreementCreatePage/ConsumerAgreementCreate.page.tsx
@@ -118,10 +118,7 @@ const ConsumerAgreementCreatePage: React.FC = () => {
             }
           : undefined
       }
-      backToAction={{
-        label: t('backToRequestsBtn'),
-        to: 'SUBSCRIBE_AGREEMENT_LIST',
-      }}
+      navigation={{ mode: 'wizard', exitAction: { to: 'SUBSCRIBE_AGREEMENT_LIST' } }}
     >
       {alertProps && (
         <Alert sx={{ mb: 3 }} severity={alertProps.severity}>

--- a/src/pages/ConsumerAgreementDetailsPage/ConsumerAgreementDetails.page.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/ConsumerAgreementDetails.page.tsx
@@ -89,7 +89,7 @@ const ConsumerAgreementDetailsPageContent: React.FC = () => {
     <PageContainer
       title={t('consumerRead.title')}
       topSideActions={actions}
-      backToAction={{ label: t('backToRequestsBtn'), to: 'SUBSCRIBE_AGREEMENT_LIST' }}
+      navigation={{ showBackButton: true }}
       statusChip={agreement ? { for: 'agreement', agreement } : undefined}
     >
       <ConsumerAgreementVersionAlerts descriptor={descriptor} />

--- a/src/pages/ConsumerClientCreatePage/ConsumerClientCreate.page.tsx
+++ b/src/pages/ConsumerClientCreatePage/ConsumerClientCreate.page.tsx
@@ -54,15 +54,14 @@ const ConsumerClientCreatePage: React.FC = () => {
     }
   }
 
-  const backToRoute = clientKind === 'API' ? 'SUBSCRIBE_INTEROP_M2M' : 'SUBSCRIBE_CLIENT_LIST'
-
   return (
     <PageContainer
       title={t('create.title')}
       description={t('create.description')}
-      backToAction={{
-        label: t('create.actions.backToClientsLabel'),
-        to: backToRoute,
+      navigation={{
+        mode: 'wizard',
+        exitAction:
+          clientKind === 'API' ? { to: 'SUBSCRIBE_INTEROP_M2M' } : { to: 'SUBSCRIBE_CLIENT_LIST' },
       }}
     >
       <Box component="form" noValidate onSubmit={formMethods.handleSubmit(onSubmit)}>

--- a/src/pages/ConsumerClientCreatePage/ConsumerClientCreate.page.tsx
+++ b/src/pages/ConsumerClientCreatePage/ConsumerClientCreate.page.tsx
@@ -62,6 +62,7 @@ const ConsumerClientCreatePage: React.FC = () => {
         mode: 'wizard',
         exitAction:
           clientKind === 'API' ? { to: 'SUBSCRIBE_INTEROP_M2M' } : { to: 'SUBSCRIBE_CLIENT_LIST' },
+        hasUnsavedChanges: formMethods.formState.isDirty,
       }}
     >
       <Box component="form" noValidate onSubmit={formMethods.handleSubmit(onSubmit)}>

--- a/src/pages/ConsumerClientCreatePage/components/OperatorsInputTable.tsx
+++ b/src/pages/ConsumerClientCreatePage/components/OperatorsInputTable.tsx
@@ -26,11 +26,11 @@ const OperatorsInputTable: React.FC = () => {
 
   const handleRemoveOperator = (operatorId: string) => {
     const newOperators = operators.filter((o) => o.userId !== operatorId)
-    setValue('operators', newOperators)
+    setValue('operators', newOperators, { shouldDirty: true })
   }
 
   const handleAddOperator = (newOperators: Users) => {
-    setValue('operators', [...operators, ...newOperators])
+    setValue('operators', [...operators, ...newOperators], { shouldDirty: true })
   }
 
   const handleOpenAddOperatorDrawer = () => {

--- a/src/pages/ConsumerClientCreatePage/components/__tests__/OperatorsInputTable.test.tsx
+++ b/src/pages/ConsumerClientCreatePage/components/__tests__/OperatorsInputTable.test.tsx
@@ -1,0 +1,53 @@
+import userEvent from '@testing-library/user-event'
+import { FormProvider, useForm } from 'react-hook-form'
+import type { Users } from '@/api/api.generatedTypes'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import type { CreateClientFormValues } from '../../ConsumerClientCreate.page'
+import OperatorsInputTable from '../OperatorsInputTable'
+
+const operator: Users[number] = {
+  userId: 'operator-id',
+  tenantId: 'tenant-id',
+  name: 'Mario',
+  familyName: 'Rossi',
+  roles: ['security'],
+}
+
+vi.mock('@/components/shared/AddOperatorsToClientDrawer', () => ({
+  AddOperatorsToClientDrawer: ({
+    isOpen,
+    onSubmit,
+  }: {
+    isOpen: boolean
+    onSubmit: (operators: Users) => void
+  }) =>
+    isOpen ? (
+      <button type="button" onClick={() => onSubmit([operator])}>
+        Confirm operators
+      </button>
+    ) : null,
+}))
+
+const TestForm = () => {
+  const formMethods = useForm<CreateClientFormValues>({
+    defaultValues: { name: '', description: '', operators: [] },
+  })
+
+  return (
+    <FormProvider {...formMethods}>
+      <OperatorsInputTable />
+      <output>{formMethods.formState.isDirty ? 'dirty' : 'pristine'}</output>
+    </FormProvider>
+  )
+}
+
+describe('OperatorsInputTable', () => {
+  it('marks the form as dirty when operators are added programmatically', async () => {
+    const screen = renderWithApplicationContext(<TestForm />, {})
+
+    await userEvent.click(screen.getByRole('button', { name: 'addBtn' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm operators' }))
+
+    expect(screen.getByText('dirty')).toBeInTheDocument()
+  })
+})

--- a/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
+++ b/src/pages/ConsumerClientManagePage/ConsumerClientManage.page.tsx
@@ -66,10 +66,7 @@ const ConsumerClientManagePage: React.FC = () => {
       description={client?.description}
       topSideActions={[voucherSimulationAction, ...actions]}
       isLoading={isLoadingClient}
-      backToAction={{
-        label: t('actions.backToClientsLabel'),
-        to: clientKind === 'API' ? 'SUBSCRIBE_INTEROP_M2M' : 'SUBSCRIBE_CLIENT_LIST',
-      }}
+      navigation={{ showBackButton: true }}
     >
       {clientKind === 'API' && (
         <Grid container>

--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -91,10 +91,7 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
       secondaryAction={secondaryAction}
       menuActions={menuActions}
       isLoading={!descriptor}
-      backToAction={{
-        label: t('actions.backToCatalogLabel'),
-        to: 'SUBSCRIBE_CATALOG_LIST',
-      }}
+      navigation={{ showBackButton: true }}
       infoSection={
         descriptor
           ? {

--- a/src/pages/ConsumerEServiceTemplateDetailsPage/ConsumerEServiceTemplateDetails.page.tsx
+++ b/src/pages/ConsumerEServiceTemplateDetailsPage/ConsumerEServiceTemplateDetails.page.tsx
@@ -60,10 +60,7 @@ const ConsumerEServiceTemplateDetailsPage: React.FC = () => {
             }
           : undefined
       }
-      backToAction={{
-        label: t('actions.backToEserviceTemplateCatalog'),
-        to: 'PROVIDE_ESERVICE_TEMPLATE_CATALOG',
-      }}
+      navigation={{ showBackButton: true }}
     >
       <React.Suspense fallback={<ConsumerEServiceTemplateDetailsSkeleton />}>
         <TabContext value={activeTab}>

--- a/src/pages/ConsumerPurposeCreatePage/ConsumerPurposeCreate.page.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/ConsumerPurposeCreate.page.tsx
@@ -12,10 +12,7 @@ const ConsumerPurposeCreatePage: React.FC = () => {
   return (
     <PageContainer
       title={t('create.emptyTitle')}
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'SUBSCRIBE_PURPOSE_LIST',
-      }}
+      navigation={{ mode: 'wizard', exitAction: { to: 'SUBSCRIBE_PURPOSE_LIST' } }}
     >
       <RequiredTextLabel />
       <PurposeCreateForm purposeTemplateId={purposeTemplateId} />

--- a/src/pages/ConsumerPurposeCreatePage/__tests__/ConsumerPurposeCreate.page.test.tsx
+++ b/src/pages/ConsumerPurposeCreatePage/__tests__/ConsumerPurposeCreate.page.test.tsx
@@ -9,6 +9,19 @@ vi.mock('./../components/PurposeCreateForm', () => ({
 }))
 
 describe('ConsumerPurposeCreatePage', () => {
+  it('renders only the wizard exit navigation', () => {
+    renderWithApplicationContext(<ConsumerPurposeCreatePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByRole('link', { name: 'exitButton' })).toHaveAttribute(
+      'href',
+      '/it/fruizione/finalita'
+    )
+    expect(screen.queryByRole('button', { name: 'backButton' })).not.toBeInTheDocument()
+  })
+
   it('renders page title', () => {
     renderWithApplicationContext(<ConsumerPurposeCreatePage />, {
       withReactQueryContext: true,

--- a/src/pages/ConsumerPurposeDetailsPage/ConsumerPurposeDetails.page.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/ConsumerPurposeDetails.page.tsx
@@ -61,10 +61,7 @@ const ConsumerPurposeDetailsPage: React.FC = () => {
       isLoading={isPurposeLoading || isDescriptorLoading}
       topSideActions={actions}
       statusChip={purpose ? { for: 'purpose', purpose: purpose } : undefined}
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'SUBSCRIBE_PURPOSE_LIST',
-      }}
+      navigation={{ showBackButton: true }}
     >
       {alertProps && (
         <Alert severity={alertProps.severity} sx={{ my: 3 }} variant={alertProps.variant}>

--- a/src/pages/ConsumerPurposeEditPage/ConsumerPurposeEdit.page.tsx
+++ b/src/pages/ConsumerPurposeEditPage/ConsumerPurposeEdit.page.tsx
@@ -61,9 +61,10 @@ const ConsumerPurposeEditPage: React.FC = () => {
     <PageContainer
       title={t('edit.emptyTitle')}
       isLoading={isLoadingPurpose}
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'SUBSCRIBE_PURPOSE_LIST',
+      navigation={{
+        mode: 'wizard',
+        exitAction: { to: 'SUBSCRIBE_PURPOSE_LIST' },
+        stepKey: activeStep,
       }}
     >
       <RequiredTextLabel />

--- a/src/pages/ConsumerPurposeFromTemplateEditPage/ConsumerPurposeFromTemplateEdit.page.tsx
+++ b/src/pages/ConsumerPurposeFromTemplateEditPage/ConsumerPurposeFromTemplateEdit.page.tsx
@@ -39,9 +39,10 @@ const ConsumerPurposeFromTemplateEditPage: React.FC = () => {
       <PageContainer
         title={t('edit.emptyTitle')}
         isLoading={isLoadingPurposeTemplate}
-        backToAction={{
-          label: t('backToListBtn'),
-          to: 'SUBSCRIBE_PURPOSE_LIST',
+        navigation={{
+          mode: 'wizard',
+          exitAction: { to: 'SUBSCRIBE_PURPOSE_LIST' },
+          stepKey: activeStep,
         }}
       >
         <RequiredTextLabel />

--- a/src/pages/ConsumerPurposeFromTemplateEditPage/__tests__/ConsumerPurposeFromTemplateEdit.page.test.tsx
+++ b/src/pages/ConsumerPurposeFromTemplateEditPage/__tests__/ConsumerPurposeFromTemplateEdit.page.test.tsx
@@ -34,13 +34,17 @@ vi.mock(
 )
 
 describe('ConsumerPurposeFromTemplateEditPage', () => {
-  it('renders back to list button', () => {
+  it('renders the wizard exit action instead of the previous back to list action', () => {
     renderWithApplicationContext(<ConsumerPurposeFromTemplateEditPage />, {
       withReactQueryContext: true,
       withRouterContext: true,
     })
 
-    expect(screen.getByText('backToListBtn')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'exitButton' })).toHaveAttribute(
+      'href',
+      '/it/fruizione/finalita'
+    )
+    expect(screen.queryByText('backToListBtn')).not.toBeInTheDocument()
   })
   it('renders required label', () => {
     renderWithApplicationContext(<ConsumerPurposeFromTemplateEditPage />, {

--- a/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/ConsumerPurposeSummary.page.tsx
@@ -143,10 +143,7 @@ const ConsumerPurposeSummaryPage: React.FC = () => {
     <PageContainer
       title={t('summary.title')}
       isLoading={isLoading}
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'SUBSCRIBE_PURPOSE_LIST',
-      }}
+      navigation={{ mode: 'back' }}
       statusChip={purpose ? { for: 'purpose', purpose } : undefined}
     >
       {alertProps && <Alert sx={{ mb: 3 }} {...alertProps} />}

--- a/src/pages/ConsumerPurposeTemplateCatalogDetailsPage/ConsumerPurposeTemplateCatalogDetailsPage.tsx
+++ b/src/pages/ConsumerPurposeTemplateCatalogDetailsPage/ConsumerPurposeTemplateCatalogDetailsPage.tsx
@@ -39,10 +39,7 @@ const ConsumerPurposeTemplateCatalogDetailsPage: React.FC = () => {
             }
           : undefined
       }
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'SUBSCRIBE_PURPOSE_TEMPLATE_LIST',
-      }}
+      navigation={{ showBackButton: true }}
     >
       <TabContext value={activeTab}>
         <TabList

--- a/src/pages/ConsumerPurposeTemplateDetailsPage/ConsumerPurposeTemplateDetails.page.tsx
+++ b/src/pages/ConsumerPurposeTemplateDetailsPage/ConsumerPurposeTemplateDetails.page.tsx
@@ -39,10 +39,7 @@ const ConsumerPurposeTemplateDetailsPage: React.FC = () => {
             }
           : undefined
       }
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'SUBSCRIBE_PURPOSE_TEMPLATE_LIST',
-      }}
+      navigation={{ showBackButton: true }}
     >
       <TabContext value={activeTab}>
         <TabList

--- a/src/pages/ConsumerPurposeTemplateEditPage/ConsumerPurposeTemplateEdit.page.tsx
+++ b/src/pages/ConsumerPurposeTemplateEditPage/ConsumerPurposeTemplateEdit.page.tsx
@@ -25,9 +25,10 @@ const ConsumerPurposeTemplateEditPage: React.FC = () => {
     <PurposeCreateContextProvider type="creator" isFromPurposeTemplate={true}>
       <PageContainer
         title={t('edit.emptyTitle')}
-        backToAction={{
-          label: t('backToListBtn'),
-          to: 'SUBSCRIBE_PURPOSE_TEMPLATE_LIST',
+        navigation={{
+          mode: 'wizard',
+          exitAction: { to: 'SUBSCRIBE_PURPOSE_TEMPLATE_LIST' },
+          stepKey: activeStep,
         }}
       >
         <Stepper steps={steps} activeIndex={activeStep} />

--- a/src/pages/ConsumerPurposeTemplateSummaryPage/ConsumerPurposeTemplateSummary.page.tsx
+++ b/src/pages/ConsumerPurposeTemplateSummaryPage/ConsumerPurposeTemplateSummary.page.tsx
@@ -73,10 +73,7 @@ const ConsumerPurposeTemplateTemplateSummaryPage: React.FC = () => {
     <PageContainer
       title={t('edit.summary.title')}
       isLoading={isLoading}
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'SUBSCRIBE_PURPOSE_TEMPLATE_LIST',
-      }}
+      navigation={{ mode: 'back' }}
       statusChip={
         purposeTemplate ? { for: 'purposeTemplate', state: purposeTemplate.state } : undefined
       }

--- a/src/pages/ConsumerSimulateGetVoucherPage/ConsumerSimulateGetVoucherPage.page.tsx
+++ b/src/pages/ConsumerSimulateGetVoucherPage/ConsumerSimulateGetVoucherPage.page.tsx
@@ -14,6 +14,7 @@ const ConsumerDebugVoucherPage: React.FC = () => {
         voucherType: clientKind === 'API' ? tVoucher('pdnd') : tVoucher('eservice'),
       })}
       description={t('description')}
+      navigation={{ mode: 'wizard', exitAction: { to: 'DEVELOPER_TOOLS' } }}
     >
       <VoucherInstructions />
     </PageContainer>

--- a/src/pages/DelegationCreatePage/DelegationCreate.page.tsx
+++ b/src/pages/DelegationCreatePage/DelegationCreate.page.tsx
@@ -28,6 +28,7 @@ export const DelegationCreatePage: React.FC = () => {
       navigation={{
         mode: 'wizard',
         exitAction: { to: 'DELEGATIONS' },
+        hasUnsavedChanges: activeStep === 'KIND' ? delegationKind != null : undefined,
         stepKey: activeStep,
       }}
     >

--- a/src/pages/DelegationCreatePage/DelegationCreate.page.tsx
+++ b/src/pages/DelegationCreatePage/DelegationCreate.page.tsx
@@ -25,9 +25,10 @@ export const DelegationCreatePage: React.FC = () => {
   return (
     <PageContainer
       title={t('delegations.create.title')}
-      backToAction={{
-        label: t('delegations.actions.backToDelegations'),
-        to: 'DELEGATIONS',
+      navigation={{
+        mode: 'wizard',
+        exitAction: { to: 'DELEGATIONS' },
+        stepKey: activeStep,
       }}
     >
       <Stack spacing={2}>

--- a/src/pages/DelegationCreatePage/__tests__/DelegationCreate.page.test.tsx
+++ b/src/pages/DelegationCreatePage/__tests__/DelegationCreate.page.test.tsx
@@ -1,0 +1,25 @@
+import userEvent from '@testing-library/user-event'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { DelegationCreatePage } from '../DelegationCreate.page'
+
+describe('DelegationCreatePage', () => {
+  it('asks for confirmation when exiting after selecting a delegation kind', async () => {
+    const screen = renderWithApplicationContext(<DelegationCreatePage />, {
+      withRouterContext: true,
+      withDialogContext: true,
+    })
+
+    await userEvent.click(
+      screen.getByRole('radio', {
+        name: /delegations\.create\.cards\.consumer/,
+      })
+    )
+    await userEvent.click(screen.getByRole('link', { name: 'exitButton' }))
+
+    expect(
+      screen.getByRole('dialog', {
+        name: 'exitDialog.title',
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/pages/DelegationDetailsPage/DelegationDetails.page.tsx
+++ b/src/pages/DelegationDetailsPage/DelegationDetails.page.tsx
@@ -13,12 +13,10 @@ import { Alert, Link } from '@mui/material'
 import { useDrawerState } from '@/hooks/useDrawerState'
 import { RejectReasonDrawer } from '@/components/shared/RejectReasonDrawer'
 import { useGetDelegationActions } from '@/hooks/useGetDelegationActions'
-import { AuthHooks } from '@/api/auth'
 
 export const DelegationDetailsPage: React.FC = () => {
   const { delegationId } = useParams<'DELEGATION_DETAILS'>()
   const { t } = useTranslation('party', { keyPrefix: 'delegations.details' })
-  const { jwt } = AuthHooks.useJwt()
 
   const { data: delegation, isLoading } = useQuery(
     DelegationQueries.getSingle({ delegationId: delegationId })
@@ -30,18 +28,11 @@ export const DelegationDetailsPage: React.FC = () => {
 
   const { actions } = useGetDelegationActions(delegation)
 
-  const backToDelegationListTabKey =
-    delegation?.delegator.id === jwt?.organizationId ? 'delegationsGranted' : 'delegationsReceived'
-
   return (
     <PageContainer
       title={t('title')}
       isLoading={isLoading}
-      backToAction={{
-        label: t('backToDelegationList'),
-        to: 'DELEGATIONS',
-        urlParams: { tab: backToDelegationListTabKey },
-      }}
+      navigation={{ showBackButton: true }}
       topSideActions={actions}
     >
       {delegation && delegation.state === 'REJECTED' && delegation.rejectionReason && (

--- a/src/pages/KeyDetailsPage/KeyDetails.page.tsx
+++ b/src/pages/KeyDetailsPage/KeyDetails.page.tsx
@@ -3,7 +3,6 @@ import { ClientQueries } from '@/api/client'
 import { PageContainer } from '@/components/layout/containers'
 import { useParams } from '@/router'
 import { Trans, useTranslation } from 'react-i18next'
-import { useClientKind } from '@/hooks/useClientKind'
 import {
   KeyGeneralInfoSectionSkeleton,
   KeyGeneralInfoSection,
@@ -15,13 +14,9 @@ import { useQuery } from '@tanstack/react-query'
 
 const KeyDetailsPage: React.FC = () => {
   const { t } = useTranslation('key')
-  const clientKind = useClientKind()
   const { clientId, kid } = useParams<
     'SUBSCRIBE_INTEROP_M2M_CLIENT_KEY_EDIT' | 'SUBSCRIBE_CLIENT_KEY_EDIT'
   >()
-
-  const backToOperatorsListRouteKey =
-    clientKind === 'API' ? 'SUBSCRIBE_INTEROP_M2M_CLIENT_EDIT' : 'SUBSCRIBE_CLIENT_EDIT'
 
   const { data: publicKey, isLoading } = useQuery(ClientQueries.getSingleKey(clientId, kid))
 
@@ -32,12 +27,7 @@ const KeyDetailsPage: React.FC = () => {
       isLoading={isLoading}
       title={publicKey?.name}
       topSideActions={actions}
-      backToAction={{
-        label: t('backToKeyListBtn'),
-        to: backToOperatorsListRouteKey,
-        params: { clientId },
-        urlParams: { tab: 'publicKeys' },
-      }}
+      navigation={{ showBackButton: true }}
     >
       <React.Suspense fallback={<KeyGeneralInfoSectionSkeleton />}>
         {publicKey?.isOrphan && (

--- a/src/pages/OperatorDetailsPage/OperatorDetails.page.tsx
+++ b/src/pages/OperatorDetailsPage/OperatorDetails.page.tsx
@@ -5,17 +5,12 @@ import {
   OperatorGeneralInfoSection,
   OperatorGeneralInfoSectionSkeleton,
 } from './components/OperatorGeneralInfoSection'
-import { useTranslation } from 'react-i18next'
 import { Grid } from '@mui/material'
-import { useClientKind } from '@/hooks/useClientKind'
 import { useGetClientOperatorsActions } from '@/hooks/useGetClientOperatorsActions'
 import { useQuery } from '@tanstack/react-query'
 import { SelfcareQueries } from '@/api/selfcare'
 
 const OperatorDetailsPage: React.FC = () => {
-  const clientKind = useClientKind()
-  const { t } = useTranslation('user')
-
   const { clientId: clientId, operatorId } = useParams<
     'SUBSCRIBE_INTEROP_M2M_CLIENT_OPERATOR_EDIT' | 'SUBSCRIBE_CLIENT_OPERATOR_EDIT'
   >()
@@ -24,20 +19,12 @@ const OperatorDetailsPage: React.FC = () => {
 
   const { actions } = useGetClientOperatorsActions(operatorId, clientId)
 
-  const backToOperatorsListRouteKey =
-    clientKind === 'API' ? 'SUBSCRIBE_INTEROP_M2M_CLIENT_EDIT' : 'SUBSCRIBE_CLIENT_EDIT'
-
   return (
     <PageContainer
       isLoading={isLoading}
       title={operatorFullname}
       topSideActions={actions}
-      backToAction={{
-        label: t('backToMemberListBtn'),
-        to: backToOperatorsListRouteKey,
-        urlParams: { tab: 'clientOperators' },
-        params: { clientId },
-      }}
+      navigation={{ showBackButton: true }}
     >
       <Grid spacing={2} container>
         <Grid item xs={7}>

--- a/src/pages/ProviderAgreementDetailsPage/ProviderAgreementDetails.page.tsx
+++ b/src/pages/ProviderAgreementDetailsPage/ProviderAgreementDetails.page.tsx
@@ -47,7 +47,7 @@ const ProviderAgreementDetailsPageContent: React.FC = () => {
     <PageContainer
       title={t('providerRead.title')}
       topSideActions={actions}
-      backToAction={{ label: t('backToRequestsBtn'), to: 'PROVIDE_AGREEMENT_LIST' }}
+      navigation={{ showBackButton: true }}
       statusChip={{ for: 'agreement', agreement }}
     >
       {agreement.state === 'PENDING' && isDelegated && (

--- a/src/pages/ProviderEServiceCreatePage/ProviderEServiceCreate.page.tsx
+++ b/src/pages/ProviderEServiceCreatePage/ProviderEServiceCreate.page.tsx
@@ -169,9 +169,10 @@ const ProviderEServiceCreatePage: React.FC = () => {
   return (
     <PageContainer
       {...intro}
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'PROVIDE_ESERVICE_LIST',
+      navigation={{
+        mode: 'wizard',
+        exitAction: { to: 'PROVIDE_ESERVICE_LIST' },
+        stepKey: activeStep,
       }}
       isLoading={!isReady}
     >

--- a/src/pages/ProviderEServiceCreatePage/__tests__/ProviderEServiceCreate.test.tsx
+++ b/src/pages/ProviderEServiceCreatePage/__tests__/ProviderEServiceCreate.test.tsx
@@ -68,6 +68,19 @@ vi.mock('@/api/eserviceTemplate', () => ({
 mockUseParams({})
 
 describe('ProviderEServiceCreatePage', () => {
+  it('renders the wizard exit action', () => {
+    mockUseActiveStep()
+    renderWithApplicationContext(<ProviderEServiceCreatePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByRole('link', { name: 'exitButton' })).toHaveAttribute(
+      'href',
+      '/it/erogazione/e-service'
+    )
+  })
+
   it('should render page with stepper(DELIVER)', () => {
     mockUseActiveStep()
     renderWithApplicationContext(<ProviderEServiceCreatePage />, {

--- a/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/ProviderEServiceDetails.page.tsx
@@ -98,10 +98,7 @@ const ProviderEServiceDetailsPage: React.FC = () => {
       secondaryAction={secondaryAction}
       menuActions={menuActions}
       isLoading={!descriptor}
-      backToAction={{
-        label: t('actions.backToListLabel'),
-        to: 'PROVIDE_ESERVICE_LIST',
-      }}
+      navigation={{ showBackButton: true }}
       infoSection={
         descriptor
           ? {

--- a/src/pages/ProviderEServiceFromTemplateCreatePage/ProviderEServiceFromTemplateCreate.page.tsx
+++ b/src/pages/ProviderEServiceFromTemplateCreatePage/ProviderEServiceFromTemplateCreate.page.tsx
@@ -119,9 +119,10 @@ const ProviderEServiceFromTemplateCreate: React.FC = () => {
           </Trans>
         )
       }
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'PROVIDE_ESERVICE_LIST',
+      navigation={{
+        mode: 'wizard',
+        exitAction: { to: 'PROVIDE_ESERVICE_LIST' },
+        stepKey: activeStep,
       }}
     >
       <Stepper steps={steps} activeIndex={activeStep} />

--- a/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/ProviderEServiceSummary.page.tsx
@@ -357,10 +357,7 @@ const ProviderEServiceSummaryPage: React.FC = () => {
             </Trans>
           ) : undefined
         }
-        backToAction={{
-          label: t('backToListBtn'),
-          to: 'PROVIDE_ESERVICE_LIST',
-        }}
+        navigation={{ mode: 'back' }}
         isLoading={isLoading}
         statusChip={{
           for: 'eservice',

--- a/src/pages/ProviderEServiceTemplateCreatePage/ProviderEServiceTemplateCreate.page.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/ProviderEServiceTemplateCreate.page.tsx
@@ -155,9 +155,10 @@ const ProviderEServiceCreatePage: React.FC = () => {
   return (
     <PageContainer
       {...intro}
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'PROVIDE_ESERVICE_TEMPLATE_LIST',
+      navigation={{
+        mode: 'wizard',
+        exitAction: { to: 'PROVIDE_ESERVICE_TEMPLATE_LIST' },
+        stepKey: activeStep,
       }}
       isLoading={!isReady}
     >

--- a/src/pages/ProviderEServiceTemplateDetailsPage/ProviderEServiceTemplateDetails.page.tsx
+++ b/src/pages/ProviderEServiceTemplateDetailsPage/ProviderEServiceTemplateDetails.page.tsx
@@ -50,10 +50,7 @@ const ProviderEServiceTemplateDetailsPage: React.FC = () => {
             }
           : undefined
       }
-      backToAction={{
-        label: t('actions.backToEserviceTemplateListLabel'),
-        to: 'PROVIDE_ESERVICE_TEMPLATE_LIST',
-      }}
+      navigation={{ showBackButton: true }}
     >
       <TabContext value={activeTab}>
         <TabList onChange={updateActiveTab} aria-label={t('tabs.ariaLabel')} variant="fullWidth">

--- a/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/ProviderEServiceTemplateSummary.page.tsx
@@ -136,10 +136,7 @@ const ProviderEServiceTemplateSummaryPage: React.FC = () => {
           eserviceTemplateName: eserviceTemplate?.eserviceTemplate.name,
           versionEserviceTemplateNumber: eserviceTemplate?.version ?? '1',
         })}
-        backToAction={{
-          label: t('backToListBtn'),
-          to: 'PROVIDE_ESERVICE_TEMPLATE_LIST',
-        }}
+        navigation={{ mode: 'back' }}
         isLoading={isLoading}
         statusChip={{
           for: 'eserviceTemplate',

--- a/src/pages/ProviderKeychainCreatePage/ProviderKeychainCreate.page.tsx
+++ b/src/pages/ProviderKeychainCreatePage/ProviderKeychainCreate.page.tsx
@@ -43,7 +43,11 @@ const ProviderKeychainCreatePage: React.FC = () => {
   return (
     <PageContainer
       title={t('create.title')}
-      navigation={{ mode: 'wizard', exitAction: { to: 'PROVIDE_KEYCHAINS_LIST' } }}
+      navigation={{
+        mode: 'wizard',
+        exitAction: { to: 'PROVIDE_KEYCHAINS_LIST' },
+        hasUnsavedChanges: formMethods.formState.isDirty,
+      }}
     >
       <Box component="form" noValidate onSubmit={formMethods.handleSubmit(onSubmit)}>
         <FormProvider {...formMethods}>

--- a/src/pages/ProviderKeychainCreatePage/ProviderKeychainCreate.page.tsx
+++ b/src/pages/ProviderKeychainCreatePage/ProviderKeychainCreate.page.tsx
@@ -43,10 +43,7 @@ const ProviderKeychainCreatePage: React.FC = () => {
   return (
     <PageContainer
       title={t('create.title')}
-      backToAction={{
-        label: t('create.actions.backToKeychainsLabel'),
-        to: 'PROVIDE_KEYCHAINS_LIST',
-      }}
+      navigation={{ mode: 'wizard', exitAction: { to: 'PROVIDE_KEYCHAINS_LIST' } }}
     >
       <Box component="form" noValidate onSubmit={formMethods.handleSubmit(onSubmit)}>
         <FormProvider {...formMethods}>

--- a/src/pages/ProviderKeychainCreatePage/__tests__/ProviderKeychainCreate.page.test.tsx
+++ b/src/pages/ProviderKeychainCreatePage/__tests__/ProviderKeychainCreate.page.test.tsx
@@ -1,0 +1,29 @@
+import userEvent from '@testing-library/user-event'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import ProviderKeychainCreatePage from '../ProviderKeychainCreate.page'
+
+describe('ProviderKeychainCreatePage', () => {
+  it('asks for confirmation when exiting with unsaved form changes', async () => {
+    mockUseJwt()
+
+    const screen = renderWithApplicationContext(<ProviderKeychainCreatePage />, {
+      withRouterContext: true,
+      withReactQueryContext: true,
+      withDialogContext: true,
+    })
+
+    await userEvent.type(
+      screen.getByRole('textbox', {
+        name: 'create.nameField.label',
+      }),
+      'Test keychain'
+    )
+    await userEvent.click(screen.getByRole('link', { name: 'exitButton' }))
+
+    expect(
+      screen.getByRole('dialog', {
+        name: 'exitDialog.title',
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/pages/ProviderKeychainCreatePage/components/UsersInputTable.tsx
+++ b/src/pages/ProviderKeychainCreatePage/components/UsersInputTable.tsx
@@ -26,11 +26,11 @@ export const UsersInputTable: React.FC = () => {
 
   const handleRemoveUser = (operatorId: string) => {
     const newUsers = users.filter((o) => o.userId !== operatorId)
-    setValue('users', newUsers)
+    setValue('users', newUsers, { shouldDirty: true })
   }
 
   const handleAddUsers = (newUsers: Users) => {
-    setValue('users', [...users, ...newUsers])
+    setValue('users', [...users, ...newUsers], { shouldDirty: true })
   }
 
   const handleOpenAddUsersDrawer = () => {

--- a/src/pages/ProviderKeychainCreatePage/components/__tests__/UsersInputTable.test.tsx
+++ b/src/pages/ProviderKeychainCreatePage/components/__tests__/UsersInputTable.test.tsx
@@ -1,0 +1,53 @@
+import userEvent from '@testing-library/user-event'
+import { FormProvider, useForm } from 'react-hook-form'
+import type { Users } from '@/api/api.generatedTypes'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import type { CreateKeychainFormValues } from '../../ProviderKeychainCreate.page'
+import { UsersInputTable } from '../UsersInputTable'
+
+const user: Users[number] = {
+  userId: 'user-id',
+  tenantId: 'tenant-id',
+  name: 'Mario',
+  familyName: 'Rossi',
+  roles: ['security'],
+}
+
+vi.mock('@/components/shared/AddUsersToKeychainDrawer', () => ({
+  AddUsersToKeychainDrawer: ({
+    isOpen,
+    onSubmit,
+  }: {
+    isOpen: boolean
+    onSubmit: (users: Users) => void
+  }) =>
+    isOpen ? (
+      <button type="button" onClick={() => onSubmit([user])}>
+        Confirm users
+      </button>
+    ) : null,
+}))
+
+const TestForm = () => {
+  const formMethods = useForm<CreateKeychainFormValues>({
+    defaultValues: { name: '', description: '', users: [] },
+  })
+
+  return (
+    <FormProvider {...formMethods}>
+      <UsersInputTable />
+      <output>{formMethods.formState.isDirty ? 'dirty' : 'pristine'}</output>
+    </FormProvider>
+  )
+}
+
+describe('UsersInputTable', () => {
+  it('marks the form as dirty when users are added programmatically', async () => {
+    const screen = renderWithApplicationContext(<TestForm />, {})
+
+    await userEvent.click(screen.getByRole('button', { name: 'addBtn' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm users' }))
+
+    expect(screen.getByText('dirty')).toBeInTheDocument()
+  })
+})

--- a/src/pages/ProviderKeychainDetailsPage/ProviderKeychainDetails.page.tsx
+++ b/src/pages/ProviderKeychainDetailsPage/ProviderKeychainDetails.page.tsx
@@ -56,10 +56,7 @@ const ProviderKeychainDetailsPage: React.FC = () => {
       title={keychain?.name ?? ''}
       topSideActions={actions}
       isLoading={isLoadingKeychain}
-      backToAction={{
-        label: t('actions.backToKeychainsListLabel'),
-        to: 'SUBSCRIBE_CATALOG_LIST',
-      }}
+      navigation={{ showBackButton: true }}
     >
       <TabContext value={activeTab}>
         <TabList onChange={updateActiveTab} aria-label={t('tabs.ariaLabel')} variant="fullWidth">

--- a/src/pages/ProviderKeychainPublicKeyDetailsPage/ProviderKeychainPublicKeyDetails.page.tsx
+++ b/src/pages/ProviderKeychainPublicKeyDetailsPage/ProviderKeychainPublicKeyDetails.page.tsx
@@ -30,12 +30,7 @@ const ProviderKeychainPublicKeyDetailsPage: React.FC = () => {
       isLoading={isLoading}
       title={publicKey?.name}
       topSideActions={actions}
-      backToAction={{
-        label: t('actions.backToKeychainsListLabel'),
-        to: 'PROVIDE_KEYCHAIN_DETAILS',
-        params: { keychainId },
-        urlParams: { tab: 'publicKeys' },
-      }}
+      navigation={{ showBackButton: true }}
     >
       <React.Suspense fallback={<ProviderKeychainPublicKeyDetailsGeneralInfoSectionSkeleton />}>
         {publicKey?.isOrphan && (

--- a/src/pages/ProviderKeychainUserDetailsPage/ProviderKeychainUserDetails.page.tsx
+++ b/src/pages/ProviderKeychainUserDetailsPage/ProviderKeychainUserDetails.page.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { PageContainer } from '@/components/layout/containers'
 import { useParams } from '@/router'
-import { useTranslation } from 'react-i18next'
 import { Grid } from '@mui/material'
 import { useQuery } from '@tanstack/react-query'
 import { useGetProducerKeychainUserActions } from '../ProviderKeychainDetailsPage/hooks/useGetProducerKeychainUserActions'
@@ -12,8 +11,6 @@ import {
 import { SelfcareQueries } from '@/api/selfcare'
 
 const ProviderKeychainUserDetailsPage: React.FC = () => {
-  const { t } = useTranslation('keychain')
-
   const { keychainId, userId } = useParams<'PROVIDE_KEYCHAIN_USER_DETAILS'>()
   const { data: user, isLoading } = useQuery(SelfcareQueries.getSingleUser(userId))
   const operatorFullname = `${user?.name} ${user?.familyName}`
@@ -25,12 +22,7 @@ const ProviderKeychainUserDetailsPage: React.FC = () => {
       isLoading={isLoading}
       title={operatorFullname}
       topSideActions={actions}
-      backToAction={{
-        label: t('actions.backToMemberListLabel'),
-        to: 'PROVIDE_KEYCHAIN_DETAILS',
-        urlParams: { tab: 'members' },
-        params: { keychainId },
-      }}
+      navigation={{ showBackButton: true }}
     >
       <Grid spacing={2} container>
         <Grid item xs={7}>

--- a/src/pages/ProviderPurposeDetailsPage/ProviderPurposeDetails.page.tsx
+++ b/src/pages/ProviderPurposeDetailsPage/ProviderPurposeDetails.page.tsx
@@ -4,7 +4,7 @@ import useGetProviderPurposesActions from '@/hooks/useGetProviderPurposesActions
 import { useMarkNotificationsAsRead } from '@/hooks/useMarkNotificationsAsRead'
 import { useParams } from '@/router'
 import React from 'react'
-import { Trans, useTranslation } from 'react-i18next'
+import { Trans } from 'react-i18next'
 import {
   ProviderPurposeDetailsGeneralInfoSection,
   ProviderPurposeDetailsGeneralInfoSectionSkeleton,
@@ -21,7 +21,6 @@ import { useQuery } from '@tanstack/react-query'
 import { ProviderPurposeDetailsTechnicalInfoSection } from './components/ProviderPurposeDetailsTechnicalInfoSection'
 
 const ProviderPurposeDetailsPage: React.FC = () => {
-  const { t } = useTranslation('purpose')
   const { purposeId } = useParams<'PROVIDE_PURPOSE_DETAILS'>()
 
   const { data: purpose, isLoading } = useQuery(PurposeQueries.getSingle(purposeId))
@@ -40,10 +39,7 @@ const ProviderPurposeDetailsPage: React.FC = () => {
       isLoading={isLoading}
       topSideActions={actions}
       statusChip={purpose ? { for: 'purpose', purpose: purpose } : undefined}
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'PROVIDE_PURPOSE_LIST',
-      }}
+      navigation={{ showBackButton: true }}
     >
       {alertProps && (
         <Alert severity={alertProps.severity} sx={{ mb: 3 }} variant={alertProps.variant}>

--- a/src/pages/RiskAnalysisCompilePage/RiskAnalysisCompile.page.tsx
+++ b/src/pages/RiskAnalysisCompilePage/RiskAnalysisCompile.page.tsx
@@ -66,10 +66,7 @@ const RiskAnalysisCompilePage: React.FC = () => {
     <PageContainer
       title={t('title')}
       isLoading={isLoading}
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'SUBSCRIBE_RISK_ANALYSIS_LIST',
-      }}
+      navigation={{ mode: 'wizard', exitAction: { to: 'SUBSCRIBE_RISK_ANALYSIS_LIST' } }}
     >
       <RequiredTextLabel />
       <Grid container sx={{ mt: 3 }}>

--- a/src/pages/RiskAnalysisEserviceAssociatedPage/RiskAnalysisEServiceAssociated.page.tsx
+++ b/src/pages/RiskAnalysisEserviceAssociatedPage/RiskAnalysisEServiceAssociated.page.tsx
@@ -72,13 +72,7 @@ const RiskAnalysisEServiceAssociatedPageContent: React.FC = () => {
   }
 
   return (
-    <PageContainer
-      backToAction={{
-        label: t('backToEServiceBtn'),
-        to: 'PROVIDE_ESERVICE_MANAGE',
-        params: { eserviceId, descriptorId },
-      }}
-    >
+    <PageContainer navigation={{ showBackButton: true }}>
       <FormProvider {...formMethods}>
         <Box>
           <SectionContainer

--- a/src/pages/RiskAnalysisExporterToolPage/RiskAnalysisExporterTool.page.tsx
+++ b/src/pages/RiskAnalysisExporterToolPage/RiskAnalysisExporterTool.page.tsx
@@ -31,9 +31,10 @@ const RiskAnalysisExporterToolPage: React.FC = () => {
     <PageContainer
       title={t('riskAnalysisExporterTool.page.title')}
       description={t('riskAnalysisExporterTool.page.description')}
-      backToAction={{
-        to: 'DEVELOPER_TOOLS',
-        label: t('backToDeveloperToolsLabel'),
+      navigation={{
+        mode: 'wizard',
+        exitAction: { to: 'DEVELOPER_TOOLS' },
+        stepKey: activeStep,
       }}
     >
       <Alert severity="info" sx={{ my: 2 }}>

--- a/src/pages/RiskAnalysisInfoCompilePage/RiskAnalysisInfoCompile.page.tsx
+++ b/src/pages/RiskAnalysisInfoCompilePage/RiskAnalysisInfoCompile.page.tsx
@@ -29,10 +29,7 @@ const RiskAnalysisInfoCompilePage: React.FC = () => {
     <PageContainer
       title={t('title')}
       isLoading={isLoading}
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'SUBSCRIBE_RISK_ANALYSIS_LIST',
-      }}
+      navigation={{ mode: 'wizard', exitAction: { to: 'SUBSCRIBE_RISK_ANALYSIS_LIST' } }}
     >
       <Grid container sx={{ mt: 3 }}>
         <Grid item xs={12}>

--- a/src/pages/RiskAnalysisSummaryPage/RiskAnalysisSummary.page.tsx
+++ b/src/pages/RiskAnalysisSummaryPage/RiskAnalysisSummary.page.tsx
@@ -44,10 +44,7 @@ const RiskAnalysisSummaryPage: React.FC = () => {
     <PageContainer
       title={isApprovalFlow ? t('titleApproval') : t('titleSummary')}
       isLoading={isLoading}
-      backToAction={{
-        label: t('backToListBtn'),
-        to: 'SUBSCRIBE_RISK_ANALYSIS_LIST',
-      }}
+      navigation={{ mode: 'back' }}
     >
       {alertProps && <Alert sx={{ mb: 3 }} {...alertProps} />}
 

--- a/src/pages/TenantCertifierAttributeDetailsPage/TenantCertifierAttributeDetails.page.tsx
+++ b/src/pages/TenantCertifierAttributeDetailsPage/TenantCertifierAttributeDetails.page.tsx
@@ -12,7 +12,6 @@ import React, { Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const TenantCertifierAttributeDetails: React.FC = () => {
-  const { t } = useTranslation('party', { keyPrefix: 'tenantCertifier.attributeDetails' })
   const { attributeId } = useParams<'TENANT_CERTIFIER_ATTRIBUTE_DETAILS'>()
 
   const { data: attributeName = '', isLoading } = useQuery({
@@ -24,10 +23,7 @@ const TenantCertifierAttributeDetails: React.FC = () => {
     <PageContainer
       title={attributeName}
       isLoading={isLoading}
-      backToAction={{
-        label: t('backToTenantCertifierBtn'),
-        to: 'TENANT_CERTIFIER',
-      }}
+      navigation={{ showBackButton: true }}
     >
       <Grid container>
         <Grid item xs={8}>

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -569,6 +569,15 @@
     "notAvailableYet": "The document will be available soon"
   },
   "requiredLabel": "*Required fields.",
+  "pageNavigation": {
+    "backButton": "Back",
+    "exitButton": "Exit",
+    "exitDialog": {
+      "title": "Do you want to exit?",
+      "description": "Any unsaved changes will be lost. Do you want to exit the flow?",
+      "confirmButton": "Exit"
+    }
+  },
   "routeLabels": {
     "LOGOUT": "Logout",
     "TOS": "Terms of Service",

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -570,6 +570,16 @@
 
   "requiredLabel": "*Campi obbligatori",
 
+  "pageNavigation": {
+    "backButton": "Indietro",
+    "exitButton": "Esci",
+    "exitDialog": {
+      "title": "Vuoi uscire?",
+      "description": "Le modifiche non salvate andranno perse. Vuoi uscire dal flusso?",
+      "confirmButton": "Esci"
+    }
+  },
+
   "routeLabels": {
     "LOGOUT": "Logout",
     "TOS": "Termini di servizio",


### PR DESCRIPTION
## 🔗 Issue

[PIN-10713](https://pagopa.atlassian.net/browse/PIN-10713)

## 📝 Description / Context

This PR standardizes page navigation across wizard, summary, and detail pages, aligning back navigation and breadcrumbs with the updated design.

Wizard flows now expose a dedicated exit action, summary pages use browser-history navigation, and detail pages display both the back action and architectural breadcrumbs.

## 🛠 List of changes

- Added a shared page navigation component supporting wizard, summary, and detail page variants.
- Replaced breadcrumbs with an “Exit” action across single-step and multi-step wizard flows.
- Added an unsaved-changes confirmation dialog when leaving a modified wizard step.
- Allowed users to leave an untouched wizard directly, without displaying the confirmation dialog.
- Reset the unsaved-changes state when moving between wizard steps.
- Configured summary pages to show only the browser-history “Back” action.
- Configured detail pages to show “Back” and breadcrumbs on separate rows.
- Updated breadcrumbs so macro-sections are visible but not clickable, intermediate pages are clickable, and the current page is not clickable.
- Migrated affected pages to the new navigation API.
- Added and updated tests covering the new navigation behavior.

## 🧪 How to test

- Open a wizard flow, such as purpose creation, e-service creation, client creation, keychain creation, delegation creation, risk analysis, or voucher simulation:
  - Verify that only the “Exit” action is displayed, without breadcrumbs or a back action.
  - Select “Exit” without changing any field and verify that the flow closes immediately.
  - Change a field and select “Exit”; verify that the unsaved-changes confirmation dialog is displayed.
  - Cancel the dialog and verify that the user remains in the current flow.
  - Confirm the exit and verify that the wizard is closed without preserving the current unsaved changes.
- Open a summary page, such as a purpose or e-service summary, and verify that only “Back” is displayed and returns to the previous browser-history entry.
- Open a detail page, such as a purpose, e-service, or agreement detail:
  - Verify that “Back” and breadcrumbs are displayed on separate rows.
  - Verify that “Back” follows the user navigation history.
  - Verify that the macro-section breadcrumb is not clickable.
  - Verify that intermediate breadcrumbs navigate to their corresponding index pages.
  - Verify that the current page breadcrumb is not clickable.

[PIN-10713]: https://pagopa.atlassian.net/browse/PIN-10713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ