### PR TITLE
bugfix: fix typo in CreateAttributeDrawer and order fields in AssignAttributeDrawer (PIN-10722, PIN-10723)

### DIFF
--- a/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
+++ b/src/pages/TenantCertifierPage/components/AssignAttributesTab/AssignAttributeDrawer.tsx
@@ -156,6 +156,15 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
       >
         <Stack component="form" noValidate spacing={3}>
           <RHFAutocompleteSingle
+            label={t('form.tenantField.label')}
+            size="small"
+            onInputChange={(_, value) => setTenantSearchParam(value)}
+            sx={{ mb: 0, flex: 1 }}
+            options={tenantOptions}
+            name="tenant"
+            rules={{ required: true }}
+          />
+          <RHFAutocompleteSingle
             label={t('form.attributeField.label')}
             size="small"
             onInputChange={(_, value) => setAttributeSearchParam(value)}
@@ -165,15 +174,6 @@ export const AssignAttributeDrawer: React.FC<AssignAttributeDrawerProps> = ({
             focusOnMount
             name="attribute"
             aria-controls={isSelectedAttributeCertifiedDiscrete ? 'value-field' : undefined}
-            rules={{ required: true }}
-          />
-          <RHFAutocompleteSingle
-            label={t('form.tenantField.label')}
-            size="small"
-            onInputChange={(_, value) => setTenantSearchParam(value)}
-            sx={{ mb: 0, flex: 1 }}
-            options={tenantOptions}
-            name="tenant"
             rules={{ required: true }}
           />
           {isSelectedAttributeCertifiedDiscrete && (

--- a/src/static/locales/en/party.json
+++ b/src/static/locales/en/party.json
@@ -78,7 +78,7 @@
       },
       "drawer": {
         "title": "Create new certified attribute",
-        "subtitle": "Once created, you can assign and revoke this attribute to other parties",
+        "subtitle": "Once created, you can assign and revoke this attribute to other parties.",
         "submitBtnLabel": "Create attribute",
         "form": {
           "kindField": {

--- a/src/static/locales/it/party.json
+++ b/src/static/locales/it/party.json
@@ -78,7 +78,7 @@
       },
       "drawer": {
         "title": "Crea nuovo attributo certificato",
-        "subtitle": "Una volta creato, potrai assegnare e revocare questo attributo agli altri enti",
+        "subtitle": "Una volta creato, potrai assegnare e revocare questo attributo agli altri enti.",
         "submitBtnLabel": "Crea attributo",
         "form": {
           "kindField": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10722](https://pagopa.atlassian.net/browse/PIN-10722)
[PIN-10723](https://pagopa.atlassian.net/browse/PIN-10723)

## 📝 Description / Context

This PR fix a typo for a . in CreateAttributeDrawer subtitle and fix the positioning of attributeName and tenant fields in AssignAttributeDrawer

## 🛠 List of changes

- fix the strings for subtitle in CreateAttributeDrawer
- fix positioning in AssignAttributeDrawer


[PIN-10722]: https://pagopa.atlassian.net/browse/PIN-10722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-10723]: https://pagopa.atlassian.net/browse/PIN-10723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ