### PR TITLE
fix/PIN-10719: gracePeriodField title label changing color on radio selection

### DIFF
--- a/src/components/shared/GracePeriodField.tsx
+++ b/src/components/shared/GracePeriodField.tsx
@@ -7,7 +7,6 @@ import React from 'react'
 import { useWatch } from 'react-hook-form'
 import { Trans, useTranslation } from 'react-i18next'
 import { RHFRadioGroup } from './react-hook-form-inputs'
-import { theme } from '@pagopa/mui-italia'
 
 type GracePeriodFieldProps = {
   description?: string
@@ -44,15 +43,12 @@ export const GracePeriodField: React.FC<GracePeriodFieldProps> = ({ description 
               </Typography>
             </Stack>
           ) : (
-            t('label')
+            <Typography component="span" variant="body1" fontWeight={600}>
+              {t('label')}
+            </Typography>
           )
         }
         options={options}
-        sx={{
-          '& .MuiFormLabel-root': {
-            color: theme.palette.text.primary,
-          },
-        }}
       />
       <Typography variant="body2">
         <Trans

--- a/src/components/shared/GracePeriodField.tsx
+++ b/src/components/shared/GracePeriodField.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import { useWatch } from 'react-hook-form'
 import { Trans, useTranslation } from 'react-i18next'
 import { RHFRadioGroup } from './react-hook-form-inputs'
+import { theme } from '@pagopa/mui-italia'
 
 type GracePeriodFieldProps = {
   description?: string
@@ -47,6 +48,11 @@ export const GracePeriodField: React.FC<GracePeriodFieldProps> = ({ description 
           )
         }
         options={options}
+        sx={{
+          '& .MuiFormLabel-root': {
+            color: theme.palette.text.primary,
+          },
+        }}
       />
       <Typography variant="body2">
         <Trans

--- a/src/components/shared/GracePeriodField.tsx
+++ b/src/components/shared/GracePeriodField.tsx
@@ -33,20 +33,16 @@ export const GracePeriodField: React.FC<GracePeriodFieldProps> = ({ description 
       <RHFRadioGroup
         name="gracePeriodDays"
         label={
-          description ? (
-            <Stack component="span">
-              <Typography component="span" variant="inherit">
-                {t('label')}
-              </Typography>
-              <Typography component="span" variant="body2" fontWeight={400}>
-                {description}
-              </Typography>
-            </Stack>
-          ) : (
+          <Stack component="span">
             <Typography component="span" variant="body1" fontWeight={600}>
               {t('label')}
             </Typography>
-          )
+            {description && (
+              <Typography component="span" variant="body2" fontWeight={400}>
+                {description}
+              </Typography>
+            )}
+          </Stack>
         }
         options={options}
       />


### PR DESCRIPTION
## 🔗 Issue

[PIN-10719](https://pagopa.atlassian.net/browse/PIN-10719)

## 📝 Description / Context

In the archive dialogs (DialogArchiveVersion and DialogArchiveEservice) the radiogroup title color changes from black to blue after a selection. 

The ticket part describing the title as not bold and gray must not be considered as of now. 
It's being discussed with design.

## 🛠 List of changes

- GracePeriodField: label color wasn't always set, causing the selection focus to override its color

## 🧪 How to test

Steps to reproduce
A provider creates an e-service.
View the e-service and select from the three-dot menu > Archive e-service.
The modal for selecting the notice period is displayed.
Or:
A provider creates an e-service.
A consumer has an active fruition request towards the first descriptor.
The provider publishes a new version of the e-service.
The provider clicks "Archive version" in the view of the first descriptor.
The modal for selecting the notice period is displayed.


[PIN-10719]: https://pagopa.atlassian.net/browse/PIN-10719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ