### PR TITLE
fix: show allowed upload file extensions (PIN-10714)

### DIFF
--- a/src/components/shared/UploadDocumentsInterface.tsx
+++ b/src/components/shared/UploadDocumentsInterface.tsx
@@ -5,6 +5,7 @@ import type { SxProps, Theme } from '@mui/material'
 import { Box, Button, Stack } from '@mui/material'
 import SaveIcon from '@mui/icons-material/Save'
 import { useTranslation } from 'react-i18next'
+import type { EServiceTechnology } from '@/api/api.generatedTypes'
 
 type UploadDocumentsInterfaceFormValues = {
   interfaceDoc: File | null
@@ -15,6 +16,7 @@ type UploadDocumentsInterfaceProps = {
   sxBox?: SxProps<Theme>
   error?: string
   dropzoneLabel?: string
+  technology?: EServiceTechnology
 }
 
 export const UploadDocumentsInterface: React.FC<UploadDocumentsInterfaceProps> = ({
@@ -22,6 +24,7 @@ export const UploadDocumentsInterface: React.FC<UploadDocumentsInterfaceProps> =
   sxBox,
   error,
   dropzoneLabel,
+  technology = 'REST',
 }) => {
   const { t } = useTranslation('eservice')
   const { t: tCommon } = useTranslation('common')
@@ -52,6 +55,7 @@ export const UploadDocumentsInterface: React.FC<UploadDocumentsInterfaceProps> =
           rules={{ required: true }}
           data-testid="fileInput"
           dropzoneLabel={dropzoneLabel ?? t('create.step4.interface.dropzoneLabel')}
+          fileType={technology === 'REST' ? 'rest' : 'soap'}
         />
 
         {selectedInterface && (

--- a/src/components/shared/__tests__/UploadDocumentsInterface.test.tsx
+++ b/src/components/shared/__tests__/UploadDocumentsInterface.test.tsx
@@ -9,7 +9,7 @@ const file = new File(['testFile'], 'testFile.pdf', { type: 'document/pdf' })
 
 describe('UploadDocumentsInterface', () => {
   it('renders the form with file input and submit button hidden initially', () => {
-    render(<UploadDocumentsInterface onSubmit={mockSubmit} />)
+    render(<UploadDocumentsInterface onSubmit={mockSubmit} technology="REST" />)
 
     // Check that the file input is rendered
     const fileInput = screen.getByTestId('fileInput')
@@ -22,7 +22,7 @@ describe('UploadDocumentsInterface', () => {
 
   it('shows the submit button when a file is ready to be uploaded', async () => {
     const user = userEvent.setup()
-    render(<UploadDocumentsInterface onSubmit={mockSubmit} />)
+    render(<UploadDocumentsInterface onSubmit={mockSubmit} technology="REST" />)
 
     const fileInput = screen.getByTestId('fileInput').querySelector('input')!
 
@@ -35,7 +35,7 @@ describe('UploadDocumentsInterface', () => {
 
   it('calls onSubmit with userEvent', async () => {
     const user = userEvent.setup()
-    render(<UploadDocumentsInterface onSubmit={mockSubmit} />)
+    render(<UploadDocumentsInterface onSubmit={mockSubmit} technology="REST" />)
 
     const fileInput = screen.getByTestId('fileInput').querySelector('input')!
 
@@ -45,5 +45,20 @@ describe('UploadDocumentsInterface', () => {
     await user.click(submitButton)
 
     await waitFor(() => expect(mockSubmit).toHaveBeenCalled())
+  })
+
+  it.each([
+    {
+      technology: 'REST' as const,
+      expected: 'dropzone.allowedExtensions.rest',
+    },
+    {
+      technology: 'SOAP' as const,
+      expected: 'dropzone.allowedExtensions.soap',
+    },
+  ])('shows the allowed extensions for $technology interfaces', ({ technology, expected }) => {
+    render(<UploadDocumentsInterface onSubmit={mockSubmit} technology={technology} />)
+
+    expect(screen.getByText(expected)).toBeInTheDocument()
   })
 })

--- a/src/components/shared/react-hook-form-inputs/RHFSingleFileInput.tsx
+++ b/src/components/shared/react-hook-form-inputs/RHFSingleFileInput.tsx
@@ -23,6 +23,7 @@ export type RHFSingleFileInputProps = Omit<
   onValueChange?: (value: File | null) => void
   drawerStyle?: boolean
   dropzoneLabel?: string
+  fileType?: 'generic' | 'rest' | 'soap' | 'eserviceImport'
 }
 
 export const RHFSingleFileInput: React.FC<RHFSingleFileInputProps> = ({
@@ -33,6 +34,7 @@ export const RHFSingleFileInput: React.FC<RHFSingleFileInputProps> = ({
   onValueChange,
   drawerStyle = false,
   dropzoneLabel,
+  fileType = 'generic',
   ...props
 }) => {
   const { t } = useTranslation('shared-components', { keyPrefix: 'singleFileInput' })
@@ -47,7 +49,11 @@ export const RHFSingleFileInput: React.FC<RHFSingleFileInputProps> = ({
   }
 
   return (
-    <InputWrapper error={error} sx={sx} infoLabel={infoLabel}>
+    <InputWrapper
+      error={error}
+      sx={sx}
+      infoLabel={infoLabel ?? t(`dropzone.allowedExtensions.${fileType}`)}
+    >
       <Controller
         name={name}
         rules={mapValidationErrorMessages(rules, tCommon)}

--- a/src/components/shared/react-hook-form-inputs/__tests__/RHFSingleFileInput.test.tsx
+++ b/src/components/shared/react-hook-form-inputs/__tests__/RHFSingleFileInput.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { TestInputWrapper } from '@/components/shared/react-hook-form-inputs/__tests__/test-utils'
 import { RHFSingleFileInput } from '@/components/shared/react-hook-form-inputs'
@@ -70,5 +70,25 @@ describe('determine whether the integration between react-hook-form and MUI’s 
     })
 
     expect(fileInput.files![0]).toEqual(null)
+  })
+
+  it('shows the allowed extensions for generic documents', () => {
+    render(
+      <TestInputWrapper>
+        <RHFSingleFileInput {...singleFileInputProps} />
+      </TestInputWrapper>
+    )
+
+    expect(screen.getByText('dropzone.allowedExtensions.generic')).toBeInTheDocument()
+  })
+
+  it('shows the allowed extension for eservice imports', () => {
+    render(
+      <TestInputWrapper>
+        <RHFSingleFileInput {...singleFileInputProps} fileType="eserviceImport" />
+      </TestInputWrapper>
+    )
+
+    expect(screen.getByText('dropzone.allowedExtensions.eserviceImport')).toBeInTheDocument()
   })
 })

--- a/src/pages/ProviderEServiceCreatePage/components/components/UploadCallbackInterfaceDoc.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/components/UploadCallbackInterfaceDoc.tsx
@@ -61,6 +61,7 @@ export const UploadCallbackInterfaceDoc: React.FC<UploadCallbackInterfaceDocProp
         sxBox={{ py: 2 }}
         error={error}
         dropzoneLabel={t('callbackInterface.dropzoneLabel')}
+        technology={descriptor?.eservice.technology}
       />
     ))
     .with({ readOnly: false, actualInterface: P.not(null) }, ({ actualInterface }) => (

--- a/src/pages/ProviderEServiceCreatePage/components/components/UploadInterfaceDoc.tsx
+++ b/src/pages/ProviderEServiceCreatePage/components/components/UploadInterfaceDoc.tsx
@@ -42,5 +42,12 @@ export const UploadInterfaceDoc: React.FC<UploadInterfaceDocProps> = ({ error })
     )
   }
 
-  return <UploadDocumentsInterface onSubmit={onSubmit} sxBox={{ py: 2 }} error={error} />
+  return (
+    <UploadDocumentsInterface
+      onSubmit={onSubmit}
+      sxBox={{ py: 2 }}
+      error={error}
+      technology={descriptor?.eservice.technology}
+    />
+  )
 }

--- a/src/pages/ProviderEServiceListPage/components/ProviderEServiceImportVersionDrawer.tsx
+++ b/src/pages/ProviderEServiceListPage/components/ProviderEServiceImportVersionDrawer.tsx
@@ -109,6 +109,7 @@ export const ProviderEServiceImportVersionDrawer: React.FC<
             name="eserviceFile"
             rules={{ required: true }}
             drawerStyle
+            fileType="eserviceImport"
           />
 
           {eserviceFile && (

--- a/src/pages/ProviderEServiceListPage/components/__tests__/ProviderEServiceImportVersionDrawer.test.tsx
+++ b/src/pages/ProviderEServiceListPage/components/__tests__/ProviderEServiceImportVersionDrawer.test.tsx
@@ -1,0 +1,21 @@
+import { screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { ProviderEServiceImportVersionDrawer } from '../ProviderEServiceImportVersionDrawer'
+
+vi.mock('@/api/eservice', () => ({
+  EServiceMutations: {
+    useImportVersion: () => ({ mutate: vi.fn() }),
+  },
+}))
+
+describe('ProviderEServiceImportVersionDrawer', () => {
+  it('shows zip as the allowed extension', () => {
+    renderWithApplicationContext(<ProviderEServiceImportVersionDrawer isOpen onClose={vi.fn()} />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.getByText('dropzone.allowedExtensions.eserviceImport')).toBeInTheDocument()
+  })
+})

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateCreateStepTechnicalSpecsInterface.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/EServiceTemplateCreateStepTechnicalSpecsInterface.tsx
@@ -67,5 +67,10 @@ export function EServiceTemplateCreateStepTechnicalSpecsInterface() {
     )
   }
 
-  return <UploadDocumentsInterface onSubmit={onSubmit} />
+  return (
+    <UploadDocumentsInterface
+      onSubmit={onSubmit}
+      technology={eserviceTemplateVersion?.eserviceTemplate.technology}
+    />
+  )
 }

--- a/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/UploadTemplateCallbackInterfaceDoc.tsx
+++ b/src/pages/ProviderEServiceTemplateCreatePage/components/EServiceTemplateCreateStepTechnicalSpecs/UploadTemplateCallbackInterfaceDoc.tsx
@@ -69,6 +69,7 @@ export const UploadTemplateCallbackInterfaceDoc: React.FC = () => {
         onSubmit={onSubmit}
         sxBox={{ py: 2 }}
         dropzoneLabel={t('callbackInterface.dropzoneLabel')}
+        technology={eserviceTemplateVersion?.eserviceTemplate.technology}
       />
     ))
     .with(P.not(null), (actualInterface) => (

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -371,7 +371,13 @@
   "singleFileInput": {
     "dropzone": {
       "button": "Upload file",
-      "label": "Drag the file here or click to select it from your computer"
+      "label": "Drag the file here or click to select it from your computer",
+      "allowedExtensions": {
+        "generic": "You can only upload files with extension .pdf, .json, .md, .yaml, .yml, .txt, .xsd, .wsdl, .xml",
+        "rest": "You can only upload files with extension .yaml, .json",
+        "soap": "You can only upload files with extension .wsdl, .xml",
+        "eserviceImport": "You can only upload files with extension .zip"
+      }
     },
     "loadingLabel": "Uploading..."
   },

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -371,7 +371,13 @@
   "singleFileInput": {
     "dropzone": {
       "button": "Carica il file",
-      "label": "Trascina qui il file o clicca qui per selezionarlo dal tuo computer"
+      "label": "Trascina qui il file o clicca qui per selezionarlo dal tuo computer",
+      "allowedExtensions": {
+        "generic": "Puoi caricare solo file con estensione .pdf, .json, .md, .yaml, .yml, .txt, .xsd, .wsdl, .xml",
+        "rest": "Puoi caricare solo file con estensione .yaml, .json",
+        "soap": "Puoi caricare solo file con estensione .wsdl, .xml",
+        "eserviceImport": "Puoi caricare solo file con estensione .zip"
+      }
     },
     "loadingLabel": "Caricamento in corso..."
   },


### PR DESCRIPTION
## 🔗 Issue

[PIN-10714](https://pagopa.atlassian.net/browse/PIN-10714)

## 📝 Description / Context

Add clear microcopy below file upload components to inform users which file extensions are supported in each flow.

## 🛠 List of changes

- Added allowed-extension hints for REST and SOAP interfaces.
- Added the `.zip` extension hint to the e-service import drawer.
- Added the supported extensions hint to generic document uploads.
- Added Italian and English translations.
- Added focused test coverage for all upload variants.

## 🧪 How to test

- Open the technical specifications of a REST e-service or e-service template and verify that the upload area shows `.yaml, .json`.
- Repeat with a SOAP e-service or template and verify that it shows `.wsdl, .xml`.
- Open the e-service import drawer and verify that the upload area shows `.zip`.
- Open a generic document upload area and verify that it shows `.pdf, .json, .md, .yaml, .yml, .txt, .xsd, .wsdl, .xml`.
- Verify the same hints for callback interface uploads where available.

[PIN-10714]: https://pagopa.atlassian.net/browse/PIN-10714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ