### PR TITLE
chore: add role checkbox to RiskAnalysisCheckboxGroup (A2-2625)

### DIFF
--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisCheckboxGroup.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisCheckboxGroup.tsx
@@ -90,6 +90,7 @@ export const RiskAnalysisCheckboxGroup: React.FC<RiskAnalysisCheckboxGroupProps>
                     value={o.value}
                     control={
                       <Checkbox
+                        role="checkbox"
                         checked={field.value?.includes(o.value) ?? false}
                         onChange={onChange}
                         name={String(o.value)}

--- a/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisCheckboxGroup.tsx
+++ b/src/components/shared/RiskAnalysisFormComponents/RiskAnalysisCheckboxGroup.tsx
@@ -91,6 +91,7 @@ export const RiskAnalysisCheckboxGroup: React.FC<RiskAnalysisCheckboxGroupProps>
                     control={
                       <Checkbox
                         role="checkbox"
+                        aria-checked={field.value?.includes(o.value) ?? false}
                         checked={field.value?.includes(o.value) ?? false}
                         onChange={onChange}
                         name={String(o.value)}


### PR DESCRIPTION
## 🔗 Issue

[A2-2625](https://pagopa.atlassian.net/browse/A2-2625)

## 📝 Description / Context

The checkbox options list is not contained within a group. Checkbox boxes should be grouped so that they can be announced as a list of various selectable items

This pull request introduces a small improvement in accessibility to the 'RiskAnalysisCheckboxGroup' component by explicitly setting the 'role' attribute on the 'Checkbox' element so that the screen reader announces that they are part of a group.


## 🧪 How to test

- Go to the risk analysis step in the create purpose flow
- Activate the screen reader and go to one of the checkboxes
- The screen reader will now announce on the individual options that it is part of the group


[A2-2625]: https://pagopa.atlassian.net/browse/A2-2625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ