### PR TITLE
fix: agreement alert labels

### DIFF
--- a/src/static/locales/en/agreement.json
+++ b/src/static/locales/en/agreement.json
@@ -134,7 +134,7 @@
     "versionAlert": {
       "deprecatedActive": "This e-service version is obsolete but still active. A new version is available.",
       "deprecatedActiveShort": "This e-service version is obsolete but still active.",
-      "archivingDescriptor": "This e-service version will be archived on {{date}}. After that date, you will only be able to use the new version to exchange data with the e-service.",
+      "archivingDescriptor": "This e-service will be archived on {{date}}. After that date, you will no longer be able to exchange data with the e-service.",
       "archivingSuspendedDescriptor": "This e-service version will be archived on {{date}}. It is currently suspended and cannot be used. A new version is available.",
       "suspendedLast": "This e-service version is currently suspended and cannot be used.",
       "suspendedLastNoNewVersion": "This e-service version is currently suspended and cannot be used. No new version is available.",

--- a/src/static/locales/it/agreement.json
+++ b/src/static/locales/it/agreement.json
@@ -134,7 +134,7 @@
     "versionAlert": {
       "deprecatedActive": "Questa versione dell’e-service è obsoleta, ma è ancora attiva. È disponibile una nuova versione.",
       "deprecatedActiveShort": "Questa versione dell’e-service è obsoleta, ma è ancora attiva.",
-      "archivingDescriptor": "Questa versione dell’e-service sarà archiviata il giorno {{date}}. Dopo questa data potrai utilizzare solo la nuova versione per scambiare dati con l’e-service.",
+      "archivingDescriptor": "Questo e-service sarà archiviato il giorno {{date}}. Dopo questa data non potrai più scambiare dati con l’e-service.",
       "archivingSuspendedDescriptor": "Questa versione dell’e-service sarà archiviata il giorno {{date}}. Al momento è sospesa e non può essere utilizzata. È disponibile una nuova versione.",
       "suspendedLast": "Questa versione dell’e-service è al momento sospesa e non può essere utilizzata.",
       "suspendedLastNoNewVersion": "Questa versione dell’e-service è al momento sospesa e non può essere utilizzata. Non è disponibile una nuova versione.",

--- a/src/utils/__tests__/agreement.utils.test.ts
+++ b/src/utils/__tests__/agreement.utils.test.ts
@@ -247,7 +247,7 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
 
   it('returns single info alert for DEPRECATED', () => {
     expect(getConsumerAgreementVersionAlertSpec({ ...baseArgs, state: 'DEPRECATED' })).toEqual([
-      { severity: 'info', content: 'deprecatedActive' },
+      { severity: 'info', content: 'deprecatedActiveShort' },
     ])
   })
 

--- a/src/utils/agreement.utils.ts
+++ b/src/utils/agreement.utils.ts
@@ -147,7 +147,9 @@ export function getConsumerAgreementVersionAlertSpec(args: {
 
   return match({ state, scope })
     .returnType<ConsumerAgreementVersionAlertSpec[]>()
-    .with({ state: 'DEPRECATED' }, () => [{ severity: 'info', content: t('deprecatedActive') }])
+    .with({ state: 'DEPRECATED' }, () => [
+      { severity: 'info', content: t('deprecatedActiveShort') },
+    ])
     .with({ state: 'ARCHIVING', scope: 'DESCRIPTOR' }, () => [
       { severity: 'warning', content: t('archivingDescriptor', { date: scheduledDate }) },
     ])


### PR DESCRIPTION
## 🔗 Issue

[PIN-10665](https://pagopa.atlassian.net/browse/PIN-10665)

## 📝 Description / Context

Copy fixes for the archiving warning alerts shown to consumers.

## 🛠 List of changes

- **IT + EN `archivingDescriptor`**: updated copy — removed reference to "new version" and clarified that after the archiving date data exchange will no longer be possible
- **agreement.utils.ts**: DEPRECATED alert now uses `deprecatedActiveShort` instead of `deprecatedActive`
- **agreement.utils.test.ts**: updated stale assertion to match the new key (`deprecatedActive` → `deprecatedActiveShort`)

## 🧪 How to test

1. As a consumer with an active agreement on an e-service in `ARCHIVING` state (scope `DESCRIPTOR`) → verify the alert shows the updated copy without the reference to the new version
2. As a consumer with an active agreement on a `DEPRECATED` e-service version → verify the alert shows the short copy (without the "a new version is available" sentence)

[PIN-10665]: https://pagopa.atlassian.net/browse/PIN-10665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ