### PR TITLE
feat: admin clone purpose action (PIN-10677)

### DIFF
--- a/src/components/dialogs/DialogClonePurpose/DialogClonePurpose.tsx
+++ b/src/components/dialogs/DialogClonePurpose/DialogClonePurpose.tsx
@@ -67,7 +67,7 @@ export const DialogClonePurpose: React.FC<DialogClonePurposeProps> = ({ purposeI
       { purposeId: purposeId, eserviceId: eserviceId },
       {
         onSuccess({ purposeId }) {
-          navigate('SUBSCRIBE_PURPOSE_SUMMARY', { params: { purposeId } })
+          navigate('SUBSCRIBE_PURPOSE_EDIT', { params: { purposeId } })
           closeDialog()
         },
       }


### PR DESCRIPTION
## 🔗 Issue

[PIN-10677](https://pagopa.atlassian.net/browse/PIN-10677)

## 📝 Description / Context

When the user clicks the button to clone the purpose, he should be redirected to the first step of the edit flow, not the summary page.

## 🛠 List of changes

- Replaced navigation form 'SUBSCRIBE_PURPOSE_SUMMARY'  to 'SUBSCRIBE_PURPOSE_EDIT' in DialogClonePurpose

## 🧪 How to test

In the forwarded purpose table or on the purpose detail page, click the "Duplicate" button. The user must be redirected in the first step of the edit flow.


[PIN-10677]: https://pagopa.atlassian.net/browse/PIN-10677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ