### PR TITLE
Feature/pin 10689 admin modifiche su step di assegnazione

### DIFF
--- a/src/api/purpose/purpose.mutations.ts
+++ b/src/api/purpose/purpose.mutations.ts
@@ -219,16 +219,40 @@ function useCreateDraftFromPurposeTemplate() {
   })
 }
 
-function useAssignRiskAnalysisReviewer({ showSuccessToast }: { showSuccessToast: boolean }) {
-  const { t } = useTranslation('mutations-feedback', {
-    keyPrefix: 'purpose.assignRiskAnalysisReviewer',
-  })
+/**
+ * Feedback variant for the risk analysis assignment mutation:
+ *  - `none`: first assignment in the self-compilation modes, which give no success feedback
+ *  - `create`: first assignment in the reviewer-compilation mode
+ *  - `edit`: any change to an assignment that already exists
+ */
+export type AssignRiskAnalysisReviewerFeedback = 'none' | 'create' | 'edit'
+
+function useAssignRiskAnalysisReviewer({
+  feedback,
+}: {
+  feedback: AssignRiskAnalysisReviewerFeedback
+}) {
+  const { t } = useTranslation('mutations-feedback', { keyPrefix: 'purpose' })
+
+  const labels =
+    feedback === 'edit'
+      ? {
+          success: t('updateRiskAnalysisAssignment.outcome.success'),
+          error: t('updateRiskAnalysisAssignment.outcome.error'),
+          loading: t('updateRiskAnalysisAssignment.loading'),
+        }
+      : {
+          success: t('assignRiskAnalysisReviewer.outcome.success'),
+          error: t('assignRiskAnalysisReviewer.outcome.error'),
+          loading: t('assignRiskAnalysisReviewer.loading'),
+        }
+
   return useMutation({
     mutationFn: PurposeServices.assignRiskAnalysisReviewer,
     meta: {
-      successToastLabel: showSuccessToast ? t('outcome.success') : undefined,
-      errorToastLabel: t('outcome.error'),
-      loadingLabel: t('loading'),
+      successToastLabel: feedback === 'none' ? undefined : labels.success,
+      errorToastLabel: labels.error,
+      loadingLabel: labels.loading,
     },
   })
 }

--- a/src/components/dialogs/Dialog.tsx
+++ b/src/components/dialogs/Dialog.tsx
@@ -28,6 +28,7 @@ import type {
   DialogSelectAgreementConsumerProps,
   DialogRequestPurposeApprovalProps,
   DialogRequestRiskAnalysisCompilationProps,
+  DialogEditRiskAnalysisAssignmentProps,
   DialogApproveRiskAnalysisProps,
   DialogRejectRiskAnalysisProps,
   DialogShowEserviceVersionsListProps,
@@ -62,6 +63,7 @@ import { DialogTenantKindPurposeTemplate } from './DialogTenantKindPurposeTempla
 import { DialogSelectAgreementConsumer } from './DialogSelectAgreementConsumer/DialogSelectAgreementConsumer'
 import { DialogRequestPurposeApproval } from './DialogRequestPurposeApproval'
 import { DialogRequestRiskAnalysisCompilation } from './DialogRequestRiskAnalysisCompilation'
+import { DialogEditRiskAnalysisAssignment } from './DialogEditRiskAnalysisAssignment'
 import { DialogApproveRiskAnalysis } from './DialogApproveRiskAnalysis'
 import { DialogRejectRiskAnalysis } from './DialogRejectRiskAnalysis'
 import { DialogShowEserviceVersionsList } from './DialogShowEserviceVersionsList/DialogShowEserviceVersionsList'
@@ -98,6 +100,7 @@ function match<T>(
   onSelectAgreementConsumer: (props: DialogSelectAgreementConsumerProps) => T,
   onRequestPurposeApproval: (props: DialogRequestPurposeApprovalProps) => T,
   onRequestRiskAnalysisCompilation: (props: DialogRequestRiskAnalysisCompilationProps) => T,
+  onEditRiskAnalysisAssignment: (props: DialogEditRiskAnalysisAssignmentProps) => T,
   onApproveRiskAnalysis: (props: DialogApproveRiskAnalysisProps) => T,
   onRejectRiskAnalysis: (props: DialogRejectRiskAnalysisProps) => T,
   onShowEserviceVersionsList: (props: DialogShowEserviceVersionsListProps) => T,
@@ -158,6 +161,8 @@ function match<T>(
         return onRequestPurposeApproval(props)
       case 'requestRiskAnalysisCompilation':
         return onRequestRiskAnalysisCompilation(props)
+      case 'editRiskAnalysisAssignment':
+        return onEditRiskAnalysisAssignment(props)
       case 'approveRiskAnalysis':
         return onApproveRiskAnalysis(props)
       case 'rejectRiskAnalysis':
@@ -208,6 +213,7 @@ const _Dialog = match(
   (props) => <DialogSelectAgreementConsumer {...props} />,
   (props) => <DialogRequestPurposeApproval {...props} />,
   (props) => <DialogRequestRiskAnalysisCompilation {...props} />,
+  (props) => <DialogEditRiskAnalysisAssignment {...props} />,
   (props) => <DialogApproveRiskAnalysis {...props} />,
   (props) => <DialogRejectRiskAnalysis {...props} />,
   (props) => <DialogShowEserviceVersionsList {...props} />,

--- a/src/components/dialogs/DialogEditRiskAnalysisAssignment.tsx
+++ b/src/components/dialogs/DialogEditRiskAnalysisAssignment.tsx
@@ -1,0 +1,130 @@
+import React from 'react'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import { match, P } from 'ts-pattern'
+import { useDialog } from '@/stores'
+import type { RiskAnalysisReviewMode } from '@/api/api.generatedTypes'
+import type { DialogEditRiskAnalysisAssignmentProps } from '@/types/dialog.types'
+
+const ReviewerNamesBlock: React.FC<{ label: string; names: Array<string> }> = ({
+  label,
+  names,
+}) => (
+  <Stack spacing={0.5}>
+    <Typography variant="body2" fontWeight={600}>
+      {label}
+    </Typography>
+    <Stack component="ul" spacing={0.5} sx={{ pl: 3, m: 0 }}>
+      {names.map((name, index) => (
+        <Typography component="li" variant="body2" key={`${index}-${name}`}>
+          {name}
+        </Typography>
+      ))}
+    </Stack>
+  </Stack>
+)
+
+export const DialogEditRiskAnalysisAssignment: React.FC<DialogEditRiskAnalysisAssignmentProps> = ({
+  fromMode,
+  toMode,
+  addedReviewerNames,
+  removedReviewerNames,
+  onConfirm,
+}) => {
+  const ariaLabelId = React.useId()
+  const ariaDescriptionId = React.useId()
+
+  const { closeDialog } = useDialog()
+  const { t } = useTranslation('purpose', { keyPrefix: 'edit.stepAssignment' })
+  const { t: tCommon } = useTranslation('common', { keyPrefix: 'actions' })
+
+  const getModeLabel = (mode: RiskAnalysisReviewMode) => t(`reviewModeField.options.${mode}`)
+
+  const getModeChangeText = () => {
+    if (fromMode === toMode) return undefined
+
+    if (fromMode === 'ADMIN_WRITES_ADMIN_SIGNS') {
+      return t('editAssignmentDialog.modeChosen', { mode: getModeLabel(toMode) })
+    }
+    return t('editAssignmentDialog.modeTransition', {
+      from: getModeLabel(fromMode),
+      to: getModeLabel(toMode),
+    })
+  }
+
+  const losesRiskAnalysis = match({ fromMode, toMode })
+    .returnType<boolean>()
+    .with(
+      {
+        fromMode: P.union('ADMIN_WRITES_ADMIN_SIGNS', 'ADMIN_WRITES_REVIEWER_SIGNS'),
+        toMode: P.union('ADMIN_WRITES_ADMIN_SIGNS', 'ADMIN_WRITES_REVIEWER_SIGNS'),
+      },
+      () => false
+    )
+    .with(
+      { fromMode: 'REVIEWER_WRITES_REVIEWER_SIGNS', toMode: 'REVIEWER_WRITES_REVIEWER_SIGNS' },
+      () => false
+    )
+    .with({ toMode: 'REVIEWER_WRITES_REVIEWER_SIGNS' }, () => true)
+    .with({ fromMode: 'REVIEWER_WRITES_REVIEWER_SIGNS' }, () => true)
+    .exhaustive()
+
+  const modeChangeText = getModeChangeText()
+
+  const handleConfirm = () => {
+    onConfirm()
+    closeDialog()
+  }
+
+  return (
+    <Dialog
+      open
+      onClose={closeDialog}
+      aria-labelledby={ariaLabelId}
+      aria-describedby={ariaDescriptionId}
+      fullWidth
+    >
+      <DialogTitle id={ariaLabelId}>{t('editAssignmentDialog.title')}</DialogTitle>
+
+      <DialogContent>
+        <Stack id={ariaDescriptionId} spacing={2}>
+          {modeChangeText && <Typography variant="body2">{modeChangeText}</Typography>}
+          {addedReviewerNames.length > 0 && (
+            <ReviewerNamesBlock
+              label={t('editAssignmentDialog.selectedReviewersLabel')}
+              names={addedReviewerNames}
+            />
+          )}
+          {removedReviewerNames.length > 0 && (
+            <ReviewerNamesBlock
+              label={t('editAssignmentDialog.removedReviewersLabel')}
+              names={removedReviewerNames}
+            />
+          )}
+          {losesRiskAnalysis && (
+            <Typography variant="body2">
+              {t('editAssignmentDialog.riskAnalysisLossWarning')}
+            </Typography>
+          )}
+        </Stack>
+      </DialogContent>
+
+      <DialogActions>
+        <Button variant="outlined" onClick={closeDialog}>
+          {tCommon('cancel')}
+        </Button>
+        <Button variant="contained" onClick={handleConfirm}>
+          {tCommon('confirm')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/components/dialogs/DialogRequestRiskAnalysisCompilation.tsx
+++ b/src/components/dialogs/DialogRequestRiskAnalysisCompilation.tsx
@@ -16,7 +16,7 @@ import type { DialogRequestRiskAnalysisCompilationProps } from '@/types/dialog.t
 
 export const DialogRequestRiskAnalysisCompilation: React.FC<
   DialogRequestRiskAnalysisCompilationProps
-> = ({ purposeId, reviewerId, reviewerName }) => {
+> = ({ purposeId, reviewerIds, reviewerNames }) => {
   const ariaLabelId = React.useId()
 
   const { t: tCommon } = useTranslation('common', { keyPrefix: 'actions' })
@@ -27,7 +27,7 @@ export const DialogRequestRiskAnalysisCompilation: React.FC<
   const { closeDialog } = useDialog()
   const navigate = useNavigate()
   const { mutate: assignReviewer, isPending } = PurposeMutations.useAssignRiskAnalysisReviewer({
-    showSuccessToast: true,
+    feedback: 'create',
   })
 
   const handleConfirm = () => {
@@ -35,7 +35,7 @@ export const DialogRequestRiskAnalysisCompilation: React.FC<
       {
         purposeId,
         reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
-        reviewerIds: [reviewerId],
+        reviewerIds,
       },
       {
         onSuccess: () => {
@@ -62,7 +62,10 @@ export const DialogRequestRiskAnalysisCompilation: React.FC<
               strong: <Typography variant="inherit" component="span" fontWeight={600} />,
             }}
           >
-            {t('description', { reviewerName })}
+            {t('description', {
+              count: reviewerNames.length,
+              reviewerNames: reviewerNames.join(', '),
+            })}
           </Trans>
         </Typography>
       </DialogContent>

--- a/src/components/dialogs/__tests__/DialogEditRiskAnalysisAssignment.test.tsx
+++ b/src/components/dialogs/__tests__/DialogEditRiskAnalysisAssignment.test.tsx
@@ -1,0 +1,175 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DialogEditRiskAnalysisAssignment } from '../DialogEditRiskAnalysisAssignment'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import type { RiskAnalysisReviewMode } from '@/api/api.generatedTypes'
+
+const closeDialogMock = vi.fn()
+const onConfirmMock = vi.fn()
+
+vi.mock('@/stores', async () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actual = await vi.importActual<typeof import('@/stores')>('@/stores')
+  return {
+    ...actual,
+    useDialog: () => ({ closeDialog: closeDialogMock }),
+  }
+})
+
+const defaultProps = {
+  type: 'editRiskAnalysisAssignment' as const,
+  fromMode: 'ADMIN_WRITES_ADMIN_SIGNS' as RiskAnalysisReviewMode,
+  toMode: 'ADMIN_WRITES_REVIEWER_SIGNS' as RiskAnalysisReviewMode,
+  addedReviewerNames: [] as Array<string>,
+  removedReviewerNames: [] as Array<string>,
+  onConfirm: onConfirmMock,
+}
+
+const renderDialog = (overrides?: Partial<typeof defaultProps>) =>
+  renderWithApplicationContext(
+    <DialogEditRiskAnalysisAssignment {...defaultProps} {...overrides} />,
+    { withReactQueryContext: true }
+  )
+
+describe('DialogEditRiskAnalysisAssignment', () => {
+  beforeEach(() => {
+    closeDialogMock.mockReset()
+    onConfirmMock.mockReset()
+  })
+
+  it('renders the dialog with its title and CTAs', () => {
+    renderDialog()
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('editAssignmentDialog.title')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'cancel' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'confirm' })).toBeInTheDocument()
+  })
+
+  describe('mode change copy', () => {
+    it('announces the chosen mode when leaving the self-compilation mode', () => {
+      renderDialog({
+        fromMode: 'ADMIN_WRITES_ADMIN_SIGNS',
+        toMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
+      })
+
+      expect(screen.getByText('editAssignmentDialog.modeChosen')).toBeInTheDocument()
+      expect(screen.queryByText('editAssignmentDialog.modeTransition')).not.toBeInTheDocument()
+    })
+
+    it('frames the change as a transition between two modes otherwise', () => {
+      renderDialog({
+        fromMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+        toMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
+      })
+
+      expect(screen.getByText('editAssignmentDialog.modeTransition')).toBeInTheDocument()
+      expect(screen.queryByText('editAssignmentDialog.modeChosen')).not.toBeInTheDocument()
+    })
+
+    it('shows no mode copy at all when only the reviewers changed', () => {
+      renderDialog({
+        fromMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+        toMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+        addedReviewerNames: ['Anna Verdi'],
+      })
+
+      expect(screen.queryByText('editAssignmentDialog.modeTransition')).not.toBeInTheDocument()
+      expect(screen.queryByText('editAssignmentDialog.modeChosen')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('reviewers blocks', () => {
+    it('lists the added reviewers only when there are any', () => {
+      renderDialog({ addedReviewerNames: ['Mario Rossi', 'Anna Verdi'] })
+
+      expect(screen.getByText('editAssignmentDialog.selectedReviewersLabel')).toBeInTheDocument()
+      expect(screen.getByText('Mario Rossi')).toBeInTheDocument()
+      expect(screen.getByText('Anna Verdi')).toBeInTheDocument()
+      expect(
+        screen.queryByText('editAssignmentDialog.removedReviewersLabel')
+      ).not.toBeInTheDocument()
+    })
+
+    it('lists the removed reviewers only when there are any', () => {
+      renderDialog({
+        fromMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+        toMode: 'ADMIN_WRITES_ADMIN_SIGNS',
+        removedReviewerNames: ['Mario Rossi'],
+      })
+
+      expect(screen.getByText('editAssignmentDialog.removedReviewersLabel')).toBeInTheDocument()
+      expect(screen.getByText('Mario Rossi')).toBeInTheDocument()
+      expect(
+        screen.queryByText('editAssignmentDialog.selectedReviewersLabel')
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows both blocks when the same mode gains and loses a reviewer', () => {
+      renderDialog({
+        fromMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+        toMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+        addedReviewerNames: ['Anna Verdi'],
+        removedReviewerNames: ['Mario Rossi'],
+      })
+
+      expect(screen.getByText('editAssignmentDialog.selectedReviewersLabel')).toBeInTheDocument()
+      expect(screen.getByText('editAssignmentDialog.removedReviewersLabel')).toBeInTheDocument()
+    })
+  })
+
+  describe('risk analysis loss warning', () => {
+    const destructiveTransitions: Array<[RiskAnalysisReviewMode, RiskAnalysisReviewMode]> = [
+      ['ADMIN_WRITES_ADMIN_SIGNS', 'REVIEWER_WRITES_REVIEWER_SIGNS'],
+      ['ADMIN_WRITES_REVIEWER_SIGNS', 'REVIEWER_WRITES_REVIEWER_SIGNS'],
+      ['REVIEWER_WRITES_REVIEWER_SIGNS', 'ADMIN_WRITES_ADMIN_SIGNS'],
+      ['REVIEWER_WRITES_REVIEWER_SIGNS', 'ADMIN_WRITES_REVIEWER_SIGNS'],
+    ]
+
+    const preservingTransitions: Array<[RiskAnalysisReviewMode, RiskAnalysisReviewMode]> = [
+      ['ADMIN_WRITES_ADMIN_SIGNS', 'ADMIN_WRITES_REVIEWER_SIGNS'],
+      ['ADMIN_WRITES_REVIEWER_SIGNS', 'ADMIN_WRITES_ADMIN_SIGNS'],
+      ['ADMIN_WRITES_ADMIN_SIGNS', 'ADMIN_WRITES_ADMIN_SIGNS'],
+      ['ADMIN_WRITES_REVIEWER_SIGNS', 'ADMIN_WRITES_REVIEWER_SIGNS'],
+      ['REVIEWER_WRITES_REVIEWER_SIGNS', 'REVIEWER_WRITES_REVIEWER_SIGNS'],
+    ]
+
+    it.each(destructiveTransitions)('warns when switching from %s to %s', (fromMode, toMode) => {
+      renderDialog({ fromMode, toMode })
+
+      expect(screen.getByText('editAssignmentDialog.riskAnalysisLossWarning')).toBeInTheDocument()
+    })
+
+    it.each(preservingTransitions)(
+      'does not warn when switching from %s to %s',
+      (fromMode, toMode) => {
+        renderDialog({ fromMode, toMode })
+
+        expect(
+          screen.queryByText('editAssignmentDialog.riskAnalysisLossWarning')
+        ).not.toBeInTheDocument()
+      }
+    )
+  })
+
+  it('on confirm, runs the callback and closes the dialog', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.click(screen.getByRole('button', { name: 'confirm' }))
+
+    expect(onConfirmMock).toHaveBeenCalledTimes(1)
+    expect(closeDialogMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('on cancel, closes the dialog without running the callback', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(closeDialogMock).toHaveBeenCalledTimes(1)
+    expect(onConfirmMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/dialogs/__tests__/DialogRequestRiskAnalysisCompilation.test.tsx
+++ b/src/components/dialogs/__tests__/DialogRequestRiskAnalysisCompilation.test.tsx
@@ -34,14 +34,17 @@ vi.mock('@/api/purpose', () => ({
 const defaultProps = {
   type: 'requestRiskAnalysisCompilation' as const,
   purposeId: 'purpose-id',
-  reviewerId: 'reviewer-uuid-1',
-  reviewerName: 'Mario Rossi',
+  reviewerIds: ['reviewer-uuid-1'],
+  reviewerNames: ['Mario Rossi'],
 }
 
-const renderDialog = () =>
-  renderWithApplicationContext(<DialogRequestRiskAnalysisCompilation {...defaultProps} />, {
-    withReactQueryContext: true,
-  })
+const renderDialog = (overrides?: Partial<typeof defaultProps>) =>
+  renderWithApplicationContext(
+    <DialogRequestRiskAnalysisCompilation {...defaultProps} {...overrides} />,
+    {
+      withReactQueryContext: true,
+    }
+  )
 
 describe('DialogRequestRiskAnalysisCompilation', () => {
   beforeEach(() => {
@@ -88,6 +91,23 @@ describe('DialogRequestRiskAnalysisCompilation', () => {
       purposeId: 'purpose-id',
       reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
       reviewerIds: ['reviewer-uuid-1'],
+    })
+  })
+
+  it('on confirm, forwards every selected reviewer', async () => {
+    const user = userEvent.setup()
+    renderDialog({
+      reviewerIds: ['reviewer-uuid-1', 'reviewer-uuid-2'],
+      reviewerNames: ['Mario Rossi', 'Anna Verdi'],
+    })
+
+    await user.click(screen.getByRole('button', { name: 'confirm' }))
+
+    const [payload] = assignReviewerMock.mock.calls[0]
+    expect(payload).toEqual({
+      purposeId: 'purpose-id',
+      reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
+      reviewerIds: ['reviewer-uuid-1', 'reviewer-uuid-2'],
     })
   })
 

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsAssignmentSection.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsAssignmentSection.tsx
@@ -15,7 +15,7 @@ export const ConsumerPurposeDetailsAssignmentSection: React.FC<
 > = ({ purpose }) => {
   const { t } = useTranslation('purpose', { keyPrefix: 'riskAnalysisAssignment' })
 
-  const modeLabel = getReviewModeLabel(purpose.reviewerWorkflow?.reviewMode, t)
+  const modeLabel = getReviewModeLabel(purpose.reviewMode, t)
 
   // We surface only the first reviewer: the BE models `reviewers` as a list to allow multiple
   // reviewers in the future, but today at most one reviewer is ever assigned.

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsAssignmentSection.test.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/__tests__/ConsumerPurposeDetailsAssignmentSection.test.tsx
@@ -25,9 +25,8 @@ describe('ConsumerPurposeDetailsAssignmentSection', () => {
     renderWithApplicationContext(
       <ConsumerPurposeDetailsAssignmentSection
         purpose={createMockPurpose({
+          reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
           reviewerWorkflow: {
-            reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-            reviewerIds: [reviewerId],
             reviewers: [{ userId: reviewerId, name: 'Mario', familyName: 'Rossi' }],
             signingState: 'ASSIGNED',
           },
@@ -45,9 +44,8 @@ describe('ConsumerPurposeDetailsAssignmentSection', () => {
     renderWithApplicationContext(
       <ConsumerPurposeDetailsAssignmentSection
         purpose={createMockPurpose({
+          reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
           reviewerWorkflow: {
-            reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-            reviewerIds: [reviewerId],
             signingState: 'ASSIGNED',
           },
         })}

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignment.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignment.tsx
@@ -66,8 +66,11 @@ export const PurposeEditStepAssignment: React.FC<ActiveStepProps> = (props) => {
 
   const defaultValues = getDefaultValues(purpose)
 
+  const formKey = [defaultValues.reviewMode, ...defaultValues.reviewerIds].join('|')
+
   return (
     <PurposeEditStepAssignmentForm
+      key={formKey}
       purpose={purpose}
       reviewers={reviewers ?? []}
       isDelegate={isDelegate}

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignment.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignment.tsx
@@ -11,14 +11,15 @@ import type { ActiveStepProps } from '@/hooks/useActiveStep'
 import type { Purpose } from '@/api/api.generatedTypes'
 import PurposeEditStepAssignmentForm, {
   PurposeEditStepAssignmentFormSkeleton,
-  beEnumToReviewModeOption,
   type PurposeEditStepAssignmentFormValues,
 } from './PurposeEditStepAssignmentForm'
 import PurposeEditStepAssignmentReadOnly from './PurposeEditStepAssignmentReadOnly'
 
 const getDefaultValues = (purpose: Purpose): PurposeEditStepAssignmentFormValues => ({
-  reviewMode: beEnumToReviewModeOption(purpose.reviewerWorkflow?.reviewMode),
-  reviewerId: purpose.reviewerWorkflow?.reviewerIds[0],
+  // A purpose with no persisted review mode has never been assigned: the form starts on
+  // self-compilation and self-approval.
+  reviewMode: purpose.reviewMode ?? 'ADMIN_WRITES_ADMIN_SIGNS',
+  reviewerIds: purpose.reviewerWorkflow?.reviewers?.map(({ userId }) => userId) ?? [],
 })
 
 export const PurposeEditStepAssignment: React.FC<ActiveStepProps> = (props) => {
@@ -30,15 +31,17 @@ export const PurposeEditStepAssignment: React.FC<ActiveStepProps> = (props) => {
     PurposeQueries.getSingle(purposeId)
   )
 
-  // The reviewers list is only consumed by the editable-draft form branch, so only
-  // fetch it when that branch will actually render (avoids a wasted call on the read-only step).
-  const isEditableDraft = purpose?.currentVersion?.state === 'DRAFT'
-  const shouldRenderForm = Boolean(purpose) && !purpose?.reviewerWorkflow && isEditableDraft
+  // The assignment can be changed until the risk analysis is approved, and only while the purpose
+  // is still a draft. The reviewers list is only consumed by the editable branch, so only fetch it
+  // when that branch will actually render (avoids a wasted call on the read-only step).
+  const isPurposeDraft = purpose?.currentVersion?.state === 'DRAFT'
+  const isRiskAnalysisSigned = purpose?.reviewerWorkflow?.signingState === 'SIGNED'
+  const isEditable = Boolean(purpose) && isPurposeDraft && !isRiskAnalysisSigned
 
   const tenantId = jwt?.organizationId
   const { data: reviewers, isLoading: isLoadingReviewers } = useQuery({
     ...TenantQueries.getPartyUsersList({ tenantId: tenantId as string, roles: ['reviewer'] }),
-    enabled: Boolean(tenantId) && shouldRenderForm,
+    enabled: Boolean(tenantId) && isEditable,
   })
 
   if (isLoadingPurpose || isLoadingReviewers) {
@@ -49,7 +52,7 @@ export const PurposeEditStepAssignment: React.FC<ActiveStepProps> = (props) => {
     throw new NotFoundError()
   }
 
-  if (purpose.reviewerWorkflow || !isEditableDraft) {
+  if (!isEditable) {
     return <PurposeEditStepAssignmentReadOnly purpose={purpose} {...props} />
   }
 

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentForm.tsx
@@ -1,13 +1,22 @@
 import React from 'react'
-import { Alert, Box, Link, Stack, Typography } from '@mui/material'
+import {
+  Alert,
+  Box,
+  type FilterOptionsState,
+  Link,
+  Stack,
+  Typography,
+  createFilterOptions,
+} from '@mui/material'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { match } from 'ts-pattern'
-import { RHFAutocompleteSingle, RHFRadioGroup } from '@/components/shared/react-hook-form-inputs'
+import { match, P } from 'ts-pattern'
+import { RHFAutocompleteMultiple, RHFRadioGroup } from '@/components/shared/react-hook-form-inputs'
 import { SectionContainer, SectionContainerSkeleton } from '@/components/layout/containers'
 import { StepActions } from '@/components/shared/StepActions'
 import type { ActiveStepProps } from '@/hooks/useActiveStep'
 import type {
+  CompactUser,
   Purpose,
   RiskAnalysisAssignmentSeed,
   RiskAnalysisReviewMode,
@@ -15,37 +24,29 @@ import type {
 } from '@/api/api.generatedTypes'
 import { PurposeMutations } from '@/api/purpose'
 import { useDialog } from '@/stores'
+import { useNavigate } from '@/router'
 import SaveIcon from '@mui/icons-material/Save'
 import SendIcon from '@mui/icons-material/Send'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 
-export type ReviewModeOption =
-  | 'selfWritesSelfSigns'
-  | 'selfWritesReviewerSigns'
-  | 'reviewerWritesReviewerSigns'
-
 export type PurposeEditStepAssignmentFormValues = {
-  reviewMode: ReviewModeOption
-  reviewerId?: string
+  reviewMode: RiskAnalysisReviewMode
+  reviewerIds: Array<string>
 }
 
-const reviewModeOptionToBeEnum = (option: ReviewModeOption): RiskAnalysisReviewMode | undefined =>
-  match(option)
-    .with('selfWritesSelfSigns', () => undefined)
-    .with('selfWritesReviewerSigns', () => 'ADMIN_WRITES_REVIEWER_SIGNS' as const)
-    .with('reviewerWritesReviewerSigns', () => 'REVIEWER_WRITES_REVIEWER_SIGNS' as const)
+type ReviewerOption = { label: string; value: string }
+
+const getFullName = (user: Pick<CompactUser, 'name' | 'familyName'>) =>
+  `${user.name} ${user.familyName}`.trim()
+
+/** Modes other than self-compilation and self-approval require at least one reviewer. */
+export const checkReviewModeNeedsReviewers = (reviewMode: RiskAnalysisReviewMode) =>
+  match(reviewMode)
+    .with('ADMIN_WRITES_ADMIN_SIGNS', () => false)
+    .with(P.union('ADMIN_WRITES_REVIEWER_SIGNS', 'REVIEWER_WRITES_REVIEWER_SIGNS'), () => true)
     .exhaustive()
 
-// Maps the persisted BE review mode to its form option. The absence of a reviewer
-// workflow (undefined) means self-compilation and self-approval (option 1).
-export const beEnumToReviewModeOption = (
-  reviewMode: RiskAnalysisReviewMode | undefined
-): ReviewModeOption =>
-  match(reviewMode)
-    .with('ADMIN_WRITES_REVIEWER_SIGNS', () => 'selfWritesReviewerSigns' as const)
-    .with('REVIEWER_WRITES_REVIEWER_SIGNS', () => 'reviewerWritesReviewerSigns' as const)
-    .with(undefined, () => 'selfWritesSelfSigns' as const)
-    .exhaustive()
+const filterReviewerOptions = createFilterOptions<ReviewerOption>()
 
 type PurposeEditStepAssignmentFormProps = ActiveStepProps & {
   purpose: Purpose
@@ -66,10 +67,30 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
 }) => {
   const { t } = useTranslation('purpose', { keyPrefix: 'edit.stepAssignment' })
   const { t: tEdit } = useTranslation('purpose', { keyPrefix: 'edit' })
-  const { mutate: assignReviewer } = PurposeMutations.useAssignRiskAnalysisReviewer({
-    showSuccessToast: false,
-  })
+  const navigate = useNavigate()
   const { openDialog } = useDialog()
+
+  // A purpose only carries a review mode once the assignment step has been completed, so its
+  // absence marks the first compilation (this holds for purposes predating the reviewer feature
+  // too). Saving an assignment that already exists is an edit instead, which asks for confirmation
+  // through its own dialog and gives its own feedback.
+  // The backend always sets `reviewMode` alongside `reviewerWorkflow`, so this single check is
+  // enough to tell the two flows apart.
+  const isEditing = purpose.reviewMode !== undefined
+
+  const { mutate: assignReviewer } = PurposeMutations.useAssignRiskAnalysisReviewer({
+    feedback: isEditing ? 'edit' : 'none',
+  })
+
+  const assignedReviewers = purpose.reviewerWorkflow?.reviewers ?? []
+  const assignedReviewerIds = assignedReviewers.map(({ userId }) => userId)
+
+  // Reviewers assigned by a previous release but no longer among the institution's users. They
+  // must stay visible so the admin can see and drop them, but they block the submit.
+  const removedReviewers = assignedReviewers.filter(
+    (assigned) => !reviewers.some((user) => user.userId === assigned.userId)
+  )
+  const removedReviewerIds = removedReviewers.map(({ userId }) => userId)
 
   const hasNoReviewers = reviewers.length === 0
   const isFormHidden = isDelegate || hasNoReviewers
@@ -77,56 +98,127 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
   const formMethods = useForm<PurposeEditStepAssignmentFormValues>({ defaultValues })
 
   const reviewMode = formMethods.watch('reviewMode')
-  const needsReviewer =
-    reviewMode === 'selfWritesReviewerSigns' || reviewMode === 'reviewerWritesReviewerSigns'
-  const isRequestReviewerCompilation = reviewMode === 'reviewerWritesReviewerSigns'
+  const needsReviewers = checkReviewModeNeedsReviewers(reviewMode)
+  const isRequestReviewerCompilation = reviewMode === 'REVIEWER_WRITES_REVIEWER_SIGNS'
 
-  const onSubmit = ({ reviewMode, reviewerId }: PurposeEditStepAssignmentFormValues) => {
+  const getReviewerName = (userId: string) => {
+    const user =
+      reviewers.find((reviewer) => reviewer.userId === userId) ??
+      assignedReviewers.find((reviewer) => reviewer.userId === userId)
+    return user ? getFullName(user) : t('readOnly.reviewerUnknown')
+  }
+
+  const goToSummary = () => {
+    navigate('SUBSCRIBE_PURPOSE_SUMMARY', { params: { purposeId: purpose.id } })
+  }
+
+  const onSubmit = ({ reviewMode, reviewerIds }: PurposeEditStepAssignmentFormValues) => {
     if (isFormHidden) {
       forward()
       return
     }
 
-    const reviewModeEnum = reviewModeOptionToBeEnum(reviewMode)
-    if (!reviewModeEnum || !reviewerId) {
-      forward()
-      return
-    }
+    // Everything below is derived from the submitted values rather than from the watched ones,
+    // so the payload can never drift from what the admin actually confirmed.
+    const submittedNeedsReviewers = checkReviewModeNeedsReviewers(reviewMode)
+    const submittedHandsOverToReviewer = reviewMode === 'REVIEWER_WRITES_REVIEWER_SIGNS'
 
-    if (isRequestReviewerCompilation) {
-      const selectedReviewer = reviewers.find((u) => u.userId === reviewerId)
-      if (!selectedReviewer) return
-      const reviewerName = [selectedReviewer.name, selectedReviewer.familyName]
-        .filter(Boolean)
-        .join(' ')
-      openDialog({
-        type: 'requestRiskAnalysisCompilation',
-        purposeId: purpose.id,
-        reviewerId,
-        reviewerName,
-      })
-      return
-    }
+    // A mode that involves no reviewer must not carry over the ones from the previous assignment.
+    const nextReviewerIds = submittedNeedsReviewers ? reviewerIds : []
 
     const payload: { purposeId: string } & RiskAnalysisAssignmentSeed = {
       purposeId: purpose.id,
-      reviewMode: reviewModeEnum,
-      reviewerIds: [reviewerId],
+      reviewMode,
+      reviewerIds: submittedNeedsReviewers ? nextReviewerIds : undefined,
     }
 
-    assignReviewer(payload, {
-      onSuccess: forward,
+    const save = () => {
+      assignReviewer(payload, {
+        // Handing the compilation over to the reviewer leaves the admin no step 3 to fill in,
+        // so that mode lands on the summary instead of moving forward.
+        onSuccess: submittedHandsOverToReviewer ? goToSummary : forward,
+      })
+    }
+
+    if (!isEditing) {
+      // First compilation keeps the flow it had: the reviewer-compilation mode confirms through
+      // its own dialog (which also owns the mutation), the other modes save straight away.
+      if (submittedHandsOverToReviewer) {
+        openDialog({
+          type: 'requestRiskAnalysisCompilation',
+          purposeId: purpose.id,
+          reviewerIds: nextReviewerIds,
+          reviewerNames: nextReviewerIds.map(getReviewerName),
+        })
+        return
+      }
+      save()
+      return
+    }
+
+    // `isEditing` guarantees the purpose carries a persisted review mode.
+    const fromMode = purpose.reviewMode as RiskAnalysisReviewMode
+
+    const addedReviewerNames = nextReviewerIds
+      .filter((userId) => !assignedReviewerIds.includes(userId))
+      .map(getReviewerName)
+    const removedReviewerNames = assignedReviewerIds
+      .filter((userId) => !nextReviewerIds.includes(userId))
+      .map(getReviewerName)
+
+    const hasChanges =
+      fromMode !== reviewMode || addedReviewerNames.length > 0 || removedReviewerNames.length > 0
+
+    if (!hasChanges) {
+      // Nothing was changed: there is nothing to confirm and nothing to persist.
+      if (submittedHandsOverToReviewer) goToSummary()
+      else forward()
+      return
+    }
+
+    openDialog({
+      type: 'editRiskAnalysisAssignment',
+      fromMode,
+      toMode: reviewMode,
+      addedReviewerNames,
+      removedReviewerNames,
+      // The mutation must be triggered from here: running it inside the dialog would race
+      // closeDialog(), and mutate() would silently no-op against a destroyed observer.
+      onConfirm: save,
     })
   }
 
-  const reviewerOptions = reviewers.map((u) => ({
-    label: `${u.name} ${u.familyName}`.trim(),
-    value: u.userId,
-  }))
+  // Reviewers no longer belonging to the institution are kept among the options so that their
+  // chip still renders, but they are filtered out of the dropdown so they cannot be picked again.
+  const reviewerOptions: Array<ReviewerOption> = [
+    ...reviewers.map((user) => ({ label: getFullName(user), value: user.userId })),
+    ...removedReviewers.map((user) => ({ label: getFullName(user), value: user.userId })),
+  ]
+
+  const filterOptions = (
+    options: Array<ReviewerOption>,
+    state: FilterOptionsState<ReviewerOption>
+  ) =>
+    filterReviewerOptions(
+      options.filter((option) => !removedReviewerIds.includes(option.value)),
+      state
+    )
+
+  const validateReviewerIds = (reviewerIds: Array<string>) => {
+    if (reviewerIds.length === 0) return t('reviewerField.requiredError')
+
+    const removed = reviewerIds.filter((userId) => removedReviewerIds.includes(userId))
+    if (removed.length === 0) return true
+
+    return t('reviewerField.removedError', {
+      count: removed.length,
+      names: removed.map(getReviewerName).join(', '),
+    })
+  }
 
   const reviewerLabelKey = isRequestReviewerCompilation
-    ? 'reviewerWritesReviewerSigns'
-    : 'selfWritesReviewerSigns'
+    ? 'REVIEWER_WRITES_REVIEWER_SIGNS'
+    : 'ADMIN_WRITES_REVIEWER_SIGNS'
 
   return (
     <FormProvider {...formMethods}>
@@ -159,29 +251,33 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
                   rules={{ required: true }}
                   options={[
                     {
-                      label: t('reviewModeField.options.selfWritesSelfSigns'),
-                      value: 'selfWritesSelfSigns',
+                      label: t('reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS'),
+                      value: 'ADMIN_WRITES_ADMIN_SIGNS',
                     },
                     {
-                      label: t('reviewModeField.options.selfWritesReviewerSigns'),
-                      value: 'selfWritesReviewerSigns',
+                      label: t('reviewModeField.options.ADMIN_WRITES_REVIEWER_SIGNS'),
+                      value: 'ADMIN_WRITES_REVIEWER_SIGNS',
                     },
                     {
-                      label: t('reviewModeField.options.reviewerWritesReviewerSigns'),
-                      value: 'reviewerWritesReviewerSigns',
+                      label: t('reviewModeField.options.REVIEWER_WRITES_REVIEWER_SIGNS'),
+                      value: 'REVIEWER_WRITES_REVIEWER_SIGNS',
                     },
                   ]}
                 />
-                {needsReviewer && (
+                {needsReviewers && (
                   <>
                     <Typography variant="body2" fontWeight={600}>
                       {t(`reviewerField.label.${reviewerLabelKey}`)}
                     </Typography>
-                    <RHFAutocompleteSingle
-                      name="reviewerId"
+                    <RHFAutocompleteMultiple
+                      name="reviewerIds"
                       label={t('reviewerField.inputLabel')}
                       options={reviewerOptions}
-                      rules={{ required: t('reviewerField.requiredError') }}
+                      filterOptions={filterOptions}
+                      rules={{
+                        required: t('reviewerField.requiredError'),
+                        validate: validateReviewerIds,
+                      }}
                     />
                   </>
                 )}

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentForm.tsx
@@ -93,6 +93,8 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
   const removedReviewerIds = removedReviewers.map(({ userId }) => userId)
 
   const hasNoReviewers = reviewers.length === 0
+
+  const hasLostItsOnlyReviewers = !isDelegate && hasNoReviewers && removedReviewers.length > 0
   const isFormHidden = isDelegate || hasNoReviewers
 
   const formMethods = useForm<PurposeEditStepAssignmentFormValues>({ defaultValues })
@@ -114,6 +116,17 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
 
   const onSubmit = ({ reviewMode, reviewerIds }: PurposeEditStepAssignmentFormValues) => {
     if (isFormHidden) {
+      if (hasLostItsOnlyReviewers) {
+        assignReviewer(
+          {
+            purposeId: purpose.id,
+            reviewMode: 'ADMIN_WRITES_ADMIN_SIGNS',
+            reviewerIds: undefined,
+          },
+          { onSuccess: forward }
+        )
+        return
+      }
       forward()
       return
     }
@@ -234,7 +247,11 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
             )}
             {!isDelegate && hasNoReviewers && (
               <Alert severity="info">
-                {t('noReviewersAlert.message')}{' '}
+                {hasLostItsOnlyReviewers
+                  ? t('noReviewersAlert.removedReviewerMessage', {
+                      count: removedReviewers.length,
+                    })
+                  : t('noReviewersAlert.message')}{' '}
                 {selfcareUsersPageUrl && (
                   <Link href={selfcareUsersPageUrl} target="_blank" rel="noopener noreferrer">
                     {t('noReviewersAlert.linkLabel')}

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentForm.tsx
@@ -107,7 +107,8 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
     const user =
       reviewers.find((reviewer) => reviewer.userId === userId) ??
       assignedReviewers.find((reviewer) => reviewer.userId === userId)
-    return user ? getFullName(user) : t('readOnly.reviewerUnknown')
+    const fullName = user && getFullName(user)
+    return fullName || t('readOnly.reviewerUnknown')
   }
 
   const goToSummary = () => {
@@ -194,8 +195,11 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
   // Reviewers no longer belonging to the institution are kept among the options so that their
   // chip still renders, but they are filtered out of the dropdown so they cannot be picked again.
   const reviewerOptions: Array<ReviewerOption> = [
-    ...reviewers.map((user) => ({ label: getFullName(user), value: user.userId })),
-    ...removedReviewers.map((user) => ({ label: getFullName(user), value: user.userId })),
+    ...reviewers.map((user) => ({ label: getReviewerName(user.userId), value: user.userId })),
+    ...removedReviewers.map((user) => ({
+      label: getReviewerName(user.userId),
+      value: user.userId,
+    })),
   ]
 
   const filterOptions = (

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentForm.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentForm.tsx
@@ -115,33 +115,23 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
   }
 
   const onSubmit = ({ reviewMode, reviewerIds }: PurposeEditStepAssignmentFormValues) => {
-    if (isFormHidden) {
-      if (hasLostItsOnlyReviewers) {
-        assignReviewer(
-          {
-            purposeId: purpose.id,
-            reviewMode: 'ADMIN_WRITES_ADMIN_SIGNS',
-            reviewerIds: undefined,
-          },
-          { onSuccess: forward }
-        )
-        return
-      }
+    if (isFormHidden && !hasLostItsOnlyReviewers) {
       forward()
       return
     }
 
-    // Everything below is derived from the submitted values rather than from the watched ones,
-    // so the payload can never drift from what the admin actually confirmed.
-    const submittedNeedsReviewers = checkReviewModeNeedsReviewers(reviewMode)
-    const submittedHandsOverToReviewer = reviewMode === 'REVIEWER_WRITES_REVIEWER_SIGNS'
+    const submittedMode: RiskAnalysisReviewMode = isFormHidden
+      ? 'ADMIN_WRITES_ADMIN_SIGNS'
+      : reviewMode
+    const submittedNeedsReviewers = checkReviewModeNeedsReviewers(submittedMode)
+    const submittedHandsOverToReviewer = submittedMode === 'REVIEWER_WRITES_REVIEWER_SIGNS'
 
     // A mode that involves no reviewer must not carry over the ones from the previous assignment.
     const nextReviewerIds = submittedNeedsReviewers ? reviewerIds : []
 
     const payload: { purposeId: string } & RiskAnalysisAssignmentSeed = {
       purposeId: purpose.id,
-      reviewMode,
+      reviewMode: submittedMode,
       reviewerIds: submittedNeedsReviewers ? nextReviewerIds : undefined,
     }
 
@@ -180,7 +170,7 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
       .map(getReviewerName)
 
     const hasChanges =
-      fromMode !== reviewMode || addedReviewerNames.length > 0 || removedReviewerNames.length > 0
+      fromMode !== submittedMode || addedReviewerNames.length > 0 || removedReviewerNames.length > 0
 
     if (!hasChanges) {
       // Nothing was changed: there is nothing to confirm and nothing to persist.
@@ -192,7 +182,7 @@ const PurposeEditStepAssignmentForm: React.FC<PurposeEditStepAssignmentFormProps
     openDialog({
       type: 'editRiskAnalysisAssignment',
       fromMode,
-      toMode: reviewMode,
+      toMode: submittedMode,
       addedReviewerNames,
       removedReviewerNames,
       // The mutation must be triggered from here: running it inside the dialog would race

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentReadOnly.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentReadOnly.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Stack } from '@mui/material'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
 import { useTranslation } from 'react-i18next'
+import { match } from 'ts-pattern'
 import { SectionContainer } from '@/components/layout/containers'
 import { StepActions } from '@/components/shared/StepActions'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
@@ -23,10 +24,10 @@ const PurposeEditStepAssignmentReadOnly: React.FC<PurposeEditStepAssignmentReadO
 
   const reviewMode = purpose.reviewMode ?? 'ADMIN_WRITES_ADMIN_SIGNS'
 
-  // The assignment is frozen either because the purpose left the draft state or because the risk
-  // analysis has been approved; the publication is the stronger reason, so it takes precedence.
-  const isPurposeDraft = purpose.currentVersion?.state === 'DRAFT'
-  const subtitle = isPurposeDraft ? t('readOnly.subtitle.signed') : t('readOnly.subtitle.published')
+  const subtitle = match(purpose.currentVersion?.state)
+    .with('DRAFT', () => t('readOnly.subtitle.signed'))
+    .with('ACTIVE', () => t('readOnly.subtitle.published'))
+    .otherwise(() => t('readOnly.subtitle.notDraft'))
 
   const reviewers = purpose.reviewerWorkflow?.reviewers ?? []
   // An assigned reviewer may no longer be resolvable (role revoked on SelfCare, left the

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentReadOnly.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/PurposeEditStepAssignmentReadOnly.tsx
@@ -8,7 +8,6 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import type { ActiveStepProps } from '@/hooks/useActiveStep'
 import type { Purpose } from '@/api/api.generatedTypes'
-import { beEnumToReviewModeOption } from './PurposeEditStepAssignmentForm'
 
 type PurposeEditStepAssignmentReadOnlyProps = ActiveStepProps & {
   purpose: Purpose
@@ -22,31 +21,35 @@ const PurposeEditStepAssignmentReadOnly: React.FC<PurposeEditStepAssignmentReadO
   const { t } = useTranslation('purpose', { keyPrefix: 'edit.stepAssignment' })
   const { t: tEdit } = useTranslation('purpose', { keyPrefix: 'edit' })
 
-  const reviewerWorkflow = purpose.reviewerWorkflow
-  const reviewModeOption = beEnumToReviewModeOption(reviewerWorkflow?.reviewMode)
+  const reviewMode = purpose.reviewMode ?? 'ADMIN_WRITES_ADMIN_SIGNS'
 
-  const reviewer = reviewerWorkflow?.reviewers?.[0]
-  // The assigned reviewer may no longer be resolvable (role revoked on SelfCare, left the
+  // The assignment is frozen either because the purpose left the draft state or because the risk
+  // analysis has been approved; the publication is the stronger reason, so it takes precedence.
+  const isPurposeDraft = purpose.currentVersion?.state === 'DRAFT'
+  const subtitle = isPurposeDraft ? t('readOnly.subtitle.signed') : t('readOnly.subtitle.published')
+
+  const reviewers = purpose.reviewerWorkflow?.reviewers ?? []
+  // An assigned reviewer may no longer be resolvable (role revoked on SelfCare, left the
   // organization, or a different tenant in a delegation): fall back to a placeholder
   // instead of rendering a blank value.
-  const reviewerName = reviewer
-    ? `${reviewer.name} ${reviewer.familyName}`.trim()
-    : t('readOnly.reviewerUnknown')
+  const reviewerNames = reviewers
+    .map((reviewer) => `${reviewer.name} ${reviewer.familyName}`.trim())
+    .map((name) => name || t('readOnly.reviewerUnknown'))
 
   return (
     <>
-      <SectionContainer title={t('title')} description={t('readOnly.subtitle')}>
+      <SectionContainer title={t('title')} description={subtitle}>
         <Stack spacing={2}>
           <InformationContainer
             label={t('readOnly.modeLabel')}
             direction="row"
-            content={t(`reviewModeField.options.${reviewModeOption}`)}
+            content={t(`reviewModeField.options.${reviewMode}`)}
           />
-          {reviewerWorkflow && (
+          {reviewerNames.length > 0 && (
             <InformationContainer
-              label={t('readOnly.reviewerLabel')}
+              label={t('readOnly.reviewerLabel', { count: reviewerNames.length })}
               direction="row"
-              content={reviewerName}
+              content={reviewerNames.join(', ')}
             />
           )}
         </Stack>

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignment.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignment.test.tsx
@@ -10,9 +10,11 @@ import { NotFoundError } from '@/utils/errors.utils'
 import { mockUseJwt } from '@/utils/testing.utils'
 import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
 import type {
+  CompactUser,
   Purpose,
   PurposeVersionState,
   RiskAnalysisReviewMode,
+  RiskAnalysisSigningState,
   User,
 } from '@/api/api.generatedTypes'
 import { createMockSelfCareUser } from '@/../__mocks__/data/user.mocks'
@@ -74,7 +76,8 @@ vi.mock('../PurposeEditStepAssignmentReadOnly', () => ({
 
 type AssignmentPurposeOverrides = {
   reviewMode?: RiskAnalysisReviewMode
-  reviewerIds?: string[]
+  reviewers?: Array<CompactUser>
+  signingState?: RiskAnalysisSigningState
   versionState?: PurposeVersionState
 }
 
@@ -82,13 +85,6 @@ function buildPurpose(
   overrides: Partial<Purpose> = {},
   assignment?: AssignmentPurposeOverrides
 ): Purpose {
-  const reviewerWorkflow: Purpose['reviewerWorkflow'] | undefined = assignment?.reviewMode
-    ? {
-        reviewMode: assignment.reviewMode,
-        reviewerIds: assignment.reviewerIds ?? [],
-        signingState: 'ASSIGNED',
-      }
-    : undefined
   const base = createMockPurpose({ id: 'purpose-123', ...overrides })
   return {
     ...base,
@@ -97,7 +93,15 @@ function buildPurpose(
       ...base.currentVersion,
       state: assignment?.versionState ?? 'DRAFT',
     },
-    ...(reviewerWorkflow ? { reviewerWorkflow } : {}),
+    ...(assignment?.reviewMode
+      ? {
+          reviewMode: assignment.reviewMode,
+          reviewerWorkflow: {
+            reviewers: assignment.reviewers ?? [],
+            signingState: assignment.signingState ?? 'ASSIGNED',
+          },
+        }
+      : {}),
   }
 }
 
@@ -232,23 +236,65 @@ describe('PurposeEditStepAssignment', () => {
     )
   })
 
-  it('defaults reviewMode to selfWritesSelfSigns when the purpose has no reviewMode set', () => {
+  it('defaults reviewMode to self-compilation when the purpose has no reviewMode set', () => {
     mockQueries({ purpose: buildPurpose(), reviewers: buildReviewers() })
 
     render(<PurposeEditStepAssignment back={vi.fn()} forward={vi.fn()} activeStep={1} />)
 
     expect(PurposeEditStepAssignmentForm).toHaveBeenCalledWith(
       expect.objectContaining({
-        defaultValues: { reviewMode: 'selfWritesSelfSigns', reviewerId: undefined },
+        defaultValues: { reviewMode: 'ADMIN_WRITES_ADMIN_SIGNS', reviewerIds: [] },
       }),
       expect.anything()
     )
   })
 
-  it('renders the read-only step (not the form) when the purpose has a persisted reviewer workflow', () => {
+  it('seeds the default values with the persisted review mode and reviewers', () => {
     const purpose = buildPurpose(
       {},
-      { reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS', reviewerIds: ['reviewer-1'] }
+      {
+        reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+        reviewers: [
+          { userId: 'reviewer-1', name: 'Mario', familyName: 'Rossi' },
+          { userId: 'reviewer-2', name: 'Anna', familyName: 'Bianchi' },
+        ],
+      }
+    )
+    mockQueries({ purpose, reviewers: buildReviewers() })
+
+    render(<PurposeEditStepAssignment back={vi.fn()} forward={vi.fn()} activeStep={1} />)
+
+    expect(PurposeEditStepAssignmentForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultValues: {
+          reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+          reviewerIds: ['reviewer-1', 'reviewer-2'],
+        },
+      }),
+      expect.anything()
+    )
+  })
+
+  it.each(['DRAFT', 'ASSIGNED', 'SUBMITTED', 'REJECTED'] as const)(
+    'renders the editable form when the risk analysis is not approved yet (%s)',
+    (signingState) => {
+      const purpose = buildPurpose(
+        {},
+        { reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS', signingState }
+      )
+      mockQueries({ purpose, reviewers: buildReviewers() })
+
+      render(<PurposeEditStepAssignment back={vi.fn()} forward={vi.fn()} activeStep={1} />)
+
+      expect(PurposeEditStepAssignmentForm).toHaveBeenCalled()
+      expect(PurposeEditStepAssignmentReadOnly).not.toHaveBeenCalled()
+    }
+  )
+
+  it('renders the read-only step (not the form) once the risk analysis has been approved', () => {
+    const purpose = buildPurpose(
+      {},
+      { reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS', signingState: 'SIGNED' }
     )
     mockQueries({ purpose, reviewers: buildReviewers() })
 
@@ -262,7 +308,7 @@ describe('PurposeEditStepAssignment', () => {
     const reviewers = buildReviewers()
     const purpose = buildPurpose(
       {},
-      { reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS', reviewerIds: ['reviewer-1'] }
+      { reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS', signingState: 'SIGNED' }
     )
     mockQueries({ purpose, reviewers })
 

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignment.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignment.test.tsx
@@ -278,10 +278,7 @@ describe('PurposeEditStepAssignment', () => {
   it.each(['DRAFT', 'ASSIGNED', 'SUBMITTED', 'REJECTED'] as const)(
     'renders the editable form when the risk analysis is not approved yet (%s)',
     (signingState) => {
-      const purpose = buildPurpose(
-        {},
-        { reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS', signingState }
-      )
+      const purpose = buildPurpose({}, { reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS', signingState })
       mockQueries({ purpose, reviewers: buildReviewers() })
 
       render(<PurposeEditStepAssignment back={vi.fn()} forward={vi.fn()} activeStep={1} />)

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignment.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignment.test.tsx
@@ -249,6 +249,36 @@ describe('PurposeEditStepAssignment', () => {
     )
   })
 
+  it('reseeds the form when a refetch changes the persisted assignment', () => {
+    mockQueries({ purpose: buildPurpose(), reviewers: buildReviewers() })
+
+    const { rerender } = render(
+      <PurposeEditStepAssignment back={vi.fn()} forward={vi.fn()} activeStep={1} />
+    )
+
+    mockQueries({
+      purpose: buildPurpose(
+        {},
+        {
+          reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+          reviewers: [{ userId: 'reviewer-1', name: 'Mario', familyName: 'Rossi' }],
+        }
+      ),
+      reviewers: buildReviewers(),
+    })
+    rerender(<PurposeEditStepAssignment back={vi.fn()} forward={vi.fn()} activeStep={1} />)
+
+    expect(PurposeEditStepAssignmentForm).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        defaultValues: {
+          reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+          reviewerIds: ['reviewer-1'],
+        },
+      }),
+      expect.anything()
+    )
+  })
+
   it('seeds the default values with the persisted review mode and reviewers', () => {
     const purpose = buildPurpose(
       {},

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
@@ -96,10 +96,13 @@ function renderComponent(overrides?: {
   )
 }
 
-/** Opens the reviewers dropdown, picks the given names and closes it again. */
+/**
+ * Picks the given reviewers from the dropdown. The autocomplete does not set
+ * `disableCloseOnSelect`, so the popup closes after every pick and has to be reopened.
+ */
 async function selectReviewers(user: ReturnType<typeof userEvent.setup>, names: Array<string>) {
-  await user.click(screen.getByRole('combobox', { name: 'reviewerField.inputLabel' }))
   for (const name of names) {
+    await user.click(screen.getByRole('combobox', { name: 'reviewerField.inputLabel' }))
     await user.click(await screen.findByRole('option', { name }))
   }
   await user.keyboard('{Escape}')
@@ -562,7 +565,8 @@ describe('PurposeEditStepAssignmentForm', () => {
         reviewers: [],
       })
 
-      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+      // The CTA still reads from the persisted mode, which is the reviewer-compilation one.
+      await user.click(screen.getByRole('button', { name: 'requestReviewerCompilationBtn' }))
 
       expect(openDialogMock).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
@@ -483,6 +483,79 @@ describe('PurposeEditStepAssignmentForm', () => {
       expect(openDialogMock).not.toHaveBeenCalled()
     })
 
+    it('explains the assignment is dangling when the institution has no other reviewer left', () => {
+      renderComponent({ purpose: purposeWithRemovedReviewer(), defaultValues, reviewers: [] })
+
+      expect(screen.getByText('noReviewersAlert.removedReviewerMessage')).toBeInTheDocument()
+      expect(screen.queryByText('noReviewersAlert.message')).not.toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'noReviewersAlert.linkLabel' })).toHaveAttribute(
+        'href',
+        'https://selfcare.test/users'
+      )
+      expect(
+        screen.queryByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('keeps the plain "no reviewers" copy when nothing was assigned in the first place', () => {
+      renderComponent({ reviewers: [] })
+
+      expect(screen.getByText('noReviewersAlert.message')).toBeInTheDocument()
+      expect(screen.queryByText('noReviewersAlert.removedReviewerMessage')).not.toBeInTheDocument()
+    })
+
+    it('keeps the delegate alert when the delegate cannot assign reviewers anyway', () => {
+      renderComponent({
+        purpose: purposeWithRemovedReviewer(),
+        defaultValues,
+        reviewers: [],
+        isDelegate: true,
+      })
+
+      expect(screen.getByText('delegateAlert')).toBeInTheDocument()
+      expect(screen.queryByText('noReviewersAlert.removedReviewerMessage')).not.toBeInTheDocument()
+    })
+
+    it('falls back to the self-compilation mode on submit, dropping the dangling assignment', async () => {
+      const user = userEvent.setup()
+      const forward = vi.fn()
+      renderComponent({
+        purpose: purposeWithRemovedReviewer(),
+        defaultValues,
+        reviewers: [],
+        forward,
+      })
+
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+
+      expect(openDialogMock).not.toHaveBeenCalled()
+      expect(assignReviewerMock).toHaveBeenCalledWith(
+        {
+          purposeId: 'purpose-id',
+          reviewMode: 'ADMIN_WRITES_ADMIN_SIGNS',
+          reviewerIds: undefined,
+        },
+        expect.objectContaining({ onSuccess: forward })
+      )
+    })
+
+    it('does not touch the assignment on submit when the delegate alert is the one shown', async () => {
+      const user = userEvent.setup()
+      const forward = vi.fn()
+      renderComponent({
+        purpose: purposeWithRemovedReviewer(),
+        defaultValues,
+        reviewers: [],
+        isDelegate: true,
+        forward,
+      })
+
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+
+      expect(assignReviewerMock).not.toHaveBeenCalled()
+      expect(forward).toHaveBeenCalled()
+    })
+
     it('blocks the submit when more than one assigned reviewer was removed', async () => {
       const user = userEvent.setup()
       const otherRemoved: CompactUser = {

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
@@ -143,9 +143,7 @@ describe('PurposeEditStepAssignmentForm', () => {
     await user.click(
       screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_REVIEWER_SIGNS' })
     )
-    expect(
-      screen.getByText('reviewerField.label.ADMIN_WRITES_REVIEWER_SIGNS')
-    ).toBeInTheDocument()
+    expect(screen.getByText('reviewerField.label.ADMIN_WRITES_REVIEWER_SIGNS')).toBeInTheDocument()
 
     expect(screen.getByRole('combobox', { name: 'reviewerField.inputLabel' })).toBeInTheDocument()
 

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
@@ -390,6 +390,33 @@ describe('PurposeEditStepAssignmentForm', () => {
       )
     })
 
+    it('uses the unavailable reviewer placeholder in the confirmation dialog when the name is empty', async () => {
+      const user = userEvent.setup()
+      const reviewerWithoutName: CompactUser = {
+        userId: 'reviewer-without-name',
+        name: '',
+        familyName: '',
+      }
+      renderComponent({
+        purpose: buildAssignedPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [reviewerWithoutName]),
+        defaultValues: {
+          reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+          reviewerIds: [reviewerWithoutName.userId],
+        },
+      })
+
+      await user.click(
+        screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS' })
+      )
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+
+      expect(openDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          removedReviewerNames: ['readOnly.reviewerUnknown'],
+        })
+      )
+    })
+
     it('runs the mutation only when the dialog is confirmed', async () => {
       const user = userEvent.setup()
       const forward = vi.fn()

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
@@ -528,7 +528,19 @@ describe('PurposeEditStepAssignmentForm', () => {
 
       await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
 
-      expect(openDialogMock).not.toHaveBeenCalled()
+      expect(assignReviewerMock).not.toHaveBeenCalled()
+      expect(openDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'editRiskAnalysisAssignment',
+          fromMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+          toMode: 'ADMIN_WRITES_ADMIN_SIGNS',
+          addedReviewerNames: [],
+          removedReviewerNames: ['Luca Neri'],
+        })
+      )
+
+      openDialogMock.mock.calls[0][0].onConfirm()
+
       expect(assignReviewerMock).toHaveBeenCalledWith(
         {
           purposeId: 'purpose-id',
@@ -536,6 +548,27 @@ describe('PurposeEditStepAssignmentForm', () => {
           reviewerIds: undefined,
         },
         expect.objectContaining({ onSuccess: forward })
+      )
+    })
+
+    it('carries the reviewer-compilation mode into the dialog so the risk analysis loss is announced', async () => {
+      const user = userEvent.setup()
+      renderComponent({
+        purpose: buildAssignedPurpose('REVIEWER_WRITES_REVIEWER_SIGNS', [removedReviewer]),
+        defaultValues: {
+          reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
+          reviewerIds: [removedReviewer.userId],
+        },
+        reviewers: [],
+      })
+
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+
+      expect(openDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
+          toMode: 'ADMIN_WRITES_ADMIN_SIGNS',
+        })
       )
     })
 

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentForm.test.tsx
@@ -7,14 +7,19 @@ import PurposeEditStepAssignmentForm, {
 } from '../PurposeEditStepAssignmentForm'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
-import type { User } from '@/api/api.generatedTypes'
+import type { CompactUser, Purpose, RiskAnalysisReviewMode, User } from '@/api/api.generatedTypes'
 
 const assignReviewerMock = vi.fn()
 const openDialogMock = vi.fn()
+const navigateMock = vi.fn()
+const useAssignRiskAnalysisReviewerMock = vi.fn((..._args: Array<unknown>) => ({
+  mutate: assignReviewerMock,
+}))
 
 vi.mock('@/api/purpose', () => ({
   PurposeMutations: {
-    useAssignRiskAnalysisReviewer: () => ({ mutate: assignReviewerMock }),
+    useAssignRiskAnalysisReviewer: (...args: Array<unknown>) =>
+      useAssignRiskAnalysisReviewerMock(...args),
   },
 }))
 
@@ -29,6 +34,7 @@ vi.mock('@/stores', async () => {
 
 vi.mock('@/router', () => ({
   Link: ({ children, ...props }: React.PropsWithChildren) => <a {...props}>{children}</a>,
+  useNavigate: () => navigateMock,
 }))
 
 const mockReviewer: User = {
@@ -48,11 +54,25 @@ const mockReviewer2: User = {
 }
 
 const DEFAULT_VALUES: PurposeEditStepAssignmentFormValues = {
-  reviewMode: 'selfWritesSelfSigns',
-  reviewerId: undefined,
+  reviewMode: 'ADMIN_WRITES_ADMIN_SIGNS',
+  reviewerIds: [],
+}
+
+/** Builds a purpose that already carries a persisted assignment, i.e. the edit flow. */
+function buildAssignedPurpose(
+  reviewMode: RiskAnalysisReviewMode,
+  reviewers: Array<CompactUser>
+): Purpose {
+  const base = createMockPurpose({ id: 'purpose-id' })
+  return {
+    ...base,
+    reviewMode,
+    reviewerWorkflow: { reviewers, signingState: 'ASSIGNED' },
+  }
 }
 
 function renderComponent(overrides?: {
+  purpose?: Purpose
   reviewers?: Array<User>
   isDelegate?: boolean
   selfcareUsersPageUrl?: string
@@ -60,7 +80,7 @@ function renderComponent(overrides?: {
   forward?: VoidFunction
   back?: VoidFunction
 }) {
-  const purpose = createMockPurpose({ id: 'purpose-id' })
+  const purpose = overrides?.purpose ?? createMockPurpose({ id: 'purpose-id' })
   return renderWithApplicationContext(
     <PurposeEditStepAssignmentForm
       purpose={purpose}
@@ -76,28 +96,35 @@ function renderComponent(overrides?: {
   )
 }
 
+/** Opens the reviewers dropdown, picks the given names and closes it again. */
+async function selectReviewers(user: ReturnType<typeof userEvent.setup>, names: Array<string>) {
+  await user.click(screen.getByRole('combobox', { name: 'reviewerField.inputLabel' }))
+  for (const name of names) {
+    await user.click(await screen.findByRole('option', { name }))
+  }
+  await user.keyboard('{Escape}')
+}
+
 describe('PurposeEditStepAssignmentForm', () => {
   beforeEach(() => {
     assignReviewerMock.mockReset()
     openDialogMock.mockReset()
+    navigateMock.mockReset()
+    useAssignRiskAnalysisReviewerMock.mockClear()
   })
 
   it('renders the 3 review mode options with the first one selected by default', () => {
     renderComponent()
 
-    const selfWritesSelfSigns = screen.getByRole('radio', {
-      name: 'reviewModeField.options.selfWritesSelfSigns',
-    })
-    const selfWritesReviewerSigns = screen.getByRole('radio', {
-      name: 'reviewModeField.options.selfWritesReviewerSigns',
-    })
-    const reviewerWritesReviewerSigns = screen.getByRole('radio', {
-      name: 'reviewModeField.options.reviewerWritesReviewerSigns',
-    })
-
-    expect(selfWritesSelfSigns).toBeChecked()
-    expect(selfWritesReviewerSigns).not.toBeChecked()
-    expect(reviewerWritesReviewerSigns).not.toBeChecked()
+    expect(
+      screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS' })
+    ).toBeChecked()
+    expect(
+      screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_REVIEWER_SIGNS' })
+    ).not.toBeChecked()
+    expect(
+      screen.getByRole('radio', { name: 'reviewModeField.options.REVIEWER_WRITES_REVIEWER_SIGNS' })
+    ).not.toBeChecked()
   })
 
   it('does not show the reviewer autocomplete when the first option is selected', () => {
@@ -114,15 +141,13 @@ describe('PurposeEditStepAssignmentForm', () => {
     renderComponent()
 
     await user.click(
-      screen.getByRole('radio', { name: 'reviewModeField.options.selfWritesReviewerSigns' })
+      screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_REVIEWER_SIGNS' })
     )
-    expect(screen.getByText('reviewerField.label.selfWritesReviewerSigns')).toBeInTheDocument()
-
     expect(
-      screen.getByRole('combobox', {
-        name: 'reviewerField.inputLabel',
-      })
+      screen.getByText('reviewerField.label.ADMIN_WRITES_REVIEWER_SIGNS')
     ).toBeInTheDocument()
+
+    expect(screen.getByRole('combobox', { name: 'reviewerField.inputLabel' })).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
     expect(await screen.findByText('reviewerField.requiredError')).toBeInTheDocument()
@@ -134,7 +159,7 @@ describe('PurposeEditStepAssignmentForm', () => {
     const { container } = renderComponent()
 
     await user.click(
-      screen.getByRole('radio', { name: 'reviewModeField.options.selfWritesReviewerSigns' })
+      screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_REVIEWER_SIGNS' })
     )
 
     const label = screen.getByText('reviewerField.inputLabel')
@@ -142,23 +167,20 @@ describe('PurposeEditStepAssignmentForm', () => {
     expect(container.querySelector('input[required]')).toBeInTheDocument()
   })
 
-  it('shows the "compiler" autocomplete with the reviewer required error when option 3 is selected, populated with the same list', async () => {
+  it('shows the "compiler" autocomplete when option 3 is selected, populated with the same list', async () => {
     const user = userEvent.setup()
     renderComponent()
 
     await user.click(
-      screen.getByRole('radio', { name: 'reviewModeField.options.reviewerWritesReviewerSigns' })
+      screen.getByRole('radio', { name: 'reviewModeField.options.REVIEWER_WRITES_REVIEWER_SIGNS' })
     )
-    expect(screen.getByText('reviewerField.label.reviewerWritesReviewerSigns')).toBeInTheDocument()
+    expect(
+      screen.getByText('reviewerField.label.REVIEWER_WRITES_REVIEWER_SIGNS')
+    ).toBeInTheDocument()
 
-    const autocomplete = screen.getByRole('combobox', {
-      name: 'reviewerField.inputLabel',
-    })
-    expect(autocomplete).toBeInTheDocument()
-
-    await user.click(autocomplete)
-    expect(screen.getByText('Mario Rossi')).toBeInTheDocument()
-    expect(screen.getByText('Anna Verdi')).toBeInTheDocument()
+    await user.click(screen.getByRole('combobox', { name: 'reviewerField.inputLabel' }))
+    expect(await screen.findByRole('option', { name: 'Mario Rossi' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Anna Verdi' })).toBeInTheDocument()
   })
 
   it('switches the primary CTA to "request compilation" when option 3 is selected', async () => {
@@ -171,7 +193,7 @@ describe('PurposeEditStepAssignmentForm', () => {
     ).not.toBeInTheDocument()
 
     await user.click(
-      screen.getByRole('radio', { name: 'reviewModeField.options.reviewerWritesReviewerSigns' })
+      screen.getByRole('radio', { name: 'reviewModeField.options.REVIEWER_WRITES_REVIEWER_SIGNS' })
     )
 
     expect(
@@ -189,117 +211,317 @@ describe('PurposeEditStepAssignmentForm', () => {
     expect(within(forwardBtn).queryByTestId('SendIcon')).not.toBeInTheDocument()
 
     await user.click(
-      screen.getByRole('radio', { name: 'reviewModeField.options.selfWritesReviewerSigns' })
+      screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_REVIEWER_SIGNS' })
     )
     const forwardBtn2 = screen.getByRole('button', { name: 'forwardBtn' })
     expect(within(forwardBtn2).getByTestId('SaveIcon')).toBeInTheDocument()
     expect(within(forwardBtn2).queryByTestId('SendIcon')).not.toBeInTheDocument()
 
     await user.click(
-      screen.getByRole('radio', { name: 'reviewModeField.options.reviewerWritesReviewerSigns' })
+      screen.getByRole('radio', { name: 'reviewModeField.options.REVIEWER_WRITES_REVIEWER_SIGNS' })
     )
     const requestBtn = screen.getByRole('button', { name: 'requestReviewerCompilationBtn' })
     expect(within(requestBtn).getByTestId('SendIcon')).toBeInTheDocument()
     expect(within(requestBtn).queryByTestId('SaveIcon')).not.toBeInTheDocument()
   })
 
-  it('on submit with option 1, does not call the API and forwards', async () => {
-    const user = userEvent.setup()
-    const forward = vi.fn()
-    renderComponent({ reviewers: [mockReviewer], forward })
+  describe('first compilation', () => {
+    it('asks for no success feedback, since the first assignment is silent', () => {
+      renderComponent()
 
-    await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+      expect(useAssignRiskAnalysisReviewerMock).toHaveBeenCalledWith({ feedback: 'none' })
+    })
 
-    expect(assignReviewerMock).not.toHaveBeenCalled()
-    expect(forward).toHaveBeenCalled()
-  })
+    it('on submit with option 1, persists the self-compilation mode without reviewers and forwards', async () => {
+      const user = userEvent.setup()
+      const forward = vi.fn()
+      renderComponent({ reviewers: [mockReviewer], forward })
 
-  it('on submit with option 2 and a reviewer selected, calls the API and forwards on success', async () => {
-    const user = userEvent.setup()
-    const forward = vi.fn()
-    renderComponent({ reviewers: [mockReviewer], forward })
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
 
-    await user.click(
-      screen.getByRole('radio', { name: 'reviewModeField.options.selfWritesReviewerSigns' })
-    )
+      expect(assignReviewerMock).toHaveBeenCalledWith(
+        {
+          purposeId: 'purpose-id',
+          reviewMode: 'ADMIN_WRITES_ADMIN_SIGNS',
+          reviewerIds: undefined,
+        },
+        expect.objectContaining({ onSuccess: forward })
+      )
+      expect(openDialogMock).not.toHaveBeenCalled()
+    })
 
-    await user.click(screen.getByRole('combobox', { name: 'reviewerField.inputLabel' }))
+    it('on submit with option 2 and a reviewer selected, calls the API and forwards on success', async () => {
+      const user = userEvent.setup()
+      const forward = vi.fn()
+      renderComponent({ reviewers: [mockReviewer], forward })
 
-    await user.click(screen.getByText('Mario Rossi'))
-    await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+      await user.click(
+        screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_REVIEWER_SIGNS' })
+      )
+      await selectReviewers(user, ['Mario Rossi'])
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
 
-    expect(assignReviewerMock).toHaveBeenCalledWith(
-      {
+      expect(assignReviewerMock).toHaveBeenCalledWith(
+        {
+          purposeId: 'purpose-id',
+          reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+          reviewerIds: ['reviewer-uuid-1'],
+        },
+        expect.objectContaining({ onSuccess: forward })
+      )
+    })
+
+    it('sends every selected reviewer, not just the first one', async () => {
+      const user = userEvent.setup()
+      renderComponent()
+
+      await user.click(
+        screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_REVIEWER_SIGNS' })
+      )
+      await selectReviewers(user, ['Mario Rossi', 'Anna Verdi'])
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+
+      expect(assignReviewerMock).toHaveBeenCalledWith(
+        expect.objectContaining({ reviewerIds: ['reviewer-uuid-1', 'reviewer-uuid-2'] }),
+        expect.anything()
+      )
+    })
+
+    it('on submit with option 3, opens the compilation dialog without calling the API', async () => {
+      const user = userEvent.setup()
+      const forward = vi.fn()
+      renderComponent({ forward })
+
+      await user.click(
+        screen.getByRole('radio', {
+          name: 'reviewModeField.options.REVIEWER_WRITES_REVIEWER_SIGNS',
+        })
+      )
+      await selectReviewers(user, ['Mario Rossi', 'Anna Verdi'])
+      await user.click(screen.getByRole('button', { name: 'requestReviewerCompilationBtn' }))
+
+      expect(assignReviewerMock).not.toHaveBeenCalled()
+      expect(forward).not.toHaveBeenCalled()
+      expect(openDialogMock).toHaveBeenCalledWith({
+        type: 'requestRiskAnalysisCompilation',
         purposeId: 'purpose-id',
-        reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-        reviewerIds: ['reviewer-uuid-1'],
-      },
-      expect.objectContaining({ onSuccess: forward })
-    )
-  })
+        reviewerIds: ['reviewer-uuid-1', 'reviewer-uuid-2'],
+        reviewerNames: ['Mario Rossi', 'Anna Verdi'],
+      })
+    })
 
-  it('on submit with option 3 and a reviewer selected, opens the confirmation dialog without calling the API', async () => {
-    const user = userEvent.setup()
-    const forward = vi.fn()
-    renderComponent({ reviewers: [mockReviewer], forward })
+    it('drops the selected reviewers when switching back to option 1 before submitting', async () => {
+      const user = userEvent.setup()
+      const forward = vi.fn()
+      renderComponent({ reviewers: [mockReviewer], forward })
 
-    await user.click(
-      screen.getByRole('radio', { name: 'reviewModeField.options.reviewerWritesReviewerSigns' })
-    )
+      await user.click(
+        screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_REVIEWER_SIGNS' })
+      )
+      await selectReviewers(user, ['Mario Rossi'])
+      await user.click(
+        screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS' })
+      )
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
 
-    await user.click(screen.getByRole('combobox', { name: 'reviewerField.inputLabel' }))
-
-    await user.click(screen.getByText('Mario Rossi'))
-    await user.click(screen.getByRole('button', { name: 'requestReviewerCompilationBtn' }))
-
-    expect(assignReviewerMock).not.toHaveBeenCalled()
-    expect(forward).not.toHaveBeenCalled()
-    expect(openDialogMock).toHaveBeenCalledWith({
-      type: 'requestRiskAnalysisCompilation',
-      purposeId: 'purpose-id',
-      reviewerId: 'reviewer-uuid-1',
-      reviewerName: 'Mario Rossi',
+      expect(assignReviewerMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reviewMode: 'ADMIN_WRITES_ADMIN_SIGNS',
+          reviewerIds: undefined,
+        }),
+        expect.anything()
+      )
     })
   })
 
-  it('after selecting option 2 with a reviewer and switching back to option 1, on submit does not call the API and only forwards', async () => {
-    const user = userEvent.setup()
-    const forward = vi.fn()
-    renderComponent({ reviewers: [mockReviewer], forward })
+  describe('edit of an existing assignment', () => {
+    const assignedPurpose = () =>
+      buildAssignedPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [
+        { userId: mockReviewer.userId, name: 'Mario', familyName: 'Rossi' },
+      ])
 
-    await user.click(
-      screen.getByRole('radio', { name: 'reviewModeField.options.selfWritesReviewerSigns' })
-    )
+    const editDefaultValues: PurposeEditStepAssignmentFormValues = {
+      reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+      reviewerIds: [mockReviewer.userId],
+    }
 
-    await user.click(screen.getByRole('combobox', { name: 'reviewerField.inputLabel' }))
+    it('asks for the edit feedback so the dedicated snackbar is shown', () => {
+      renderComponent({ purpose: assignedPurpose(), defaultValues: editDefaultValues })
 
-    await user.click(screen.getByText('Mario Rossi'))
+      expect(useAssignRiskAnalysisReviewerMock).toHaveBeenCalledWith({ feedback: 'edit' })
+    })
 
-    await user.click(
-      screen.getByRole('radio', { name: 'reviewModeField.options.selfWritesSelfSigns' })
-    )
-    await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+    it('opens the confirmation dialog with the mode change and the added reviewer, without calling the API', async () => {
+      const user = userEvent.setup()
+      renderComponent({ purpose: assignedPurpose(), defaultValues: editDefaultValues })
 
-    expect(assignReviewerMock).not.toHaveBeenCalled()
-    expect(forward).toHaveBeenCalled()
+      await selectReviewers(user, ['Anna Verdi'])
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+
+      expect(assignReviewerMock).not.toHaveBeenCalled()
+      expect(openDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'editRiskAnalysisAssignment',
+          fromMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+          toMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+          addedReviewerNames: ['Anna Verdi'],
+          removedReviewerNames: [],
+        })
+      )
+    })
+
+    it('reports the dropped reviewers as removed when the new mode needs none', async () => {
+      const user = userEvent.setup()
+      renderComponent({ purpose: assignedPurpose(), defaultValues: editDefaultValues })
+
+      await user.click(
+        screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS' })
+      )
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+
+      expect(openDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+          toMode: 'ADMIN_WRITES_ADMIN_SIGNS',
+          addedReviewerNames: [],
+          removedReviewerNames: ['Mario Rossi'],
+        })
+      )
+    })
+
+    it('runs the mutation only when the dialog is confirmed', async () => {
+      const user = userEvent.setup()
+      const forward = vi.fn()
+      renderComponent({ purpose: assignedPurpose(), defaultValues: editDefaultValues, forward })
+
+      await user.click(
+        screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS' })
+      )
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+
+      expect(assignReviewerMock).not.toHaveBeenCalled()
+
+      openDialogMock.mock.calls[0][0].onConfirm()
+
+      expect(assignReviewerMock).toHaveBeenCalledWith(
+        {
+          purposeId: 'purpose-id',
+          reviewMode: 'ADMIN_WRITES_ADMIN_SIGNS',
+          reviewerIds: undefined,
+        },
+        expect.objectContaining({ onSuccess: forward })
+      )
+    })
+
+    it('goes to the summary instead of the next step when the new mode is the reviewer compilation', async () => {
+      const user = userEvent.setup()
+      renderComponent({ purpose: assignedPurpose(), defaultValues: editDefaultValues })
+
+      await user.click(
+        screen.getByRole('radio', {
+          name: 'reviewModeField.options.REVIEWER_WRITES_REVIEWER_SIGNS',
+        })
+      )
+      await user.click(screen.getByRole('button', { name: 'requestReviewerCompilationBtn' }))
+
+      openDialogMock.mock.calls[0][0].onConfirm()
+      assignReviewerMock.mock.calls[0][1].onSuccess()
+
+      expect(navigateMock).toHaveBeenCalledWith('SUBSCRIBE_PURPOSE_SUMMARY', {
+        params: { purposeId: 'purpose-id' },
+      })
+    })
+
+    it('skips the dialog and just moves on when nothing was changed', async () => {
+      const user = userEvent.setup()
+      const forward = vi.fn()
+      renderComponent({ purpose: assignedPurpose(), defaultValues: editDefaultValues, forward })
+
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+
+      expect(openDialogMock).not.toHaveBeenCalled()
+      expect(assignReviewerMock).not.toHaveBeenCalled()
+      expect(forward).toHaveBeenCalled()
+    })
+  })
+
+  describe('reviewer removed from the institution', () => {
+    const removedReviewer: CompactUser = {
+      userId: 'removed-uuid',
+      name: 'Luca',
+      familyName: 'Neri',
+    }
+    const purposeWithRemovedReviewer = () =>
+      buildAssignedPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [removedReviewer])
+    const defaultValues: PurposeEditStepAssignmentFormValues = {
+      reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+      reviewerIds: [removedReviewer.userId],
+    }
+
+    it('keeps the removed reviewer visible as a selected chip', () => {
+      renderComponent({ purpose: purposeWithRemovedReviewer(), defaultValues })
+
+      expect(screen.getByText('Luca Neri')).toBeInTheDocument()
+    })
+
+    it('does not offer the removed reviewer among the dropdown options', async () => {
+      const user = userEvent.setup()
+      renderComponent({ purpose: purposeWithRemovedReviewer(), defaultValues })
+
+      await user.click(screen.getByRole('combobox', { name: 'reviewerField.inputLabel' }))
+
+      expect(await screen.findByRole('option', { name: 'Mario Rossi' })).toBeInTheDocument()
+      expect(screen.queryByRole('option', { name: 'Luca Neri' })).not.toBeInTheDocument()
+    })
+
+    it('blocks the submit with a singular error while the removed reviewer is still selected', async () => {
+      const user = userEvent.setup()
+      renderComponent({ purpose: purposeWithRemovedReviewer(), defaultValues })
+
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+
+      expect(await screen.findByText('reviewerField.removedError')).toBeInTheDocument()
+      expect(assignReviewerMock).not.toHaveBeenCalled()
+      expect(openDialogMock).not.toHaveBeenCalled()
+    })
+
+    it('blocks the submit when more than one assigned reviewer was removed', async () => {
+      const user = userEvent.setup()
+      const otherRemoved: CompactUser = {
+        userId: 'removed-uuid-2',
+        name: 'Sara',
+        familyName: 'Gialli',
+      }
+      renderComponent({
+        purpose: buildAssignedPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [
+          removedReviewer,
+          otherRemoved,
+        ]),
+        defaultValues: {
+          reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+          reviewerIds: [removedReviewer.userId, otherRemoved.userId],
+        },
+      })
+
+      await user.click(screen.getByRole('button', { name: 'forwardBtn' }))
+
+      expect(await screen.findByText('reviewerField.removedError')).toBeInTheDocument()
+      expect(assignReviewerMock).not.toHaveBeenCalled()
+    })
   })
 
   it('prefills the form from defaultValues so coming back to the step preserves the selection', () => {
     renderComponent({
       defaultValues: {
-        reviewMode: 'selfWritesReviewerSigns',
-        reviewerId: mockReviewer2.userId,
+        reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
+        reviewerIds: [mockReviewer2.userId],
       },
     })
 
     expect(
-      screen.getByRole('radio', { name: 'reviewModeField.options.selfWritesReviewerSigns' })
+      screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_REVIEWER_SIGNS' })
     ).toBeChecked()
-    expect(
-      screen.getByRole('combobox', {
-        name: 'reviewerField.inputLabel',
-      })
-    ).toHaveValue('Anna Verdi')
+    expect(screen.getByText('Anna Verdi')).toBeInTheDocument()
   })
 
   it('shows the info alert and hides the form when the institution has no reviewers', () => {
@@ -311,7 +533,7 @@ describe('PurposeEditStepAssignmentForm', () => {
       'https://selfcare.test/users'
     )
     expect(
-      screen.queryByRole('radio', { name: 'reviewModeField.options.selfWritesSelfSigns' })
+      screen.queryByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS' })
     ).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'backWithoutSaveBtn' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'forwardBtn' })).toBeInTheDocument()
@@ -333,7 +555,7 @@ describe('PurposeEditStepAssignmentForm', () => {
 
     expect(screen.getByText('delegateAlert')).toBeInTheDocument()
     expect(
-      screen.queryByRole('radio', { name: 'reviewModeField.options.selfWritesSelfSigns' })
+      screen.queryByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS' })
     ).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'backWithoutSaveBtn' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'forwardBtn' })).toBeInTheDocument()
@@ -356,7 +578,7 @@ describe('PurposeEditStepAssignmentForm', () => {
     expect(screen.queryByText('noReviewersAlert.message')).not.toBeInTheDocument()
     expect(screen.queryByText('delegateAlert')).not.toBeInTheDocument()
     expect(
-      screen.getByRole('radio', { name: 'reviewModeField.options.selfWritesSelfSigns' })
+      screen.getByRole('radio', { name: 'reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS' })
     ).toBeInTheDocument()
   })
 

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentReadOnly.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentReadOnly.test.tsx
@@ -5,7 +5,12 @@ import userEvent from '@testing-library/user-event'
 import PurposeEditStepAssignmentReadOnly from '../PurposeEditStepAssignmentReadOnly'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
-import type { CompactUser, Purpose, RiskAnalysisReviewMode } from '@/api/api.generatedTypes'
+import type {
+  CompactUser,
+  Purpose,
+  PurposeVersionState,
+  RiskAnalysisReviewMode,
+} from '@/api/api.generatedTypes'
 
 const mockReviewer: CompactUser = {
   userId: 'reviewer-uuid-1',
@@ -13,14 +18,19 @@ const mockReviewer: CompactUser = {
   familyName: 'Rossi',
 }
 
-function buildPurpose(reviewMode: RiskAnalysisReviewMode, reviewers: Array<CompactUser>): Purpose {
+function buildPurpose(
+  reviewMode: RiskAnalysisReviewMode,
+  reviewers: Array<CompactUser>,
+  versionState: PurposeVersionState = 'DRAFT'
+): Purpose {
+  const base = createMockPurpose({ id: 'purpose-id' })
   return {
-    ...createMockPurpose({ id: 'purpose-id' }),
+    ...base,
+    currentVersion: base.currentVersion && { ...base.currentVersion, state: versionState },
+    reviewMode,
     reviewerWorkflow: {
-      reviewMode,
-      reviewerIds: reviewers.map((r) => r.userId),
       reviewers,
-      signingState: 'ASSIGNED',
+      signingState: 'SIGNED',
     },
   }
 }
@@ -47,7 +57,9 @@ describe('PurposeEditStepAssignmentReadOnly', () => {
     renderComponent({ purpose })
 
     expect(screen.getByText('readOnly.modeLabel')).toBeInTheDocument()
-    expect(screen.getByText('reviewModeField.options.selfWritesSelfSigns')).toBeInTheDocument()
+    expect(
+      screen.getByText('reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS')
+    ).toBeInTheDocument()
     expect(screen.queryByText('readOnly.reviewerLabel')).not.toBeInTheDocument()
   })
 
@@ -55,7 +67,9 @@ describe('PurposeEditStepAssignmentReadOnly', () => {
     renderComponent({ purpose: buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [mockReviewer]) })
 
     expect(screen.getByText('readOnly.modeLabel')).toBeInTheDocument()
-    expect(screen.getByText('reviewModeField.options.selfWritesReviewerSigns')).toBeInTheDocument()
+    expect(
+      screen.getByText('reviewModeField.options.ADMIN_WRITES_REVIEWER_SIGNS')
+    ).toBeInTheDocument()
     expect(screen.getByText('readOnly.reviewerLabel')).toBeInTheDocument()
     expect(screen.getByText('Mario Rossi')).toBeInTheDocument()
   })
@@ -67,10 +81,37 @@ describe('PurposeEditStepAssignmentReadOnly', () => {
 
     expect(screen.getByText('readOnly.modeLabel')).toBeInTheDocument()
     expect(
-      screen.getByText('reviewModeField.options.reviewerWritesReviewerSigns')
+      screen.getByText('reviewModeField.options.REVIEWER_WRITES_REVIEWER_SIGNS')
     ).toBeInTheDocument()
     expect(screen.getByText('readOnly.reviewerLabel')).toBeInTheDocument()
     expect(screen.getByText('Mario Rossi')).toBeInTheDocument()
+  })
+
+  it('lists every assigned reviewer, not just the first one', () => {
+    renderComponent({
+      purpose: buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [
+        mockReviewer,
+        { userId: 'reviewer-uuid-2', name: 'Anna', familyName: 'Verdi' },
+      ]),
+    })
+
+    expect(screen.getByText('Mario Rossi, Anna Verdi')).toBeInTheDocument()
+  })
+
+  it('explains the assignment is frozen because the risk analysis was approved, while the purpose is still a draft', () => {
+    renderComponent({ purpose: buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [mockReviewer]) })
+
+    expect(screen.getByText('readOnly.subtitle.signed')).toBeInTheDocument()
+    expect(screen.queryByText('readOnly.subtitle.published')).not.toBeInTheDocument()
+  })
+
+  it('explains the assignment is frozen because the purpose has been published', () => {
+    renderComponent({
+      purpose: buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [mockReviewer], 'ACTIVE'),
+    })
+
+    expect(screen.getByText('readOnly.subtitle.published')).toBeInTheDocument()
+    expect(screen.queryByText('readOnly.subtitle.signed')).not.toBeInTheDocument()
   })
 
   it('does not render any radio group, autocomplete or submit CTA', () => {
@@ -97,13 +138,23 @@ describe('PurposeEditStepAssignmentReadOnly', () => {
     expect(back).toHaveBeenCalledTimes(1)
   })
 
-  it('falls back to a placeholder when the workflow exposes no resolvable reviewer', () => {
+  it('hides the reviewer row when the workflow carries no reviewer', () => {
     renderComponent({
       purpose: buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', []),
     })
 
+    expect(screen.queryByText('readOnly.reviewerLabel')).not.toBeInTheDocument()
+    expect(screen.queryByText('Mario Rossi')).not.toBeInTheDocument()
+  })
+
+  it('falls back to a placeholder when an assigned reviewer has no resolvable name', () => {
+    renderComponent({
+      purpose: buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [
+        { userId: 'reviewer-uuid-3', name: '', familyName: '' },
+      ]),
+    })
+
     expect(screen.getByText('readOnly.reviewerLabel')).toBeInTheDocument()
     expect(screen.getByText('readOnly.reviewerUnknown')).toBeInTheDocument()
-    expect(screen.queryByText('Mario Rossi')).not.toBeInTheDocument()
   })
 })

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentReadOnly.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentReadOnly.test.tsx
@@ -112,6 +112,19 @@ describe('PurposeEditStepAssignmentReadOnly', () => {
     expect(screen.queryByText('readOnly.subtitle.signed')).not.toBeInTheDocument()
   })
 
+  it.each(['WAITING_FOR_APPROVAL', 'SUSPENDED', 'REJECTED', 'ARCHIVED'] as const)(
+    'uses a generic explanation when the purpose is %s but not published',
+    (versionState) => {
+      renderComponent({
+        purpose: buildPurpose('ADMIN_WRITES_REVIEWER_SIGNS', [mockReviewer], versionState),
+      })
+
+      expect(screen.getByText('readOnly.subtitle.notDraft')).toBeInTheDocument()
+      expect(screen.queryByText('readOnly.subtitle.published')).not.toBeInTheDocument()
+      expect(screen.queryByText('readOnly.subtitle.signed')).not.toBeInTheDocument()
+    }
+  )
+
   it('does not render any radio group, autocomplete or submit CTA', () => {
     renderComponent()
 

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentReadOnly.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepAssignment/__tests__/PurposeEditStepAssignmentReadOnly.test.tsx
@@ -57,9 +57,7 @@ describe('PurposeEditStepAssignmentReadOnly', () => {
     renderComponent({ purpose })
 
     expect(screen.getByText('readOnly.modeLabel')).toBeInTheDocument()
-    expect(
-      screen.getByText('reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS')
-    ).toBeInTheDocument()
+    expect(screen.getByText('reviewModeField.options.ADMIN_WRITES_ADMIN_SIGNS')).toBeInTheDocument()
     expect(screen.queryByText('readOnly.reviewerLabel')).not.toBeInTheDocument()
   })
 

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
@@ -54,7 +54,7 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
     return <RiskAnalysisFormSkeleton />
   }
 
-  const reviewMode = purpose.reviewerWorkflow?.reviewMode
+  const reviewMode = purpose.reviewMode
   const signingState = purpose.reviewerWorkflow?.signingState
 
   const stepMode = match<

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
@@ -139,13 +139,13 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
   }
 
   const handleRequestApproval = (answers: Record<string, string[]>) => {
-    const reviewerId = purpose.reviewerWorkflow?.reviewerIds?.[0]
+    const reviewerId = purpose.reviewerWorkflow?.reviewers?.[0]?.userId
     if (!reviewerId) {
       // If we land here the purpose is malformed;
       // log loudly and no-op rather than crashing the route —
       // this is a UI action handler, not a place to throw to the ErrorBoundary.
       console.error(
-        'PurposeEditStepRiskAnalysis: reviewerIds is missing on a purpose in ADMIN_WRITES_REVIEWER_SIGNS mode'
+        'PurposeEditStepRiskAnalysis: reviewers is missing on a purpose in ADMIN_WRITES_REVIEWER_SIGNS mode'
       )
       return
     }

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/PurposeEditStepRiskAnalysis.tsx
@@ -61,8 +61,11 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
     { reviewMode: typeof reviewMode; signingState: typeof signingState },
     RiskAnalysisStepMode
   >({ reviewMode, signingState })
-    // Option 1: no reviewer workflow → behaves as today.
-    .with({ reviewMode: undefined }, () => ({ kind: 'editable' }))
+    // Option 1: self-compilation and self-approval, no reviewer workflow → behaves as today.
+    // `undefined` covers the purposes created before the BE started sending the review mode.
+    .with({ reviewMode: P.union(undefined, 'ADMIN_WRITES_ADMIN_SIGNS') }, () => ({
+      kind: 'editable',
+    }))
     // Option 2: admin compiles, reviewer signs.
     .with(
       { reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS', signingState: P.union('SUBMITTED', 'SIGNED') },
@@ -139,8 +142,8 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
   }
 
   const handleRequestApproval = (answers: Record<string, string[]>) => {
-    const reviewerId = purpose.reviewerWorkflow?.reviewers?.[0]?.userId
-    if (!reviewerId) {
+    const reviewer: CompactUser | undefined = purpose.reviewerWorkflow?.reviewers?.[0]
+    if (!reviewer) {
       // If we land here the purpose is malformed;
       // log loudly and no-op rather than crashing the route —
       // this is a UI action handler, not a place to throw to the ErrorBoundary.
@@ -150,11 +153,6 @@ export const PurposeEditStepRiskAnalysis: React.FC<ActiveStepProps> = ({ back })
       return
     }
 
-    const reviewer: CompactUser = purpose.reviewerWorkflow?.reviewers?.[0] ?? {
-      userId: reviewerId,
-      name: '',
-      familyName: '',
-    }
     openDialog({
       type: 'requestPurposeApproval',
       reviewer,

--- a/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
+++ b/src/pages/ConsumerPurposeEditPage/components/PurposeEditStepRiskAnalysis/__tests__/PurposeEditStepRiskAnalysis.test.tsx
@@ -13,6 +13,7 @@ import type {
   PurposeUpdateContent,
   ReviewerWorkflow,
   RiskAnalysisFormConfig,
+  RiskAnalysisReviewMode,
   RiskAnalysisSubmissionSeed,
 } from '@/api/api.generatedTypes'
 
@@ -86,11 +87,14 @@ function mockQueries(
   })
 }
 
-function buildPurpose(reviewerWorkflow?: ReviewerWorkflow): Purpose {
-  return {
-    ...createMockPurpose({ id: 'purpose-123' }),
-    ...(reviewerWorkflow ? { reviewerWorkflow } : {}),
-  }
+type ReviewSetup = { reviewMode: RiskAnalysisReviewMode } & ReviewerWorkflow
+
+function buildPurpose(review?: ReviewSetup): Purpose {
+  const purpose = createMockPurpose({ id: 'purpose-123' })
+  if (!review) return purpose
+
+  const { reviewMode, ...reviewerWorkflow } = review
+  return { ...purpose, reviewMode, reviewerWorkflow }
 }
 
 function getLastFormProps(): RiskAnalysisFormSpyProps {
@@ -129,7 +133,6 @@ describe('PurposeEditStepRiskAnalysis', () => {
     mockQueries(
       buildPurpose({
         reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-        reviewerIds: ['reviewer-1'],
         signingState: 'DRAFT',
       }),
       createMockRiskAnalysisFormConfig()
@@ -145,7 +148,6 @@ describe('PurposeEditStepRiskAnalysis', () => {
     mockQueries(
       buildPurpose({
         reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-        reviewerIds: ['reviewer-1'],
         signingState: 'SUBMITTED',
       }),
       createMockRiskAnalysisFormConfig()
@@ -167,7 +169,6 @@ describe('PurposeEditStepRiskAnalysis', () => {
     mockQueries(
       buildPurpose({
         reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-        reviewerIds: ['reviewer-1'],
         signingState: 'SIGNED',
       }),
       createMockRiskAnalysisFormConfig()
@@ -186,7 +187,6 @@ describe('PurposeEditStepRiskAnalysis', () => {
     mockQueries(
       buildPurpose({
         reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-        reviewerIds: ['reviewer-1'],
         signingState: 'REJECTED',
       }),
       createMockRiskAnalysisFormConfig()
@@ -202,7 +202,6 @@ describe('PurposeEditStepRiskAnalysis', () => {
     mockQueries(
       buildPurpose({
         reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
-        reviewerIds: ['reviewer-1'],
         signingState: 'ASSIGNED',
       }),
       createMockRiskAnalysisFormConfig()
@@ -224,7 +223,6 @@ describe('PurposeEditStepRiskAnalysis', () => {
     mockQueries(
       buildPurpose({
         reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
-        reviewerIds: ['reviewer-1'],
         signingState: 'SIGNED',
       }),
       createMockRiskAnalysisFormConfig()
@@ -248,7 +246,6 @@ describe('PurposeEditStepRiskAnalysis', () => {
       mockQueries(
         buildPurpose({
           reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
-          reviewerIds: ['reviewer-1'],
           signingState,
         }),
         createMockRiskAnalysisFormConfig()
@@ -264,7 +261,6 @@ describe('PurposeEditStepRiskAnalysis', () => {
     mockQueries(
       buildPurpose({
         reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-        reviewerIds: ['reviewer-1'],
         signingState: 'SIGNED',
       }),
       createMockRiskAnalysisFormConfig()
@@ -310,7 +306,6 @@ describe('PurposeEditStepRiskAnalysis', () => {
     const reviewer = { userId: 'reviewer-1', name: 'Mario', familyName: 'Rossi' }
     const purpose = buildPurpose({
       reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-      reviewerIds: ['reviewer-1'],
       reviewers: [reviewer],
       signingState: 'DRAFT',
     })
@@ -356,11 +351,10 @@ describe('PurposeEditStepRiskAnalysis', () => {
     })
   })
 
-  it('in option 2 logs and no-ops when reviewerIds is missing (BE contract violation) instead of opening a malformed dialog', () => {
+  it('in option 2 logs and no-ops when reviewers is missing (BE contract violation) instead of opening a malformed dialog', () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const purpose = buildPurpose({
       reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-      reviewerIds: [],
       reviewers: [],
       signingState: 'DRAFT',
     })
@@ -370,38 +364,15 @@ describe('PurposeEditStepRiskAnalysis', () => {
 
     getLastFormProps().onSubmit({ purpose: ['OTHER'] })
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/reviewerIds/))
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringMatching(/reviewers/))
     expect(openDialogMock).not.toHaveBeenCalled()
 
     consoleErrorSpy.mockRestore()
   })
 
-  it('in option 2 still opens the dialog when reviewerIds is present but reviewers is not yet populated (staggered BE release)', () => {
-    const purpose = buildPurpose({
-      reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-      reviewerIds: ['reviewer-1'],
-      reviewers: [],
-      signingState: 'DRAFT',
-    })
-    mockQueries(purpose, createMockRiskAnalysisFormConfig())
-
-    render(<PurposeEditStepRiskAnalysis back={vi.fn()} forward={vi.fn()} activeStep={2} />)
-
-    getLastFormProps().onSubmit({ purpose: ['OTHER'] })
-
-    // The missing reviewers[] must not block the admin: the dialog opens with a placeholder
-    // reviewer built from reviewerId (name + surname simply unavailable until the BE backfills).
-    expect(openDialogMock).toHaveBeenCalledTimes(1)
-    expect(openDialogMock.mock.calls[0][0]).toMatchObject({
-      type: 'requestPurposeApproval',
-      reviewer: { userId: 'reviewer-1', name: '', familyName: '' },
-    })
-  })
-
   it('in option 2 the draft save only persists and navigates without submitting', () => {
     const purpose = buildPurpose({
       reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-      reviewerIds: ['reviewer-1'],
       signingState: 'DRAFT',
     })
     mockQueries(purpose, createMockRiskAnalysisFormConfig())

--- a/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/__tests__/ConsumerPurposeSummary.page.test.tsx
@@ -14,7 +14,11 @@ import {
   createMockPurposeCompatiblePersonalDataYes,
   createMockPurposeCompatiblePersonalDataNo,
 } from '@/../__mocks__/data/purpose.mocks'
-import type { ReviewerWorkflow, RiskAnalysisSigningState } from '@/api/api.generatedTypes'
+import type {
+  ReviewerWorkflow,
+  RiskAnalysisReviewMode,
+  RiskAnalysisSigningState,
+} from '@/api/api.generatedTypes'
 
 const mockPurposeId = 'test-purpose-id'
 mockUseParams({ purposeId: mockPurposeId })
@@ -270,19 +274,27 @@ describe('ConsumerPurposeSummaryPage', () => {
 
   describe('risk analysis review status (options 2 / 3)', () => {
     const renderWithReviewerWorkflow = (signingState: RiskAnalysisSigningState | undefined) => {
+      const reviewMode: RiskAnalysisReviewMode | undefined = signingState
+        ? signingState === 'ASSIGNED'
+          ? 'REVIEWER_WRITES_REVIEWER_SIGNS'
+          : 'ADMIN_WRITES_REVIEWER_SIGNS'
+        : undefined
+
       const reviewerWorkflow: ReviewerWorkflow | undefined = signingState
         ? {
-            reviewMode:
-              signingState === 'ASSIGNED'
-                ? 'REVIEWER_WRITES_REVIEWER_SIGNS'
-                : 'ADMIN_WRITES_REVIEWER_SIGNS',
-            reviewerIds: ['11111111-2222-3333-4444-555555555555'],
+            reviewers: [
+              {
+                userId: '11111111-2222-3333-4444-555555555555',
+                name: 'Mario',
+                familyName: 'Rossi',
+              },
+            ],
             signingState,
           }
         : undefined
 
       useQueryMock.mockReturnValue({
-        data: { ...createMockPurposeCompatiblePersonalDataYes(), reviewerWorkflow },
+        data: { ...createMockPurposeCompatiblePersonalDataYes(), reviewMode, reviewerWorkflow },
         isLoading: false,
       })
 

--- a/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryAssignmentAccordion.tsx
@@ -16,7 +16,7 @@ export const ConsumerPurposeSummaryAssignmentAccordion: React.FC<
   const { data: purpose } = useSuspenseQuery(PurposeQueries.getSingle(purposeId))
   const { t } = useTranslation('purpose', { keyPrefix: 'riskAnalysisAssignment' })
 
-  const modeLabel = getReviewModeLabel(purpose.reviewerWorkflow?.reviewMode, t)
+  const modeLabel = getReviewModeLabel(purpose.reviewMode, t)
 
   // We surface only the first reviewer: the BE models `reviewers` as a list to allow multiple
   // reviewers in the future, but today at most one reviewer is ever assigned.

--- a/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryAssignmentAccordion.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryAssignmentAccordion.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react'
 import { ConsumerPurposeSummaryAssignmentAccordion } from '../ConsumerPurposeSummaryAssignmentAccordion'
 import { renderWithApplicationContext } from '@/utils/testing.utils'
 import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
-import type { Purpose, ReviewerWorkflow } from '@/api/api.generatedTypes'
+import type { Purpose, ReviewerWorkflow, RiskAnalysisReviewMode } from '@/api/api.generatedTypes'
 
 const useSuspenseQueryMock = vi.fn()
 
@@ -23,9 +23,13 @@ vi.mock('@/api/purpose', () => ({
 
 const REVIEWER_ID = '11111111-2222-3333-4444-555555555555'
 
-const setPurpose = (reviewerWorkflow: ReviewerWorkflow | undefined) => {
+const setPurpose = (
+  reviewMode: RiskAnalysisReviewMode | undefined,
+  reviewerWorkflow?: ReviewerWorkflow
+) => {
   const purpose: Purpose = {
     ...createMockPurpose(),
+    reviewMode,
     reviewerWorkflow,
   }
   useSuspenseQueryMock.mockReturnValue({ data: purpose })
@@ -36,23 +40,24 @@ describe('ConsumerPurposeSummaryAssignmentAccordion', () => {
     vi.clearAllMocks()
   })
 
-  it('option 1 (autonomy) and fallback (reviewerWorkflow undefined): renders only "Modalità" row with autonomy copy', () => {
-    setPurpose(undefined)
+  it.each<RiskAnalysisReviewMode | undefined>([undefined, 'ADMIN_WRITES_ADMIN_SIGNS'])(
+    'option 1 (autonomy, reviewMode %s): renders only "Modalità" row with autonomy copy',
+    (reviewMode) => {
+      setPurpose(reviewMode)
 
-    renderWithApplicationContext(
-      <ConsumerPurposeSummaryAssignmentAccordion purposeId="test-id" />,
-      { withReactQueryContext: true }
-    )
+      renderWithApplicationContext(
+        <ConsumerPurposeSummaryAssignmentAccordion purposeId="test-id" />,
+        { withReactQueryContext: true }
+      )
 
-    expect(screen.getByText('mode.label')).toBeInTheDocument()
-    expect(screen.getByText('mode.autonomy')).toBeInTheDocument()
-    expect(screen.queryByText('reviewer.label')).not.toBeInTheDocument()
-  })
+      expect(screen.getByText('mode.label')).toBeInTheDocument()
+      expect(screen.getByText('mode.autonomy')).toBeInTheDocument()
+      expect(screen.queryByText('reviewer.label')).not.toBeInTheDocument()
+    }
+  )
 
   it('option 2 (ADMIN_WRITES_REVIEWER_SIGNS): renders "Modalità" + "Valutatore" rows with the reviewer name', () => {
-    setPurpose({
-      reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-      reviewerIds: [REVIEWER_ID],
+    setPurpose('ADMIN_WRITES_REVIEWER_SIGNS', {
       reviewers: [{ userId: REVIEWER_ID, name: 'Mario', familyName: 'Rossi' }],
       signingState: 'ASSIGNED',
     })
@@ -69,9 +74,7 @@ describe('ConsumerPurposeSummaryAssignmentAccordion', () => {
   })
 
   it('option 3 (REVIEWER_WRITES_REVIEWER_SIGNS): renders "Modalità" + "Valutatore" rows with the reviewer name', () => {
-    setPurpose({
-      reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
-      reviewerIds: [REVIEWER_ID],
+    setPurpose('REVIEWER_WRITES_REVIEWER_SIGNS', {
       reviewers: [{ userId: REVIEWER_ID, name: 'Mario', familyName: 'Rossi' }],
       signingState: 'ASSIGNED',
     })
@@ -88,11 +91,7 @@ describe('ConsumerPurposeSummaryAssignmentAccordion', () => {
   })
 
   it('does not render the "Valutatore" row when the reviewer workflow has no reviewers', () => {
-    setPurpose({
-      reviewMode: 'ADMIN_WRITES_REVIEWER_SIGNS',
-      reviewerIds: [REVIEWER_ID],
-      signingState: 'ASSIGNED',
-    })
+    setPurpose('ADMIN_WRITES_REVIEWER_SIGNS', { signingState: 'ASSIGNED' })
 
     renderWithApplicationContext(
       <ConsumerPurposeSummaryAssignmentAccordion purposeId="test-id" />,

--- a/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryRiskAnalysisAccordion.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryRiskAnalysisAccordion.test.tsx
@@ -28,10 +28,12 @@ vi.mock('@/components/shared/RiskAnalysisInfoSummary', () => ({
 const setPurpose = (signingState: RiskAnalysisSigningState | undefined) => {
   const purpose: Purpose = {
     ...createMockPurpose(),
+    reviewMode: signingState ? 'REVIEWER_WRITES_REVIEWER_SIGNS' : undefined,
     reviewerWorkflow: signingState
       ? {
-          reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
-          reviewerIds: ['11111111-2222-3333-4444-555555555555'],
+          reviewers: [
+            { userId: '11111111-2222-3333-4444-555555555555', name: 'Mario', familyName: 'Rossi' },
+          ],
           signingState,
         }
       : undefined,

--- a/src/pages/ConsumerPurposeSummaryPage/hooks/useGetPurposeRiskAnalysisReviewStatus.ts
+++ b/src/pages/ConsumerPurposeSummaryPage/hooks/useGetPurposeRiskAnalysisReviewStatus.ts
@@ -1,6 +1,6 @@
 import type { Purpose, RiskAnalysisSigningState } from '@/api/api.generatedTypes'
 import { useTranslation } from 'react-i18next'
-import { match } from 'ts-pattern'
+import { match, P } from 'ts-pattern'
 
 type RiskAnalysisReviewChip = {
   label: string
@@ -57,7 +57,7 @@ export function useGetPurposeRiskAnalysisReviewStatus(
     ? match(reviewMode)
         .with('ADMIN_WRITES_REVIEWER_SIGNS', () => t('infoAlert.adminWritesReviewerSigns'))
         .with('REVIEWER_WRITES_REVIEWER_SIGNS', () => t('infoAlert.reviewerWritesReviewerSigns'))
-        .with(undefined, () => undefined)
+        .with(P.union('ADMIN_WRITES_ADMIN_SIGNS', undefined), () => undefined)
         .exhaustive()
     : undefined
 

--- a/src/pages/ConsumerPurposeSummaryPage/hooks/useGetPurposeRiskAnalysisReviewStatus.ts
+++ b/src/pages/ConsumerPurposeSummaryPage/hooks/useGetPurposeRiskAnalysisReviewStatus.ts
@@ -35,7 +35,7 @@ export function useGetPurposeRiskAnalysisReviewStatus(
   })
 
   const signingState = purpose?.reviewerWorkflow?.signingState
-  const reviewMode = purpose?.reviewerWorkflow?.reviewMode
+  const reviewMode = purpose?.reviewMode
 
   const chip = match(signingState)
     .returnType<RiskAnalysisReviewChip | undefined>()

--- a/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
+++ b/src/pages/ConsumerPurposesListPage/components/__tests__/ConsumerPurposesTableRow.test.tsx
@@ -15,14 +15,14 @@ const buildPurpose = (
 ) => {
   const reviewerWorkflow: ReviewerWorkflow | undefined = signingState
     ? {
-        reviewMode: 'REVIEWER_WRITES_REVIEWER_SIGNS',
-        reviewerIds: [],
+        reviewers: [],
         signingState,
       }
     : undefined
 
   return createMockPurpose({
     currentVersion: { state: currentVersionState },
+    reviewMode: signingState ? 'REVIEWER_WRITES_REVIEWER_SIGNS' : undefined,
     reviewerWorkflow,
   })
 }

--- a/src/pages/RiskAnalysisListPage/__test__/RiskAnalysisList.page.test.tsx
+++ b/src/pages/RiskAnalysisListPage/__test__/RiskAnalysisList.page.test.tsx
@@ -26,7 +26,14 @@ vi.mock('@/api/purpose', () => ({
             },
             reviewerWorkflow: {
               signingState: 'ASSIGNED',
-              sentToReviewerAt: new Date().toISOString(),
+              reviewers: [
+                {
+                  userId: 'reviewer-1',
+                  name: 'Mario',
+                  familyName: 'Rossi',
+                  sentToReviewerAt: new Date().toISOString(),
+                },
+              ],
             },
           },
         ],
@@ -68,7 +75,14 @@ describe('RiskAnalysisListPage', () => {
             },
             reviewerWorkflow: {
               signingState: 'ASSIGNED',
-              sentToReviewerAt: new Date().toISOString(),
+              reviewers: [
+                {
+                  userId: 'reviewer-1',
+                  name: 'Mario',
+                  familyName: 'Rossi',
+                  sentToReviewerAt: new Date().toISOString(),
+                },
+              ],
             },
           },
         ],

--- a/src/pages/RiskAnalysisListPage/components/RiskAnalysisTableRow.tsx
+++ b/src/pages/RiskAnalysisListPage/components/RiskAnalysisTableRow.tsx
@@ -14,9 +14,8 @@ export const RiskAnalysisTableRow: React.FC<{
 }> = ({ purpose }) => {
   const { t } = useTranslation('purpose', { keyPrefix: 'riskAnalysisList' })
 
-  const sentDate = purpose.reviewerWorkflow?.sentToReviewerAt
-    ? new Date(purpose.reviewerWorkflow.sentToReviewerAt)
-    : null
+  const sentToReviewerAt = purpose.reviewerWorkflow?.reviewers?.[0]?.sentToReviewerAt
+  const sentDate = sentToReviewerAt ? new Date(sentToReviewerAt) : null
 
   const formattedDate = sentDate
     ? sentDate.toLocaleDateString('it-IT', {

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -673,6 +673,13 @@
         "error": "It was not possible to assign the risk analysis."
       }
     },
+    "updateRiskAnalysisAssignment": {
+      "loading": "We are updating the risk analysis assignment",
+      "outcome": {
+        "success": "You have updated the risk analysis assignment.",
+        "error": "It was not possible to update the risk analysis assignment."
+      }
+    },
     "submitRiskAnalysis": {
       "loading": "We are assigning the risk analysis to a reviewer",
       "outcome": {

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -133,7 +133,8 @@
       "readOnly": {
         "subtitle": {
           "signed": "You cannot modify the assignment because the risk analysis has been approved.",
-          "published": "You cannot modify the assignment because the purpose has been published."
+          "published": "You cannot modify the assignment because the purpose has been published.",
+          "notDraft": "You cannot modify the assignment because the purpose is no longer a draft."
         },
         "modeLabel": "Mode",
         "reviewerLabel_one": "Reviewer",

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -123,6 +123,8 @@
       },
       "noReviewersAlert": {
         "message": "Your institution does not yet have a user with the reviewer role. You can add one from the Reserved Area or complete the risk analysis yourself.",
+        "removedReviewerMessage_one": "The reviewer assigned to this risk analysis has been removed. There is nobody else with the reviewer role in your institution: you can assign the role from the Reserved Area or complete the risk analysis yourself.",
+        "removedReviewerMessage_other": "The reviewers assigned to this risk analysis have been removed. There is nobody else with the reviewer role in your institution: you can assign the role from the Reserved Area or complete the risk analysis yourself.",
         "linkLabel": "Go to Users"
       },
       "delegateAlert": "As the delegate to consuming the e-service {{name}}, you cannot assign the risk analysis to a reviewer but you can complete it yourself.",

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -98,18 +98,28 @@
       "reviewModeField": {
         "label": "Choose a mode",
         "options": {
-          "selfWritesSelfSigns": "Self-compilation and self-approval",
-          "selfWritesReviewerSigns": "Self-compilation and reviewer approval",
-          "reviewerWritesReviewerSigns": "Reviewer compilation and approval"
+          "ADMIN_WRITES_ADMIN_SIGNS": "Self-compilation and self-approval",
+          "ADMIN_WRITES_REVIEWER_SIGNS": "Self-compilation and reviewer approval",
+          "REVIEWER_WRITES_REVIEWER_SIGNS": "Reviewer compilation and approval"
         }
       },
       "reviewerField": {
         "label": {
-          "selfWritesReviewerSigns": "Who will approve the risk analysis?",
-          "reviewerWritesReviewerSigns": "Who will fill in the risk analysis?"
+          "ADMIN_WRITES_REVIEWER_SIGNS": "Who will approve the risk analysis?",
+          "REVIEWER_WRITES_REVIEWER_SIGNS": "Who will fill in the risk analysis?"
         },
         "inputLabel": "Select the reviewer",
-        "requiredError": "To proceed, please select a reviewer"
+        "requiredError": "To proceed, please select a reviewer",
+        "removedError_one": "The reviewer {{names}} has been removed from your institution's users",
+        "removedError_other": "The reviewers {{names}} have been removed from your institution's users"
+      },
+      "editAssignmentDialog": {
+        "title": "Edit assignment",
+        "modeChosen": "You have chosen the mode {{mode}}.",
+        "modeTransition": "You are switching from {{from}} to {{to}}.",
+        "selectedReviewersLabel": "Who you selected",
+        "removedReviewersLabel": "Who you removed",
+        "riskAnalysisLossWarning": "If you confirm, you will lose all the risk analysis information already filled in."
       },
       "noReviewersAlert": {
         "message": "Your institution does not yet have a user with the reviewer role. You can add one from the Reserved Area or complete the risk analysis yourself.",
@@ -119,9 +129,13 @@
       "forwardBtn": "Save draft and proceed",
       "requestReviewerCompilationBtn": "Request compilation",
       "readOnly": {
-        "subtitle": "You cannot modify the assignment because you have submitted the risk assessment to the evaluator.",
+        "subtitle": {
+          "signed": "You cannot modify the assignment because the risk analysis has been approved.",
+          "published": "You cannot modify the assignment because the purpose has been published."
+        },
         "modeLabel": "Mode",
-        "reviewerLabel": "Reviewer",
+        "reviewerLabel_one": "Reviewer",
+        "reviewerLabel_other": "Reviewers",
         "reviewerUnknown": "Reviewer not available",
         "forwardBtn": "Next"
       }

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -237,7 +237,8 @@
   },
   "dialogRequestRiskAnalysisCompilation": {
     "title": "Request compilation and approval",
-    "description": "If you confirm, you will assign the compilation and approval of the risk analysis to the reviewer <strong>{{reviewerName}}</strong> and you will no longer be able to change this choice."
+    "description_one": "If you confirm, you will assign the compilation and approval of the risk analysis to the reviewer <strong>{{reviewerNames}}</strong> and you will no longer be able to change this choice.",
+    "description_other": "If you confirm, you will assign the compilation and approval of the risk analysis to the reviewers <strong>{{reviewerNames}}</strong> and you will no longer be able to change this choice."
   },
   "dialogRejectDelegatedVersionDraft": {
     "title": "Reject Publication",

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -673,6 +673,13 @@
         "error": "Non è stato possibile assegnare l’analisi del rischio."
       }
     },
+    "updateRiskAnalysisAssignment": {
+      "loading": "Stiamo modificando l’assegnazione dell’analisi del rischio",
+      "outcome": {
+        "success": "Hai modificato l’assegnazione dell’analisi del rischio.",
+        "error": "Non è stato possibile modificare l’assegnazione dell’analisi del rischio."
+      }
+    },
     "submitRiskAnalysis": {
       "loading": "Stiamo assegnando l’analisi del rischio a un valutatore",
       "outcome": {

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -133,7 +133,8 @@
       "readOnly": {
         "subtitle": {
           "signed": "Non puoi modificare l’assegnazione perché l’analisi del rischio è stata approvata.",
-          "published": "Non puoi modificare l’assegnazione perché la finalità è stata pubblicata."
+          "published": "Non puoi modificare l’assegnazione perché la finalità è stata pubblicata.",
+          "notDraft": "Non puoi modificare l’assegnazione perché la finalità non è più in bozza."
         },
         "modeLabel": "Modalità",
         "reviewerLabel_one": "Valutatore",

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -98,18 +98,28 @@
       "reviewModeField": {
         "label": "Scegli una modalità",
         "options": {
-          "selfWritesSelfSigns": "Compilazione e approvazione in autonomia",
-          "selfWritesReviewerSigns": "Compilazione in autonomia e approvazione del valutatore",
-          "reviewerWritesReviewerSigns": "Compilazione e approvazione del valutatore"
+          "ADMIN_WRITES_ADMIN_SIGNS": "Compilazione e approvazione in autonomia",
+          "ADMIN_WRITES_REVIEWER_SIGNS": "Compilazione in autonomia e approvazione del valutatore",
+          "REVIEWER_WRITES_REVIEWER_SIGNS": "Compilazione e approvazione del valutatore"
         }
       },
       "reviewerField": {
         "label": {
-          "selfWritesReviewerSigns": "Chi approverà l’analisi del rischio?",
-          "reviewerWritesReviewerSigns": "Chi compilerà l’analisi del rischio?"
+          "ADMIN_WRITES_REVIEWER_SIGNS": "Chi approverà l’analisi del rischio?",
+          "REVIEWER_WRITES_REVIEWER_SIGNS": "Chi compilerà l’analisi del rischio?"
         },
         "inputLabel": "Seleziona valutatore",
-        "requiredError": "Per proseguire, seleziona un valutatore"
+        "requiredError": "Per proseguire, seleziona un valutatore",
+        "removedError_one": "Il valutatore {{names}} è stato rimosso dagli utenti del tuo ente",
+        "removedError_other": "I valutatori {{names}} sono stati rimossi dagli utenti del tuo ente"
+      },
+      "editAssignmentDialog": {
+        "title": "Modifica assegnazione",
+        "modeChosen": "Hai scelto la modalità {{mode}}.",
+        "modeTransition": "Stai passando da {{from}} a {{to}}.",
+        "selectedReviewersLabel": "Chi hai selezionato",
+        "removedReviewersLabel": "Chi hai rimosso",
+        "riskAnalysisLossWarning": "Se confermi, perderai tutte le informazioni dell’analisi del rischio già compilate."
       },
       "noReviewersAlert": {
         "message": "Il tuo ente non ha ancora un utente con ruolo di valutatore. Puoi aggiungerlo dall’Area Riservata o compilare in autonomia l’analisi del rischio.",
@@ -119,9 +129,13 @@
       "forwardBtn": "Salva bozza e prosegui",
       "requestReviewerCompilationBtn": "Richiedi compilazione",
       "readOnly": {
-        "subtitle": "Non puoi modificare l'assegnazione perché hai inviato l'analisi del rischio al valutatore.",
+        "subtitle": {
+          "signed": "Non puoi modificare l’assegnazione perché l’analisi del rischio è stata approvata.",
+          "published": "Non puoi modificare l’assegnazione perché la finalità è stata pubblicata."
+        },
         "modeLabel": "Modalità",
-        "reviewerLabel": "Valutatore",
+        "reviewerLabel_one": "Valutatore",
+        "reviewerLabel_other": "Valutatori",
         "reviewerUnknown": "Valutatore non disponibile",
         "forwardBtn": "Avanti"
       }

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -123,6 +123,8 @@
       },
       "noReviewersAlert": {
         "message": "Il tuo ente non ha ancora un utente con ruolo di valutatore. Puoi aggiungerlo dall’Area Riservata o compilare in autonomia l’analisi del rischio.",
+        "removedReviewerMessage_one": "Il valutatore assegnato a questa analisi del rischio è stato rimosso. Nel tuo ente non ci sono altre persone con il ruolo di valutatore: puoi assegnarlo dall’Area Riservata oppure compilare l’analisi in autonomia.",
+        "removedReviewerMessage_other": "I valutatori assegnati a questa analisi del rischio sono stati rimossi. Nel tuo ente non ci sono altre persone con il ruolo di valutatore: puoi assegnarlo dall’Area Riservata oppure compilare l’analisi in autonomia.",
         "linkLabel": "Vai a Utenti"
       },
       "delegateAlert": "Come delegato alla fruizione dell’e-service {{name}}, non puoi assegnare l'analisi del rischio a un valutatore ma puoi compilarla in autonomia.",

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -237,7 +237,8 @@
   },
   "dialogRequestRiskAnalysisCompilation": {
     "title": "Richiedi compilazione e approvazione",
-    "description": "Se confermi, assegnerai la compilazione e l'approvazione dell'analisi del rischio al valutatore <strong>{{reviewerName}}</strong> e non potrai più modificare questa scelta."
+    "description_one": "Se confermi, assegnerai la compilazione e l'approvazione dell'analisi del rischio al valutatore <strong>{{reviewerNames}}</strong> e non potrai più modificare questa scelta.",
+    "description_other": "Se confermi, assegnerai la compilazione e l'approvazione dell'analisi del rischio ai valutatori <strong>{{reviewerNames}}</strong> e non potrai più modificare questa scelta."
   },
   "dialogRejectDelegatedVersionDraft": {
     "title": "Rifiuta pubblicazione",

--- a/src/types/dialog.types.ts
+++ b/src/types/dialog.types.ts
@@ -8,6 +8,7 @@ import type {
   TargetTenantKind,
   CompactAgreement,
   CompactUser,
+  RiskAnalysisReviewMode,
 } from '@/api/api.generatedTypes'
 import type { RouteKey } from '@/router'
 import type { DialogProps as MUIDialogProps } from '@mui/material'
@@ -49,6 +50,7 @@ export type DialogProps =
   | DialogSelectAgreementConsumerProps
   | DialogRequestPurposeApprovalProps
   | DialogRequestRiskAnalysisCompilationProps
+  | DialogEditRiskAnalysisAssignmentProps
   | DialogApproveRiskAnalysisProps
   | DialogRejectRiskAnalysisProps
   | DialogShowEserviceVersionsListProps
@@ -210,8 +212,21 @@ export type DialogRequestPurposeApprovalProps = {
 export type DialogRequestRiskAnalysisCompilationProps = {
   type: 'requestRiskAnalysisCompilation'
   purposeId: string
-  reviewerId: string
-  reviewerName: string
+  reviewerIds: string[]
+  reviewerNames: string[]
+}
+
+export type DialogEditRiskAnalysisAssignmentProps = {
+  type: 'editRiskAnalysisAssignment'
+  /** Review mode currently persisted on the purpose. */
+  fromMode: RiskAnalysisReviewMode
+  /** Review mode the admin is about to save. */
+  toMode: RiskAnalysisReviewMode
+  /** Full names of the reviewers added on top of the persisted ones. */
+  addedReviewerNames: string[]
+  /** Full names of the persisted reviewers the admin is dropping. */
+  removedReviewerNames: string[]
+  onConfirm: VoidFunction
 }
 
 export type DialogApproveRiskAnalysisProps = {

--- a/src/utils/purpose.utils.ts
+++ b/src/utils/purpose.utils.ts
@@ -1,6 +1,6 @@
 import type { Purpose, RiskAnalysisReviewMode } from '@/api/api.generatedTypes'
 import type { TFunction } from 'i18next'
-import { match } from 'ts-pattern'
+import { match, P } from 'ts-pattern'
 
 export function getPurposeFailureReasons(
   purpose: Purpose
@@ -65,7 +65,8 @@ export function checkIsRulesetExpired(expirationDate: string | undefined) {
 }
 
 /**
- * Returns the localized label for the risk analysis review mode. An undefined mode means the risk
+ * Returns the localized label for the risk analysis review mode. `ADMIN_WRITES_ADMIN_SIGNS` (and
+ * an undefined mode, for purposes created before the BE started sending it) means the risk
  * analysis was completed and approved autonomously, with no reviewer assigned. Both the purpose
  * summary and details surfaces share the `riskAnalysisAssignment` i18n block.
  */
@@ -74,7 +75,7 @@ export function getReviewModeLabel(
   t: TFunction<'purpose', 'riskAnalysisAssignment'>
 ) {
   return match(reviewMode)
-    .with(undefined, () => t('mode.autonomy'))
+    .with(P.union(undefined, 'ADMIN_WRITES_ADMIN_SIGNS'), () => t('mode.autonomy'))
     .with('ADMIN_WRITES_REVIEWER_SIGNS', () => t('mode.adminWritesReviewerSigns'))
     .with('REVIEWER_WRITES_REVIEWER_SIGNS', () => t('mode.reviewerWritesReviewerSigns'))
     .exhaustive()


### PR DESCRIPTION
## 🔗 Issue
[PIN-10689](https://pagopa.atlassian.net/browse/PIN-10689)

## 📝 Description / Context
The "Assegnazione" step of the purpose editing flow was write-once: as soon as the purpose carried a reviewer workflow, the step switched to a read-only summary. The admin therefore had no way to change their mind about the review mode, nor to fix an assignment pointing at a reviewer who had since left the institution.

The step now stays editable until the risk analysis is approved, allows more than one reviewer, and asks for explicit confirmation before persisting any change — spelling out the mode transition, the reviewers gained and lost, and whether the compiled risk analysis will be discarded.

The step is also aligned to the new backend contract, where `reviewMode` moved from `ReviewerWorkflow` onto `Purpose`, self-compilation became the explicit `ADMIN_WRITES_ADMIN_SIGNS` value instead of an absent workflow, and `reviewerIds` was dropped in favour of the enriched `reviewers` list. Only the files belonging to the assignment step are migrated here: the summary, details, risk analysis step and risk analysis list surfaces are covered by their own tickets.

## 🛠 List of changes
- Make the assignment form editable while the purpose is a draft and the risk analysis is not `SIGNED`, instead of only before the first assignment
- Replace the single reviewer autocomplete with a multiple one, sending every selected reviewer in `reviewerIds`
- Add `DialogEditRiskAnalysisAssignment`, shown only when editing an existing assignment: mode transition copy, added/removed reviewer lists and the risk analysis loss warning on any switch into or out of the reviewer-compilation mode
- Skip the dialog entirely when the submitted values match the persisted ones
- Keep reviewers no longer belonging to the institution visible as selected chips while excluding them from the dropdown, and block the submit with a singular/plural error until they are dropped
- When the institution has no reviewer left to replace the removed ones, explain the assignment is dangling with a dedicated singular/plural alert and rewrite the assignment to self-compilation on submit, so the purpose never carries reviewers who no longer exist
- Add the dedicated "assignment updated" snackbar for the edit flow, landing on step 3 for the self-compilation modes and on the summary for the reviewer-compilation one; the first compilation keeps its current feedback
- Use `RiskAnalysisReviewMode` directly as the radio group value, removing the `ReviewModeOption` type and its two mapping helpers
- Show every assigned reviewer in the read-only step, with a subtitle explaining whether the assignment is frozen by the approval or by the publication
- Pluralize the compilation dialog copy and pass reviewers as lists
- Add and update unit tests for the container, the form, the read-only step and both dialogs

## 🧪 How to test
- Open a draft purpose that has never been assigned and go to "Modifica finalità" → "Assegnazione": the form behaves as before, no confirmation dialog appears on save
- Assign the purpose choosing "Compilazione in autonomia e approvazione del valutatore" with two reviewers, then come back to the step: the form is still editable and prefilled with both reviewers
- Change the mode to "Compilazione e approvazione del valutatore" and save: the dialog announces the transition, lists the reviewer changes and warns that the compiled risk analysis will be lost; on confirm the "assignment updated" snackbar appears on the summary page
- Switch between "Compilazione e approvazione in autonomia" and "Compilazione in autonomia e approvazione del valutatore": the dialog shows no loss warning and, on confirm, the snackbar appears on step 3
- Save without touching anything: no dialog is shown and the flow just moves on
- With a purpose assigned to a reviewer who is no longer among the institution's users, but with other reviewers available, check the reviewer is shown as a chip, is absent from the dropdown, and that saving is blocked by the error below the field until they are removed
- Revoke the reviewer role from every user of the institution while a purpose is assigned: the step shows the "reviewer removed and none left" alert, and proceeding switches the purpose to "Compilazione e approvazione in autonomia"
- Approve the risk analysis, then reopen the step: it renders read-only with every assigned reviewer listed

[PIN-10689]: https://pagopa.atlassian.net/browse/PIN-10689
