### PR TITLE
feat: add assignment section to reviewer view with assignment date an…

### DIFF
--- a/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryGeneralInformationAccordion.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryGeneralInformationAccordion.tsx
@@ -8,6 +8,7 @@ import { PurposeQueries } from '@/api/purpose'
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { useGetPurposeInfoAlert } from '@/hooks/useGetPurposeInfoAlert'
 import { AuthHooks } from '@/api/auth'
+import { formatDateStringNumeric } from '@/utils/format.utils'
 
 type ConsumerPurposeSummaryGeneralInformationAccordionProps = {
   purposeId: string
@@ -16,7 +17,7 @@ type ConsumerPurposeSummaryGeneralInformationAccordionProps = {
 export const ConsumerPurposeSummaryGeneralInformationAccordion: React.FC<
   ConsumerPurposeSummaryGeneralInformationAccordionProps
 > = ({ purposeId }) => {
-  const { isReviewer } = AuthHooks.useJwt()
+  const { jwt, isReviewer } = AuthHooks.useJwt()
   const { data: purpose } = useSuspenseQuery(PurposeQueries.getSingle(purposeId))
 
   const { data: remainingDailyCalls } = useQuery({
@@ -35,6 +36,13 @@ export const ConsumerPurposeSummaryGeneralInformationAccordion: React.FC<
     keyPrefix: 'summary.alerts',
     showFallback: false,
   })
+
+  const loggedReviewer = purpose?.reviewerWorkflow?.reviewers?.find((r) => r.userId === jwt?.uid)
+  const assignmentDate = loggedReviewer?.sentToReviewerAt
+    ? formatDateStringNumeric(loggedReviewer.sentToReviewerAt)
+    : '-'
+
+  console.log('isReviewer', isReviewer)
 
   return (
     <Stack spacing={2}>
@@ -93,6 +101,24 @@ export const ConsumerPurposeSummaryGeneralInformationAccordion: React.FC<
           {generalInfoAlertProps && <Alert sx={{ mt: 3 }} {...generalInfoAlertProps} />}
         </Stack>
       </SectionContainer>
+      {isReviewer && (
+        <SectionContainer innerSection sx={{ pt: 4 }} title={t('assignmentSection.label')}>
+          <Stack spacing={2}>
+            <InformationContainer
+              label={t('assignmentSection.assignmentDate.label')}
+              content={assignmentDate}
+            />
+            <InformationContainer
+              label={t('assignmentSection.reviewers.label')}
+              content={
+                purpose.reviewerWorkflow?.reviewers
+                  ?.map((reviewer) => reviewer.familyName)
+                  .join(', ') ?? '-'
+              }
+            />
+          </Stack>
+        </SectionContainer>
+      )}
     </Stack>
   )
 }

--- a/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryGeneralInformationAccordion.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/ConsumerPurposeSummaryGeneralInformationAccordion.tsx
@@ -42,8 +42,6 @@ export const ConsumerPurposeSummaryGeneralInformationAccordion: React.FC<
     ? formatDateStringNumeric(loggedReviewer.sentToReviewerAt)
     : '-'
 
-  console.log('isReviewer', isReviewer)
-
   return (
     <Stack spacing={2}>
       <InformationContainer content={purpose.title} direction="row" label={t('name.label')} />

--- a/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryGeneralInformationAccordion.test.tsx
+++ b/src/pages/ConsumerPurposeSummaryPage/components/__tests__/ConsumerPurposeSummaryGeneralInformationAccordion.test.tsx
@@ -3,6 +3,7 @@ import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
 import { ConsumerPurposeSummaryGeneralInformationAccordion } from '../ConsumerPurposeSummaryGeneralInformationAccordion'
 import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
 import { waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 
 const useSuspenseQueryMock = vi.fn()
 const remainingDailyCallsQueryFn = vi.fn().mockResolvedValue({
@@ -80,5 +81,33 @@ describe('ConsumerPurposeSummaryGeneralInformationAccordion', () => {
     await waitFor(() => {
       expect(remainingDailyCallsQueryFn).not.toHaveBeenCalled()
     })
+  })
+
+  it('should not show assignment section when user is not reviewer', async () => {
+    mockUseJwt({ isReviewer: false })
+
+    renderWithApplicationContext(
+      <ConsumerPurposeSummaryGeneralInformationAccordion purposeId="purpose-id" />,
+      {
+        withReactQueryContext: true,
+      }
+    )
+
+    expect(screen.queryByText('assignmentSection.assignmentDate.label')).not.toBeInTheDocument()
+    expect(screen.queryByText('assignmentSection.reviewers.label')).not.toBeInTheDocument()
+  })
+
+  it('should show assignment section when user is reviewer', async () => {
+    mockUseJwt({ isReviewer: true })
+
+    renderWithApplicationContext(
+      <ConsumerPurposeSummaryGeneralInformationAccordion purposeId="purpose-id" />,
+      {
+        withReactQueryContext: true,
+      }
+    )
+
+    expect(screen.queryByText('assignmentSection.assignmentDate.label')).toBeInTheDocument()
+    expect(screen.queryByText('assignmentSection.reviewers.label')).toBeInTheDocument()
   })
 })

--- a/src/pages/RiskAnalysisInfoCompilePage/RiskAnalysisInfoCompile.page.tsx
+++ b/src/pages/RiskAnalysisInfoCompilePage/RiskAnalysisInfoCompile.page.tsx
@@ -34,8 +34,6 @@ const RiskAnalysisInfoCompilePage: React.FC = () => {
     ? formatDateStringNumeric(loggedReviewer.sentToReviewerAt)
     : '-'
 
-  console.log('purpose', purpose)
-
   return (
     <PageContainer
       title={t('title')}
@@ -48,7 +46,7 @@ const RiskAnalysisInfoCompilePage: React.FC = () => {
       <Grid container sx={{ mt: 3 }}>
         <Grid item xs={12}>
           {!purpose ? (
-            <RiskAnalysisInfoCompilePageSkeleton />
+            <RiskAnalysisInfoCompilePageSkeleton isReviewer={isReviewer} />
           ) : (
             <Stack spacing={3}>
               <SectionContainer title={t('generalInfoSection.label')}>
@@ -156,12 +154,18 @@ const RiskAnalysisLoadEstimateAndReviewersSectionSkeleton: React.FC = () => (
   </SectionContainer>
 )
 
-const RiskAnalysisInfoCompilePageSkeleton: React.FC = () => {
+type RiskAnalysisInfoCompilePageSkeletonProps = {
+  isReviewer: boolean
+}
+
+const RiskAnalysisInfoCompilePageSkeleton: React.FC<RiskAnalysisInfoCompilePageSkeletonProps> = ({
+  isReviewer,
+}) => {
   return (
     <Stack spacing={3}>
       <RiskAnalysisGeneralInfoSectionSkeleton />
       <RiskAnalysisLoadEstimateAndReviewersSectionSkeleton />
-      <RiskAnalysisLoadEstimateAndReviewersSectionSkeleton />
+      {isReviewer && <RiskAnalysisLoadEstimateAndReviewersSectionSkeleton />}
     </Stack>
   )
 }

--- a/src/pages/RiskAnalysisInfoCompilePage/RiskAnalysisInfoCompile.page.tsx
+++ b/src/pages/RiskAnalysisInfoCompilePage/RiskAnalysisInfoCompile.page.tsx
@@ -6,11 +6,15 @@ import { useTranslation } from 'react-i18next'
 import { Button, Grid, Skeleton, Stack } from '@mui/material'
 import { useQuery } from '@tanstack/react-query'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
+import { formatDateStringNumeric } from '@/utils/format.utils'
+import { AuthHooks } from '@/api/auth'
 
 const RiskAnalysisInfoCompilePage: React.FC = () => {
   const { t } = useTranslation('purpose', { keyPrefix: 'riskAnalysisInfoCompile' })
   const { purposeId } = useParams<'SUBSCRIBE_RISK_ANALYSIS_INFO_COMPILE'>()
   const navigate = useNavigate()
+
+  const { jwt, isReviewer } = AuthHooks.useJwt()
 
   const { data: purpose, isLoading } = useQuery({
     ...PurposeQueries.getSingle(purposeId),
@@ -24,6 +28,13 @@ const RiskAnalysisInfoCompilePage: React.FC = () => {
       })
     }
   }
+
+  const loggedReviewer = purpose?.reviewerWorkflow?.reviewers?.find((r) => r.userId === jwt?.uid)
+  const assignmentDate = loggedReviewer?.sentToReviewerAt
+    ? formatDateStringNumeric(loggedReviewer.sentToReviewerAt)
+    : '-'
+
+  console.log('purpose', purpose)
 
   return (
     <PageContainer
@@ -93,6 +104,24 @@ const RiskAnalysisInfoCompilePage: React.FC = () => {
                   />
                 </Stack>
               </SectionContainer>
+              {isReviewer && (
+                <SectionContainer title={t('reviewersSection.label')}>
+                  <Stack spacing={3}>
+                    <InformationContainer
+                      label={t('reviewersSection.assignmentDate.label')}
+                      content={assignmentDate}
+                    />
+                    <InformationContainer
+                      label={t('reviewersSection.reviewers.label')}
+                      content={
+                        purpose.reviewerWorkflow?.reviewers
+                          ?.map((reviewer) => reviewer.familyName)
+                          .join(', ') ?? '-'
+                      }
+                    />
+                  </Stack>
+                </SectionContainer>
+              )}
             </Stack>
           )}
         </Grid>
@@ -118,7 +147,7 @@ const RiskAnalysisGeneralInfoSectionSkeleton: React.FC = () => (
   </SectionContainer>
 )
 
-const RiskAnalysisLoadEstimateSectionSkeleton: React.FC = () => (
+const RiskAnalysisLoadEstimateAndReviewersSectionSkeleton: React.FC = () => (
   <SectionContainer title="">
     <Stack spacing={3}>
       <Skeleton variant="text" width="30%" height={32} />
@@ -131,7 +160,8 @@ const RiskAnalysisInfoCompilePageSkeleton: React.FC = () => {
   return (
     <Stack spacing={3}>
       <RiskAnalysisGeneralInfoSectionSkeleton />
-      <RiskAnalysisLoadEstimateSectionSkeleton />
+      <RiskAnalysisLoadEstimateAndReviewersSectionSkeleton />
+      <RiskAnalysisLoadEstimateAndReviewersSectionSkeleton />
     </Stack>
   )
 }

--- a/src/pages/RiskAnalysisInfoCompilePage/__tests__/RiskAnalysisInfoCompile.page.test.tsx
+++ b/src/pages/RiskAnalysisInfoCompilePage/__tests__/RiskAnalysisInfoCompile.page.test.tsx
@@ -214,4 +214,40 @@ describe('RiskAnalysisInfoCompilePage', () => {
 
     expect(mockNavigate).not.toHaveBeenCalled()
   })
+
+  it('should not show reviewers section when user is not reviewer', async () => {
+    const mockPurpose = createMockPurpose()
+
+    useQueryMock.mockReturnValue({
+      data: mockPurpose,
+      isLoading: false,
+    })
+    mockUseJwt({ isReviewer: false })
+
+    renderWithApplicationContext(<RiskAnalysisInfoCompilePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.queryByText('reviewersSection.assignmentDate.label')).not.toBeInTheDocument()
+    expect(screen.queryByText('reviewersSection.reviewers.label')).not.toBeInTheDocument()
+  })
+
+  it('should show reviewers section when user is reviewer', async () => {
+    const mockPurpose = createMockPurpose()
+
+    useQueryMock.mockReturnValue({
+      data: mockPurpose,
+      isLoading: false,
+    })
+    mockUseJwt({ isReviewer: true })
+
+    renderWithApplicationContext(<RiskAnalysisInfoCompilePage />, {
+      withReactQueryContext: true,
+      withRouterContext: true,
+    })
+
+    expect(screen.queryByText('reviewersSection.assignmentDate.label')).toBeInTheDocument()
+    expect(screen.queryByText('reviewersSection.reviewers.label')).toBeInTheDocument()
+  })
 })

--- a/src/static/locales/en/purpose.json
+++ b/src/static/locales/en/purpose.json
@@ -280,6 +280,15 @@
           "label": "Total threshold set by the producer",
           "value": "{{value}} API calls/day"
         }
+      },
+      "assignmentSection": {
+        "label": "Assignment",
+        "assignmentDate": {
+          "label": "Assignment date"
+        },
+        "reviewers": {
+          "label": "Assigned to"
+        }
       }
     },
     "assignmentSection": {
@@ -636,6 +645,15 @@
       "label": "Estimate API calls",
       "dailyCalls": {
         "label": "Estimated number of API calls/day"
+      }
+    },
+    "reviewersSection": {
+      "label": "Assignment",
+      "assignmentDate": {
+        "label": "Assignment date"
+      },
+      "reviewers": {
+        "label": "Assigned to"
       }
     },
     "beginCompileBtn": "Start compilation"

--- a/src/static/locales/it/purpose.json
+++ b/src/static/locales/it/purpose.json
@@ -280,6 +280,15 @@
           "label": "Soglia totale prevista dall'erogatore",
           "value": "{{value}} chiamate API/giorno"
         }
+      },
+      "assignmentSection": {
+        "label": "Assegnazione",
+        "assignmentDate": {
+          "label": "Data di assegnazione"
+        },
+        "reviewers": {
+          "label": "Assegnata a"
+        }
       }
     },
     "assignmentSection": {
@@ -636,6 +645,15 @@
       "label": "Stima chiamate API",
       "dailyCalls": {
         "label": "Stima numero chiamate API/giorno"
+      }
+    },
+    "reviewersSection": {
+      "label": "Assegnazione",
+      "assignmentDate": {
+        "label": "Data di assegnazione"
+      },
+      "reviewers": {
+        "label": "Assegnata a"
       }
     },
     "beginCompileBtn": "Inizia la compilazione"


### PR DESCRIPTION
## 🔗 Issue

[PIN-10681](https://pagopa.atlassian.net/browse/PIN-10681)

## 📝 Description / Context

This pull request introduces a new section for reviewers in both the Consumer Purpose Summary and Risk Analysis Info Compile pages, displaying assignment details for reviewers. It also updates translation files to support the new UI labels in both English and Italian. 

* Added a reviewer assignment section to `ConsumerPurposeSummaryGeneralInformationAccordion`, visible only to reviewers, showing assignment date and assigned reviewers. 



[PIN-10681]: https://pagopa.atlassian.net/browse/PIN-10681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ