### PR TITLE
Bugfix/PIN-10665 revisione banner

### DIFF
--- a/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementVersionAlerts.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementVersionAlerts.tsx
@@ -27,6 +27,7 @@ export const ConsumerAgreementVersionAlerts: React.FC<ConsumerAgreementVersionAl
     archivedAt: descriptor.archivedAt,
     isObsoleteDescriptor,
     t,
+    activeDescriptorState: activeDescriptor.state,
   })
 
   if (alerts.length === 0) return null

--- a/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementVersionAlerts.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementVersionAlerts.tsx
@@ -27,7 +27,7 @@ export const ConsumerAgreementVersionAlerts: React.FC<ConsumerAgreementVersionAl
     archivedAt: descriptor.archivedAt,
     isObsoleteDescriptor,
     t,
-    activeDescriptorState: activeDescriptor.state,
+    activeDescriptorState: activeDescriptor?.state,
   })
 
   if (alerts.length === 0) return null

--- a/src/pages/ConsumerAgreementDetailsPage/components/__tests__/ConsumerAgreementVersionAlerts.test.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/__tests__/ConsumerAgreementVersionAlerts.test.tsx
@@ -30,7 +30,22 @@ describe('ConsumerAgreementVersionAlerts', () => {
     expect(alerts[0]).toHaveClass(/MuiAlert-standardInfo/)
   })
 
-  it('renders a single warning alert when state is ARCHIVING + scope DESCRIPTOR (no see-details action)', () => {
+  it('renders a warning alert plus obsolete-version info alert when state is ARCHIVING + scope DESCRIPTOR and the descriptor is obsolete', () => {
+    renderAlerts(
+      createMockEServiceDescriptorCatalog({
+        id: 'obsolete-descriptor-id',
+        state: 'ARCHIVING',
+        archivingSchedule: { scope: 'DESCRIPTOR', archivableOn: '2026-12-01T00:00:00.000Z' },
+      })
+    )
+    const alerts = screen.getAllByRole('alert')
+    expect(alerts).toHaveLength(2)
+    expect(alerts[0]).toHaveClass(/MuiAlert-standardWarning/)
+    expect(alerts[1]).toHaveClass(/MuiAlert-standardInfo/)
+    expect(screen.queryByRole('button', { name: 'seeDetails' })).toBeNull()
+  })
+
+  it('renders a single warning alert when state is ARCHIVING + scope DESCRIPTOR and the descriptor is the active one', () => {
     renderAlerts(
       createMockEServiceDescriptorCatalog({
         state: 'ARCHIVING',

--- a/src/static/locales/en/agreement.json
+++ b/src/static/locales/en/agreement.json
@@ -135,6 +135,7 @@
       "deprecatedActive": "This e-service version is obsolete but still active. A new version is available.",
       "deprecatedActiveShort": "This e-service version is obsolete but still active.",
       "archivingDescriptor": "This e-service version will be archived on {{date}}. After that date, you will only be able to use the new version to exchange data with the e-service.",
+      "archivingDescriptorShort": "This e-service version will be archived on {{date}}.",
       "archivingSuspendedDescriptor": "This e-service version will be archived on {{date}}. It is currently suspended and cannot be used. A new version is available.",
       "suspendedLast": "This e-service version is currently suspended and cannot be used.",
       "suspendedLastNoNewVersion": "This e-service version is currently suspended and cannot be used. No new version is available.",

--- a/src/static/locales/it/agreement.json
+++ b/src/static/locales/it/agreement.json
@@ -135,6 +135,7 @@
       "deprecatedActive": "Questa versione dell’e-service è obsoleta, ma è ancora attiva. È disponibile una nuova versione.",
       "deprecatedActiveShort": "Questa versione dell’e-service è obsoleta, ma è ancora attiva.",
       "archivingDescriptor": "Questa versione dell’e-service sarà archiviata il giorno {{date}}. Dopo questa data potrai utilizzare solo la nuova versione per scambiare dati con l’e-service.",
+      "archivingDescriptorShort": "Questa versione dell’e-service sarà archiviata il giorno {{date}}.",
       "archivingSuspendedDescriptor": "Questa versione dell’e-service sarà archiviata il giorno {{date}}. Al momento è sospesa e non può essere utilizzata. È disponibile una nuova versione.",
       "suspendedLast": "Questa versione dell’e-service è al momento sospesa e non può essere utilizzata.",
       "suspendedLastNoNewVersion": "Questa versione dell’e-service è al momento sospesa e non può essere utilizzata. Non è disponibile una nuova versione.",

--- a/src/utils/__tests__/agreement.utils.test.ts
+++ b/src/utils/__tests__/agreement.utils.test.ts
@@ -251,7 +251,7 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     ])
   })
 
-  it('returns single warning alert with date for ARCHIVING + scope DESCRIPTOR (no see-details)', () => {
+  it('returns single warning alert with date for ARCHIVING + scope DESCRIPTOR when the descriptor is not obsolete', () => {
     const result = getConsumerAgreementVersionAlertSpec({
       ...baseArgs,
       state: 'ARCHIVING',
@@ -262,6 +262,20 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     expect(result[0]).toMatchObject({ severity: 'warning' })
     expect(result[0].content).toMatch(/^archivingDescriptor:/)
     expect(result[0].showSeeDetailsAction).toBeUndefined()
+  })
+
+  it('returns warning + obsolete info alert for ARCHIVING + scope DESCRIPTOR when the descriptor is obsolete', () => {
+    const result = getConsumerAgreementVersionAlertSpec({
+      ...baseArgs,
+      state: 'ARCHIVING',
+      scope: 'DESCRIPTOR',
+      archivableOn: '2026-12-01T00:00:00.000Z',
+      isObsoleteDescriptor: true,
+    })
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({ severity: 'warning' })
+    expect(result[0].content).toMatch(/^archivingDescriptor:/)
+    expect(result[1]).toEqual({ severity: 'info', content: 'deprecatedActive' })
   })
 
   it('returns warning with see-details + obsolete info alert for ARCHIVING + scope ESERVICE when the descriptor is obsolete', () => {

--- a/src/utils/__tests__/agreement.utils.test.ts
+++ b/src/utils/__tests__/agreement.utils.test.ts
@@ -238,6 +238,7 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     archivableOn: undefined,
     archivedAt: undefined,
     isObsoleteDescriptor: false,
+    activeDescriptorState: undefined,
     t,
   } as const
 

--- a/src/utils/__tests__/agreement.utils.test.ts
+++ b/src/utils/__tests__/agreement.utils.test.ts
@@ -265,6 +265,19 @@ describe('getConsumerAgreementVersionAlertSpec utility function testing', () => 
     expect(result[0].showSeeDetailsAction).toBeUndefined()
   })
 
+  it('returns short warning alert for ARCHIVING + scope DESCRIPTOR when the active descriptor is also archiving', () => {
+    const result = getConsumerAgreementVersionAlertSpec({
+      ...baseArgs,
+      state: 'ARCHIVING',
+      scope: 'DESCRIPTOR',
+      archivableOn: '2026-12-01T00:00:00.000Z',
+      activeDescriptorState: 'ARCHIVING',
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ severity: 'warning' })
+    expect(result[0].content).toMatch(/^archivingDescriptorShort:/)
+  })
+
   it('returns warning + obsolete info alert for ARCHIVING + scope DESCRIPTOR when the descriptor is obsolete', () => {
     const result = getConsumerAgreementVersionAlertSpec({
       ...baseArgs,

--- a/src/utils/agreement.utils.ts
+++ b/src/utils/agreement.utils.ts
@@ -148,9 +148,17 @@ export function getConsumerAgreementVersionAlertSpec(args: {
   return match({ state, scope })
     .returnType<ConsumerAgreementVersionAlertSpec[]>()
     .with({ state: 'DEPRECATED' }, () => [{ severity: 'info', content: t('deprecatedActive') }])
-    .with({ state: 'ARCHIVING', scope: 'DESCRIPTOR' }, () => [
-      { severity: 'warning', content: t('archivingDescriptor', { date: scheduledDate }) },
-    ])
+    .with({ state: 'ARCHIVING', scope: 'DESCRIPTOR' }, () => {
+      const alerts: ConsumerAgreementVersionAlertSpec[] = [
+        { severity: 'warning', content: t('archivingDescriptor', { date: scheduledDate }) },
+      ]
+
+      if (isObsoleteDescriptor) {
+        alerts.push({ severity: 'info', content: t('deprecatedActive') })
+      }
+
+      return alerts
+    })
     .with({ state: 'ARCHIVING', scope: 'ESERVICE' }, () => {
       const alerts: ConsumerAgreementVersionAlertSpec[] = [
         {

--- a/src/utils/agreement.utils.ts
+++ b/src/utils/agreement.utils.ts
@@ -8,7 +8,7 @@ import type {
 } from '@/api/api.generatedTypes'
 import type { AlertColor } from '@mui/material'
 import type { TFunction } from 'i18next'
-import { match } from 'ts-pattern'
+import { P, match } from 'ts-pattern'
 import { formatDateStringNumeric } from './format.utils'
 
 /**
@@ -140,38 +140,42 @@ export function getConsumerAgreementVersionAlertSpec(args: {
   archivedAt: string | undefined
   isObsoleteDescriptor: boolean
   t: TFunction<'agreement', 'consumerRead.versionAlert'>
+  activeDescriptorState: EServiceDescriptorState | undefined
 }): ConsumerAgreementVersionAlertSpec[] {
-  const { state, scope, archivableOn, archivedAt, isObsoleteDescriptor, t } = args
+  const { state, scope, archivableOn, archivedAt, isObsoleteDescriptor, t, activeDescriptorState } =
+    args
   const scheduledDate = archivableOn ? formatDateStringNumeric(archivableOn) : ''
   const archivedDate = archivedAt ? formatDateStringNumeric(archivedAt) : ''
 
-  return match({ state, scope })
+  return match({ state, scope, activeDescriptorState })
     .returnType<ConsumerAgreementVersionAlertSpec[]>()
     .with({ state: 'DEPRECATED' }, () => [{ severity: 'info', content: t('deprecatedActive') }])
-    .with({ state: 'ARCHIVING', scope: 'DESCRIPTOR' }, () => {
-      const alerts: ConsumerAgreementVersionAlertSpec[] = [
-        { severity: 'warning', content: t('archivingDescriptor', { date: scheduledDate }) },
+    .with(
+      {
+        state: 'ARCHIVING',
+        scope: 'DESCRIPTOR',
+        activeDescriptorState: P.union('ARCHIVING', 'ARCHIVING_SUSPENDED'),
+      },
+      () => [
+        { severity: 'warning', content: t('archivingDescriptorShort', { date: scheduledDate }) },
       ]
-
-      if (isObsoleteDescriptor) {
-        alerts.push({ severity: 'info', content: t('deprecatedActive') })
-      }
-
-      return alerts
-    })
-    .with({ state: 'ARCHIVING', scope: 'ESERVICE' }, () => {
-      const alerts: ConsumerAgreementVersionAlertSpec[] = [
-        {
-          severity: 'warning',
-          content: t('archivingEService', { date: scheduledDate }),
-          showSeeDetailsAction: true,
-        },
-      ]
-      if (isObsoleteDescriptor) {
-        alerts.push({ severity: 'info', content: t('deprecatedActiveShort') })
-      }
-      return alerts
-    })
+    )
+    .with({ state: 'ARCHIVING', scope: 'DESCRIPTOR' }, () => [
+      { severity: 'warning', content: t('archivingDescriptor', { date: scheduledDate }) },
+      ...(isObsoleteDescriptor
+        ? [{ severity: 'info' as AlertColor, content: t('deprecatedActive') }]
+        : []),
+    ])
+    .with({ state: 'ARCHIVING', scope: 'ESERVICE' }, () => [
+      {
+        severity: 'warning',
+        content: t('archivingEService', { date: scheduledDate }),
+        showSeeDetailsAction: true,
+      },
+      ...(isObsoleteDescriptor
+        ? [{ severity: 'info' as AlertColor, content: t('deprecatedActiveShort') }]
+        : []),
+    ])
     .with({ state: 'ARCHIVING_SUSPENDED', scope: 'DESCRIPTOR' }, () => [
       { severity: 'error', content: t('archivingSuspendedDescriptor', { date: scheduledDate }) },
     ])


### PR DESCRIPTION
## 🔗 Issue

[PIN-10665](https://pagopa.atlassian.net/browse/PIN-10665)

## 📝 Description / Context

Case 1:
Descriptor (obsolete v1) under archiving, e-service upgradable. | Show the informational banner. | "This e-service version is obsolete but still active. A new version is available."

Case 2:
Descriptor (obsolete v1) and e-service under archiving, NOT upgradable. | Show the informational banner. | "This e-service version is obsolete but still active."

Case 3:
Descriptor under archiving on the latest version (v2), e-service NOT upgradable. | Do NOT show the banner. | No banner. In general, information about “upgrading to a new version” must not be shown.

Case 4:
Concurrent archiving: descriptor under archiving and subsequently e-service under archiving, NOT upgradable. | Do NOT show the banner. | No banner. In general, information about “upgrading to a new version” must not be shown.


## 🛠 List of changes

- agreement.json
- ConsumerAgreementVersionAlerts

## 🧪 How to test

As per description


[PIN-10665]: https://pagopa.atlassian.net/browse/PIN-10665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ