### PR TITLE
feature: approve risk analysis lock(PIN-10678)

### DIFF
--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -523,6 +523,7 @@ export interface CatalogEServiceDescriptor {
   archivingSchedule?: ArchivingSchedule;
   asyncExchangeProperties?: AsyncExchangeProperties;
   asyncExchangeCallbackInterface?: EServiceDoc;
+  templateRef?: EServiceTemplateRef;
 }
 
 /** Models Client details */
@@ -1134,6 +1135,8 @@ export interface CompactProducerDescriptor {
   version: string;
   audience: string[];
   requireCorrections?: boolean;
+  /** @format date-time */
+  archivableOn?: string;
 }
 
 export interface ProducerEService {
@@ -6658,10 +6661,10 @@ export namespace Tenants {
   }
 
   /**
-   * @description Retrieve the certified attributes
+   * @description Retrieves the certified attributes assigned by the requester tenant acting as certifier, paired with the tenants they are assigned to. It does not return the attributes assigned to the requester tenant.
    * @tags tenants
    * @name GetRequesterCertifiedAttributes
-   * @summary Gets the certified attributes of the requester
+   * @summary Gets the certified attributes assigned by the requester as certifier
    * @request GET:/tenants/attributes/certified
    * @secure
    */

--- a/src/api/purpose/__tests__/purpose.services.test.ts
+++ b/src/api/purpose/__tests__/purpose.services.test.ts
@@ -1,0 +1,39 @@
+import { createMockPurpose } from '@/../__mocks__/data/purpose.mocks'
+import axiosInstance from '@/config/axios'
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
+import { PurposeServices } from '../purpose.services'
+
+vi.mock('@/config/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+describe('PurposeServices', () => {
+  it('should include the purpose metadata version returned in the response header', async () => {
+    const purpose = createMockPurpose()
+    vi.mocked(axiosInstance.get).mockResolvedValueOnce({
+      data: purpose,
+      headers: { 'x-metadata-version': '3' },
+    })
+
+    const result = await PurposeServices.getSingle('purpose-id')
+
+    expect(result).toEqual({ ...purpose, metadataVersion: 3 })
+  })
+
+  it('should send the purpose metadata version when signing the risk analysis', async () => {
+    vi.mocked(axiosInstance.post).mockResolvedValueOnce({ data: {} })
+
+    await PurposeServices.signRiskAnalysis({
+      purposeId: 'purpose-id',
+      metadataVersionToSign: 3,
+    })
+
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      `${BACKEND_FOR_FRONTEND_URL}/purposes/purpose-id/riskAnalysis/sign`,
+      { metadataVersionToSign: 3 }
+    )
+  })
+})

--- a/src/api/purpose/purpose.services.ts
+++ b/src/api/purpose/purpose.services.ts
@@ -25,6 +25,7 @@ import type {
   ReversePurposeUpdateContent,
   RiskAnalysisAssignmentSeed,
   RiskAnalysisFormConfig,
+  RiskAnalysisSignSeed,
   RiskAnalysisSubmissionSeed,
   RiskAnalysisRejectionSeed,
   SignRiskAnalysisParams,
@@ -70,7 +71,18 @@ async function getSingle(purposeId: string) {
   const response = await axiosInstance.get<Purpose>(
     `${BACKEND_FOR_FRONTEND_URL}/purposes/${purposeId}`
   )
-  return REMOVE_ME_remapPurpose(response.data)
+  const metadataVersionHeader = response.headers['x-metadata-version']
+  const metadataVersion =
+    metadataVersionHeader === undefined ? undefined : Number(metadataVersionHeader)
+
+  if (
+    metadataVersion !== undefined &&
+    (!Number.isInteger(metadataVersion) || metadataVersion < 0)
+  ) {
+    throw new Error('Invalid purpose metadata version')
+  }
+
+  return { ...REMOVE_ME_remapPurpose(response.data), metadataVersion }
 }
 
 async function getRiskAnalysisLatest(params?: RetrieveLatestRiskAnalysisConfigurationParams) {
@@ -317,9 +329,13 @@ async function submitRiskAnalysis({
   return response.data
 }
 
-async function signRiskAnalysis({ purposeId }: SignRiskAnalysisParams) {
+async function signRiskAnalysis({
+  purposeId,
+  ...payload
+}: SignRiskAnalysisParams & RiskAnalysisSignSeed) {
   const response = await axiosInstance.post<CreatedResource>(
-    `${BACKEND_FOR_FRONTEND_URL}/purposes/${purposeId}/riskAnalysis/sign`
+    `${BACKEND_FOR_FRONTEND_URL}/purposes/${purposeId}/riskAnalysis/sign`,
+    payload
   )
   return response.data
 }

--- a/src/components/dialogs/DialogApproveRiskAnalysis.tsx
+++ b/src/components/dialogs/DialogApproveRiskAnalysis.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next'
 
 export const DialogApproveRiskAnalysis: React.FC<DialogApproveRiskAnalysisProps> = ({
   purposeId,
+  metadataVersionToSign,
 }) => {
   const ariaLabelId = React.useId()
 
@@ -33,7 +34,7 @@ export const DialogApproveRiskAnalysis: React.FC<DialogApproveRiskAnalysisProps>
 
   const onProceed = () => {
     signRiskAnalysis(
-      { purposeId },
+      { purposeId, metadataVersionToSign },
       {
         onSuccess() {
           navigate('SUBSCRIBE_RISK_ANALYSIS_APPROVAL_SUCCESS', {

--- a/src/components/dialogs/__tests__/DialogapproveRiskAnalysis.test.tsx
+++ b/src/components/dialogs/__tests__/DialogapproveRiskAnalysis.test.tsx
@@ -34,7 +34,13 @@ describe('DialogApproveRiskAnalysis', () => {
   })
 
   it('should render dialog informations', () => {
-    render(<DialogApproveRiskAnalysis purposeId="test-purpose-id" type="approveRiskAnalysis" />)
+    render(
+      <DialogApproveRiskAnalysis
+        purposeId="test-purpose-id"
+        metadataVersionToSign={3}
+        type="approveRiskAnalysis"
+      />
+    )
 
     expect(screen.getByText('title')).toBeInTheDocument()
     expect(screen.getByText('description')).toBeInTheDocument()
@@ -45,7 +51,13 @@ describe('DialogApproveRiskAnalysis', () => {
   it('should close dialog when cancel is clicked', async () => {
     const user = userEvent.setup()
 
-    render(<DialogApproveRiskAnalysis purposeId="test-purpose-id" type="approveRiskAnalysis" />)
+    render(
+      <DialogApproveRiskAnalysis
+        purposeId="test-purpose-id"
+        metadataVersionToSign={3}
+        type="approveRiskAnalysis"
+      />
+    )
 
     await user.click(
       screen.getByRole('button', {
@@ -59,7 +71,13 @@ describe('DialogApproveRiskAnalysis', () => {
   it('should call signRiskAnalysis when confirm is clicked', async () => {
     const user = userEvent.setup()
 
-    render(<DialogApproveRiskAnalysis purposeId="test-purpose-id" type="approveRiskAnalysis" />)
+    render(
+      <DialogApproveRiskAnalysis
+        purposeId="test-purpose-id"
+        metadataVersionToSign={3}
+        type="approveRiskAnalysis"
+      />
+    )
 
     await user.click(
       screen.getByRole('button', {
@@ -70,6 +88,7 @@ describe('DialogApproveRiskAnalysis', () => {
     expect(signRiskAnalysisMock).toHaveBeenCalledWith(
       {
         purposeId: 'test-purpose-id',
+        metadataVersionToSign: 3,
       },
       expect.any(Object)
     )
@@ -84,7 +103,13 @@ describe('DialogApproveRiskAnalysis', () => {
       options.onSuccess()
     })
 
-    render(<DialogApproveRiskAnalysis purposeId="test-purpose-id" type="approveRiskAnalysis" />)
+    render(
+      <DialogApproveRiskAnalysis
+        purposeId="test-purpose-id"
+        metadataVersionToSign={3}
+        type="approveRiskAnalysis"
+      />
+    )
 
     await user.click(
       screen.getByRole('button', {
@@ -107,7 +132,13 @@ describe('DialogApproveRiskAnalysis', () => {
       isPending: true,
     })
 
-    render(<DialogApproveRiskAnalysis purposeId="test-purpose-id" type="approveRiskAnalysis" />)
+    render(
+      <DialogApproveRiskAnalysis
+        purposeId="test-purpose-id"
+        metadataVersionToSign={3}
+        type="approveRiskAnalysis"
+      />
+    )
 
     expect(screen.getByRole('button', { name: 'actions.cancel' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'actions.confirm' })).toBeDisabled()

--- a/src/pages/RiskAnalysisSummaryPage/hooks/__tests__/useRiskAnalysisSummaryPage.test.ts
+++ b/src/pages/RiskAnalysisSummaryPage/hooks/__tests__/useRiskAnalysisSummaryPage.test.ts
@@ -1,9 +1,11 @@
-import { renderHook } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { useRiskAnalysisSummaryPage } from '../useRiskAnalysisSummaryPage'
 
 const navigateMock = vi.fn()
 const useQueryMock = vi.fn()
+const openDialogMock = vi.fn()
+const showToastMock = vi.fn()
 
 vi.mock('@/router', () => ({
   useNavigate: () => navigateMock,
@@ -23,6 +25,11 @@ vi.mock('@tanstack/react-query', async () => {
     queryOptions: actual.queryOptions,
   }
 })
+
+vi.mock('@/stores', () => ({
+  useDialog: () => ({ openDialog: openDialogMock }),
+  useToastNotificationStore: () => showToastMock,
+}))
 
 vi.mock('../../ConsumerPurposeSummaryPage/hooks/useGetConsumerPurposeAlertProps', () => ({
   useGetConsumerPurposeAlertProps: () => undefined,
@@ -145,5 +152,72 @@ describe('useRiskAnalysisSummaryPage', () => {
     expect(navigateMock).toHaveBeenCalledWith('SUBSCRIBE_RISK_ANALYSIS_COMPILE', {
       params: { purposeId: 'test-purpose-id' },
     })
+  })
+
+  it('should refetch the purpose and pass its metadata version to the approval dialog', async () => {
+    const purpose = {
+      currentVersion: {},
+      metadataVersion: 3,
+      eservice: { mode: 'RECEIVE', descriptor: { state: 'ACTIVE' } },
+      agreement: { state: 'ACTIVE' },
+    }
+    const refetch = vi.fn().mockResolvedValue({ data: purpose, isError: false })
+    useQueryMock.mockReturnValue({ data: purpose, isLoading: false, refetch })
+
+    const { result } = renderHook(() => useRiskAnalysisSummaryPage())
+
+    await act(() => result.current.handleApproveDraft())
+
+    expect(refetch).toHaveBeenCalledTimes(1)
+    expect(openDialogMock).toHaveBeenCalledWith({
+      type: 'approveRiskAnalysis',
+      purposeId: 'test-purpose-id',
+      metadataVersionToSign: 3,
+    })
+  })
+
+  it('should show an error toast instead of opening the dialog when the purpose changed', async () => {
+    const purpose = {
+      currentVersion: {},
+      metadataVersion: 3,
+      eservice: { mode: 'RECEIVE', descriptor: { state: 'ACTIVE' } },
+      agreement: { state: 'ACTIVE' },
+    }
+    const refetch = vi.fn().mockResolvedValue({
+      data: { ...purpose, metadataVersion: 4 },
+      isError: false,
+    })
+    useQueryMock.mockReturnValue({ data: purpose, isLoading: false, refetch })
+
+    const { result } = renderHook(() => useRiskAnalysisSummaryPage())
+
+    await act(() => result.current.handleApproveDraft())
+
+    expect(showToastMock).toHaveBeenCalledWith('error', 'error')
+    expect(openDialogMock).not.toHaveBeenCalled()
+  })
+
+  it('should show an error toast when the risk analysis has already been signed', async () => {
+    const purpose = {
+      currentVersion: {},
+      metadataVersion: 3,
+      eservice: { mode: 'RECEIVE', descriptor: { state: 'ACTIVE' } },
+      agreement: { state: 'ACTIVE' },
+    }
+    const refetch = vi.fn().mockResolvedValue({
+      data: {
+        ...purpose,
+        reviewerWorkflow: { signingState: 'SIGNED' },
+      },
+      isError: false,
+    })
+    useQueryMock.mockReturnValue({ data: purpose, isLoading: false, refetch })
+
+    const { result } = renderHook(() => useRiskAnalysisSummaryPage())
+
+    await act(() => result.current.handleApproveDraft())
+
+    expect(showToastMock).toHaveBeenCalledWith('error', 'error')
+    expect(openDialogMock).not.toHaveBeenCalled()
   })
 })

--- a/src/pages/RiskAnalysisSummaryPage/hooks/useRiskAnalysisSummaryPage.ts
+++ b/src/pages/RiskAnalysisSummaryPage/hooks/useRiskAnalysisSummaryPage.ts
@@ -3,14 +3,19 @@ import { useNavigate, useParams } from '@/router'
 import { checkIsRulesetExpired } from '@/utils/purpose.utils'
 import { useQuery } from '@tanstack/react-query'
 import { useGetConsumerPurposeAlertProps } from '../../ConsumerPurposeSummaryPage/hooks/useGetConsumerPurposeAlertProps'
-import { useDialog } from '@/stores'
+import { useDialog, useToastNotificationStore } from '@/stores'
+import { useTranslation } from 'react-i18next'
 
 export function useRiskAnalysisSummaryPage() {
   const { purposeId } = useParams<'SUBSCRIBE_RISK_ANALYSIS_SUMMARY'>()
   const navigate = useNavigate()
   const { openDialog } = useDialog()
+  const showToast = useToastNotificationStore((state) => state.showToast)
+  const { t } = useTranslation('mutations-feedback', {
+    keyPrefix: 'purpose.signRiskAnalysis.outcome',
+  })
 
-  const { data: purpose, isLoading } = useQuery(PurposeQueries.getSingle(purposeId))
+  const { data: purpose, isLoading, refetch } = useQuery(PurposeQueries.getSingle(purposeId))
 
   const isEserviceDeliverMode = purpose?.eservice.mode === 'DELIVER'
 
@@ -42,11 +47,31 @@ export function useRiskAnalysisSummaryPage() {
     })
   }
 
-  const handleApproveDraft = () => {
+  const handleApproveDraft = async () => {
     if (!purpose?.currentVersion) return
+
+    const metadataVersion = purpose.metadataVersion
+    const { data: refreshedPurpose, isError } = await refetch()
+    const refreshedSigningState = refreshedPurpose?.reviewerWorkflow?.signingState
+    const isRiskAnalysisConcluded =
+      refreshedSigningState === 'SIGNED' || refreshedSigningState === 'REJECTED'
+
+    if (
+      isError ||
+      !refreshedPurpose ||
+      metadataVersion === undefined ||
+      refreshedPurpose.metadataVersion === undefined ||
+      refreshedPurpose.metadataVersion !== metadataVersion ||
+      isRiskAnalysisConcluded
+    ) {
+      showToast(t('error'), 'error')
+      return
+    }
+
     openDialog({
       type: 'approveRiskAnalysis',
       purposeId,
+      metadataVersionToSign: refreshedPurpose.metadataVersion,
     })
   }
 

--- a/src/types/dialog.types.ts
+++ b/src/types/dialog.types.ts
@@ -232,6 +232,7 @@ export type DialogEditRiskAnalysisAssignmentProps = {
 export type DialogApproveRiskAnalysisProps = {
   type: 'approveRiskAnalysis'
   purposeId: string
+  metadataVersionToSign: number
 }
 
 export type DialogRejectRiskAnalysisProps = {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10678](https://pagopa.atlassian.net/browse/PIN-10678)

## 📝 Description / Context

Prevent stale or concurrent risk analysis approvals by using the purpose metadata version exposed by the backend.

Before opening the approval dialog, the purpose is refreshed and its metadata version is compared with the version originally loaded by the page. The refreshed version is then sent to the sign endpoint, allowing the backend to perform the final atomic consistency check.

This PR is stacked on `feature/PIN-10689_admin-modifiche-su-step-di-assegnazione` and depends on the backend risk analysis PR stack, including [interop-be-monorepo#3658](https://github.com/pagopa/interop-be-monorepo/pull/3658).

## 🛠 List of changes

- Read `X-Metadata-Version` from the purpose response headers.
- Refetch the purpose before opening the approval confirmation dialog.
- Prevent approval when the metadata version changed or the risk analysis is already concluded.
- Show the existing approval error toast when stale data is detected.
- Send `metadataVersionToSign` in the `/riskAnalysis/sign` request body.
- Regenerate API types from the combined backend risk analysis stack and current `develop` OpenAPI contract.
- Add focused tests for metadata header handling, stale versions, concluded analyses, dialog propagation, and the sign request payload.

## 🧪 How to test

- Log in as a reviewer and open a risk analysis awaiting approval.
- Select “Approve risk analysis” and verify that the confirmation dialog opens.
- Confirm the approval and verify that the request to `/purposes/{purposeId}/riskAnalysis/sign` contains `metadataVersionToSign`.
- Verify that a successful approval navigates to the confirmation page.
- Open the same risk analysis in two browser sessions and approve or update it in one session.
- Attempt approval from the stale session and verify that an error toast is displayed without navigating to the success page.

[PIN-10678]: https://pagopa.atlassian.net/browse/PIN-10678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ