### PR TITLE
fix: show contextual grace period archive error (PIN-10688)

### DIFF
--- a/src/api/eservice/__tests__/eservice.mutations.test.ts
+++ b/src/api/eservice/__tests__/eservice.mutations.test.ts
@@ -1,0 +1,74 @@
+import { AxiosError } from 'axios'
+import { vi } from 'vitest'
+import type * as ReactQuery from '@tanstack/react-query'
+import { renderHookWithApplicationContext } from '@/utils/testing.utils'
+
+const capturedMutationOptions: Array<Record<string, unknown>> = []
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof ReactQuery>('@tanstack/react-query')
+  return {
+    ...actual,
+    useMutation: (options: Record<string, unknown>) => {
+      capturedMutationOptions.push(options)
+      return actual.useMutation(options)
+    },
+  }
+})
+
+const { mockScheduleArchiveEservice } = vi.hoisted(() => ({
+  mockScheduleArchiveEservice: vi.fn(),
+}))
+
+vi.mock('../eservice.services', () => ({
+  EServiceServices: {
+    scheduleArchiveEservice: mockScheduleArchiveEservice,
+  },
+}))
+
+import { EServiceMutations } from '../eservice.mutations'
+
+afterEach(() => {
+  capturedMutationOptions.length = 0
+  vi.clearAllMocks()
+})
+
+function getErrorToastLabel() {
+  const options = capturedMutationOptions.find(
+    (option) => option.mutationFn === mockScheduleArchiveEservice
+  )
+  expect(options).toBeDefined()
+  return (options!.meta as Record<string, unknown>).errorToastLabel as (error: unknown) => string
+}
+
+function makeApiError(code: string) {
+  return new AxiosError('test', undefined, undefined, undefined, {
+    status: 400,
+    statusText: 'Bad Request',
+    data: { errors: [{ code }] },
+    headers: {},
+    config: {} as never,
+  })
+}
+
+describe('useScheduleArchiveEservice', () => {
+  it('returns the contextual error label when the grace period is lower than a descriptor', () => {
+    renderHookWithApplicationContext(() => EServiceMutations.useScheduleArchiveEservice(), {
+      withReactQueryContext: true,
+    })
+
+    const errorToastLabel = getErrorToastLabel()
+
+    expect(errorToastLabel(makeApiError('001-0070'))).toBe('outcome.gracePeriodError')
+  })
+
+  it('returns the default error label for other errors', () => {
+    renderHookWithApplicationContext(() => EServiceMutations.useScheduleArchiveEservice(), {
+      withReactQueryContext: true,
+    })
+
+    const errorToastLabel = getErrorToastLabel()
+
+    expect(errorToastLabel(new Error('generic error'))).toBe('outcome.error')
+  })
+})

--- a/src/api/eservice/__tests__/eservice.mutations.test.ts
+++ b/src/api/eservice/__tests__/eservice.mutations.test.ts
@@ -41,26 +41,29 @@ function getErrorToastLabel() {
   return (options!.meta as Record<string, unknown>).errorToastLabel as (error: unknown) => string
 }
 
-function makeApiError(code: string) {
+function makeApiError(...codes: string[]) {
   return new AxiosError('test', undefined, undefined, undefined, {
     status: 400,
     statusText: 'Bad Request',
-    data: { errors: [{ code }] },
+    data: { errors: codes.map((code) => ({ code })) },
     headers: {},
     config: {} as never,
   })
 }
 
 describe('useScheduleArchiveEservice', () => {
-  it('returns the contextual error label when the grace period is lower than a descriptor', () => {
-    renderHookWithApplicationContext(() => EServiceMutations.useScheduleArchiveEservice(), {
-      withReactQueryContext: true,
-    })
+  it.each([['001-0070'], ['001-0001', '001-0070']])(
+    'returns the contextual error label when the response includes the grace period error (%j)',
+    (...codes) => {
+      renderHookWithApplicationContext(() => EServiceMutations.useScheduleArchiveEservice(), {
+        withReactQueryContext: true,
+      })
 
-    const errorToastLabel = getErrorToastLabel()
+      const errorToastLabel = getErrorToastLabel()
 
-    expect(errorToastLabel(makeApiError('001-0070'))).toBe('outcome.gracePeriodError')
-  })
+      expect(errorToastLabel(makeApiError(...codes))).toBe('outcome.gracePeriodError')
+    }
+  )
 
   it('returns the default error label for other errors', () => {
     renderHookWithApplicationContext(() => EServiceMutations.useScheduleArchiveEservice(), {
@@ -70,5 +73,7 @@ describe('useScheduleArchiveEservice', () => {
     const errorToastLabel = getErrorToastLabel()
 
     expect(errorToastLabel(new Error('generic error'))).toBe('outcome.error')
+    expect(errorToastLabel(makeApiError('001-0001', '001-0002'))).toBe('outcome.error')
+    expect(errorToastLabel(makeApiError())).toBe('outcome.error')
   })
 })

--- a/src/api/eservice/eservice.mutations.ts
+++ b/src/api/eservice/eservice.mutations.ts
@@ -9,8 +9,7 @@ import type {
 import { EServiceServices } from './eservice.services'
 import { EServiceQueries } from './eservice.queries'
 import type { AttributeKey } from '@/types/attribute.types'
-
-const GRACE_PERIOD_DAYS_LOWER_THAN_DESCRIPTOR_ERROR_CODE = '001-0070'
+import { GRACE_PERIOD_DAYS_LOWER_THAN_DESCRIPTOR_ERROR_CODE } from '@/config/constants'
 
 function useCreateDraft() {
   const { t } = useTranslation('mutations-feedback', { keyPrefix: 'eservice.createDraft' })

--- a/src/api/eservice/eservice.mutations.ts
+++ b/src/api/eservice/eservice.mutations.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
+import { AxiosError } from 'axios'
 import type {
   EServiceRiskAnalysisSeed,
   UpdateEServiceDescriptorSeed,
@@ -8,6 +9,8 @@ import type {
 import { EServiceServices } from './eservice.services'
 import { EServiceQueries } from './eservice.queries'
 import type { AttributeKey } from '@/types/attribute.types'
+
+const GRACE_PERIOD_DAYS_LOWER_THAN_DESCRIPTOR_ERROR_CODE = '001-0070'
 
 function useCreateDraft() {
   const { t } = useTranslation('mutations-feedback', { keyPrefix: 'eservice.createDraft' })
@@ -241,7 +244,16 @@ function useScheduleArchiveEservice() {
         t('outcome.success', {
           days: (variables as { gracePeriodDays: number }).gracePeriodDays,
         }),
-      errorToastLabel: t('outcome.error'),
+      errorToastLabel: (error: unknown) => {
+        if (
+          error instanceof AxiosError &&
+          error.response?.data?.errors?.[0]?.code ===
+            GRACE_PERIOD_DAYS_LOWER_THAN_DESCRIPTOR_ERROR_CODE
+        ) {
+          return t('outcome.gracePeriodError')
+        }
+        return t('outcome.error')
+      },
     },
   })
 }

--- a/src/api/eservice/eservice.mutations.ts
+++ b/src/api/eservice/eservice.mutations.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { AxiosError } from 'axios'
 import type {
   EServiceRiskAnalysisSeed,
+  ProblemError,
   UpdateEServiceDescriptorSeed,
   UpdateEServiceDescriptorTemplateInstanceSeed,
 } from '../api.generatedTypes'
@@ -246,8 +247,10 @@ function useScheduleArchiveEservice() {
       errorToastLabel: (error: unknown) => {
         if (
           error instanceof AxiosError &&
-          error.response?.data?.errors?.[0]?.code ===
-            GRACE_PERIOD_DAYS_LOWER_THAN_DESCRIPTOR_ERROR_CODE
+          error.response?.data?.errors?.some(
+            (problemError: ProblemError) =>
+              problemError.code === GRACE_PERIOD_DAYS_LOWER_THAN_DESCRIPTOR_ERROR_CODE
+          )
         ) {
           return t('outcome.gracePeriodError')
         }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -51,6 +51,7 @@ export const GRACE_PERIOD_DAYS_OPTIONS = [
   30, 60, 90, 120,
 ] as const satisfies readonly GracePeriodDays[]
 export const DEFAULT_GRACE_PERIOD_DAYS: GracePeriodDays = 60
+export const GRACE_PERIOD_DAYS_LOWER_THAN_DESCRIPTOR_ERROR_CODE = '001-0070'
 export const userRolesGuideLink = `${DOCUMENTATION_URL}/per-iniziare/primo-accesso-e-configurazione-iniziale`
 export const notificationGuideLink = `https://developer.pagopa.it/pdnd-interoperabilita/guides/manuale-operativo-pdnd-interoperabilita/v1.0/riferimenti-tecnici/notifiche`
 export const notificationMailChangeLink =

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -156,6 +156,7 @@
     "scheduleArchiveEservice": {
       "outcome": {
         "success": "This e-service will be archived in {{days}} days",
+        "gracePeriodError": "You cannot archive the e-service before a version that is already being archived. Select a longer grace period.",
         "error": "This e-service could not be archived. Please try again later."
       }
     },

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -156,6 +156,7 @@
     "scheduleArchiveEservice": {
       "outcome": {
         "success": "Questo e-service sarà archiviato tra {{days}} giorni",
+        "gracePeriodError": "Non puoi archiviare l’e-service prima di una versione già in fase di archiviazione. Seleziona una durata più lunga.",
         "error": "Non è stato possibile procedere con l'archiviazione di questo e-service. Riprova più tardi."
       }
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,7 +71,6 @@ export default defineConfig(({ mode }) => {
           '**/api/attribute/**',
           '**/api/auth/**',
           '**/api/client/**',
-          '**/api/eservice/**',
           '**/api/party/**',
           '**/api/purpose/**',
           '**/api/voucher/**',


### PR DESCRIPTION
## 🔗 Issue

[PIN-10688](https://pagopa.atlassian.net/browse/PIN-10688)

## 📝 Description / Context

Display a contextual error message when attempting to archive an e-service with a grace period shorter than the one already scheduled for one of its versions.

## 🛠 List of changes

- Handle the BFF `001-0070` error code in the e-service archive mutation
- Display the contextual error message defined in Figma
- Add Italian and English translations
- Add focused tests for the contextual message and generic error fallback

### Coverage note

`src/api/eservice/**` had been excluded from coverage since PIN-3244, a legacy 2023 task created while bringing repository coverage to 80%. Since these API modules now contain testable application behavior and this PR adds focused mutation tests, the exclusion has been removed. This allows LCOV to report coverage for the same new lines evaluated by SonarCloud.

## 🧪 How to test

- Open the details page of a provider e-service
- Schedule one of its versions for archiving with a 120-day grace period
- Attempt to archive the entire e-service with a 60-day grace period
- Verify that the following contextual error is displayed: “Non puoi archiviare l’e-service prima di una versione già in fase di archiviazione. Seleziona una durata più lunga.”
- Verify that unrelated failures still display the generic archive error

[PIN-10688]: https://pagopa.atlassian.net/browse/PIN-10688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ