### PR TITLE
fix: restrict provider agreement details access (PIN-10780)

### DIFF
--- a/src/pages/ProviderAgreementDetailsPage/ProviderAgreementDetails.page.tsx
+++ b/src/pages/ProviderAgreementDetailsPage/ProviderAgreementDetails.page.tsx
@@ -1,4 +1,6 @@
 import { AgreementQueries } from '@/api/agreement'
+import { AuthHooks } from '@/api/auth'
+import { DelegationQueries } from '@/api/delegation'
 import { PageContainer } from '@/components/layout/containers'
 import useGetAgreementsActions from '@/hooks/useGetAgreementsActions'
 import { useMarkNotificationsAsRead } from '@/hooks/useMarkNotificationsAsRead'
@@ -17,6 +19,7 @@ import {
 import { ProviderAgreementDetailsContextProvider } from './components/ProviderAgreementDetailsContext'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { match } from 'ts-pattern'
+import { NotFoundError } from '@/utils/errors.utils'
 
 const ProviderAgreementDetailsPage: React.FC = () => {
   return (
@@ -28,12 +31,33 @@ const ProviderAgreementDetailsPage: React.FC = () => {
 
 const ProviderAgreementDetailsPageContent: React.FC = () => {
   const { t } = useTranslation('agreement')
+  const { jwt } = AuthHooks.useJwt()
 
   const { agreementId } = useParams<'SUBSCRIBE_AGREEMENT_READ'>()
   const { data: agreement } = useSuspenseQuery(AgreementQueries.getSingle(agreementId))
+  const organizationId = jwt?.organizationId
+  const {
+    data: { results: producerDelegations },
+  } = useSuspenseQuery(
+    DelegationQueries.getList({
+      limit: 1,
+      offset: 0,
+      eserviceIds: [agreement.eservice.id],
+      states: ['ACTIVE'],
+      kind: 'DELEGATED_PRODUCER',
+      delegateIds: organizationId ? [organizationId] : [],
+    })
+  )
   const { actions } = useGetAgreementsActions(agreement, 'PRODUCER')
 
   useMarkNotificationsAsRead(agreementId)
+
+  const canAccessAgreement =
+    agreement.producer.id === organizationId || producerDelegations.length > 0
+
+  if (!canAccessAgreement) {
+    throw new NotFoundError()
+  }
 
   const suspendedBy = match(agreement)
     .with({ suspendedByProducer: true }, () => 'byProducer' as const)

--- a/src/pages/ProviderAgreementDetailsPage/__tests__/ProviderAgreementDetails.page.test.tsx
+++ b/src/pages/ProviderAgreementDetailsPage/__tests__/ProviderAgreementDetails.page.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { createMockAgreement } from '@/../__mocks__/data/agreement.mocks'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
+import { NotFoundError } from '@/utils/errors.utils'
+import type * as ReactQuery from '@tanstack/react-query'
+import type * as Router from '@/router'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ProviderAgreementDetailsPage from '../ProviderAgreementDetails.page'
+
+const { mockedUseSuspenseQuery } = vi.hoisted(() => ({
+  mockedUseSuspenseQuery: vi.fn(),
+}))
+
+vi.mock('@/router', async (importOriginal) => ({
+  ...(await importOriginal<typeof Router>()),
+  useParams: () => ({ agreementId: 'agreement-id' }),
+}))
+
+vi.mock('@/hooks/useGetAgreementsActions', () => ({
+  default: () => ({ actions: [] }),
+}))
+
+vi.mock('@/hooks/useMarkNotificationsAsRead', () => ({
+  useMarkNotificationsAsRead: vi.fn(),
+}))
+
+vi.mock(
+  '../components/ProviderAgreementDetailsGeneralInfoSection/ProviderAgreementDetailsGeneralInfoSection',
+  () => ({
+    ProviderAgreementDetailsGeneralInfoSection: () => <div>Agreement details</div>,
+    ProviderAgreementDetailsGeneralInfoSectionSkeleton: () => null,
+  })
+)
+
+vi.mock(
+  '../components/ProviderAgreementDetailsAttributesSectionsList/ProviderAgreementDetailsAttributesSectionsList',
+  () => ({
+    ProviderAgreementDetailsAttributesSectionsList: () => null,
+    ProviderAgreementDetailsAttributesSectionsListSkeleton: () => null,
+  })
+)
+
+vi.mock('@tanstack/react-query', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactQuery>()),
+  useSuspenseQuery: mockedUseSuspenseQuery,
+}))
+
+function renderPage() {
+  return renderWithApplicationContext(<ProviderAgreementDetailsPage />, {
+    withReactQueryContext: true,
+    withRouterContext: true,
+  })
+}
+
+function mockQueries(producerDelegations: Array<{ id: string }> = []) {
+  mockedUseSuspenseQuery.mockImplementation(({ queryKey }) => {
+    if (queryKey[0] === 'AgreementGetSingle') {
+      return {
+        data: createMockAgreement({
+          consumer: { id: 'consumer-id' },
+          producer: { id: 'producer-id' },
+        }),
+      }
+    }
+
+    return { data: { results: producerDelegations } }
+  })
+}
+
+describe('ProviderAgreementDetailsPage', () => {
+  beforeEach(() => {
+    mockUseJwt({ jwt: { organizationId: 'consumer-id' } })
+    mockQueries()
+  })
+
+  it('prevents a consumer from opening the provider agreement details via direct URL', () => {
+    expect(() => renderPage()).toThrow(NotFoundError)
+  })
+
+  it('allows the producer to open the provider agreement details', () => {
+    mockUseJwt({ jwt: { organizationId: 'producer-id' } })
+
+    renderPage()
+
+    expect(screen.getByText('Agreement details')).toBeInTheDocument()
+  })
+
+  it('allows an active producer delegate to open the provider agreement details', () => {
+    mockUseJwt({ jwt: { organizationId: 'delegate-id' } })
+    mockQueries([{ id: 'producer-delegation-id' }])
+
+    renderPage()
+
+    expect(screen.getByText('Agreement details')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## 🔗 Issue

[PIN-10780](https://pagopa.atlassian.net/browse/PIN-10780)

## 📝 Description / Context

Consumers could access the provider agreement details page by opening its direct URL, even though the agreement was correctly excluded from their provider requests list.

This change restricts the provider details page to the agreement producer and active producer delegates.

## 🛠 List of changes

- Check the current organization against the agreement producer
- Allow access to active producer delegates for the agreement's e-service
- Redirect unauthorized organizations to the not-found page
- Add tests covering consumers, producers, and active producer delegates

## 🧪 How to test

- Log in as the consumer of an agreement owned by another producer
- Open `/ui/it/erogazione/richieste/<agreement-id>` directly and verify that the not-found page is shown
- Log in as the agreement producer and verify that the same provider details page is accessible
- Log in as an active producer delegate and verify that the page remains accessible

[PIN-10780]: https://pagopa.atlassian.net/browse/PIN-10780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ