### PR TITLE
feat: allow custom threshold removal (PIN-10711)

### DIFF
--- a/src/api/eservice/eservice.mutations.ts
+++ b/src/api/eservice/eservice.mutations.ts
@@ -259,9 +259,19 @@ function useCancelEserviceArchiving() {
   })
 }
 
-function useUpdateVersion({ isThresholdOnlyUpdate }: { isThresholdOnlyUpdate?: boolean } = {}) {
+function useUpdateVersion({
+  isThresholdOnlyUpdate,
+  isAttributeThresholdRemoval,
+}: {
+  isThresholdOnlyUpdate?: boolean
+  isAttributeThresholdRemoval?: boolean
+} = {}) {
   const { t } = useTranslation('mutations-feedback', {
-    keyPrefix: isThresholdOnlyUpdate ? 'eservice.updateThresholds' : 'eservice.updateVersion',
+    keyPrefix: isAttributeThresholdRemoval
+      ? 'eservice.removeAttributeThreshold'
+      : isThresholdOnlyUpdate
+        ? 'eservice.updateThresholds'
+        : 'eservice.updateVersion',
   })
   return useMutation({
     mutationFn: EServiceServices.updateVersion,
@@ -275,9 +285,17 @@ function useUpdateVersion({ isThresholdOnlyUpdate }: { isThresholdOnlyUpdate?: b
 
 function useUpdateInstanceVersion({
   isThresholdOnlyUpdate,
-}: { isThresholdOnlyUpdate?: boolean } = {}) {
+  isAttributeThresholdRemoval,
+}: {
+  isThresholdOnlyUpdate?: boolean
+  isAttributeThresholdRemoval?: boolean
+} = {}) {
   const { t } = useTranslation('mutations-feedback', {
-    keyPrefix: isThresholdOnlyUpdate ? 'eservice.updateThresholds' : 'eservice.updateVersion',
+    keyPrefix: isAttributeThresholdRemoval
+      ? 'eservice.removeAttributeThreshold'
+      : isThresholdOnlyUpdate
+        ? 'eservice.updateThresholds'
+        : 'eservice.updateVersion',
   })
   return useMutation({
     mutationFn: EServiceServices.updateInstanceVersion,

--- a/src/components/layout/containers/AttributeContainer.tsx
+++ b/src/components/layout/containers/AttributeContainer.tsx
@@ -47,6 +47,7 @@ type AttributeContainerProps<
   checked?: boolean
   onRemove?: (id: string, name: string) => void
   onCustomizeThreshold?: VoidFunction
+  onRemoveThreshold?: VoidFunction
   hideThreshold?: boolean
   onOpenConfigDrawer?: VoidFunction
 }
@@ -67,6 +68,7 @@ export const AttributeContainer = <
   checked,
   onRemove,
   onCustomizeThreshold,
+  onRemoveThreshold,
   hideThreshold,
   onOpenConfigDrawer,
 }: AttributeContainerProps<TAttribute>) => {
@@ -107,6 +109,14 @@ export const AttributeContainer = <
         label: t('actions.changeThreshold'),
       }
       actions.push(customizeThresholdAction)
+    }
+
+    if (onRemoveThreshold && attribute.dailyCallsPerConsumer !== undefined) {
+      const removeThresholdAction: ActionItemButton = {
+        action: onRemoveThreshold,
+        label: t('actions.removeThreshold'),
+      }
+      actions.push(removeThresholdAction)
     }
 
     const inspectAttributeDetails: ActionItemButton = {

--- a/src/components/layout/containers/__tests__/AttributeContainer.test.tsx
+++ b/src/components/layout/containers/__tests__/AttributeContainer.test.tsx
@@ -93,6 +93,37 @@ describe('AttributeContainer', () => {
     expect(screen.getByRole('menuitem', { name: 'actions.changeThreshold' })).toBeInTheDocument()
   })
 
+  it('should show and invoke "removeThreshold" when a customized threshold exists', async () => {
+    const user = userEvent.setup()
+    const onRemoveThreshold = vi.fn()
+    renderWithApplicationContext(
+      <AttributeContainer
+        attribute={{ ...baseAttribute, dailyCallsPerConsumer: 100 }}
+        onRemoveThreshold={onRemoveThreshold}
+      />,
+      { withReactQueryContext: true }
+    )
+
+    await user.click(screen.getByLabelText('iconButtonAriaLabel'))
+    await user.click(screen.getByRole('menuitem', { name: 'actions.removeThreshold' }))
+
+    expect(onRemoveThreshold).toHaveBeenCalledOnce()
+  })
+
+  it('should not show "removeThreshold" when no customized threshold exists', async () => {
+    const user = userEvent.setup()
+    renderWithApplicationContext(
+      <AttributeContainer attribute={baseAttribute} onRemoveThreshold={vi.fn()} />,
+      { withReactQueryContext: true }
+    )
+
+    await user.click(screen.getByLabelText('iconButtonAriaLabel'))
+
+    expect(
+      screen.queryByRole('menuitem', { name: 'actions.removeThreshold' })
+    ).not.toBeInTheDocument()
+  })
+
   it('should show threshold value when hideThreshold is false', async () => {
     renderWithApplicationContext(
       <AttributeContainer

--- a/src/components/shared/AddAttributesToForm/AttributeGroup.tsx
+++ b/src/components/shared/AddAttributesToForm/AttributeGroup.tsx
@@ -22,6 +22,8 @@ import {
   ConfigureCertifiedDiscreteAttributeDrawer,
   useConfigureCertifiedDiscreteAttributeDrawer,
 } from './ConfigureCertifiedDiscreteAttributeDrawer'
+import omit from 'lodash/omit'
+import { useToastNotification } from '@/stores'
 
 export type AttributeGroupProps = {
   group: Array<FormDescriptorAttribute>
@@ -44,6 +46,10 @@ export const AttributeGroup: React.FC<AttributeGroupProps> = ({
 }) => {
   const { t } = useTranslation('attribute', { keyPrefix: 'group' })
   const { t: tAttribute } = useTranslation('attribute')
+  const { t: tAttributeContainer } = useTranslation('shared-components', {
+    keyPrefix: 'attributeContainer',
+  })
+  const { showToast } = useToastNotification()
   const [isAttributeAutocompleteVisible, setIsAttributeAutocompleteVisible] = React.useState(
     group.length === 0
   )
@@ -66,7 +72,10 @@ export const AttributeGroup: React.FC<AttributeGroupProps> = ({
     }
   }
 
-  const { watch, setValue, getValues } = useFormContext<{ attributes: FormDescriptorAttributes }>()
+  const { watch, setValue, getValues, trigger } = useFormContext<{
+    attributes: FormDescriptorAttributes
+    dailyCallsTotal?: number
+  }>()
   const attributeGroups = watch(`attributes.${attributeKey}`)
 
   const handleAddAttributeToGroup = (attribute: CompactAttribute) => {
@@ -74,6 +83,18 @@ export const AttributeGroup: React.FC<AttributeGroupProps> = ({
     newAttributeGroups[groupIndex].push(attribute)
     setValue(`attributes.${attributeKey}`, newAttributeGroups)
     setIsAttributeAutocompleteVisible(false)
+  }
+
+  const handleRemoveThreshold = (attributeId: string) => {
+    const attributes = getValues('attributes')
+    const groups = [...attributes.certified]
+    groups[groupIndex] = groups[groupIndex].map((attribute) =>
+      attribute.id === attributeId ? omit(attribute, 'dailyCallsPerConsumer') : attribute
+    )
+
+    setValue('attributes.certified', groups, { shouldValidate: false })
+    trigger('dailyCallsTotal')
+    showToast(tAttributeContainer('removeThresholdSuccess'), 'success')
   }
 
   const handleSubmitConfigureDiscreteAttributeDrawer = (
@@ -150,6 +171,11 @@ export const AttributeGroup: React.FC<AttributeGroupProps> = ({
                     onCustomizeThreshold={
                       withThreshold
                         ? () => openCustomizeThresholdDrawer(attribute, groupIndex)
+                        : undefined
+                    }
+                    onRemoveThreshold={
+                      withThreshold && attribute.dailyCallsPerConsumer !== undefined
+                        ? () => handleRemoveThreshold(attribute.id)
                         : undefined
                     }
                     onOpenConfigDrawer={

--- a/src/components/shared/AddAttributesToForm/__tests__/AttributeGroup.test.tsx
+++ b/src/components/shared/AddAttributesToForm/__tests__/AttributeGroup.test.tsx
@@ -5,14 +5,17 @@ import { vi, describe, it, expect } from 'vitest'
 import { renderWithApplicationContext, ReactHookFormWrapper } from '@/utils/testing.utils'
 import { createMockDescriptorAttribute } from '@/../__mocks__/data/attribute.mocks'
 import type { DescriptorAttribute } from '@/api/api.generatedTypes'
+import { useFormContext } from 'react-hook-form'
 
 vi.mock('@/components/layout/containers', () => ({
   AttributeContainer: ({
     attribute,
     onRemove,
+    onRemoveThreshold,
   }: {
     attribute: DescriptorAttribute
     onRemove?: (id: string, name: string) => void
+    onRemoveThreshold?: VoidFunction
   }) => (
     <div data-testid={`attribute-container-${attribute.id}`}>
       {attribute.name}
@@ -22,6 +25,11 @@ vi.mock('@/components/layout/containers', () => ({
           onClick={() => onRemove(attribute.id, attribute.name)}
         >
           remove
+        </button>
+      )}
+      {onRemoveThreshold && (
+        <button data-testid={`remove-threshold-${attribute.id}`} onClick={onRemoveThreshold}>
+          remove threshold
         </button>
       )}
     </div>
@@ -77,6 +85,11 @@ const emptyFormValues = {
   },
 }
 
+const FormValuesObserver = () => {
+  const { watch } = useFormContext()
+  return <output data-testid="form-values">{JSON.stringify(watch())}</output>
+}
+
 const renderComponent = (
   props: Partial<React.ComponentProps<typeof AttributeGroup>> = {},
   formValues = defaultFormValues
@@ -94,6 +107,7 @@ const renderComponent = (
   return renderWithApplicationContext(
     <ReactHookFormWrapper defaultValues={formValues}>
       <AttributeGroup {...defaultProps} />
+      <FormValuesObserver />
     </ReactHookFormWrapper>,
     { withReactQueryContext: true }
   )
@@ -164,5 +178,25 @@ describe('AttributeGroup', () => {
 
     // After removing the last attribute, autocomplete should show due to state change
     expect(screen.getByTestId('attribute-autocomplete')).toBeInTheDocument()
+  })
+
+  it('should remove a customized threshold from the form attribute', () => {
+    const attributeWithThreshold = createMockDescriptorAttribute({
+      id: 'attr-with-threshold',
+      dailyCallsPerConsumer: 100,
+    })
+    const formValues = {
+      attributes: {
+        certified: [[attributeWithThreshold]] as Array<Array<DescriptorAttribute>>,
+        verified: [] as Array<Array<DescriptorAttribute>>,
+        declared: [] as Array<Array<DescriptorAttribute>>,
+      },
+    }
+
+    renderComponent({ group: [attributeWithThreshold], withThreshold: true }, formValues)
+    fireEvent.click(screen.getByTestId('remove-threshold-attr-with-threshold'))
+
+    expect(screen.getByTestId('form-values')).not.toHaveTextContent('dailyCallsPerConsumer')
+    expect(screen.getByText('removeThresholdSuccess')).toBeInTheDocument()
   })
 })

--- a/src/components/shared/ReadOnlyDescriptorAttributes.tsx
+++ b/src/components/shared/ReadOnlyDescriptorAttributes.tsx
@@ -100,6 +100,7 @@ type AttributeGroupsListSectionProps = {
   ownershipData?: AttributeOwnershipData
   hasBlockingAttribute?: boolean
   hideThreshold?: boolean
+  onRemoveThreshold?: (attribute: DescriptorAttribute, attributeGroupIndex: number) => void
 }
 
 export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProps> = ({
@@ -110,6 +111,7 @@ export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProp
   ownershipData,
   hasBlockingAttribute = false,
   hideThreshold = false,
+  onRemoveThreshold,
 }) => {
   const { t: tAttribute } = useTranslation('attribute')
 
@@ -140,6 +142,7 @@ export const AttributeGroupsListSection: React.FC<AttributeGroupsListSectionProp
               ownershipData={ownershipData}
               hasBlockingAttribute={hasBlockingAttribute}
               hideThreshold={hideThreshold}
+              onRemoveThreshold={onRemoveThreshold}
             />
           ))}
         </Stack>
@@ -164,6 +167,7 @@ type AttributeGroupProps = {
   ownershipData?: AttributeOwnershipData
   hasBlockingAttribute?: boolean
   hideThreshold?: boolean
+  onRemoveThreshold?: (attribute: DescriptorAttribute, attributeGroupIndex: number) => void
 }
 
 function getGroupColorAndText(
@@ -236,6 +240,7 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
   ownershipData,
   hasBlockingAttribute = false,
   hideThreshold = false,
+  onRemoveThreshold,
 }) => {
   const { open } = useCustomizeThresholdDrawer()
   const { t: tAttribute } = useTranslation('attribute')
@@ -293,6 +298,13 @@ const AttributeGroup: React.FC<AttributeGroupProps> = ({
                     : undefined
                 }
                 onCustomizeThreshold={withThreshold ? () => open(attribute, index) : undefined}
+                onRemoveThreshold={
+                  withThreshold &&
+                  onRemoveThreshold &&
+                  attribute.dailyCallsPerConsumer !== undefined
+                    ? () => onRemoveThreshold(attribute, index)
+                    : undefined
+                }
                 hideThreshold={hideThreshold}
               />
             </Box>

--- a/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDescriptorAttributesSection.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/__tests__/ProviderEServiceDescriptorAttributesSection.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ProviderEServiceDescriptorAttributesSection } from '../components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection'
 import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
@@ -40,12 +41,17 @@ const descriptorMock = {
   },
 }
 
+let isTemplateInstance = false
+
 vi.mock('@tanstack/react-query', async () => {
   const actual = (await vi.importActual('@tanstack/react-query')) as Record<string, unknown>
   return {
     ...actual,
     useSuspenseQuery: () => ({
-      data: descriptorMock,
+      data: {
+        ...descriptorMock,
+        templateRef: isTemplateInstance ? { templateVersionId: 'template-version-id' } : undefined,
+      },
     }),
   }
 })
@@ -78,6 +84,8 @@ vi.mock('../components', () => ({
 describe('ProviderEServiceDescriptorAttributesSection', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    isTemplateInstance = false
+    mockUseJwt({ currentRoles: ['admin'], isAdmin: true, isViewer: false })
   })
 
   it('renders thresholds correctly', () => {
@@ -98,11 +106,66 @@ describe('ProviderEServiceDescriptorAttributesSection', () => {
     expect(screen.getByText('modify')).toBeInTheDocument()
   })
 
-  it('hides the threshold edit action for viewer users', () => {
+  it('hides the threshold actions for viewer users', async () => {
+    const user = userEvent.setup()
     mockUseJwt({ isAdmin: false, isViewer: true })
     renderWithApplicationContext(<ProviderEServiceDescriptorAttributesSection />, {
       withReactQueryContext: true,
     })
     expect(screen.queryByText('modify')).not.toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('iconButtonAriaLabel'))
+    expect(
+      screen.queryByRole('menuitem', { name: 'actions.removeThreshold' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('removes a customized threshold after confirmation', async () => {
+    const user = userEvent.setup()
+    renderWithApplicationContext(<ProviderEServiceDescriptorAttributesSection />, {
+      withReactQueryContext: true,
+    })
+
+    await user.click(screen.getByLabelText('iconButtonAriaLabel'))
+    await user.click(screen.getByRole('menuitem', { name: 'actions.removeThreshold' }))
+
+    expect(screen.getByRole('dialog', { name: 'title' })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'confirm' }))
+
+    expect(useUpdateVersion).toHaveBeenCalledOnce()
+    expect(useUpdateVersion.mock.calls[0][0].attributes.certified[0][0]).toEqual(
+      expect.objectContaining({ dailyCallsPerConsumer: undefined })
+    )
+  })
+
+  it('removes a customized threshold from a template instance', async () => {
+    const user = userEvent.setup()
+    isTemplateInstance = true
+    renderWithApplicationContext(<ProviderEServiceDescriptorAttributesSection />, {
+      withReactQueryContext: true,
+    })
+
+    await user.click(screen.getByLabelText('iconButtonAriaLabel'))
+    await user.click(screen.getByRole('menuitem', { name: 'actions.removeThreshold' }))
+    await user.click(screen.getByRole('button', { name: 'confirm' }))
+
+    expect(useUpdateInstanceVersion).toHaveBeenCalledOnce()
+    expect(useUpdateInstanceVersion.mock.calls[0][0].attributes.certified[0][0]).toEqual(
+      expect.objectContaining({ dailyCallsPerConsumer: undefined })
+    )
+  })
+
+  it('does not remove a customized threshold when confirmation is cancelled', async () => {
+    const user = userEvent.setup()
+    renderWithApplicationContext(<ProviderEServiceDescriptorAttributesSection />, {
+      withReactQueryContext: true,
+    })
+
+    await user.click(screen.getByLabelText('iconButtonAriaLabel'))
+    await user.click(screen.getByRole('menuitem', { name: 'actions.removeThreshold' }))
+    await user.click(screen.getByRole('button', { name: 'cancel' }))
+
+    expect(useUpdateVersion).not.toHaveBeenCalled()
+    expect(useUpdateInstanceVersion).not.toHaveBeenCalled()
   })
 })

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
@@ -20,8 +20,10 @@ import {
   useCustomizeThresholdDrawer,
 } from '@/components/shared/CustomizeThresholdDrawer'
 import cloneDeep from 'lodash/cloneDeep'
-import type { DescriptorAttributes } from '@/api/api.generatedTypes'
+import type { DescriptorAttribute, DescriptorAttributes } from '@/api/api.generatedTypes'
 import { remapDescriptorAttributesToDescriptorAttributesSeed } from '@/utils/attribute.utils'
+import { useDialog } from '@/stores'
+import omit from 'lodash/omit'
 
 export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
   const { t } = useTranslation('eservice', { keyPrefix: 'read.sections.attributes' })
@@ -31,6 +33,10 @@ export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
   const { t: tCustomizeThresholdDrawer } = useTranslation('eservice', {
     keyPrefix: 'read.drawers.customizeThresholdDrawer',
   })
+  const { t: tRemoveThresholdDialog } = useTranslation('eservice', {
+    keyPrefix: 'read.dialogs.removeAttributeThreshold',
+  })
+  const { openDialog } = useDialog()
   const { jwt, isAdmin, isOperatorAPI, isViewer } = AuthHooks.useJwt()
 
   const { eserviceId, descriptorId } = useParams<'PROVIDE_ESERVICE_MANAGE'>()
@@ -102,6 +108,12 @@ export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
   const { mutate: updateInstanceVersion } = EServiceMutations.useUpdateInstanceVersion({
     isThresholdOnlyUpdate: true,
   })
+  const { mutate: removeAttributeThreshold } = EServiceMutations.useUpdateVersion({
+    isAttributeThresholdRemoval: true,
+  })
+  const { mutate: removeInstanceAttributeThreshold } = EServiceMutations.useUpdateInstanceVersion({
+    isAttributeThresholdRemoval: true,
+  })
 
   const handleUpdateDailyCalls = (
     id: string,
@@ -169,6 +181,49 @@ export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
     )
   }
 
+  const handleRemoveCertifiedAttributeThreshold = (
+    attribute: DescriptorAttribute,
+    attributeGroupIndex: number
+  ) => {
+    openDialog({
+      type: 'basic',
+      title: tRemoveThresholdDialog('title'),
+      description: tRemoveThresholdDialog('description', { attributeName: attribute.name }),
+      onProceed: () => {
+        const updatedAttributes: DescriptorAttributes = cloneDeep(descriptor.attributes)
+        updatedAttributes.certified[attributeGroupIndex] = updatedAttributes.certified[
+          attributeGroupIndex
+        ].map((currentAttribute) =>
+          currentAttribute.id === attribute.id
+            ? omit(currentAttribute, 'dailyCallsPerConsumer')
+            : currentAttribute
+        )
+
+        const attributes = remapDescriptorAttributesToDescriptorAttributesSeed(updatedAttributes)
+
+        if (isEserviceFromTemplate) {
+          removeInstanceAttributeThreshold({
+            eserviceId: descriptor.eservice.id,
+            descriptorId: descriptor.id,
+            dailyCallsPerConsumer: descriptor.dailyCallsPerConsumer,
+            dailyCallsTotal: descriptor.dailyCallsTotal,
+            attributes,
+          })
+          return
+        }
+
+        removeAttributeThreshold({
+          eserviceId: descriptor.eservice.id,
+          descriptorId: descriptor.id,
+          voucherLifespan: descriptor.voucherLifespan,
+          dailyCallsPerConsumer: descriptor.dailyCallsPerConsumer,
+          dailyCallsTotal: descriptor.dailyCallsTotal,
+          attributes,
+        })
+      },
+    })
+  }
+
   const customizeThresholdDrawerSubtitle = (
     <Typography variant="body2">
       <Trans
@@ -221,6 +276,7 @@ export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
           descriptorAttributes={descriptorAttributes}
           topSideActions={getAttributeSectionActions('certified')}
           withThreshold={!isViewer}
+          onRemoveThreshold={handleRemoveCertifiedAttributeThreshold}
         />
         <Divider sx={{ my: 3 }} />
         <AttributeGroupsListSection

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -622,6 +622,12 @@
     "disabledTooltip": "Test e-service archived from the catalog and not usable."
   },
   "read": {
+    "dialogs": {
+      "removeAttributeThreshold": {
+        "title": "Remove threshold",
+        "description": "<p>You are about to remove the custom threshold for the certified attribute <strong>{{attributeName}}</strong>.</p><p>If you confirm, consumers with this attribute will use the threshold for consumers without custom thresholds. If the organization has other attributes with custom thresholds, the highest threshold will apply.</p>"
+      }
+    },
     "versionHeaderLabel": "Version",
     "versionListModal": {
       "title": "Version statuses",

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -82,6 +82,13 @@
         "error": "The API call threshold for this attribute could not be changed. Please make sure you entered the correct information."
       }
     },
+    "removeAttributeThreshold": {
+      "loading": "The certified attribute API call threshold is being removed",
+      "outcome": {
+        "success": "You removed the certified attribute API call threshold.",
+        "error": "The certified attribute API call threshold could not be removed. Please try again."
+      }
+    },
     "publishVersionDraft": {
       "loading": "E-service version draft is being published",
       "outcome": {

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -423,9 +423,11 @@
     "actions": {
       "customizeThreshold": "Customize threshold",
       "changeThreshold": "Change threshold",
+      "removeThreshold": "Remove threshold",
       "inspectAttributeDetails": "Attribute details",
       "modifyCertifiedDiscreteAttribute": "Modify attribute"
     },
+    "removeThresholdSuccess": "You removed the certified attribute API call threshold.",
 
     "na": "n/a"
   },

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -622,6 +622,12 @@
     "disabledTooltip": "E-service di test archiviato dal catalogo e non utilizzabile"
   },
   "read": {
+    "dialogs": {
+      "removeAttributeThreshold": {
+        "title": "Rimuovi soglia",
+        "description": "<p>Stai per rimuovere la soglia personalizzata per l’attributo certificato <strong>{{attributeName}}</strong>.</p><p>Se confermi, ai fruitori con questo attributo sarà applicata la soglia prevista per chi non ha soglie personalizzate. Oppure, se l’ente possiede altri attributi con soglie personalizzate, sarà applicata la soglia più alta.</p>"
+      }
+    },
     "versionHeaderLabel": "Versione",
     "versionListModal": {
       "title": "Stato versioni",

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -82,6 +82,13 @@
         "error": "Non è stato possibile modificare la soglia di chiamate API dell’attributo. Controlla di aver inserito le informazioni corrette."
       }
     },
+    "removeAttributeThreshold": {
+      "loading": "La soglia di chiamate API dell'attributo certificato è in fase di rimozione",
+      "outcome": {
+        "success": "Hai rimosso la soglia di chiamate API dell’attributo certificato.",
+        "error": "Non è stato possibile rimuovere la soglia di chiamate API dell’attributo. Riprova."
+      }
+    },
     "publishVersionDraft": {
       "loading": "Stiamo pubblicando la versione in bozza",
       "outcome": {

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -423,9 +423,11 @@
     "actions": {
       "customizeThreshold": "Personalizza soglia",
       "changeThreshold": "Modifica soglia",
+      "removeThreshold": "Rimuovi soglia",
       "inspectAttributeDetails": "Dettagli attributo",
       "modifyCertifiedDiscreteAttribute": "Modifica attributo"
     },
+    "removeThresholdSuccess": "Hai rimosso la soglia di chiamate API dell’attributo certificato.",
     "na": "n/a"
   },
   "attributeGroupContainer": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10711](https://pagopa.atlassian.net/browse/PIN-10711)

## 📝 Description / Context

Allow producers to remove a previously assigned custom daily-call threshold while configuring an E-service or managing its descriptor attributes.

## 🛠 List of changes

- Add the “Remove threshold” action when a custom threshold is configured.
- Support threshold removal in E-service creation, version creation, and template instance flows.
- Add a confirmation dialog when removing a threshold from the E-service details page.
- Support threshold removal for both standard E-services and template instances.
- Add localized labels, confirmation copy, and mutation feedback.
- Cover the new behavior with focused component and page tests.

## 🧪 How to test

- Start an E-service creation, new version, or template instance flow and assign a custom threshold to an attribute.
- Select “Remove threshold” and verify that the attribute remains selected, its threshold is cleared, and the “Customize threshold” action is shown again.
- Open the descriptor attributes section of a producer E-service with an existing custom threshold and select “Remove threshold”.
- Cancel the confirmation dialog and verify that the threshold remains unchanged.
- Confirm the removal and verify that the threshold disappears and a success notification is displayed.
- Verify that the removal action is not shown for attributes without a custom threshold.

[PIN-10711]: https://pagopa.atlassian.net/browse/PIN-10711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ