### PR TITLE
feat: show personalized consumer thresholds (PIN-10710)

### DIFF
--- a/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/ConsumerEServiceDetails.page.tsx
@@ -146,7 +146,7 @@ const ConsumerEServiceDetailsPage: React.FC = () => {
           </TabList>
 
           <TabPanel value="eserviceDetail">
-            <ConsumerEServiceDetailsTab />
+            <ConsumerEServiceDetailsTab delegators={delegators} />
           </TabPanel>
 
           <TabPanel value="linkedPurposeTemplates">

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceDescriptorAttributes.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceDescriptorAttributes.tsx
@@ -13,10 +13,45 @@ import { useTranslation } from 'react-i18next'
 import { InformationContainer } from '@pagopa/interop-fe-commons'
 import { Divider, Stack } from '@mui/material'
 import { formatThousands } from '@/utils/format.utils'
+import type {
+  DelegationTenant,
+  DescriptorAttributes,
+  TenantAttributes,
+} from '@/api/api.generatedTypes'
+import { isAttributeOwned } from '@/utils/attribute.utils'
 
-export const ConsumerEServiceDescriptorAttributes: React.FC = () => {
+function getCustomizedDailyCallsPerConsumer(
+  descriptorAttributes: DescriptorAttributes['certified'],
+  ownedAttributes: TenantAttributes['certified']
+): number | undefined {
+  return descriptorAttributes.flat().reduce<number | undefined>((max, attribute) => {
+    if (
+      attribute.dailyCallsPerConsumer === undefined ||
+      !isAttributeOwned(
+        'certified',
+        attribute.id,
+        ownedAttributes,
+        attribute.discreteConfig ? { discreteConfig: attribute.discreteConfig } : undefined
+      )
+    ) {
+      return max
+    }
+
+    return max === undefined
+      ? attribute.dailyCallsPerConsumer
+      : Math.max(max, attribute.dailyCallsPerConsumer)
+  }, undefined)
+}
+
+type ConsumerEServiceDescriptorAttributesProps = {
+  delegators?: DelegationTenant[]
+}
+
+export const ConsumerEServiceDescriptorAttributes: React.FC<
+  ConsumerEServiceDescriptorAttributesProps
+> = ({ delegators = [] }) => {
   const { t } = useTranslation('eservice', { keyPrefix: 'read.sections.attributes' })
-  const { jwt } = AuthHooks.useJwt()
+  const { jwt, isReviewer } = AuthHooks.useJwt()
 
   const { eserviceId, descriptorId } = useParams<'SUBSCRIBE_CATALOG_VIEW'>()
   const { data: descriptor } = useSuspenseQuery(
@@ -32,6 +67,10 @@ export const ConsumerEServiceDescriptorAttributes: React.FC = () => {
       ],
     })
 
+  const delegatorCertifiedAttributes = useSuspenseQueries({
+    queries: delegators.map(({ id }) => AttributeQueries.getPartyCertifiedList(id)),
+  })
+
   const ownershipData: AttributeOwnershipData = React.useMemo(
     () => ({
       certified: ownedCertified.attributes,
@@ -41,6 +80,48 @@ export const ConsumerEServiceDescriptorAttributes: React.FC = () => {
     }),
     [ownedCertified, ownedVerified, ownedDeclared, descriptor.eservice.producer.id]
   )
+
+  const customizedThresholds = React.useMemo(() => {
+    const currentTenantThreshold = isReviewer
+      ? undefined
+      : getCustomizedDailyCallsPerConsumer(
+          descriptor.attributes.certified,
+          ownedCertified.attributes
+        )
+
+    const delegatorThresholds = delegators.flatMap((delegator, index) => {
+      const ownedAttributes = delegatorCertifiedAttributes[index]?.data.attributes
+      if (!ownedAttributes) return []
+
+      const dailyCallsPerConsumer = getCustomizedDailyCallsPerConsumer(
+        descriptor.attributes.certified,
+        ownedAttributes
+      )
+
+      return dailyCallsPerConsumer === undefined
+        ? []
+        : [{ id: delegator.id, label: delegator.name, dailyCallsPerConsumer }]
+    })
+
+    return currentTenantThreshold === undefined
+      ? delegatorThresholds
+      : [
+          {
+            id: jwt?.organizationId ?? 'current-tenant',
+            label: t('thresholds.customized.currentTenantLabel'),
+            dailyCallsPerConsumer: currentTenantThreshold,
+          },
+          ...delegatorThresholds,
+        ]
+  }, [
+    delegators,
+    delegatorCertifiedAttributes,
+    descriptor.attributes.certified,
+    isReviewer,
+    jwt?.organizationId,
+    ownedCertified.attributes,
+    t,
+  ])
 
   return (
     <SectionContainer title={t('title')} description={t('description')}>
@@ -62,6 +143,19 @@ export const ConsumerEServiceDescriptorAttributes: React.FC = () => {
           />
         </Stack>
       </SectionContainer>
+      {customizedThresholds.length > 0 && (
+        <SectionContainer innerSection title={t('thresholds.customized.title')}>
+          <Stack spacing={2}>
+            {customizedThresholds.map(({ id, label, dailyCallsPerConsumer }) => (
+              <InformationContainer
+                key={id}
+                label={label}
+                content={`${formatThousands(dailyCallsPerConsumer)}`}
+              />
+            ))}
+          </Stack>
+        </SectionContainer>
+      )}
       <Divider sx={{ my: 3 }} />
       <ReadOnlyDescriptorAttributes
         descriptorAttributes={descriptor.attributes}

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceDetailsTab.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceDetailsTab.tsx
@@ -17,8 +17,13 @@ import {
   ConsumerEServiceSignalHubSectionSkeleton,
 } from './ConsumerEServiceSignalHubSection'
 import { AuthHooks } from '@/api/auth'
+import type { DelegationTenant } from '@/api/api.generatedTypes'
 
-const ConsumerEServiceDetailsTab: React.FC = () => {
+type ConsumerEServiceDetailsTabProps = {
+  delegators?: DelegationTenant[]
+}
+
+const ConsumerEServiceDetailsTab: React.FC<ConsumerEServiceDetailsTabProps> = ({ delegators }) => {
   const { isReviewer } = AuthHooks.useJwt()
 
   return (
@@ -36,7 +41,7 @@ const ConsumerEServiceDetailsTab: React.FC = () => {
           <ConsumerEServiceSignalHubSection />
         </React.Suspense>
         <React.Suspense fallback={<ConsumerEServiceDescriptorAttributesSkeleton />}>
-          <ConsumerEServiceDescriptorAttributes />
+          <ConsumerEServiceDescriptorAttributes delegators={delegators} />
         </React.Suspense>
       </Grid>
     </Grid>

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/__tests__/ConsumerEServiceDescriptorAttributes.test.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/__tests__/ConsumerEServiceDescriptorAttributes.test.tsx
@@ -93,18 +93,32 @@ function setupMocks(overrides?: {
   ownedCertified?: ReturnType<typeof createStandardCertifiedTenantAttribute>[]
   ownedVerified?: ReturnType<typeof createVerifiedTenantAttribute>[]
   ownedDeclared?: ReturnType<typeof createDeclaredTenantAttribute>[]
+  delegatedCertified?: ReturnType<typeof createStandardCertifiedTenantAttribute>[][]
+  descriptorAttributes?: typeof baseDescriptor.attributes
 }) {
   mockUseJwt()
-  useSuspenseQueryMock.mockReturnValue({ data: baseDescriptor })
-  useSuspenseQueriesMock.mockReturnValue([
-    { data: { attributes: overrides?.ownedCertified ?? [] } },
-    { data: { attributes: overrides?.ownedVerified ?? [] } },
-    { data: { attributes: overrides?.ownedDeclared ?? [] } },
-  ])
+  useSuspenseQueryMock.mockReturnValue({
+    data: {
+      ...baseDescriptor,
+      attributes: overrides?.descriptorAttributes ?? baseDescriptor.attributes,
+    },
+  })
+  useSuspenseQueriesMock.mockReset()
+  useSuspenseQueriesMock
+    .mockReturnValueOnce([
+      { data: { attributes: overrides?.ownedCertified ?? [] } },
+      { data: { attributes: overrides?.ownedVerified ?? [] } },
+      { data: { attributes: overrides?.ownedDeclared ?? [] } },
+    ])
+    .mockReturnValueOnce(
+      (overrides?.delegatedCertified ?? []).map((attributes) => ({ data: { attributes } }))
+    )
 }
 
-function renderComponent() {
-  return renderWithApplicationContext(<ConsumerEServiceDescriptorAttributes />, {
+function renderComponent(
+  props: React.ComponentProps<typeof ConsumerEServiceDescriptorAttributes> = {}
+) {
+  return renderWithApplicationContext(<ConsumerEServiceDescriptorAttributes {...props} />, {
     withReactQueryContext: true,
     withRouterContext: true,
   })
@@ -217,5 +231,95 @@ describe('ConsumerEServiceDescriptorAttributes', () => {
     expect(screen.getByText('thresholds.title')).toBeInTheDocument()
     expect(screen.getByText('thresholds.dailyCallsPerConsumer.label')).toBeInTheDocument()
     expect(screen.getByText('thresholds.dailyCallsTotal.label')).toBeInTheDocument()
+  })
+
+  it('should show the custom threshold assigned to the consumer certified attribute', () => {
+    setupMocks({
+      ownedCertified: [
+        createStandardCertifiedTenantAttribute({
+          id: 'cert-attr-1',
+          revocationTimestamp: undefined,
+        }),
+      ],
+      descriptorAttributes: {
+        ...baseDescriptor.attributes,
+        certified: [[{ ...certifiedAttr, dailyCallsPerConsumer: 500 }]],
+      },
+    })
+    renderComponent()
+
+    expect(screen.getByText('thresholds.customized.title')).toBeInTheDocument()
+    expect(screen.getByText('thresholds.customized.currentTenantLabel')).toBeInTheDocument()
+    expect(screen.getByText('500')).toBeInTheDocument()
+    expect(screen.getByText('1000')).toBeInTheDocument()
+  })
+
+  it('should not show a custom threshold the consumer does not own', () => {
+    setupMocks({
+      descriptorAttributes: {
+        ...baseDescriptor.attributes,
+        certified: [[{ ...certifiedAttr, dailyCallsPerConsumer: 500 }]],
+      },
+    })
+    renderComponent()
+
+    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(screen.queryByText('500')).not.toBeInTheDocument()
+    expect(screen.queryByText('thresholds.customized.title')).not.toBeInTheDocument()
+  })
+
+  it('should show the custom threshold assigned to a consumer delegator', () => {
+    setupMocks({
+      delegatedCertified: [
+        [
+          createStandardCertifiedTenantAttribute({
+            id: 'cert-attr-1',
+            revocationTimestamp: undefined,
+          }),
+        ],
+      ],
+      descriptorAttributes: {
+        ...baseDescriptor.attributes,
+        certified: [[{ ...certifiedAttr, dailyCallsPerConsumer: 750 }]],
+      },
+    })
+    renderComponent({ delegators: [{ id: 'delegator-id', name: 'Delegator' }] })
+
+    expect(screen.getByText('thresholds.customized.title')).toBeInTheDocument()
+    expect(screen.getByText('Delegator')).toBeInTheDocument()
+    expect(screen.getByText('750')).toBeInTheDocument()
+    expect(screen.getByText('1000')).toBeInTheDocument()
+  })
+
+  it('should show the highest custom threshold among the certified attributes owned by the consumer', () => {
+    setupMocks({
+      ownedCertified: [
+        createStandardCertifiedTenantAttribute({
+          id: 'cert-attr-1',
+          revocationTimestamp: undefined,
+        }),
+        createStandardCertifiedTenantAttribute({
+          id: 'cert-attr-2',
+          revocationTimestamp: undefined,
+        }),
+      ],
+      descriptorAttributes: {
+        ...baseDescriptor.attributes,
+        certified: [
+          [{ ...certifiedAttr, dailyCallsPerConsumer: 500 }],
+          [
+            createMockDescriptorAttribute({
+              id: 'cert-attr-2',
+              name: 'Second certified attribute',
+              dailyCallsPerConsumer: 750,
+            }),
+          ],
+        ],
+      },
+    })
+    renderComponent()
+
+    expect(screen.getByText('750')).toBeInTheDocument()
+    expect(screen.queryByText('500')).not.toBeInTheDocument()
   })
 })

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/__tests__/ConsumerEServiceDescriptorAttributes.test.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/__tests__/ConsumerEServiceDescriptorAttributes.test.tsx
@@ -14,6 +14,7 @@ import {
   createMockDescriptorAttribute,
   createMockAttribute,
 } from '@/../__mocks__/data/attribute.mocks'
+import { formatThousands } from '@/utils/format.utils'
 
 mockUseParams({
   eserviceId: 'eservice-id-001',
@@ -251,7 +252,7 @@ describe('ConsumerEServiceDescriptorAttributes', () => {
     expect(screen.getByText('thresholds.customized.title')).toBeInTheDocument()
     expect(screen.getByText('thresholds.customized.currentTenantLabel')).toBeInTheDocument()
     expect(screen.getByText('500')).toBeInTheDocument()
-    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(screen.getByText(formatThousands(1000))).toBeInTheDocument()
   })
 
   it('should not show a custom threshold the consumer does not own', () => {
@@ -263,7 +264,7 @@ describe('ConsumerEServiceDescriptorAttributes', () => {
     })
     renderComponent()
 
-    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(screen.getByText(formatThousands(1000))).toBeInTheDocument()
     expect(screen.queryByText('500')).not.toBeInTheDocument()
     expect(screen.queryByText('thresholds.customized.title')).not.toBeInTheDocument()
   })
@@ -288,7 +289,7 @@ describe('ConsumerEServiceDescriptorAttributes', () => {
     expect(screen.getByText('thresholds.customized.title')).toBeInTheDocument()
     expect(screen.getByText('Delegator')).toBeInTheDocument()
     expect(screen.getByText('750')).toBeInTheDocument()
-    expect(screen.getByText('1000')).toBeInTheDocument()
+    expect(screen.getByText(formatThousands(1000))).toBeInTheDocument()
   })
 
   it('should show the highest custom threshold among the certified attributes owned by the consumer', () => {

--- a/src/static/locales/en/eservice.json
+++ b/src/static/locales/en/eservice.json
@@ -964,6 +964,10 @@
           "dailyCallsTotal": {
             "label": "Total threshold for consumer"
           },
+          "customized": {
+            "title": "Custom API call thresholds",
+            "currentTenantLabel": "For your institution"
+          },
           "noThresholdTemplate": "This e-service template has no suggested thresholds"
         }
       },

--- a/src/static/locales/it/eservice.json
+++ b/src/static/locales/it/eservice.json
@@ -964,6 +964,10 @@
           "dailyCallsTotal": {
             "label": "Soglia giornaliera totale"
           },
+          "customized": {
+            "title": "Soglie di chiamate API personalizzate",
+            "currentTenantLabel": "Per il tuo ente"
+          },
           "noThresholdTemplate": "Questo template di e-service non ha soglie suggerite"
         }
       },


### PR DESCRIPTION
## 🔗 Issue

[PIN-10710](https://pagopa.atlassian.net/browse/PIN-10710)

## 📝 Description / Context

Allow consumers to see the custom API call thresholds applicable to their institution when viewing an e-service details page. The same information is displayed for consumer delegators, following the related Figma design rules.

## 🛠 List of changes

- Added a dedicated section for custom API call thresholds without replacing the default thresholds.
- Displayed the current institution threshold only when it owns the associated certified attribute.
- Displayed the applicable threshold for each consumer delegator.
- Used the highest applicable threshold when multiple certified attributes define custom values.
- Added Italian and English translations.
- Added focused tests for current institutions, delegators, missing attributes, and multiple applicable thresholds.

## 🧪 How to test

- Open the catalog and select an e-service whose certified attribute defines a custom threshold owned by the current institution.
- Open the “Thresholds and attributes” section and verify that:
  - the default API thresholds remain visible;
  - the custom thresholds section is displayed;
  - the “For your institution” row shows the applicable value.
- Repeat the flow as a consumer delegate and verify that each applicable delegator is listed with its custom threshold.
- Open the e-service as an institution that does not own any certified attribute with a custom threshold and verify that the custom section is not displayed.

[PIN-10710]: https://pagopa.atlassian.net/browse/PIN-10710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ