### PR TITLE
fix: add free of charge motivation toggle (PIN-10605)

### DIFF
--- a/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepGeneral/PurposeTemplateEditStepGeneral.tsx
+++ b/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepGeneral/PurposeTemplateEditStepGeneral.tsx
@@ -30,7 +30,7 @@ export const PurposeTemplateEditStepGeneral: React.FC<ActiveStepProps> = (props)
     purposeTitle: purposeTemplate.purposeTitle ?? t('title'),
     purposeDescription: purposeTemplate.purposeDescription ?? t('description'),
     purposeDailyCalls: purposeTemplate?.purposeDailyCalls,
-    purposeIsFreeOfCharge: purposeTemplate?.purposeIsFreeOfCharge ? 'true' : 'false',
+    purposeIsFreeOfCharge: purposeTemplate.purposeIsFreeOfCharge,
     purposeFreeOfChargeReason:
       purposeTemplate?.purposeFreeOfChargeReason ?? t('freeOfChargeReason'),
     targetTenantKind: purposeTemplate.targetTenantKind,

--- a/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepGeneral/PurposeTemplateEditStepGeneralForm.tsx
+++ b/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepGeneral/PurposeTemplateEditStepGeneralForm.tsx
@@ -1,6 +1,6 @@
 import { PurposeTemplateMutations } from '@/api/purposeTemplate/purposeTemplate.mutations'
 import { SectionContainer, SectionContainerSkeleton } from '@/components/layout/containers'
-import { RHFTextField, RHFRadioGroup } from '@/components/shared/react-hook-form-inputs'
+import { RHFSwitch, RHFTextField } from '@/components/shared/react-hook-form-inputs'
 import { StepActions } from '@/components/shared/StepActions'
 import type { ActiveStepProps } from '@/hooks/useActiveStep'
 import { Box } from '@mui/system'
@@ -15,10 +15,8 @@ import { transformRiskAnalysisFormTemplateToSeed } from '@/utils/purposeTemplate
 
 export type PurposeTemplateEditStepGeneralFormValues = Omit<
   PurposeTemplateSeed,
-  'purposeRiskAnalysisForm' | 'purposeIsFreeOfCharge'
-> & {
-  purposeIsFreeOfCharge: 'true' | 'false'
-}
+  'purposeRiskAnalysisForm'
+>
 
 type PurposeTemplateEditStepGeneralFormProps = ActiveStepProps & {
   purposeTemplate: PurposeTemplateWithCompactCreator
@@ -39,13 +37,12 @@ const PurposeTemplateEditStepGeneralForm: React.FC<PurposeTemplateEditStepGenera
 
   const onSubmit = (values: PurposeTemplateEditStepGeneralFormValues) => {
     const { purposeIsFreeOfCharge, purposeFreeOfChargeReason, ...data } = values
-    const isFreeOfChargeBool = purposeIsFreeOfCharge === 'true'
     const purposeTemplateId = purposeTemplate.id
 
     const requestPayload: PurposeTemplateSeed = {
       ...data,
-      purposeIsFreeOfCharge: isFreeOfChargeBool,
-      purposeFreeOfChargeReason: isFreeOfChargeBool ? purposeFreeOfChargeReason : undefined,
+      purposeIsFreeOfCharge,
+      ...(purposeIsFreeOfCharge ? { purposeFreeOfChargeReason } : {}),
       handlesPersonalData: purposeTemplate.handlesPersonalData,
       purposeRiskAnalysisForm:
         purposeTemplate.purposeRiskAnalysisForm?.answers &&
@@ -95,22 +92,13 @@ const PurposeTemplateEditStepGeneralForm: React.FC<PurposeTemplateEditStepGenera
             rules={{ required: true, minLength: 10 }}
           />
 
-          <RHFRadioGroup
+          <RHFSwitch
             name="purposeIsFreeOfCharge"
-            label={t('edit.step1.purposeTemplateIsFreeOfCharge.radioButton.label')}
-            options={[
-              {
-                label: t('edit.step1.purposeTemplateIsFreeOfCharge.radioButton.YES'),
-                value: 'true',
-              },
-              {
-                label: t('edit.step1.purposeTemplateIsFreeOfCharge.radioButton.NO'),
-                value: 'false',
-              },
-            ]}
+            label={t('edit.step1.purposeTemplateIsFreeOfCharge.switchLabel')}
+            sx={{ pl: 2 }}
           />
 
-          {isFreeOfCharge === 'true' && (
+          {isFreeOfCharge && (
             <RHFTextField
               name="purposeFreeOfChargeReason"
               label={t('edit.step1.purposeTemplateIsFreeOfCharge.reasonField.label')}
@@ -118,6 +106,7 @@ const PurposeTemplateEditStepGeneralForm: React.FC<PurposeTemplateEditStepGenera
               multiline
               inputProps={{ maxLength: 250 }}
               rules={{ required: true, minLength: 10 }}
+              required
             />
           )}
 

--- a/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepGeneral/__tests__/PurposeTemplateEditStepGeneralForm.test.tsx
+++ b/src/pages/ConsumerPurposeTemplateEditPage/components/PurposeTemplateEditStepGeneral/__tests__/PurposeTemplateEditStepGeneralForm.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockPurposeTemplate } from '../../../../../../__mocks__/data/purposeTemplate.mocks'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import PurposeTemplateEditStepGeneralForm, {
+  type PurposeTemplateEditStepGeneralFormValues,
+} from '../PurposeTemplateEditStepGeneralForm'
+
+const updateDraftMock = vi.fn()
+
+vi.mock('@/api/purposeTemplate/purposeTemplate.mutations', () => ({
+  PurposeTemplateMutations: {
+    useUpdateDraft: () => ({ mutate: updateDraftMock }),
+  },
+}))
+
+const purposeTemplate = createMockPurposeTemplate({
+  id: 'purpose-template-id',
+  purposeIsFreeOfCharge: true,
+  purposeFreeOfChargeReason: 'A valid free of charge reason',
+})
+
+const defaultValues = {
+  purposeTitle: 'Test purpose template',
+  purposeDescription: 'A valid purpose template description',
+  targetTenantKind: 'PA',
+  targetDescription: 'A valid target description',
+  purposeIsFreeOfCharge: true,
+  purposeFreeOfChargeReason: 'A valid free of charge reason',
+  purposeDailyCalls: 10,
+  handlesPersonalData: true,
+} satisfies PurposeTemplateEditStepGeneralFormValues
+
+function renderComponent(isFreeOfCharge = true) {
+  return renderWithApplicationContext(
+    <PurposeTemplateEditStepGeneralForm
+      purposeTemplate={purposeTemplate}
+      defaultValues={{ ...defaultValues, purposeIsFreeOfCharge: isFreeOfCharge }}
+      activeStep={0}
+      forward={vi.fn()}
+      back={vi.fn()}
+    />,
+    { withReactQueryContext: true, withRouterContext: true }
+  )
+}
+
+describe('PurposeTemplateEditStepGeneralForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the free of charge reason when the switch is enabled', () => {
+    renderComponent()
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'edit.step1.purposeTemplateIsFreeOfCharge.switchLabel',
+      })
+    ).toBeChecked()
+    expect(
+      screen.getByRole('textbox', {
+        name: 'edit.step1.purposeTemplateIsFreeOfCharge.reasonField.label',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('shows the free of charge reason after enabling the switch', async () => {
+    const user = userEvent.setup()
+    renderComponent(false)
+
+    const freeOfChargeSwitch = screen.getByRole('checkbox', {
+      name: 'edit.step1.purposeTemplateIsFreeOfCharge.switchLabel',
+    })
+
+    expect(freeOfChargeSwitch).not.toBeChecked()
+    expect(
+      screen.queryByRole('textbox', {
+        name: 'edit.step1.purposeTemplateIsFreeOfCharge.reasonField.label',
+      })
+    ).not.toBeInTheDocument()
+
+    await user.click(freeOfChargeSwitch)
+
+    expect(
+      screen.getByRole('textbox', {
+        name: 'edit.step1.purposeTemplateIsFreeOfCharge.reasonField.label',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('omits the free of charge reason from the payload when the switch is disabled', async () => {
+    const user = userEvent.setup()
+    renderComponent(false)
+
+    await user.click(screen.getByRole('button', { name: 'edit.forwardWithSaveBtn' }))
+
+    await waitFor(() => {
+      expect(updateDraftMock).toHaveBeenCalledTimes(1)
+    })
+
+    const payload = updateDraftMock.mock.calls[0]?.[0]
+    expect(payload).toMatchObject({
+      purposeTemplateId: 'purpose-template-id',
+      purposeIsFreeOfCharge: false,
+    })
+    expect(payload).not.toHaveProperty('purposeFreeOfChargeReason')
+  })
+})

--- a/src/static/locales/en/purposeTemplate.json
+++ b/src/static/locales/en/purposeTemplate.json
@@ -62,14 +62,10 @@
         "infoLabel": "Min 10 characters, max 250 characters"
       },
       "purposeTemplateIsFreeOfCharge": {
-        "radioButton": {
-          "label": "Indicate whether access to the data made available through the use of this E-service is free of charge.",
-          "YES": "Yes",
-          "NO": "No"
-        },
+        "switchLabel": "I am entitled to use the e-service free of charge",
         "reasonField": {
-          "label": "Justification for free-of-charge access (required)",
-          "infoLabel": "You are required to specify whether the provision of data free of charge is due to a legal exemption/exclusion or other reason. Min 10 characters, max 250 characters."
+          "label": "Explain why you can use the e-service free of charge (required)",
+          "infoLabel": "Specify whether this is based on a legal exemption or exclusion, or on another reason. Min 10, max 250 characters"
         }
       },
       "APICallsField": {

--- a/src/static/locales/it/purposeTemplate.json
+++ b/src/static/locales/it/purposeTemplate.json
@@ -62,14 +62,10 @@
         "infoLabel": "Min 10 caratteri, max 250 caratteri"
       },
       "purposeTemplateIsFreeOfCharge": {
-        "radioButton": {
-          "label": "Indicare se l’accesso ai dati messi a disposizione con la fruizione del presente E-service è a titolo gratuito",
-          "YES": "Sì",
-          "NO": "No"
-        },
+        "switchLabel": "Ho diritto all’utilizzo dell’e-service a titolo gratuito",
         "reasonField": {
-          "label": "Motivazione titolo gratuito (richiesto)",
-          "infoLabel": "Si richiede di specificare se la messa a disposizione dei dati è a titolo gratuito in forza di una esenzione/esclusione prevista dalla legge o altro. Min 10 caratteri, max 250 caratteri"
+          "label": "Spiega perché puoi usare l’e-service a titolo gratuito (richiesto)",
+          "infoLabel": "Indica se lo fai in base a un’esenzione o a un’esclusione prevista dalla legge, oppure per un altro motivo. Min 10, max 250 caratteri"
         }
       },
       "APICallsField": {


### PR DESCRIPTION
## 🔗 Issue

[PIN-10605](https://pagopa.atlassian.net/browse/PIN-10605)

## 📝 Description / Context

Align the purpose template general information form with the expected free-of-charge access flow and the provided Figma design.

## 🛠 List of changes

- Replace the free-of-charge radio group with a boolean switch
- Conditionally show the required free-of-charge reason field
- Omit the reason from the update payload when the switch is disabled
- Align Italian and English copy with the design
- Add focused tests for enabled and disabled states and payload serialization

## 🧪 How to test

- Navigate to **Fruizione → I miei template finalità**
- Create a new purpose template and open the **Informazioni generali** step
- Verify that disabling the free-of-charge switch hides the reason field
- Enable the switch and verify that the required reason field appears and accepts between 10 and 250 characters
- Save the draft in both states and verify that the flow continues correctly

[PIN-10605]: https://pagopa.atlassian.net/browse/PIN-10605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ