### PR TITLE
feat: add external developer tool links (PIN-10709)

### DIFF
--- a/src/pages/DeveloperToolsPage/DeveloperTools.page.tsx
+++ b/src/pages/DeveloperToolsPage/DeveloperTools.page.tsx
@@ -89,7 +89,7 @@ const DeveloperToolsPage: React.FC = () => {
             description={
               <Box>
                 {t('sectionOpenApiAnalysis.description')}
-                <Box component="ul" sx={{ m: 0, pl: 3 }}>
+                <Box component="ul" sx={{ m: 0, pl: 3, listStyleType: 'square' }}>
                   <li>{t('sectionOpenApiAnalysis.openApiCheckerDescription')}</li>
                   <li>{t('sectionOpenApiAnalysis.schemaEditorDescription')}</li>
                 </Box>

--- a/src/pages/DeveloperToolsPage/DeveloperTools.page.tsx
+++ b/src/pages/DeveloperToolsPage/DeveloperTools.page.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { PageContainer, SectionContainer } from '@/components/layout/containers'
-import { Grid, Stack, Tooltip } from '@mui/material'
+import { Button, Grid, Stack, Tooltip } from '@mui/material'
 import { Link } from '@/router'
 import DownloadIcon from '@mui/icons-material/Download'
 import UploadIcon from '@mui/icons-material/Upload'
+import LaunchIcon from '@mui/icons-material/Launch'
 import { useTranslation } from 'react-i18next'
+import { openApiCheckerLink, schemaEditorLink } from '@/config/constants'
 
 const DeveloperToolsPage: React.FC = () => {
   const { t } = useTranslation('developer-tools', { keyPrefix: 'developerTools.page' })
@@ -79,6 +81,42 @@ const DeveloperToolsPage: React.FC = () => {
                 {t('sectionDebugClientAssertion.button')}
               </Link>
             </Stack>
+          </SectionContainer>
+        </Grid>
+        <Grid item xs={7}>
+          <SectionContainer
+            title={t('sectionOpenApiChecker.title')}
+            description={t('sectionOpenApiChecker.description')}
+          >
+            <Button
+              component="a"
+              variant="outlined"
+              size="medium"
+              href={openApiCheckerLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              endIcon={<LaunchIcon />}
+            >
+              {t('sectionOpenApiChecker.button')}
+            </Button>
+          </SectionContainer>
+        </Grid>
+        <Grid item xs={7}>
+          <SectionContainer
+            title={t('sectionSchemaEditor.title')}
+            description={t('sectionSchemaEditor.description')}
+          >
+            <Button
+              component="a"
+              variant="outlined"
+              size="medium"
+              href={schemaEditorLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              endIcon={<LaunchIcon />}
+            >
+              {t('sectionSchemaEditor.button')}
+            </Button>
           </SectionContainer>
         </Grid>
       </Grid>

--- a/src/pages/DeveloperToolsPage/DeveloperTools.page.tsx
+++ b/src/pages/DeveloperToolsPage/DeveloperTools.page.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { PageContainer, SectionContainer } from '@/components/layout/containers'
-import { Button, Grid, Stack, Tooltip } from '@mui/material'
+import { Box, Button, Grid, Stack, Tooltip } from '@mui/material'
 import { Link } from '@/router'
 import DownloadIcon from '@mui/icons-material/Download'
 import UploadIcon from '@mui/icons-material/Upload'
@@ -85,38 +85,42 @@ const DeveloperToolsPage: React.FC = () => {
         </Grid>
         <Grid item xs={7}>
           <SectionContainer
-            title={t('sectionOpenApiChecker.title')}
-            description={t('sectionOpenApiChecker.description')}
+            title={t('sectionOpenApiAnalysis.title')}
+            description={
+              <Box>
+                {t('sectionOpenApiAnalysis.description')}
+                <Box component="ul" sx={{ m: 0, pl: 3 }}>
+                  <li>{t('sectionOpenApiAnalysis.openApiCheckerDescription')}</li>
+                  <li>{t('sectionOpenApiAnalysis.schemaEditorDescription')}</li>
+                </Box>
+              </Box>
+            }
+            descriptionTypographyProps={{ component: 'div' }}
           >
-            <Button
-              component="a"
-              variant="outlined"
-              size="medium"
-              href={openApiCheckerLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              endIcon={<LaunchIcon />}
-            >
-              {t('sectionOpenApiChecker.button')}
-            </Button>
-          </SectionContainer>
-        </Grid>
-        <Grid item xs={7}>
-          <SectionContainer
-            title={t('sectionSchemaEditor.title')}
-            description={t('sectionSchemaEditor.description')}
-          >
-            <Button
-              component="a"
-              variant="outlined"
-              size="medium"
-              href={schemaEditorLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              endIcon={<LaunchIcon />}
-            >
-              {t('sectionSchemaEditor.button')}
-            </Button>
+            <Stack direction="row" spacing={2}>
+              <Button
+                component="a"
+                variant="contained"
+                size="medium"
+                href={openApiCheckerLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                endIcon={<LaunchIcon />}
+              >
+                {t('sectionOpenApiAnalysis.openApiCheckerButton')}
+              </Button>
+              <Button
+                component="a"
+                variant="outlined"
+                size="medium"
+                href={schemaEditorLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                endIcon={<LaunchIcon />}
+              >
+                {t('sectionOpenApiAnalysis.schemaEditorButton')}
+              </Button>
+            </Stack>
           </SectionContainer>
         </Grid>
       </Grid>

--- a/src/pages/DeveloperToolsPage/__test__/DeveloperToolsPage.test.tsx
+++ b/src/pages/DeveloperToolsPage/__test__/DeveloperToolsPage.test.tsx
@@ -44,4 +44,28 @@ describe('Developer tools page', () => {
 
     expect(history.location.pathname).contain('/tool-sviluppo/debug-voucher')
   })
+
+  it('should render links to OpenAPI Checker and Schema Editor', () => {
+    renderWithApplicationContext(<DeveloperToolsPage />, {
+      withRouterContext: true,
+      withReactQueryContext: false,
+    })
+
+    expect(screen.getByRole('link', { name: 'sectionOpenApiChecker.button' })).toHaveAttribute(
+      'href',
+      'https://italia.github.io/api-oas-checker/'
+    )
+    expect(screen.getByRole('link', { name: 'sectionOpenApiChecker.button' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
+    expect(screen.getByRole('link', { name: 'sectionSchemaEditor.button' })).toHaveAttribute(
+      'href',
+      'https://schema.gov.it/schema-editor'
+    )
+    expect(screen.getByRole('link', { name: 'sectionSchemaEditor.button' })).toHaveAttribute(
+      'target',
+      '_blank'
+    )
+  })
 })

--- a/src/pages/DeveloperToolsPage/__test__/DeveloperToolsPage.test.tsx
+++ b/src/pages/DeveloperToolsPage/__test__/DeveloperToolsPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { screen } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DeveloperToolsPage from '../DeveloperTools.page'
 import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
@@ -45,27 +45,30 @@ describe('Developer tools page', () => {
     expect(history.location.pathname).contain('/tool-sviluppo/debug-voucher')
   })
 
-  it('should render links to OpenAPI Checker and Schema Editor', () => {
+  it('should render links to OpenAPI Checker and Schema Editor in the same section', () => {
     renderWithApplicationContext(<DeveloperToolsPage />, {
       withRouterContext: true,
       withReactQueryContext: false,
     })
 
-    expect(screen.getByRole('link', { name: 'sectionOpenApiChecker.button' })).toHaveAttribute(
-      'href',
-      'https://italia.github.io/api-oas-checker/'
-    )
-    expect(screen.getByRole('link', { name: 'sectionOpenApiChecker.button' })).toHaveAttribute(
-      'target',
-      '_blank'
-    )
-    expect(screen.getByRole('link', { name: 'sectionSchemaEditor.button' })).toHaveAttribute(
-      'href',
-      'https://schema.gov.it/schema-editor'
-    )
-    expect(screen.getByRole('link', { name: 'sectionSchemaEditor.button' })).toHaveAttribute(
-      'target',
-      '_blank'
-    )
+    const sectionHeading = screen.getByRole('heading', { name: 'sectionOpenApiAnalysis.title' })
+    const section = sectionHeading.closest('section')
+
+    expect(section).not.toBeNull()
+    if (!section) {
+      throw new Error('OpenAPI analysis section not found')
+    }
+
+    const openApiCheckerLink = within(section).getByRole('link', {
+      name: 'sectionOpenApiAnalysis.openApiCheckerButton',
+    })
+    const schemaEditorLink = within(section).getByRole('link', {
+      name: 'sectionOpenApiAnalysis.schemaEditorButton',
+    })
+
+    expect(openApiCheckerLink).toHaveAttribute('href', 'https://italia.github.io/api-oas-checker/')
+    expect(openApiCheckerLink).toHaveAttribute('target', '_blank')
+    expect(schemaEditorLink).toHaveAttribute('href', 'https://schema.gov.it/schema-editor')
+    expect(schemaEditorLink).toHaveAttribute('target', '_blank')
   })
 })

--- a/src/static/locales/en/developer-tools.json
+++ b/src/static/locales/en/developer-tools.json
@@ -22,15 +22,13 @@
         "firstButton": "Simulate for e-service",
         "secondButton": "Simulate for Interop"
       },
-      "sectionOpenApiChecker": {
-        "title": "OpenAPI Checker",
-        "description": "Check whether your OpenAPI specifications comply with the Italian guidelines.",
-        "button": "Go to OpenAPI Checker"
-      },
-      "sectionSchemaEditor": {
-        "title": "Schema Editor",
-        "description": "Create and edit the schemas to use in your API specifications.",
-        "button": "Go to Schema Editor"
+      "sectionOpenApiAnalysis": {
+        "title": "OpenAPI file analysis",
+        "description": "Before publishing, you can validate the OpenAPI file of a REST interface with these tools:",
+        "openApiCheckerDescription": "check technical compliance with the ModI guidelines using OpenAPI Checker;",
+        "schemaEditorDescription": "check the semantic quality of your data schema through the score calculated by Schema Editor.",
+        "openApiCheckerButton": "OpenAPI Checker",
+        "schemaEditorButton": "Schema Editor"
       }
     }
   },

--- a/src/static/locales/en/developer-tools.json
+++ b/src/static/locales/en/developer-tools.json
@@ -21,6 +21,16 @@
         "description": "After creating and selecting a client, you can simulate obtaining a voucher through this tool.",
         "firstButton": "Simulate for e-service",
         "secondButton": "Simulate for Interop"
+      },
+      "sectionOpenApiChecker": {
+        "title": "OpenAPI Checker",
+        "description": "Check whether your OpenAPI specifications comply with the Italian guidelines.",
+        "button": "Go to OpenAPI Checker"
+      },
+      "sectionSchemaEditor": {
+        "title": "Schema Editor",
+        "description": "Create and edit the schemas to use in your API specifications.",
+        "button": "Go to Schema Editor"
       }
     }
   },

--- a/src/static/locales/it/developer-tools.json
+++ b/src/static/locales/it/developer-tools.json
@@ -22,15 +22,13 @@
         "firstButton": "Simula per e-service",
         "secondButton": "Simula per Interoperabilità"
       },
-      "sectionOpenApiChecker": {
-        "title": "OpenAPI Checker",
-        "description": "Verifica la conformità delle tue specifiche OpenAPI alle linee guida italiane.",
-        "button": "Vai a OpenAPI Checker"
-      },
-      "sectionSchemaEditor": {
-        "title": "Schema Editor",
-        "description": "Crea e modifica gli schemi da utilizzare nelle tue specifiche API.",
-        "button": "Vai a Schema Editor"
+      "sectionOpenApiAnalysis": {
+        "title": "Analisi file OpenAPI",
+        "description": "Prima della pubblicazione, puoi verificare il file OpenAPI di un’interfaccia REST con questi strumenti per:",
+        "openApiCheckerDescription": "controllare la conformità tecnica secondo le linee guida ModI con OpenAPI Checker;",
+        "schemaEditorDescription": "verificare la qualità semantica del tuo schema dati attraverso lo score calcolato dallo Schema Editor.",
+        "openApiCheckerButton": "OpenAPI Checker",
+        "schemaEditorButton": "Schema Editor"
       }
     }
   },

--- a/src/static/locales/it/developer-tools.json
+++ b/src/static/locales/it/developer-tools.json
@@ -21,6 +21,16 @@
         "description": "Dopo aver creato e selezionato un client, puoi simulare l’ottenimento di un voucher attraverso questo strumento.",
         "firstButton": "Simula per e-service",
         "secondButton": "Simula per Interoperabilità"
+      },
+      "sectionOpenApiChecker": {
+        "title": "OpenAPI Checker",
+        "description": "Verifica la conformità delle tue specifiche OpenAPI alle linee guida italiane.",
+        "button": "Vai a OpenAPI Checker"
+      },
+      "sectionSchemaEditor": {
+        "title": "Schema Editor",
+        "description": "Crea e modifica gli schemi da utilizzare nelle tue specifiche API.",
+        "button": "Vai a Schema Editor"
       }
     }
   },


### PR DESCRIPTION
## 🔗 Issue

[PIN-10709](https://pagopa.atlassian.net/browse/PIN-10709)

## 📝 Description / Context

Add direct access to OpenAPI Checker and Schema Editor from the Developer Tools page, making API specification validation and schema editing tools easier to find.

## 🛠 List of changes

- Added dedicated sections for OpenAPI Checker and Schema Editor
- Added external links that open safely in a new browser tab
- Reused the existing centralized tool URLs
- Added Italian and English translations
- Added focused test coverage for both links

## 🧪 How to test

- Open the Developer Tools page at `/tool-sviluppo`
- Verify that the OpenAPI Checker and Schema Editor sections are displayed
- Click each button and verify that the corresponding tool opens in a new browser tab

[PIN-10709]: https://pagopa.atlassian.net/browse/PIN-10709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ