### PR TITLE
ci: use Node 22.14.0 in workflows (PIN-10661)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18.15.0]
+        node: [22.14.0]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -59,7 +59,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
         os: [ubuntu-latest]
-        node: [18.15.0]
+        node: [22.14.0]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -123,7 +123,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18.15.0]
+        node: [22.14.0]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -131,7 +131,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install node 16
+      - name: Install node
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3
         with:
           node-version: ${{ matrix.node }}


### PR DESCRIPTION
## 🔗 Issue

[PIN-10661](https://pagopa.atlassian.net/browse/PIN-10661)

## 📝 Description / Context

Align the Node.js version used by the frontend CI with the `22.14.0` version already used by the Docker image build, removing inconsistencies between validation and publishing environments.

## 🛠 List of changes

- Updated the build and lint job to use Node.js `22.14.0`
- Updated all coverage shards to use Node.js `22.14.0`
- Updated the artifact publishing job to use Node.js `22.14.0`
- Removed the outdated Node 16 reference from the publish step name
- Kept the existing action versions and job dependencies unchanged

## 🧪 How to test

- Open the GitHub Actions run and verify that build, coverage, and publish jobs resolve Node.js `22.14.0`
- Verify that the publish job remains dependent on successful build and coverage jobs

[PIN-10661]: https://pagopa.atlassian.net/browse/PIN-10661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ