### PR TITLE
ci: migrate to SonarQube scan action (PIN-10660)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 permissions:
   contents: read
-  actions: write
-  pull-requests: read
 
 jobs:
   build:
@@ -104,9 +99,8 @@ jobs:
           pattern: lcov-shard-*
           path: coverage-reports
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >


### PR DESCRIPTION
## 🔗 Issue

[PIN-10660](https://pagopa.atlassian.net/browse/PIN-10660)

## 📝 Description / Context

Migrate the SonarCloud analysis from the deprecated `SonarSource/sonarcloud-github-action` to the supported `SonarSource/sonarqube-scan-action`.

The new action is pinned to the immutable SHA of release `v8.2.1`, while preserving the existing coverage shard integration and workflow triggers.

## 🛠 List of changes

- Replace the deprecated SonarCloud action with `SonarSource/sonarqube-scan-action@v8.2.1`.
- Pin the action to its immutable commit SHA.
- Remove the unused `GITHUB_TOKEN` environment variable.
- Remove unnecessary workflow permissions.
- Preserve the import of all four LCOV coverage reports.

## 🧪 How to test

- Open a pull request and verify that all four coverage shard jobs complete successfully.
- Verify that the SonarCloud job downloads the four LCOV artifacts.
- Verify that the SonarCloud scan completes successfully and publishes the Quality Gate.
- Verify that GitHub Advanced Security no longer reports the Sonar action as unpinned.

[PIN-10660]: https://pagopa.atlassian.net/browse/PIN-10660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ