### PR TITLE
fix: forward delegation for verified attributes (PIN-7448)

### DIFF
--- a/src/api/api.generatedTypes.ts
+++ b/src/api/api.generatedTypes.ts
@@ -2047,6 +2047,8 @@ export interface VerifiedTenantAttributeSeed {
   id: string;
   /** @format uuid */
   agreementId: string;
+  /** @format uuid */
+  delegationId?: string;
   /** @format date-time */
   expirationDate?: string;
 }
@@ -4533,6 +4535,8 @@ export interface UpdateVerifiedAttributeParams {
 export interface RevokeVerifiedAttributePayload {
   /** @format uuid */
   agreementId: string;
+  /** @format uuid */
+  delegationId?: string;
 }
 
 export interface RevokeVerifiedAttributeParams {

--- a/src/api/attribute/__tests__/attribute.services.test.ts
+++ b/src/api/attribute/__tests__/attribute.services.test.ts
@@ -1,0 +1,53 @@
+import { BACKEND_FOR_FRONTEND_URL } from '@/config/env'
+import axiosInstance from '@/config/axios'
+import { AttributeServices } from '../attribute.services'
+
+vi.mock('@/config/axios', () => ({
+  default: {
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+describe('AttributeServices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should pass the producer delegation when verifying an attribute', async () => {
+    await AttributeServices.verifyPartyAttribute({
+      partyId: 'consumer-id',
+      id: 'attribute-id',
+      agreementId: 'agreement-id',
+      delegationId: 'delegation-id',
+    })
+
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      `${BACKEND_FOR_FRONTEND_URL}/tenants/consumer-id/attributes/verified`,
+      {
+        id: 'attribute-id',
+        agreementId: 'agreement-id',
+        delegationId: 'delegation-id',
+      }
+    )
+  })
+
+  it('should pass the producer delegation when revoking an attribute', async () => {
+    await AttributeServices.revokeVerifiedPartyAttribute({
+      partyId: 'consumer-id',
+      attributeId: 'attribute-id',
+      agreementId: 'agreement-id',
+      delegationId: 'delegation-id',
+    })
+
+    expect(axiosInstance.delete).toHaveBeenCalledWith(
+      `${BACKEND_FOR_FRONTEND_URL}/tenants/consumer-id/attributes/verified/attribute-id`,
+      {
+        data: {
+          agreementId: 'agreement-id',
+          delegationId: 'delegation-id',
+        },
+      }
+    )
+  })
+})

--- a/src/api/attribute/attribute.services.ts
+++ b/src/api/attribute/attribute.services.ts
@@ -13,6 +13,7 @@ import type {
   GetAttributesParams,
   GetRequesterCertifiedAttributesParams,
   RequesterCertifiedAttributes,
+  RevokeVerifiedAttributePayload,
   UpdateVerifiedTenantAttributeSeed,
   VerifiedAttributesResponse,
   VerifiedTenantAttributeSeed,
@@ -163,15 +164,11 @@ async function updateVerifiedPartyAttribute({
 async function revokeVerifiedPartyAttribute({
   partyId,
   attributeId,
-  agreementId,
-}: {
-  partyId: string
-  attributeId: string
-  agreementId: string
-}) {
+  ...payload
+}: { partyId: string; attributeId: string } & RevokeVerifiedAttributePayload) {
   return axiosInstance.delete<Attribute>(
     `${BACKEND_FOR_FRONTEND_URL}/tenants/${partyId}/attributes/verified/${attributeId}`,
-    { data: { agreementId } }
+    { data: payload }
   )
 }
 

--- a/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsAttributesSectionsList/ProviderAgreementDetailsVerifiedAttributesSection/ProviderAgreementDetailsVerifiedAttributesDrawer.tsx
+++ b/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsAttributesSectionsList/ProviderAgreementDetailsVerifiedAttributesSection/ProviderAgreementDetailsVerifiedAttributesDrawer.tsx
@@ -153,6 +153,7 @@ function useGetDrawerComponents(
         partyId: agreement.consumer.id,
         attributeId,
         agreementId: agreement.id,
+        delegationId: agreement.delegation?.id,
       },
       { onSuccess: closeProviderAgreementVerifiedAttributesDrawer }
     )
@@ -178,6 +179,7 @@ function useGetDrawerComponents(
         id: attributeId,
         expirationDate: selectedExpirationDate,
         agreementId: agreement.id,
+        delegationId: agreement.delegation?.id,
       },
       { onSuccess: closeProviderAgreementVerifiedAttributesDrawer }
     )

--- a/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsAttributesSectionsList/ProviderAgreementDetailsVerifiedAttributesSection/__tests__/ProviderAgreementDetailsVerifiedAttributesDrawer.test.tsx
+++ b/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsAttributesSectionsList/ProviderAgreementDetailsVerifiedAttributesSection/__tests__/ProviderAgreementDetailsVerifiedAttributesDrawer.test.tsx
@@ -1,0 +1,91 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockAgreement } from '@/../__mocks__/data/agreement.mocks'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { ProviderAgreementDetailsVerifiedAttributesDrawer } from '../ProviderAgreementDetailsVerifiedAttributesDrawer'
+
+const { contextMock, verifyAttributeMock, revokeAttributeMock } = vi.hoisted(() => ({
+  contextMock: vi.fn(),
+  verifyAttributeMock: vi.fn(),
+  revokeAttributeMock: vi.fn(),
+}))
+
+vi.mock('@/api/attribute', () => ({
+  AttributeMutations: {
+    useVerifyPartyAttribute: () => ({ mutate: verifyAttributeMock }),
+    useRevokeVerifiedPartyAttribute: () => ({ mutate: revokeAttributeMock }),
+    useUpdateVerifiedPartyAttribute: () => ({ mutate: vi.fn() }),
+  },
+}))
+
+vi.mock('@/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsContext', () => ({
+  useProviderAgreementDetailsContext: contextMock,
+}))
+
+vi.mock('../ProviderAgreementDetailsVerifiedAttributesDrawerForm', () => ({
+  ProviderAgreementDetailsVerifiedAttributesDrawerForm: () => null,
+}))
+
+const agreement = createMockAgreement({
+  delegation: {
+    id: 'delegation-id',
+    delegate: { id: 'delegate-id', name: 'Delegate tenant' },
+  },
+})
+
+function renderDrawer(type: 'verify' | 'revoke') {
+  return renderWithApplicationContext(
+    <ProviderAgreementDetailsVerifiedAttributesDrawer
+      providerAgreementVerifiedAttributesDrawerState={{
+        isOpen: true,
+        attributeId: 'attribute-id',
+        type,
+      }}
+      onClose={vi.fn()}
+    />,
+    {}
+  )
+}
+
+describe('ProviderAgreementDetailsVerifiedAttributesDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    contextMock.mockReturnValue({ agreement })
+  })
+
+  it('should pass the producer delegation when verifying an attribute', async () => {
+    const user = userEvent.setup()
+    renderDrawer('verify')
+
+    await user.click(screen.getByRole('button', { name: 'actions.verify' }))
+
+    expect(verifyAttributeMock).toHaveBeenCalledWith(
+      {
+        partyId: agreement.consumer.id,
+        id: 'attribute-id',
+        expirationDate: undefined,
+        agreementId: agreement.id,
+        delegationId: agreement.delegation?.id,
+      },
+      expect.any(Object)
+    )
+  })
+
+  it('should pass the producer delegation when revoking an attribute', async () => {
+    const user = userEvent.setup()
+    renderDrawer('revoke')
+
+    await user.click(screen.getByRole('button', { name: 'actions.revoke' }))
+
+    expect(revokeAttributeMock).toHaveBeenCalledWith(
+      {
+        partyId: agreement.consumer.id,
+        attributeId: 'attribute-id',
+        agreementId: agreement.id,
+        delegationId: agreement.delegation?.id,
+      },
+      expect.any(Object)
+    )
+  })
+})


### PR DESCRIPTION
## 🔗 Issue

[PIN-7448](https://pagopa.atlassian.net/browse/PIN-7448)

## 📝 Description / Context

The backend now requires producer delegates to explicitly provide the delegation identifier when verifying or revoking tenant verified attributes (check this [PR](https://github.com/pagopa/interop-be-monorepo/pull/3708))

This change propagates the producer delegation available on the agreement through the frontend BFF requests. It preserves the existing behavior for agreements managed directly by the producer.

## 🛠 List of changes

- Regenerated the affected BFF API payload types with the optional `delegationId`.
- Forwarded `agreement.delegation.id` when verifying and revoking verified attributes.
- Reused the generated revoke payload instead of maintaining a duplicated local type.
- Added focused tests covering drawer mutations and HTTP request payloads for delegated agreements.

## 🧪 How to test

- Log in as the delegate of an Eservice producer.
- Open the provider agreement details page for a delegated agreement containing verified attributes.
- Verify an attribute and confirm that the operation succeeds and the request payload contains the agreement delegation ID.
- Revoke a verified attribute and confirm that the operation succeeds and the request payload contains the same delegation ID.
- Repeat the operations as the original producer on a non-delegated agreement and confirm that they still work without a delegation ID.

[PIN-7448]: https://pagopa.atlassian.net/browse/PIN-7448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ