### PR TITLE
fix: update confirm dialog titles for e-service publication requests (PIN-10810)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interop-dashboard-frontend",
-  "version": "2.6.0",
+  "version": "2.6.1-RC1",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interop-dashboard-frontend",
-  "version": "2.6.1-RC1",
+  "version": "2.6.1",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "scripts": {

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -104,7 +104,7 @@
       },
       "confirmDialog": {
         "title": "Request e-service publication",
-        "titleNewVersion": "Request New E-service Version Publication",
+        "titleNewVersion": "Request version publication",
         "description": "You are about to forward to <strong>{{delegatorName}}</strong> the request to publish a new version of the <strong>{{eserviceName}}</strong> e-service.",
         "actions": {
           "proceed": "Submit request"

--- a/src/static/locales/en/mutations-feedback.json
+++ b/src/static/locales/en/mutations-feedback.json
@@ -103,7 +103,8 @@
         "error": "It was not possible to forward the new e-service version to the delegator for approval. Please try again!"
       },
       "confirmDialog": {
-        "title": "Request New E-service Version Publication",
+        "title": "Request e-service publication",
+        "titleNewVersion": "Request New E-service Version Publication",
         "description": "You are about to forward to <strong>{{delegatorName}}</strong> the request to publish a new version of the <strong>{{eserviceName}}</strong> e-service.",
         "actions": {
           "proceed": "Submit request"

--- a/src/static/locales/it/mutations-feedback.json
+++ b/src/static/locales/it/mutations-feedback.json
@@ -103,7 +103,8 @@
         "error": "Non è stato possibile inoltrare al delegante la versione per approvazione. Per favore, riprova!"
       },
       "confirmDialog": {
-        "title": "Richiedi pubblicazione versione",
+        "title": "Richiedi pubblicazione e-service",
+        "titleNewVersion": "Richiedi pubblicazione versione",
         "description": "Stai per inoltrare a <strong>{{delegatorName}}</strong> la richiesta di pubblicazione di una nuova versione dell’e-service <strong>{{eserviceName}}</strong>.",
         "actions": {
           "proceed": "Inoltra richiesta"


### PR DESCRIPTION
## 🔗 Issue

[PIN-10810](https://pagopa.atlassian.net/browse/PIN-10810)

## 📝 Description / Context

* Added a new `titleNewVersion` field to the `confirmDialog` section in both it and en.
* Updated the existing `title` field in both locale files to refer to the first e-service publication request.



[PIN-10810]: https://pagopa.atlassian.net/browse/PIN-10810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ