### PR TITLE
chore: add aria-expanded attribute to SidebarMobile (A2-2596)

### DIFF
--- a/src/components/sidebar/components/Sidebar.tsx
+++ b/src/components/sidebar/components/Sidebar.tsx
@@ -123,6 +123,7 @@ const SidebarMobile: React.FC<{ children: React.ReactNode; labelMobile: string }
             sx={{ padding: { xs: 1 } }}
             data-testid="hamburger-mobile-icon"
             aria-label="hamburger-mobile-icon"
+            aria-expanded={isOpenSidebar}
             onClick={handleOpenSidebar}
             size="large"
           >


### PR DESCRIPTION
## 🔗 Issue

[A2-2596](https://pagopa.atlassian.net/browse/A2-2596)

## 📝 Description / Context

This pull request makes a small accessibility improvement to the `SidebarMobile` component. The change adds the `aria-expanded` attribute to the hamburger menu button, which helps assistive technologies understand whether the sidebar is open or closed.



[A2-2596]: https://pagopa.atlassian.net/browse/A2-2596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ