### PR TITLE
feat: update several general info section to use 'dl' (A2-2598)

### DIFF
--- a/src/components/shared/EserviceTemplate/EServiceTemplateGeneralInfoSection.tsx
+++ b/src/components/shared/EserviceTemplate/EServiceTemplateGeneralInfoSection.tsx
@@ -146,21 +146,23 @@ export const EServiceTemplateGeneralInfoSection: React.FC<
           //TODO: THE API is not ready yet
         ]}
       >
-        <Stack spacing={2} component="dl">
-          <InformationContainer
-            label={t('version.label')}
-            content={eserviceTemplateVersion?.version.toString() || '1'}
-          />
-          <InformationContainer
-            label={
-              eserviceTemplateVersion
-                ? t(`personalDataField.${eserviceTemplateVersion?.eserviceTemplate.mode}.label`)
-                : ''
-            }
-            content={t(
-              `personalDataField.value.${eserviceTemplateVersion?.eserviceTemplate.personalData}`
-            )}
-          />
+        <Stack spacing={2}>
+          <Stack component="dl" spacing={2} sx={{ m: 0 }}>
+            <InformationContainer
+              label={t('version.label')}
+              content={eserviceTemplateVersion?.version.toString() || '1'}
+            />
+            <InformationContainer
+              label={
+                eserviceTemplateVersion
+                  ? t(`personalDataField.${eserviceTemplateVersion?.eserviceTemplate.mode}.label`)
+                  : ''
+              }
+              content={t(
+                `personalDataField.value.${eserviceTemplateVersion?.eserviceTemplate.personalData}`
+              )}
+            />
+          </Stack>
           {(isAdmin || isOperatorAPI) &&
             routeKey === 'PROVIDE_ESERVICE_TEMPLATE_DETAILS' &&
             eserviceTemplateVersion?.eserviceTemplate.personalData === undefined && (

--- a/src/components/shared/EserviceTemplate/EServiceTemplateGeneralInfoSection.tsx
+++ b/src/components/shared/EserviceTemplate/EServiceTemplateGeneralInfoSection.tsx
@@ -146,7 +146,7 @@ export const EServiceTemplateGeneralInfoSection: React.FC<
           //TODO: THE API is not ready yet
         ]}
       >
-        <Stack spacing={2}>
+        <Stack spacing={2} component="dl">
           <InformationContainer
             label={t('version.label')}
             content={eserviceTemplateVersion?.version.toString() || '1'}

--- a/src/components/shared/EserviceTemplate/EServiceTemplateTechnicalInfoSection.tsx
+++ b/src/components/shared/EserviceTemplate/EServiceTemplateTechnicalInfoSection.tsx
@@ -57,7 +57,7 @@ export const EServiceTemplateTechnicalInfoSection: React.FC<
     <SectionContainer title={t('title')} description={t('description')}>
       <Stack spacing={2}>
         <SectionContainer innerSection>
-          <Stack spacing={2}>
+          <Stack component="dl" spacing={2} sx={{ m: 0 }}>
             <InformationContainer
               label={t('technology')}
               content={eserviceTemplate.eserviceTemplate.technology}
@@ -86,11 +86,13 @@ export const EServiceTemplateTechnicalInfoSection: React.FC<
                 ]
           }
         >
-          <InformationContainer
-            label={t('thresholds.voucherLifespan.label')}
-            labelDescription={t('thresholds.voucherLifespan.labelDescription')}
-            content={`${voucherLifespan}`}
-          />
+          <Stack component="dl" spacing={2} sx={{ m: 0 }}>
+            <InformationContainer
+              label={t('thresholds.voucherLifespan.label')}
+              labelDescription={t('thresholds.voucherLifespan.labelDescription')}
+              content={`${voucherLifespan}`}
+            />
+          </Stack>
         </SectionContainer>
         <Divider />
         <EServiceTemplateDocumentationSection

--- a/src/components/shared/EserviceTemplate/EServiceTemplateThresholds.tsx
+++ b/src/components/shared/EserviceTemplate/EServiceTemplateThresholds.tsx
@@ -1,5 +1,6 @@
 import { InformationContainer } from '@pagopa/interop-fe-commons'
 import { EmptySectionTextCard } from '../EmptySectionTextCard'
+import { Stack } from '@mui/material'
 
 type EServiceTemplateThresholdsProps = {
   dailyCallsTotal?: string
@@ -21,9 +22,9 @@ export const EServiceTemplateThresholds: React.FC<EServiceTemplateThresholdsProp
   if (noThresholds) return <EmptySectionTextCard text={emptyMessage} />
 
   return (
-    <>
+    <Stack component="dl" spacing={2} sx={{ m: 0 }}>
       <InformationContainer label={dailyCallsPerConsumerLabel} content={dailyCallsPerConsumer} />
       <InformationContainer label={dailyCallsTotalLabel} content={dailyCallsTotal} />
-    </>
+    </Stack>
   )
 }

--- a/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsGeneralInfoSection/ConsumerAgreementDetailsGeneralInfoSection.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsGeneralInfoSection/ConsumerAgreementDetailsGeneralInfoSection.tsx
@@ -56,7 +56,7 @@ export const ConsumerAgreementDetailsGeneralInfoSection: React.FC = () => {
   return (
     <>
       <SectionContainer title={t('title')}>
-        <Stack spacing={2}>
+        <Stack spacing={2} component="dl">
           <InformationContainer
             label={t('eServiceField.label')}
             content={

--- a/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsGeneralInfoSection/ConsumerAgreementDetailsGeneralInfoSection.tsx
+++ b/src/pages/ConsumerAgreementDetailsPage/components/ConsumerAgreementDetailsGeneralInfoSection/ConsumerAgreementDetailsGeneralInfoSection.tsx
@@ -56,85 +56,81 @@ export const ConsumerAgreementDetailsGeneralInfoSection: React.FC = () => {
   return (
     <>
       <SectionContainer title={t('title')}>
-        <Stack spacing={2} component="dl">
-          <InformationContainer
-            label={t('eServiceField.label')}
-            content={
-              <Link
-                to="SUBSCRIBE_CATALOG_VIEW"
-                params={{
-                  eserviceId: agreement.eservice.id,
-                  descriptorId: agreement.descriptorId,
-                }}
-              >
-                {t('eServiceField.value', {
-                  name: agreement.eservice.name,
-                  version: agreement.eservice.version,
-                })}
-              </Link>
-            }
-          />
-          <InformationContainer
-            label={t('providerField.label')}
-            content={agreement.producer.name}
-          />
-          <InformationContainer
-            label={t('consumerField.label')}
-            content={agreement.consumer.name}
-          />
-          {isDelegated && (
+        <Stack spacing={2}>
+          <Stack spacing={2} component="dl" sx={{ m: 0 }}>
             <InformationContainer
-              label={t('delegatedConsumerField.label')}
-              content={agreement.delegation?.delegate.name as string}
+              label={t('eServiceField.label')}
+              content={
+                <Link
+                  to="SUBSCRIBE_CATALOG_VIEW"
+                  params={{
+                    eserviceId: agreement.eservice.id,
+                    descriptorId: agreement.descriptorId,
+                  }}
+                >
+                  {t('eServiceField.value', {
+                    name: agreement.eservice.name,
+                    version: agreement.eservice.version,
+                  })}
+                </Link>
+              }
             />
-          )}
-          {agreement.state === 'REJECTED' && agreement.rejectionReason && (
             <InformationContainer
-              label={t('rejectionMessageField.label')}
-              direction="column"
-              content={agreement.rejectionReason}
+              label={t('providerField.label')}
+              content={agreement.producer.name}
             />
+            <InformationContainer
+              label={t('consumerField.label')}
+              content={agreement.consumer.name}
+            />
+            {isDelegated && (
+              <InformationContainer
+                label={t('delegatedConsumerField.label')}
+                content={agreement.delegation?.delegate.name as string}
+              />
+            )}
+            {agreement.state === 'REJECTED' && agreement.rejectionReason && (
+              <InformationContainer
+                label={t('rejectionMessageField.label')}
+                direction="column"
+                content={agreement.rejectionReason}
+              />
+            )}
+          </Stack>
+          <Divider />
+          {agreement.isContractPresent && (
+            <IconLink
+              data-testid="download-agreement-document-button"
+              component="button"
+              disabled={!agreement.isDocumentReady}
+              startIcon={<DownloadIcon />}
+              sx={{ alignSelf: 'start' }}
+              onClick={handleDownloadSignedAgreementDocument}
+              tooltip={!agreement.isDocumentReady ? tShared('notAvailableYet') : undefined}
+            >
+              {t('documentation.link.label')}
+            </IconLink>
           )}
-          <>
-            <Divider />
-            {agreement.isContractPresent && (
-              <>
-                <IconLink
-                  data-testid="download-agreement-document-button"
-                  component="button"
-                  disabled={!agreement.isDocumentReady}
-                  startIcon={<DownloadIcon />}
-                  sx={{ alignSelf: 'start' }}
-                  onClick={handleDownloadSignedAgreementDocument}
-                  tooltip={!agreement.isDocumentReady ? tShared('notAvailableYet') : undefined}
-                >
-                  {t('documentation.link.label')}
-                </IconLink>
-              </>
-            )}
-            {agreement.state !== 'PENDING' && (
-              <>
-                <IconLink
-                  startIcon={<RuleIcon />}
-                  component="button"
-                  sx={{ alignSelf: 'start' }}
-                  onClick={handleOpenCertifiedAttributesDrawer}
-                >
-                  {t('certifiedAttributeLink.label')}
-                </IconLink>
-              </>
-            )}
-            {agreement.producer.contactMail && (
-              <IconLink
-                onClick={handleOpenContactDrawer}
-                startIcon={<ContactMailIcon />}
-                component="button"
-                sx={{ alignSelf: 'start' }}
-              >
-                {t('providerDetailsLink.label')}
-              </IconLink>
-            )}
-          </>
+          {agreement.state !== 'PENDING' && (
+            <IconLink
+              startIcon={<RuleIcon />}
+              component="button"
+              sx={{ alignSelf: 'start' }}
+              onClick={handleOpenCertifiedAttributesDrawer}
+            >
+              {t('certifiedAttributeLink.label')}
+            </IconLink>
+          )}
+          {agreement.producer.contactMail && (
+            <IconLink
+              onClick={handleOpenContactDrawer}
+              startIcon={<ContactMailIcon />}
+              component="button"
+              sx={{ alignSelf: 'start' }}
+            >
+              {t('providerDetailsLink.label')}
+            </IconLink>
+          )}
         </Stack>
       </SectionContainer>
       {agreement.producer.contactMail && (

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceDescriptorAttributes.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceDescriptorAttributes.tsx
@@ -45,7 +45,7 @@ export const ConsumerEServiceDescriptorAttributes: React.FC = () => {
   return (
     <SectionContainer title={t('title')} description={t('description')}>
       <SectionContainer innerSection title={t('thresholds.title')}>
-        <Stack spacing={2}>
+        <Stack component="dl" spacing={2} sx={{ m: 0 }}>
           <InformationContainer
             label={t('thresholds.dailyCallsPerConsumer.label')}
             content={

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
@@ -69,7 +69,6 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
   return (
     <>
       <SectionContainer
-        component="dl"
         title={t('title')}
         bottomActions={[
           showTechnicalDetailsAction,
@@ -77,7 +76,7 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
           ...(hasContactInformations ? [showProducerContactsAction] : []),
         ]}
       >
-        <Stack spacing={2}>
+        <Stack component="dl" spacing={2}>
           <InformationContainer
             label={t('producer.label')}
             content={descriptor.eservice.producer.name}
@@ -127,7 +126,7 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
           />
         </Stack>
         <SectionContainer innerSection title={t('delegationSection.title')} sx={{ mt: 3 }}>
-          <Stack spacing={2}>
+          <Stack component="dl" spacing={2}>
             <InformationContainer
               label={t('delegationSection.isConsumerDelegable.label')}
               content={t(

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
@@ -76,7 +76,7 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
           ...(hasContactInformations ? [showProducerContactsAction] : []),
         ]}
       >
-        <Stack component="dl" spacing={2}>
+        <Stack component="dl" spacing={2} sx={{ m: 0 }}>
           <InformationContainer
             label={t('producer.label')}
             content={descriptor.eservice.producer.name}
@@ -126,7 +126,7 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
           />
         </Stack>
         <SectionContainer innerSection title={t('delegationSection.title')} sx={{ mt: 3 }}>
-          <Stack component="dl" spacing={2}>
+          <Stack component="dl" spacing={2} sx={{ m: 0 }}>
             <InformationContainer
               label={t('delegationSection.isConsumerDelegable.label')}
               content={t(

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceGeneralInfoSection/ConsumerEServiceGeneralInfoSection.tsx
@@ -69,6 +69,7 @@ export const ConsumerEServiceGeneralInfoSection: React.FC = () => {
   return (
     <>
       <SectionContainer
+        component="dl"
         title={t('title')}
         bottomActions={[
           showTechnicalDetailsAction,

--- a/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceSignalHubSection.tsx
+++ b/src/pages/ConsumerEServiceDetailsPage/components/ConsumerEServiceDetailsTab/ConsumerEServiceSignalHubSection.tsx
@@ -42,7 +42,7 @@ export const ConsumerEServiceSignalHubSection: React.FC = () => {
         }
       >
         <SectionContainer innerSection>
-          <Stack spacing={2}>
+          <Stack component="dl" spacing={2} sx={{ m: 0 }}>
             <InformationContainer
               label={t('consumer.status.label')}
               content={t(`consumer.status.content.${isSignalHubEnabled}`)}

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsGeneralInfoSection.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsGeneralInfoSection.tsx
@@ -68,7 +68,7 @@ export const ConsumerPurposeDetailsGeneralInfoSection: React.FC<
         },
       ]}
     >
-      <Stack spacing={2}>
+      <Stack spacing={2} component="dl">
         <InformationContainer
           label={t('eServiceField.label')}
           content={

--- a/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsGeneralInfoSection.tsx
+++ b/src/pages/ConsumerPurposeDetailsPage/components/PurposeDetailsTab/ConsumerPurposeDetailsGeneralInfoSection.tsx
@@ -68,7 +68,7 @@ export const ConsumerPurposeDetailsGeneralInfoSection: React.FC<
         },
       ]}
     >
-      <Stack spacing={2} component="dl">
+      <Stack spacing={2} component="dl" sx={{ m: 0 }}>
         <InformationContainer
           label={t('eServiceField.label')}
           content={

--- a/src/pages/DelegationDetailsPage/components/DelegationGeneralInfoSection.tsx
+++ b/src/pages/DelegationDetailsPage/components/DelegationGeneralInfoSection.tsx
@@ -99,7 +99,7 @@ export const DelegationGeneralInfoSection: React.FC<DelegationGeneralInfoSection
     <Grid container>
       <Grid item xs={7}>
         <SectionContainer title={t('title')} bottomActions={downloadContractActions}>
-          <Stack spacing={2}>
+          <Stack spacing={2} component="dl">
             <InformationContainer
               label={t('eserviceNameField.label')}
               content={match({

--- a/src/pages/DelegationDetailsPage/components/DelegationGeneralInfoSection.tsx
+++ b/src/pages/DelegationDetailsPage/components/DelegationGeneralInfoSection.tsx
@@ -99,7 +99,7 @@ export const DelegationGeneralInfoSection: React.FC<DelegationGeneralInfoSection
     <Grid container>
       <Grid item xs={7}>
         <SectionContainer title={t('title')} bottomActions={downloadContractActions}>
-          <Stack spacing={2} component="dl">
+          <Stack spacing={2} component="dl" sx={{ m: 0 }}>
             <InformationContainer
               label={t('eserviceNameField.label')}
               content={match({

--- a/src/pages/OperatorDetailsPage/components/OperatorGeneralInfoSection.tsx
+++ b/src/pages/OperatorDetailsPage/components/OperatorGeneralInfoSection.tsx
@@ -63,6 +63,7 @@ export const OperatorGeneralInfoSection: React.FC<OperatorGeneralInfoSectionProp
     >
       <InformationContainer
         component="dl"
+        sx={{ m: 0 }}
         label={t('productRoleField.label')}
         content={userRoles}
       />

--- a/src/pages/OperatorDetailsPage/components/OperatorGeneralInfoSection.tsx
+++ b/src/pages/OperatorDetailsPage/components/OperatorGeneralInfoSection.tsx
@@ -61,7 +61,11 @@ export const OperatorGeneralInfoSection: React.FC<OperatorGeneralInfoSectionProp
         },
       ]}
     >
-      <InformationContainer label={t('productRoleField.label')} content={userRoles} />
+      <InformationContainer
+        component="dl"
+        label={t('productRoleField.label')}
+        content={userRoles}
+      />
     </SectionContainer>
   )
 }

--- a/src/pages/PartyRegistryPage/components/PartyContactsSection/PartyContactsSection.tsx
+++ b/src/pages/PartyRegistryPage/components/PartyContactsSection/PartyContactsSection.tsx
@@ -53,7 +53,7 @@ export const PartyContactsSection: React.FC = () => {
               : undefined
           }
         >
-          <Stack spacing={2}>
+          <Stack component="dl" spacing={2} sx={{ m: 0 }}>
             <InformationContainer label={t('mailField.label')} content={email?.address || 'n/a'} />
             {isAdmin && (
               <InformationContainer

--- a/src/pages/PartyRegistryPage/components/PartyGeneralInfoSection/PartyGeneralInfoSection.tsx
+++ b/src/pages/PartyRegistryPage/components/PartyGeneralInfoSection/PartyGeneralInfoSection.tsx
@@ -18,7 +18,7 @@ export const PartyGeneralInfoSection: React.FC = () => {
     <Grid container>
       <Grid item xs={8}>
         <SectionContainer title={t('title')}>
-          <Stack spacing={2}>
+          <Stack component="dl" spacing={2} sx={{ m: 0 }}>
             <InformationContainer
               label={t('onBoardingDateField.label')}
               content={onBoardedAtFormatted}

--- a/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsGeneralInfoSection/ProviderAgreementDetailsGeneralInfoSection.tsx
+++ b/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsGeneralInfoSection/ProviderAgreementDetailsGeneralInfoSection.tsx
@@ -112,8 +112,8 @@ export const ProviderAgreementDetailsGeneralInfoSection: React.FC = () => {
 
   return (
     <>
-      <SectionContainer title={t('title')} bottomActions={actions}>
-        <Stack spacing={2}>
+      <SectionContainer title={t('title')} bottomActions={actions} component="dl">
+        <Stack spacing={2} component="dl">
           <InformationContainer
             label={t('eServiceField.label')}
             content={

--- a/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsGeneralInfoSection/ProviderAgreementDetailsGeneralInfoSection.tsx
+++ b/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsGeneralInfoSection/ProviderAgreementDetailsGeneralInfoSection.tsx
@@ -113,7 +113,7 @@ export const ProviderAgreementDetailsGeneralInfoSection: React.FC = () => {
   return (
     <>
       <SectionContainer title={t('title')} bottomActions={actions}>
-        <Stack spacing={2} component="dl">
+        <Stack spacing={2} component="dl" sx={{ m: 0 }}>
           <InformationContainer
             label={t('eServiceField.label')}
             content={

--- a/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsGeneralInfoSection/ProviderAgreementDetailsGeneralInfoSection.tsx
+++ b/src/pages/ProviderAgreementDetailsPage/components/ProviderAgreementDetailsGeneralInfoSection/ProviderAgreementDetailsGeneralInfoSection.tsx
@@ -112,7 +112,7 @@ export const ProviderAgreementDetailsGeneralInfoSection: React.FC = () => {
 
   return (
     <>
-      <SectionContainer title={t('title')} bottomActions={actions} component="dl">
+      <SectionContainer title={t('title')} bottomActions={actions}>
         <Stack spacing={2} component="dl">
           <InformationContainer
             label={t('eServiceField.label')}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
@@ -204,7 +204,7 @@ export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
           sx={{ p: 0 }}
           topSideActions={getThresholdSectionActions()}
         >
-          <Stack spacing={1} mt={1} mb={3}>
+          <Stack component="dl" spacing={1} mt={1} mb={3}>
             <InformationContainer
               label={t('thresholds.dailyCallsPerConsumer.label')}
               content={`${descriptor.dailyCallsPerConsumer}`}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDescriptorAttributesSection.tsx
@@ -204,7 +204,7 @@ export const ProviderEServiceDescriptorAttributesSection: React.FC = () => {
           sx={{ p: 0 }}
           topSideActions={getThresholdSectionActions()}
         >
-          <Stack component="dl" spacing={1} mt={1} mb={3}>
+          <Stack component="dl" spacing={1} sx={{ m: 0, mt: 1, mb: 3 }}>
             <InformationContainer
               label={t('thresholds.dailyCallsPerConsumer.label')}
               content={`${descriptor.dailyCallsPerConsumer}`}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
@@ -202,18 +202,20 @@ export const ProviderEServiceGeneralInfoSection: React.FC = () => {
           ...(!isEserviceFromTemplate && !isViewer ? [exportVersionListAction] : []),
         ]}
       >
-        <Stack spacing={2} component="dl">
-          <InformationContainer label={t('version.label')} content={descriptor.version} />
-          <InformationContainer
-            label={t(`personalDataField.${descriptor.eservice.mode}.label`)}
-            content={t(`personalDataField.value.${descriptor.eservice.personalData}`)}
-          />
-          <InformationContainer
-            label={t('exchangeType.label')}
-            content={t(
-              `exchangeType.value.${descriptor.eservice.asyncExchange ? 'async' : 'sync'}`
-            )}
-          />
+        <Stack spacing={2}>
+          <Stack component="dl" spacing={2} sx={{ m: 0 }}>
+            <InformationContainer label={t('version.label')} content={descriptor.version} />
+            <InformationContainer
+              label={t(`personalDataField.${descriptor.eservice.mode}.label`)}
+              content={t(`personalDataField.value.${descriptor.eservice.personalData}`)}
+            />
+            <InformationContainer
+              label={t('exchangeType.label')}
+              content={t(
+                `exchangeType.value.${descriptor.eservice.asyncExchange ? 'async' : 'sync'}`
+              )}
+            />
+          </Stack>
           {(isAdmin || isOperatorAPI) && !arePersonalDataSet && !isEserviceFromTemplate && (
             <Alert severity="warning" sx={{ alignItems: 'center' }} variant="outlined">
               <Stack spacing={25} direction="row" alignItems="center">
@@ -233,21 +235,23 @@ export const ProviderEServiceGeneralInfoSection: React.FC = () => {
           )}
           {isEserviceFromTemplate ? (
             <>
-              <InformationContainer
-                label={t('eserviceTemplateName.label')}
-                content={
-                  <Link
-                    to="SUBSCRIBE_ESERVICE_TEMPLATE_DETAILS"
-                    params={{
-                      eServiceTemplateId: descriptor.templateRef?.templateId as string,
-                      eServiceTemplateVersionId: descriptor.templateRef
-                        ?.templateVersionId as string,
-                    }}
-                  >
-                    {descriptor.templateRef?.templateName}
-                  </Link>
-                }
-              />
+              <Stack component="dl" sx={{ m: 0 }}>
+                <InformationContainer
+                  label={t('eserviceTemplateName.label')}
+                  content={
+                    <Link
+                      to="SUBSCRIBE_ESERVICE_TEMPLATE_DETAILS"
+                      params={{
+                        eServiceTemplateId: descriptor.templateRef?.templateId as string,
+                        eServiceTemplateVersionId: descriptor.templateRef
+                          ?.templateVersionId as string,
+                      }}
+                    >
+                      {descriptor.templateRef?.templateName}
+                    </Link>
+                  }
+                />
+              </Stack>
               <Divider />
               <SectionContainer
                 innerSection

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceGeneralInfoSection/ProviderEServiceGeneralInfoSection.tsx
@@ -202,7 +202,7 @@ export const ProviderEServiceGeneralInfoSection: React.FC = () => {
           ...(!isEserviceFromTemplate && !isViewer ? [exportVersionListAction] : []),
         ]}
       >
-        <Stack spacing={2}>
+        <Stack spacing={2} component="dl">
           <InformationContainer label={t('version.label')} content={descriptor.version} />
           <InformationContainer
             label={t(`personalDataField.${descriptor.eservice.mode}.label`)}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceSignalHubSection/ProviderEServiceSignalHubSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceSignalHubSection/ProviderEServiceSignalHubSection.tsx
@@ -92,7 +92,7 @@ export const ProviderEServiceSignalHubSection: React.FC = () => {
                     ]
               }
             >
-              <Stack spacing={2}>
+              <Stack component="dl" spacing={2} sx={{ m: 0 }}>
                 <InformationContainer
                   label={t('innerSection.status.label')}
                   content={t(`innerSection.status.content.${isSignalHubEnabled}`)}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDelegationsSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDelegationsSection.tsx
@@ -51,7 +51,7 @@ export const ProviderEServiceDelegationsSection: React.FC<
               ]
         }
       >
-        <Stack spacing={2}>
+        <Stack component="dl" spacing={2} sx={{ m: 0 }}>
           <InformationContainer
             label={t('isConsumerDelegable.label')}
             content={t(`isConsumerDelegable.value.${isConsumerDelegable}`)}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDocumentationSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceDocumentationSection.tsx
@@ -73,62 +73,64 @@ export const ProviderEServiceDocumentationSection: React.FC<
               ]
         }
       >
-        <InformationContainer
-          label={t('documentation.label')}
-          content={
-            <Stack alignItems="start" spacing={0.5}>
-              {docs.map((doc) => {
-                if (!doc) return null
-                return (
-                  <IconLink
-                    key={doc.id}
-                    component="button"
-                    onClick={handleDownloadDocument.bind(null, doc)}
-                    startIcon={<AttachFileIcon fontSize="small" />}
-                    aria-label={tCommon('ariaLabels.downloadDocument', {
-                      name: doc.prettyName,
-                    })}
-                  >
-                    {doc.prettyName}
-                  </IconLink>
-                )
-              })}
-            </Stack>
-          }
-        />
-        {descriptor.eservice.asyncExchange && (
+        <Stack component="dl" spacing={2} sx={{ m: 0 }}>
           <InformationContainer
-            label={t('callbackInterface.label')}
+            label={t('documentation.label')}
             content={
-              descriptor.asyncExchangeCallbackInterface ? (
-                <IconLink
-                  component="button"
-                  onClick={handleDownloadDocument.bind(
-                    null,
-                    descriptor.asyncExchangeCallbackInterface
-                  )}
-                  startIcon={<AttachFileIcon fontSize="small" />}
-                  aria-label={tCommon('ariaLabels.downloadDocument', {
-                    name: descriptor.asyncExchangeCallbackInterface.prettyName,
-                  })}
-                >
-                  {descriptor.asyncExchangeCallbackInterface.prettyName}
-                </IconLink>
-              ) : (
-                '-'
-              )
+              <Stack alignItems="start" spacing={0.5}>
+                {docs.map((doc) => {
+                  if (!doc) return null
+                  return (
+                    <IconLink
+                      key={doc.id}
+                      component="button"
+                      onClick={handleDownloadDocument.bind(null, doc)}
+                      startIcon={<AttachFileIcon fontSize="small" />}
+                      aria-label={tCommon('ariaLabels.downloadDocument', {
+                        name: doc.prettyName,
+                      })}
+                    >
+                      {doc.prettyName}
+                    </IconLink>
+                  )
+                })}
+              </Stack>
             }
           />
-        )}
-        {descriptor.interface?.checksum && (
-          <InformationContainer
-            label={t('documentation.interfaceChecksum')}
-            content={descriptor.interface.checksum}
-            copyToClipboard={{
-              value: descriptor.interface.checksum,
-            }}
-          />
-        )}
+          {descriptor.eservice.asyncExchange && (
+            <InformationContainer
+              label={t('callbackInterface.label')}
+              content={
+                descriptor.asyncExchangeCallbackInterface ? (
+                  <IconLink
+                    component="button"
+                    onClick={handleDownloadDocument.bind(
+                      null,
+                      descriptor.asyncExchangeCallbackInterface
+                    )}
+                    startIcon={<AttachFileIcon fontSize="small" />}
+                    aria-label={tCommon('ariaLabels.downloadDocument', {
+                      name: descriptor.asyncExchangeCallbackInterface.prettyName,
+                    })}
+                  >
+                    {descriptor.asyncExchangeCallbackInterface.prettyName}
+                  </IconLink>
+                ) : (
+                  '-'
+                )
+              }
+            />
+          )}
+          {descriptor.interface?.checksum && (
+            <InformationContainer
+              label={t('documentation.interfaceChecksum')}
+              content={descriptor.interface.checksum}
+              copyToClipboard={{
+                value: descriptor.interface.checksum,
+              }}
+            />
+          )}
+        </Stack>
       </SectionContainer>
       <ProviderEServiceUpdateDocumentationDrawer
         isOpen={isOpen}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceTechnicalInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceTechnicalInfoSection.tsx
@@ -31,7 +31,7 @@ export const ProviderEServiceTechnicalInfoSection: React.FC = () => {
     <SectionContainer title={t('title')} description={t('description')}>
       <Stack spacing={2}>
         <SectionContainer innerSection>
-          <Stack spacing={2}>
+          <Stack component="dl" spacing={2} sx={{ m: 0 }}>
             <InformationContainer
               label={t('eserviceId.label')}
               content={eserviceId}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceVoucherLifespanSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceTechnicalInfoSection/ProviderEServiceVoucherLifespanSection.tsx
@@ -89,7 +89,7 @@ export const ProviderEServiceVoucherLifespanSection: React.FC<
             : []
         }
       >
-        <Stack spacing={2}>
+        <Stack component="dl" spacing={2} sx={{ m: 0 }}>
           <InformationContainer
             label={t('thresholds.voucherLifespan.label')}
             labelDescription={t('thresholds.voucherLifespan.labelDescription')}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceVersionInfoSection/ProviderEServiceVersionInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceVersionInfoSection/ProviderEServiceVersionInfoSection.tsx
@@ -57,6 +57,7 @@ export const ProviderEServiceVersionInfoSection: React.FC = () => {
           >
             <InformationContainer
               label={t('details.descriptorDescription.label')}
+              component="dl"
               content={
                 <Typography variant="body2" component="span">
                   {descriptor.description ?? ''}
@@ -84,6 +85,7 @@ export const ProviderEServiceVersionInfoSection: React.FC = () => {
                 }
               >
                 <InformationContainer
+                  component="dl"
                   label={t('agreementApprovalPolicy.label')}
                   content={t(
                     `agreementApprovalPolicy.content.${descriptor.agreementApprovalPolicy}`
@@ -98,7 +100,7 @@ export const ProviderEServiceVersionInfoSection: React.FC = () => {
             title={t('lifeCycle.title')}
             titleTypographyProps={{ variant: 'body1', fontWeight: 600 }}
           >
-            <Stack spacing={2}>
+            <Stack component="dl" spacing={2} sx={{ m: 0 }}>
               {!isViewingLatestVersion && latestDescriptor.publishedAt && (
                 <InformationContainer
                   label={t('lifeCycle.lastVersionDate')}

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceVersionInfoSection/ProviderEServiceVersionInfoSection.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceVersionInfoSection/ProviderEServiceVersionInfoSection.tsx
@@ -58,6 +58,7 @@ export const ProviderEServiceVersionInfoSection: React.FC = () => {
             <InformationContainer
               label={t('details.descriptorDescription.label')}
               component="dl"
+              sx={{ m: 0 }}
               content={
                 <Typography variant="body2" component="span">
                   {descriptor.description ?? ''}
@@ -86,6 +87,7 @@ export const ProviderEServiceVersionInfoSection: React.FC = () => {
               >
                 <InformationContainer
                   component="dl"
+                  sx={{ m: 0 }}
                   label={t('agreementApprovalPolicy.label')}
                   content={t(
                     `agreementApprovalPolicy.content.${descriptor.agreementApprovalPolicy}`

--- a/src/pages/ProviderKeychainPublicKeyDetailsPage/components/ProviderKeychainPublicKeyDetailsGeneralInfoSection.tsx
+++ b/src/pages/ProviderKeychainPublicKeyDetailsPage/components/ProviderKeychainPublicKeyDetailsGeneralInfoSection.tsx
@@ -36,7 +36,7 @@ export const ProviderKeychainPublicKeyDetailsGeneralInfoSection: React.FC<
             },
           ]}
         >
-          <Stack spacing={2} component="dl">
+          <Stack spacing={2} component="dl" sx={{ m: 0 }}>
             <InformationContainer
               label={t('creationDateField.label')}
               content={formatDateString(publicKey.createdAt)}

--- a/src/pages/ProviderKeychainPublicKeyDetailsPage/components/ProviderKeychainPublicKeyDetailsGeneralInfoSection.tsx
+++ b/src/pages/ProviderKeychainPublicKeyDetailsPage/components/ProviderKeychainPublicKeyDetailsGeneralInfoSection.tsx
@@ -36,7 +36,7 @@ export const ProviderKeychainPublicKeyDetailsGeneralInfoSection: React.FC<
             },
           ]}
         >
-          <Stack spacing={2}>
+          <Stack spacing={2} component="dl">
             <InformationContainer
               label={t('creationDateField.label')}
               content={formatDateString(publicKey.createdAt)}

--- a/src/pages/ProviderKeychainUserDetailsPage/components/ProviderKeychainUserDetailsGeneralInfoSection.tsx
+++ b/src/pages/ProviderKeychainUserDetailsPage/components/ProviderKeychainUserDetailsGeneralInfoSection.tsx
@@ -51,7 +51,11 @@ export const ProviderKeychainUserDetailsGeneralInfoSection: React.FC<
         },
       ]}
     >
-      <InformationContainer label={t('productRoleField.label')} content={userRoles} />
+      <InformationContainer
+        component="dl"
+        label={t('productRoleField.label')}
+        content={userRoles}
+      />
     </SectionContainer>
   )
 }

--- a/src/pages/ProviderKeychainUserDetailsPage/components/ProviderKeychainUserDetailsGeneralInfoSection.tsx
+++ b/src/pages/ProviderKeychainUserDetailsPage/components/ProviderKeychainUserDetailsGeneralInfoSection.tsx
@@ -53,6 +53,7 @@ export const ProviderKeychainUserDetailsGeneralInfoSection: React.FC<
     >
       <InformationContainer
         component="dl"
+        sx={{ m: 0 }}
         label={t('productRoleField.label')}
         content={userRoles}
       />

--- a/src/pages/ProviderPurposeDetailsPage/components/ProviderPurposeDetailsGeneralInfoSection.tsx
+++ b/src/pages/ProviderPurposeDetailsPage/components/ProviderPurposeDetailsGeneralInfoSection.tsx
@@ -68,7 +68,7 @@ export const ProviderPurposeDetailsGeneralInfoSection: React.FC<
         },
       ]}
     >
-      <Stack spacing={2} component="dl">
+      <Stack spacing={2} component="dl" sx={{ m: 0 }}>
         <InformationContainer
           label={t('eServiceField.label')}
           content={

--- a/src/pages/ProviderPurposeDetailsPage/components/ProviderPurposeDetailsGeneralInfoSection.tsx
+++ b/src/pages/ProviderPurposeDetailsPage/components/ProviderPurposeDetailsGeneralInfoSection.tsx
@@ -68,7 +68,7 @@ export const ProviderPurposeDetailsGeneralInfoSection: React.FC<
         },
       ]}
     >
-      <Stack spacing={2}>
+      <Stack spacing={2} component="dl">
         <InformationContainer
           label={t('eServiceField.label')}
           content={

--- a/src/pages/ProviderPurposeDetailsPage/components/ProviderPurposeDetailsTechnicalInfoSection.tsx
+++ b/src/pages/ProviderPurposeDetailsPage/components/ProviderPurposeDetailsTechnicalInfoSection.tsx
@@ -18,7 +18,7 @@ export const ProviderPurposeDetailsTechnicalInfoSection: React.FC<
 
   return (
     <SectionContainer title={t('title')} description={t('description')}>
-      <Stack spacing={2}>
+      <Stack component="dl" spacing={2} sx={{ m: 0 }}>
         <InformationContainer
           label={t('purposeField.label')}
           content={purpose.id}


### PR DESCRIPTION
## 🔗 Issue

[A2-2598](https://pagopa.atlassian.net/browse/A2-2598)

## 📝 Description / Context
This pull request standardizes the layout of information sections across many components by wrapping groups of `InformationContainer` elements in a `Stack` component with `component="dl"` and consistent spacing and margin styles. This improves semantic HTML structure and visual consistency throughout the application.

**Layout and Semantic Structure Improvements:**

- Updated multiple components  to wrap `InformationContainer` elements in a `Stack` with `component="dl"` and `sx={{ m: 0 }}` for better semantic HTML and consistent styling.
Components updated:

-  `EServiceTemplateGeneralInfoSection`, 
- `EServiceTemplateTechnicalInfoSection`, 
- `EServiceTemplateThresholds`, 
- `ConsumerAgreementDetailsGeneralInfoSection`, 
- `ConsumerEServiceDescriptorAttributes`, 
- `ConsumerEServiceGeneralInfoSection`, 
- `ConsumerEServiceSignalHubSection`, 
- `ConsumerPurposeDetailsGeneralInfoSection`, 
- `DelegationGeneralInfoSection`, 
- `OperatorGeneralInfoSection`, 
- `PartyContactsSection`, 
- `PartyGeneralInfoSection`, 
- `ProviderAgreementDetailsGeneralInfoSection`, 
- `ProviderEServiceDescriptorAttributesSection`, 
- `ProviderEServiceGeneralInfoSection`, 
- `ProviderEServiceSignalHubSection`, 
- `ProviderEServiceDelegationsSection`, 
- `ProviderEServiceDocumentationSection`,  
- `ProviderEServiceTechnicalInfoSection`

These changes collectively enhance the accessibility and maintainability of the codebase by ensuring that information sections are consistently and semantically structured.

[A2-2598]: https://pagopa.atlassian.net/browse/A2-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ