### PR TITLE
feat: show the clone action to the delegator (PIN-10876)

### DIFF
--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -248,7 +248,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
     expect(result.current.menuActions[3].label).toBe('suspendVersion')
   })
 
-  it('should not return actions if user is admin and delegator, e-service is PUBLISHED with no draft descriptors', () => {
+  it('should return the correct actions if user is admin and delegator, e-service is PUBLISHED with no draft descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
       delegation: createMockDelegationWithCompactTenants({
@@ -259,10 +259,11 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
   })
 
-  it('should not return actions if user is admin and delegator, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
+  it('should return the correct actions if user is admin and delegator, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
       draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
@@ -274,8 +275,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(1)
-    expect(result.current.menuActions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
+    expect(result.current.menuActions[1].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is admin and delegator, e-service is PUBLISHED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -290,8 +292,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(1)
-    expect(result.current.menuActions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
+    expect(result.current.menuActions[1].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is admin and delegate, e-service is PUBLISHED with no draft descriptors', () => {
@@ -370,7 +373,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
     expect(result.current.menuActions[3].label).toBe('deleteDraft')
   })
 
-  it('should not return actions if user is admin and delegator, e-service is SUSPENDED with no draft descriptors', () => {
+  it('should return the correct actions if user is admin and delegator, e-service is SUSPENDED with no draft descriptors', () => {
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
       delegation: createMockDelegationWithCompactTenants({
@@ -381,10 +384,11 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
   })
 
-  it('should not return actions if user is admin and delegator, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
+  it('should return the correct actions if user is admin and delegator, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
       draftDescriptor: { id: 'test-2', state: 'DRAFT', version: '2' },
@@ -396,7 +400,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
   })
 
   it('should return the correct actions if user is admin and delegator, e-service is SUSPENDED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -411,8 +416,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(1)
-    expect(result.current.menuActions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
+    expect(result.current.menuActions[1].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is admin and delegate, e-service is SUSPENDED with no draft descriptors', () => {
@@ -656,7 +662,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
     expect(result.current.menuActions[3].label).toBe('suspendVersion')
   })
 
-  it('should not return actions if user is an api operator and delegator, e-service is PUBLISHED with no draft descriptors', () => {
+  it('should return the correct actions if user is an api operator and delegator, e-service is PUBLISHED with no draft descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
@@ -668,10 +674,11 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
   })
 
-  it('should not return actions if user is an api operator and delegator, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
+  it('should return the correct actions if user is an api operator and delegator, e-service is PUBLISHED with a draft descriptor in state DRAFT', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
@@ -684,8 +691,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(1)
-    expect(result.current.menuActions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
+    expect(result.current.menuActions[1].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is an api operator and delegator, e-service is PUBLISHED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -701,8 +709,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(1)
-    expect(result.current.menuActions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
+    expect(result.current.menuActions[1].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is an api operator and delegate, e-service is PUBLISHED with no draft descriptors', () => {
@@ -798,7 +807,7 @@ describe('useGetProviderEServiceTableActions tests', () => {
     expect(result.current.menuActions[3].label).toBe('deleteDraft')
   })
 
-  it('should not return actions if user is an api operator and delegator, e-service is SUSPENDED with no draft descriptors', () => {
+  it('should return the correct actions if user is an api operator and delegator, e-service is SUSPENDED with no draft descriptors', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
@@ -810,10 +819,11 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
   })
 
-  it('should not return actions if user is an api operator and delegator, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
+  it('should return the correct actions if user is an api operator and delegator, e-service is SUSPENDED with a draft descriptor in state DRAFT', () => {
     mockUseJwt({ isAdmin: false, isOperatorAPI: true })
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'SUSPENDED', version: '1' },
@@ -826,7 +836,8 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(0)
+    expect(result.current.menuActions).toHaveLength(1)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
   })
 
   it('should return the correct actions if user is an api operator and delegator, e-service is SUSPENDED with a draft descriptor in state WAITING_FOR_APPROVAL', () => {
@@ -842,8 +853,9 @@ describe('useGetProviderEServiceTableActions tests', () => {
       }),
     })
     const { result } = renderUseGetProviderEServiceTableActionsHook(descriptorMock)
-    expect(result.current.menuActions).toHaveLength(1)
-    expect(result.current.menuActions[0].label).toBe('manageDraft')
+    expect(result.current.menuActions).toHaveLength(2)
+    expect(result.current.menuActions[0].label).toBe('cloneEservice')
+    expect(result.current.menuActions[1].label).toBe('manageDraft')
   })
 
   it('should return the correct actions if user is an api operator and delegate, e-service is SUSPENDED with no draft descriptors', () => {
@@ -1449,7 +1461,7 @@ describe('useGetProviderEServiceActions slot split bypass (preserve legacy behav
     mockUseJwt({ isAdmin: true })
   })
 
-  it('PUBLISHED + delegator: no slot split, only viewAllVersions in menu', () => {
+  it('PUBLISHED + delegator: no slot split, cloneEservice and viewAllVersions in menu', () => {
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
       delegation: createMockDelegationWithCompactTenants({
@@ -1459,7 +1471,53 @@ describe('useGetProviderEServiceActions slot split bypass (preserve legacy behav
     const { result } = renderDetailsPageHook(descriptorMock)
     expect(result.current.primaryAction).toBeUndefined()
     expect(result.current.headerInfoActions).toHaveLength(0)
-    expect(result.current.menuActions.map((a) => a.label)).toEqual(['viewAllVersions'])
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'cloneEservice',
+      'viewAllVersions',
+    ])
+  })
+
+  it('PUBLISHED + delegate: no slot split, cloneEservice stays hidden', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'PUBLISHED', version: '1' },
+      delegation: createMockDelegationWithCompactTenants({
+        delegate: { id: 'organizationId', name: 'delegate-name' },
+      }),
+    })
+    const { result } = renderDetailsPageHook(descriptorMock)
+    expect(result.current.menuActions.map((a) => a.label)).not.toContain('cloneEservice')
+  })
+
+  it('ARCHIVING + delegator: cloneEservice and viewAllVersions in menu', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVING', version: '1' },
+      delegation: createMockDelegationWithCompactTenants({
+        delegator: { id: 'organizationId', name: 'delegator-name' },
+      }),
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, {
+      archivingSchedule: { scope: 'ESERVICE' },
+    })
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'cloneEservice',
+      'viewAllVersions',
+    ])
+  })
+
+  it('ARCHIVING_SUSPENDED + delegator: cloneEservice and viewAllVersions in menu', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVING_SUSPENDED', version: '1' },
+      delegation: createMockDelegationWithCompactTenants({
+        delegator: { id: 'organizationId', name: 'delegator-name' },
+      }),
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, {
+      archivingSchedule: { scope: 'ESERVICE' },
+    })
+    expect(result.current.menuActions.map((a) => a.label)).toEqual([
+      'cloneEservice',
+      'viewAllVersions',
+    ])
   })
 })
 

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -377,7 +377,9 @@ export function useGetProviderEServiceActions(
       deleteAction,
       suspendAction,
     ])
-    .with({ isAdmin: true, isDelegator: true, isDelegate: false, hasVersionDraft: false }, () => [])
+    .with({ isAdmin: true, isDelegator: true, isDelegate: false, hasVersionDraft: false }, () => [
+      cloneAction,
+    ])
     .with(
       {
         isAdmin: true,
@@ -386,7 +388,7 @@ export function useGetProviderEServiceActions(
         hasVersionDraft: true,
         isDraftWaitingForApproval: false,
       },
-      () => [editDraftAction]
+      () => [cloneAction, editDraftAction]
     )
     .with(
       {
@@ -396,7 +398,7 @@ export function useGetProviderEServiceActions(
         hasVersionDraft: true,
         isDraftWaitingForApproval: true,
       },
-      () => [editDraftAction]
+      () => [cloneAction, editDraftAction]
     )
     .with({ isAdmin: true, isDelegator: false, isDelegate: true, hasVersionDraft: false }, () => [
       createNewDraftAction,
@@ -433,10 +435,9 @@ export function useGetProviderEServiceActions(
       deleteAction,
       suspendAction,
     ])
-    .with(
-      { isAdmin: false, isDelegator: true, isDelegate: false, hasVersionDraft: false },
-      () => []
-    )
+    .with({ isAdmin: false, isDelegator: true, isDelegate: false, hasVersionDraft: false }, () => [
+      cloneAction,
+    ])
     .with(
       {
         isAdmin: false,
@@ -445,7 +446,7 @@ export function useGetProviderEServiceActions(
         hasVersionDraft: true,
         isDraftWaitingForApproval: false,
       },
-      () => [editDraftAction]
+      () => [cloneAction, editDraftAction]
     )
     .with(
       {
@@ -455,7 +456,7 @@ export function useGetProviderEServiceActions(
         hasVersionDraft: true,
         isDraftWaitingForApproval: true,
       },
-      () => [editDraftAction]
+      () => [cloneAction, editDraftAction]
     )
     .with({ isAdmin: false, isDelegator: false, isDelegate: true, hasVersionDraft: false }, () => [
       createNewDraftAction,
@@ -506,7 +507,9 @@ export function useGetProviderEServiceActions(
       editDraftAction,
       deleteAction,
     ])
-    .with({ isAdmin: true, isDelegator: true, isDelegate: false, hasVersionDraft: false }, () => [])
+    .with({ isAdmin: true, isDelegator: true, isDelegate: false, hasVersionDraft: false }, () => [
+      cloneAction,
+    ])
     .with(
       {
         isAdmin: true,
@@ -515,7 +518,7 @@ export function useGetProviderEServiceActions(
         hasVersionDraft: true,
         isDraftWaitingForApproval: false,
       },
-      () => []
+      () => [cloneAction]
     )
     .with(
       {
@@ -525,7 +528,7 @@ export function useGetProviderEServiceActions(
         hasVersionDraft: true,
         isDraftWaitingForApproval: true,
       },
-      () => [editDraftAction]
+      () => [cloneAction, editDraftAction]
     )
     .with({ isAdmin: true, isDelegator: false, isDelegate: true, hasVersionDraft: false }, () => [
       reactivateAction,
@@ -562,10 +565,9 @@ export function useGetProviderEServiceActions(
       editDraftAction,
       deleteAction,
     ])
-    .with(
-      { isAdmin: false, isDelegator: true, isDelegate: false, hasVersionDraft: false },
-      () => []
-    )
+    .with({ isAdmin: false, isDelegator: true, isDelegate: false, hasVersionDraft: false }, () => [
+      cloneAction,
+    ])
     .with(
       {
         isAdmin: false,
@@ -574,7 +576,7 @@ export function useGetProviderEServiceActions(
         hasVersionDraft: true,
         isDraftWaitingForApproval: false,
       },
-      () => []
+      () => [cloneAction]
     )
     .with(
       {
@@ -584,7 +586,7 @@ export function useGetProviderEServiceActions(
         hasVersionDraft: true,
         isDraftWaitingForApproval: true,
       },
-      () => [editDraftAction]
+      () => [cloneAction, editDraftAction]
     )
     .with({ isAdmin: false, isDelegator: false, isDelegate: true, hasVersionDraft: false }, () => [
       reactivateAction,
@@ -1101,8 +1103,8 @@ export function useGetProviderEServiceActions(
         : isDelegator && where === 'tableRow' && !hasPersonalData
           ? [rejectDelegatedVersionDraftAction]
           : [],
-    ARCHIVING: isDelegator ? [] : [suspendAction, cloneAction],
-    ARCHIVING_SUSPENDED: isDelegator ? [] : [reactivateAction, cloneAction],
+    ARCHIVING: isDelegator ? [cloneAction] : [suspendAction, cloneAction],
+    ARCHIVING_SUSPENDED: isDelegator ? [cloneAction] : [reactivateAction, cloneAction],
   }
 
   const operatorAPIActions: Record<EServiceDescriptorState, Array<ActionItemButton>> = {


### PR DESCRIPTION
## Jira Issue
[PIN-10876](https://pagopa.atlassian.net/browse/PIN-10876)

## Context/Why
- The delegator has no way to duplicate its own e-service: the action is missing from the menu.
- Duplicating creates a separate new e-service and does not touch the delegated one, so there is nothing the delegation needs to protect.
- Depends on PIN-10875, which removes the same block on the backend.

## Services Impacted
- pdnd-interop-frontend

## Key Changes
- `useGetProviderEServiceActions.ts`: the delegator now gets the clone action on published and suspended versions, and while the e-service is being archived. The delegate and template instances are unchanged.
- `useGetProviderEServiceActions.test.ts`: delegator expectations updated for those states, plus a case that keeps the clone action hidden for the delegate.

## Traceability Checklist
- [x] Branch name contain the Jira key
- [x] PR title is compliant with the standard (type(scope): descrizione (KEY))
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno endpoint definition updated

[PIN-10876]: https://pagopa.atlassian.net/browse/PIN-10876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ