### PR TITLE
feature/10872: cant delegate an e-service that is in ARCHIVED state

### DIFF
--- a/src/pages/DelegationCreatePage/components/DelegationCreateEServiceAutocomplete.tsx
+++ b/src/pages/DelegationCreatePage/components/DelegationCreateEServiceAutocomplete.tsx
@@ -67,6 +67,16 @@ export const DelegationCreateEServiceAutocomplete: React.FC<
       offset: 0,
       delegated: false,
       personalData: 'DEFINED',
+      // cant delegate an e-service that is in ARCHIVED state, so we don't need to show it in the autocomplete
+      states: [
+        'PUBLISHED',
+        'DEPRECATED',
+        'DRAFT',
+        'SUSPENDED',
+        'WAITING_FOR_APPROVAL',
+        'ARCHIVING',
+        'ARCHIVING_SUSPENDED',
+      ],
     }),
     enabled: delegationKind === 'DELEGATED_PRODUCER',
     select: (d) => d.results ?? [],

--- a/src/pages/DelegationCreatePage/components/__tests__/DelegationCreateEServiceAutocomplete.test.tsx
+++ b/src/pages/DelegationCreatePage/components/__tests__/DelegationCreateEServiceAutocomplete.test.tsx
@@ -70,7 +70,7 @@ describe('DelegationCreateEServiceAutocomplete', () => {
     >)
   })
 
-  it('uses the full set of provider states for a producer delegation', () => {
+  it('filters out ARCHIVED e-services from the provider autocomplete for a producer delegation', () => {
     renderWithApplicationContext(
       <DelegationCreateEServiceAutocomplete delegationKind="DELEGATED_PRODUCER" />,
       { withReactQueryContext: true }

--- a/src/pages/DelegationCreatePage/components/__tests__/DelegationCreateEServiceAutocomplete.test.tsx
+++ b/src/pages/DelegationCreatePage/components/__tests__/DelegationCreateEServiceAutocomplete.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { vi } from 'vitest'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { DelegationCreateEServiceAutocomplete } from '../DelegationCreateEServiceAutocomplete'
+
+const { mockedGetProviderList, mockedGetCatalogList } = vi.hoisted(() => ({
+  mockedGetProviderList: vi.fn(() => ({ queryKey: ['provider-list'], queryFn: vi.fn() })),
+  mockedGetCatalogList: vi.fn(() => ({ queryKey: ['catalog-list'], queryFn: vi.fn() })),
+}))
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+
+  return {
+    ...actual,
+    useQuery: vi.fn(),
+  }
+})
+
+vi.mock('@pagopa/interop-fe-commons', async () => {
+  const actual = await vi.importActual<typeof import('@pagopa/interop-fe-commons')>(
+    '@pagopa/interop-fe-commons'
+  )
+
+  return {
+    ...actual,
+    useAutocompleteTextInput: () => ['', vi.fn()],
+  }
+})
+
+vi.mock('@/api/eservice', () => ({
+  EServiceQueries: {
+    getProviderList: mockedGetProviderList,
+    getCatalogList: mockedGetCatalogList,
+  },
+}))
+
+vi.mock('@/components/shared/react-hook-form-inputs', () => ({
+  RHFAutocompleteSingle: ({
+    label,
+    options,
+  }: {
+    label: string
+    options: Array<{ label: string; value: string }>
+  }) => (
+    <div>
+      <div>{label}</div>
+      <ul>
+        {options.map((option) => (
+          <li key={option.value}>{option.label}</li>
+        ))}
+      </ul>
+    </div>
+  ),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+describe('DelegationCreateEServiceAutocomplete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useQuery).mockReturnValue({ data: [], isLoading: false } as ReturnType<
+      typeof useQuery
+    >)
+  })
+
+  it('uses the full set of provider states for a producer delegation', () => {
+    renderWithApplicationContext(
+      <DelegationCreateEServiceAutocomplete delegationKind="DELEGATED_PRODUCER" />,
+      { withReactQueryContext: true }
+    )
+
+    expect(mockedGetProviderList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: '',
+        limit: 50,
+        offset: 0,
+        delegated: false,
+        personalData: 'DEFINED',
+        states: [
+          'PUBLISHED',
+          'DEPRECATED',
+          'DRAFT',
+          'SUSPENDED',
+          'WAITING_FOR_APPROVAL',
+          'ARCHIVING',
+          'ARCHIVING_SUSPENDED',
+        ],
+      })
+    )
+
+    expect(mockedGetCatalogList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: '',
+        limit: 50,
+        offset: 0,
+        states: ['PUBLISHED'],
+        isConsumerDelegable: true,
+      })
+    )
+  })
+})


### PR DESCRIPTION
## 🔗 Issue

[PIN-10872](https://pagopa.atlassian.net/browse/PIN-10872)

## 📝 Description / Context

Can't delegate an e-service that is in ARCHIVED state, so we don't need to show it in the autocomplete

## 🛠 List of changes

- added `states` queryParams to getProviderList not including the `ARCHIVED` state

## 🧪 How to test

Go to: Il tuo ente > Gestione delle deleghe > Crea delega


[PIN-10872]: https://pagopa.atlassian.net/browse/PIN-10872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ