### PR TITLE
feature/PIN-10881: revoke delegation description changed

### DIFF
--- a/src/components/dialogs/DialogRevokeDelegation.tsx
+++ b/src/components/dialogs/DialogRevokeDelegation.tsx
@@ -21,6 +21,7 @@ import { match } from 'ts-pattern'
 export const DialogRevokeDelegation: React.FC<DialogRevokeDelegationProps> = ({
   delegationId,
   eserviceName,
+  delegateName,
   delegationKind,
 }) => {
   const ariaLabelId = React.useId()
@@ -67,7 +68,8 @@ export const DialogRevokeDelegation: React.FC<DialogRevokeDelegationProps> = ({
               }}
             >
               {t('content.description', {
-                eserviceName: eserviceName,
+                eserviceName,
+                delegateName,
               })}
             </Trans>
           </Typography>

--- a/src/components/dialogs/__tests__/DialogRevokeDelegation.test.tsx
+++ b/src/components/dialogs/__tests__/DialogRevokeDelegation.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DialogRevokeDelegation } from '../DialogRevokeDelegation'
+import type { DialogRevokeDelegationProps } from '@/types/dialog.types'
+import { renderWithApplicationContext } from '@/utils/testing.utils'
+
+const mockCloseDialog = vi.fn()
+
+vi.mock('react-i18next', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useTranslation: (_namespace: string, options?: { keyPrefix?: string }) => ({
+    t: (key: string) => `${options?.keyPrefix ? `${options.keyPrefix}.` : ''}${key}`,
+  }),
+}))
+
+vi.mock('@/stores', async () => {
+  const actual = await vi.importActual<typeof import('@/stores')>('@/stores')
+  return {
+    ...actual,
+    useDialog: () => ({ closeDialog: mockCloseDialog, openDialog: vi.fn() }),
+  }
+})
+
+const mockRevokeProducerDelegation = vi.fn()
+const mockRevokeConsumerDelegation = vi.fn()
+
+vi.mock('@/api/delegation', () => ({
+  DelegationMutations: {
+    useRevokeProducerDelegation: () => ({ mutate: mockRevokeProducerDelegation }),
+    useRevokeConsumerDelegation: () => ({ mutate: mockRevokeConsumerDelegation }),
+  },
+}))
+
+const renderDialog = (overrides: Partial<DialogRevokeDelegationProps> = {}) => {
+  const props: DialogRevokeDelegationProps = {
+    type: 'revokeDelegation',
+    delegationId: 'delegation-1',
+    eserviceName: 'My e-service',
+    delegateName: 'Comune di Roma',
+    delegationKind: 'DELEGATED_PRODUCER',
+    ...overrides,
+  }
+
+  return renderWithApplicationContext(<DialogRevokeDelegation {...props} />, {
+    withReactQueryContext: true,
+    withRouterContext: true,
+  })
+}
+
+describe('DialogRevokeDelegation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders producer delegation copy and keeps revoke disabled until confirmation is checked', () => {
+    renderDialog()
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('dialogRevokeDelegation.producer.title')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'actions.cancel' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'dialogRevokeDelegation.producer.actions.revoke' })
+    ).toBeDisabled()
+    expect(
+      screen.getByText('dialogRevokeDelegation.producer.content.description')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('checkbox')).toBeInTheDocument()
+  })
+
+  it('revokes a producer delegation only after confirmation and closes the dialog', async () => {
+    renderDialog()
+
+    const revokeButton = screen.getByRole('button', {
+      name: 'dialogRevokeDelegation.producer.actions.revoke',
+    })
+    expect(revokeButton).toBeDisabled()
+    expect(mockRevokeProducerDelegation).not.toHaveBeenCalled()
+    expect(mockCloseDialog).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByRole('checkbox'))
+    expect(revokeButton).toBeEnabled()
+
+    await userEvent.click(revokeButton)
+
+    expect(mockRevokeProducerDelegation).toHaveBeenCalledTimes(1)
+    expect(mockRevokeProducerDelegation).toHaveBeenCalledWith({ delegationId: 'delegation-1' })
+    expect(mockCloseDialog).toHaveBeenCalledTimes(1)
+    expect(mockRevokeConsumerDelegation).not.toHaveBeenCalled()
+  })
+
+  it('uses the consumer revoke mutation when delegationKind is DELEGATED_CONSUMER', async () => {
+    renderDialog({ delegationKind: 'DELEGATED_CONSUMER', delegateName: 'Comune di Roma' })
+
+    await userEvent.click(screen.getByRole('checkbox'))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'dialogRevokeDelegation.consumer.actions.revoke' })
+    )
+
+    expect(mockRevokeConsumerDelegation).toHaveBeenCalledTimes(1)
+    expect(mockRevokeConsumerDelegation).toHaveBeenCalledWith({ delegationId: 'delegation-1' })
+    expect(mockRevokeProducerDelegation).not.toHaveBeenCalled()
+    expect(mockCloseDialog).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the dialog when the cancel button is clicked', async () => {
+    renderDialog()
+
+    await userEvent.click(screen.getByRole('button', { name: 'actions.cancel' }))
+
+    expect(mockCloseDialog).toHaveBeenCalledTimes(1)
+    expect(mockRevokeProducerDelegation).not.toHaveBeenCalled()
+    expect(mockRevokeConsumerDelegation).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/__tests__/useGetDelegationActions.test.tsx
+++ b/src/hooks/__tests__/useGetDelegationActions.test.tsx
@@ -1,0 +1,96 @@
+import { renderHookWithApplicationContext, mockUseJwt } from '@/utils/testing.utils'
+import { vi } from 'vitest'
+import { useGetDelegationActions } from '../useGetDelegationActions'
+import { createMockDelegation } from '../../../__mocks__/data/delegation.mocks'
+
+const openDialogMock = vi.fn()
+
+vi.mock('@/stores', async () => {
+  const actual = await vi.importActual<typeof import('@/stores')>('@/stores')
+
+  return {
+    ...actual,
+    useDialog: () => ({
+      openDialog: openDialogMock,
+      closeDialog: vi.fn(),
+    }),
+  }
+})
+
+describe('useGetDelegationActions', () => {
+  beforeEach(() => {
+    openDialogMock.mockClear()
+    mockUseJwt({ isAdmin: true })
+  })
+
+  it('returns the revoke action for an active producer delegation and passes delegateName to the dialog', () => {
+    const delegation = createMockDelegation({
+      id: 'delegation-id',
+      kind: 'DELEGATED_PRODUCER',
+      state: 'ACTIVE',
+      delegator: {
+        id: 'organizationId',
+        name: 'My organization',
+      },
+      delegate: {
+        id: 'delegate-id',
+        name: 'Delegated company',
+      },
+      eservice: {
+        id: 'eservice-id',
+        name: 'Eservice name',
+      },
+    })
+
+    const { result } = renderHookWithApplicationContext(() => useGetDelegationActions(delegation), {
+      withReactQueryContext: true,
+    })
+
+    expect(result.current.actions).toHaveLength(1)
+    expect(result.current.actions[0].label).toBe('revoke')
+
+    result.current.actions[0].action()
+
+    expect(openDialogMock).toHaveBeenCalledWith({
+      type: 'revokeDelegation',
+      delegationId: 'delegation-id',
+      eserviceName: 'Eservice name',
+      delegateName: 'Delegated company',
+      delegationKind: 'DELEGATED_PRODUCER',
+    })
+  })
+
+  it('uses a fallback delegate name when the delegation has no delegate name', () => {
+    const delegation = createMockDelegation({
+      id: 'delegation-id',
+      kind: 'DELEGATED_PRODUCER',
+      state: 'ACTIVE',
+      delegator: {
+        id: 'organizationId',
+        name: 'My organization',
+      },
+      delegate: {
+        id: 'delegate-id',
+        name: undefined,
+      },
+      eservice: {
+        id: 'eservice-id',
+        name: 'Eservice name',
+      },
+    })
+
+    const { result } = renderHookWithApplicationContext(() => useGetDelegationActions(delegation), {
+      withReactQueryContext: true,
+    })
+
+    result.current.actions[0].action()
+
+    expect(openDialogMock).toHaveBeenCalledWith({
+      type: 'revokeDelegation',
+      delegationId: 'delegation-id',
+      eserviceName: 'Eservice name',
+      delegateName: '-',
+      delegationKind: 'DELEGATED_PRODUCER',
+    })
+  })
+})

--- a/src/hooks/useGetDelegationActions.ts
+++ b/src/hooks/useGetDelegationActions.ts
@@ -53,6 +53,7 @@ export function useGetDelegationActions(delegation: Delegation | CompactDelegati
       type: 'revokeDelegation',
       delegationId: delegation.id,
       eserviceName: delegation.eservice?.name ?? '-',
+      delegateName: delegation.delegate.name ?? '-',
       delegationKind: delegation.kind,
     })
   }

--- a/src/static/locales/en/shared-components.json
+++ b/src/static/locales/en/shared-components.json
@@ -217,7 +217,7 @@
     "producer": {
       "title": "Producer Delegation Revocation",
       "content": {
-        "description": "The delegate will lose management of your e-service <strong>{{eserviceName}} with producer delegation</strong>, and the service requests and the purposes associated with it. The e-service will return under your control in the state it was in at the time of revocation. Do you have doubts? <1>Read the guide</1>.",
+        "description": "If you confirm, the delegated entity <strong>{{delegateName}}</strong> will lose management of your e-service <strong>{{eserviceName}} with producer delegation</strong>, as well as the consumption requests and the associated purposes. If archive requests were present, they will be cancelled. The e-service will now be managed by your organization. Do you have doubts? <1>Read the guide</1>.",
         "checkbox": "I have read and I want to proceed with the revocation"
       },
       "actions": {

--- a/src/static/locales/it/shared-components.json
+++ b/src/static/locales/it/shared-components.json
@@ -217,7 +217,7 @@
     "producer": {
       "title": "Revoca della delega all'erogazione",
       "content": {
-        "description": "Il delegato perderà la gestione del tuo e-service <strong>{{eserviceName}} con delega all'erogazione</strong>, e delle richieste di fruizione e le finalità ad esso associate. L’e-service tornerà sotto il tuo controllo nello stato in cui si trova all’atto della revoca. Hai dubbi? <1>Consulta la guida</1>.",
+        "description": "Se confermi, l’ente delegato <strong>{{delegateName}}</strong> perderà la gestione del tuo e-service <strong>{{eserviceName}} con delega all’erogazione</strong>, oltre alle richieste di fruizione e alle finalità associate. Se erano presenti richieste di archiviazione, saranno annullate. L’e-service sarà ora gestito dal tuo ente. Hai dubbi? <1>Consulta la guida</1>.",
         "checkbox": "Ho letto e voglio procedere con la revoca"
       },
       "actions": {

--- a/src/types/dialog.types.ts
+++ b/src/types/dialog.types.ts
@@ -161,6 +161,7 @@ export type DialogRevokeDelegationProps = {
   type: 'revokeDelegation'
   delegationId: string
   eserviceName: string
+  delegateName: string
   delegationKind: DelegationKind
 }
 


### PR DESCRIPTION
## 🔗 Issue

[PIN-10881](https://pagopa.atlassian.net/browse/PIN-10881)

## 📝 Description / Context

Description text in revoke delegation dialog has to be changed and warn about the archiving flow as well as per Figma.

## 🛠 List of changes

- dialogRevokeDelegation and useGetDelegationActions must pass new param
- shared-components.json description for dialogRevokeDelegation changed 

## 🧪 How to test

Il mio ente > Gestione deleghe > Visualizza una delega per eservice in erogazione > Revoca


[PIN-10881]: https://pagopa.atlassian.net/browse/PIN-10881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ