### PR TITLE
bugfix/PIN-10886: hide delegate alerts to delegator + block new archiving request for eservice if already in progress

### DIFF
--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -1479,6 +1479,38 @@ describe('useGetProviderEServiceActions slot split (where=detailsPage, admin hap
     ).toBeInTheDocument()
   })
 
+  it('delegate cannot open a new e-service archiving request while another delegated archiving request is in progress', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
+      delegation: createMockDelegationWithCompactTenants({
+        delegate: { id: 'organizationId', name: 'Comune di Roma' },
+        delegator: { id: 'delegator-id', name: 'Comune di Milano' },
+      }),
+    })
+
+    const { result } = renderDetailsPageHook(descriptorMock, {
+      delegatedArchivingRequest: {
+        requestedAt: '2026-12-01T00:00:00.000Z',
+        descriptorId: 'different-descriptor-id',
+        requesterId: 'requester-id',
+        gracePeriodDays: 30,
+        archivingReason: 'Motivo archiviazione',
+      },
+    })
+
+    const archiveEserviceAction = result.current.menuActions.find(
+      (action) => action.label === 'archiveEservice'
+    )
+
+    expect(archiveEserviceAction).toBeDefined()
+
+    act(() => {
+      archiveEserviceAction?.action()
+    })
+
+    expect(screen.getByRole('button', { name: 'actions.goBack' })).toBeInTheDocument()
+  })
+
   it('delegate e-service request uses approved cancel-dialog variant when state is ARCHIVING', async () => {
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'ARCHIVING', version: '1' },

--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -1479,7 +1479,7 @@ describe('useGetProviderEServiceActions slot split (where=detailsPage, admin hap
     ).toBeInTheDocument()
   })
 
-  it('delegate cannot open a new e-service archiving request while another delegated archiving request is in progress', () => {
+  it('delegate cannot open a new e-service archiving request while another archiving request is in progress', () => {
     const descriptorMock = createMockEServiceProvider({
       activeDescriptor: { id: 'test-1', state: 'DEPRECATED', version: '1' },
       delegation: createMockDelegationWithCompactTenants({

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -60,6 +60,7 @@ export function useGetProviderEServiceActions(
 
   const isDelegator = delegation?.delegator.id === jwt?.organizationId
   const isDelegate = delegation?.delegate.id === jwt?.organizationId
+
   const isArchivingRequestInProgress = Boolean(
     isDelegate && delegatedArchivingRequest && !delegatedArchivingRequest.rejectedAt
   )
@@ -257,6 +258,11 @@ export function useGetProviderEServiceActions(
   }
 
   const handleArchiveEservice = () => {
+    if (isArchivingRequestInProgress) {
+      openDialog({ type: 'blockArchivingRequest' })
+      return
+    }
+
     openDialog({
       type: 'archiveEservice',
       eserviceId,

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -61,9 +61,9 @@ export function useGetProviderEServiceActions(
   const isDelegator = delegation?.delegator.id === jwt?.organizationId
   const isDelegate = delegation?.delegate.id === jwt?.organizationId
 
-const isArchivingRequestInProgress = Boolean(
-  delegatedArchivingRequest && !delegatedArchivingRequest.rejectedAt
-)
+  const isArchivingRequestInProgress = Boolean(
+    delegatedArchivingRequest && !delegatedArchivingRequest.rejectedAt
+  )
   const isArchivingRequestFromActiveDescriptor = Boolean(
     isArchivingRequestInProgress && delegatedArchivingRequest?.descriptorId === activeDescriptorId
   )

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -61,9 +61,9 @@ export function useGetProviderEServiceActions(
   const isDelegator = delegation?.delegator.id === jwt?.organizationId
   const isDelegate = delegation?.delegate.id === jwt?.organizationId
 
-  const isArchivingRequestInProgress = Boolean(
-    isDelegate && delegatedArchivingRequest && !delegatedArchivingRequest.rejectedAt
-  )
+const isArchivingRequestInProgress = Boolean(
+  delegatedArchivingRequest && !delegatedArchivingRequest.rejectedAt
+)
   const isArchivingRequestFromActiveDescriptor = Boolean(
     isArchivingRequestInProgress && delegatedArchivingRequest?.descriptorId === activeDescriptorId
   )

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts.tsx
@@ -5,6 +5,7 @@ import StickyNote2Icon from '@mui/icons-material/StickyNote2'
 import { useTranslation } from 'react-i18next'
 import { formatDateStringNumeric } from '@/utils/format.utils'
 import { Drawer } from '@/components/shared/Drawer'
+import { AuthHooks } from '@/api/auth'
 import {
   getActiveDescriptor,
   getEServiceDescriptorAlertSpec,
@@ -25,8 +26,11 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
   >(null)
 
   const { t } = useTranslation('eservice', { keyPrefix: 'read.alert' })
+  const { jwt } = AuthHooks.useJwt()
 
   if (!descriptor) return null
+
+  const isDelegate = descriptor.delegation?.delegate.id === jwt?.organizationId
 
   const activeDescriptor = getActiveDescriptor(descriptor.eservice.descriptors)
   const isEServiceBeingArchived = isDescriptorPendingArchiving(activeDescriptor?.state)
@@ -52,28 +56,40 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
 
   const delegatorName = descriptor.delegation?.delegator.name || '-'
 
-  const shouldShowDelegatedArchivingRequestRejectedAlert = Boolean(
-    isDescriptorDelegatedArchivingRequest && delegatedArchivingRequest?.rejectedAt
+  const shouldShowDelegatedVersionArchivingRequestRejectedAlert = Boolean(
+    isDelegate && isDescriptorDelegatedArchivingRequest && delegatedArchivingRequest?.rejectedAt
   )
 
-  const shouldShowDelegatedArchivingRequestAlert =
-    isDescriptorDelegatedArchivingRequest && !shouldShowDelegatedArchivingRequestRejectedAlert
+  const shouldShowDelegatedVersionArchivingRequestAlert =
+    isDelegate &&
+    isDescriptorDelegatedArchivingRequest &&
+    !shouldShowDelegatedVersionArchivingRequestRejectedAlert &&
+    !isCurrentDescriptorArchiving
+
+  const shouldShowDelegatedVersionArchivingRequestAcceptedAlert = Boolean(
+    isDelegate &&
+    isDescriptorDelegatedArchivingRequest &&
+    !delegatedArchivingRequest?.rejectedAt &&
+    isCurrentDescriptorArchiving
+  )
 
   const delegatedEServiceArchivingDate = descriptor.archivingSchedule?.archivableOn
     ? formatDateStringNumeric(descriptor.archivingSchedule.archivableOn)
     : '-'
 
   const shouldShowDelegatedEServiceArchivingRequestRejectedAlert = Boolean(
-    isEServiceDelegatedArchivingRequest && delegatedArchivingRequest?.rejectedAt
+    isDelegate && isEServiceDelegatedArchivingRequest && delegatedArchivingRequest?.rejectedAt
   )
 
   const shouldShowDelegatedEServiceArchivingRequestAcceptedAlert = Boolean(
+    isDelegate &&
     isEServiceDelegatedArchivingRequest &&
     !delegatedArchivingRequest?.rejectedAt &&
     isCurrentDescriptorArchiving
   )
 
   const shouldShowDelegatedEServiceArchivingRequestAlert =
+    isDelegate &&
     isEServiceDelegatedArchivingRequest &&
     !delegatedArchivingRequest?.rejectedAt &&
     !isCurrentDescriptorArchiving
@@ -92,8 +108,9 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
 
   if (
     !alert &&
-    !shouldShowDelegatedArchivingRequestRejectedAlert &&
-    !shouldShowDelegatedArchivingRequestAlert &&
+    !shouldShowDelegatedVersionArchivingRequestRejectedAlert &&
+    !shouldShowDelegatedVersionArchivingRequestAlert &&
+    !shouldShowDelegatedVersionArchivingRequestAcceptedAlert &&
     !shouldShowDelegatedEServiceArchivingRequestRejectedAlert &&
     !shouldShowDelegatedEServiceArchivingRequestAcceptedAlert &&
     !shouldShowDelegatedEServiceArchivingRequestAlert &&
@@ -102,10 +119,20 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
   )
     return null
 
+  const shouldHideGenericAlert =
+    shouldShowDelegatedVersionArchivingRequestAlert ||
+    shouldShowDelegatedVersionArchivingRequestAcceptedAlert ||
+    shouldShowDelegatedEServiceArchivingRequestAlert ||
+    shouldShowDelegatedEServiceArchivingRequestAcceptedAlert
+
+  const visibleGenericAlert = shouldHideGenericAlert ? null : alert
+
   return (
     <Stack spacing={2} sx={{ mb: 3 }}>
-      {alert && <Alert severity={alert.severity}>{alert.content}</Alert>}
-      {shouldShowDelegatedArchivingRequestRejectedAlert && (
+      {visibleGenericAlert && (
+        <Alert severity={visibleGenericAlert.severity}>{visibleGenericAlert.content}</Alert>
+      )}
+      {shouldShowDelegatedVersionArchivingRequestRejectedAlert && (
         <Alert
           severity="error"
           action={
@@ -123,11 +150,20 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
           {t('delegatedDescriptorArchivingRequestRejected')}
         </Alert>
       )}
-      {shouldShowDelegatedArchivingRequestAlert && (
+      {shouldShowDelegatedVersionArchivingRequestAlert && (
         <Alert severity="info">
           {t('delegatedDescriptorArchivingRequest', {
             date: delegatedArchivingRequest?.requestedAt
               ? formatDateStringNumeric(delegatedArchivingRequest.requestedAt)
+              : '-',
+          })}
+        </Alert>
+      )}
+      {shouldShowDelegatedVersionArchivingRequestAcceptedAlert && (
+        <Alert severity="info">
+          {t('archivingDescriptor', {
+            date: descriptor.archivingSchedule?.archivableOn
+              ? formatDateStringNumeric(descriptor.archivingSchedule.archivableOn)
               : '-',
           })}
         </Alert>
@@ -150,7 +186,7 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
           {t('delegatedEServiceArchivingRequestRejected')}
         </Alert>
       )}
-      {shouldShowDelegatedEServiceArchivingRequestAcceptedAlert && !alert && (
+      {shouldShowDelegatedEServiceArchivingRequestAcceptedAlert && (
         <Alert severity="info">
           {t('archivingEService', {
             date: delegatedEServiceArchivingDate,

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/ProviderEServiceDetailsAlerts.tsx
@@ -56,17 +56,17 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
 
   const delegatorName = descriptor.delegation?.delegator.name || '-'
 
-  const shouldShowDelegatedVersionArchivingRequestRejectedAlert = Boolean(
+  const shouldShowDelegatedDescriptorArchivingRequestRejectedAlert = Boolean(
     isDelegate && isDescriptorDelegatedArchivingRequest && delegatedArchivingRequest?.rejectedAt
   )
 
-  const shouldShowDelegatedVersionArchivingRequestAlert =
+  const shouldShowDelegatedDescriptorArchivingRequestAlert =
     isDelegate &&
     isDescriptorDelegatedArchivingRequest &&
-    !shouldShowDelegatedVersionArchivingRequestRejectedAlert &&
+    !shouldShowDelegatedDescriptorArchivingRequestRejectedAlert &&
     !isCurrentDescriptorArchiving
 
-  const shouldShowDelegatedVersionArchivingRequestAcceptedAlert = Boolean(
+  const shouldShowDelegatedDescriptorArchivingRequestAcceptedAlert = Boolean(
     isDelegate &&
     isDescriptorDelegatedArchivingRequest &&
     !delegatedArchivingRequest?.rejectedAt &&
@@ -108,9 +108,9 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
 
   if (
     !alert &&
-    !shouldShowDelegatedVersionArchivingRequestRejectedAlert &&
-    !shouldShowDelegatedVersionArchivingRequestAlert &&
-    !shouldShowDelegatedVersionArchivingRequestAcceptedAlert &&
+    !shouldShowDelegatedDescriptorArchivingRequestRejectedAlert &&
+    !shouldShowDelegatedDescriptorArchivingRequestAlert &&
+    !shouldShowDelegatedDescriptorArchivingRequestAcceptedAlert &&
     !shouldShowDelegatedEServiceArchivingRequestRejectedAlert &&
     !shouldShowDelegatedEServiceArchivingRequestAcceptedAlert &&
     !shouldShowDelegatedEServiceArchivingRequestAlert &&
@@ -120,8 +120,8 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
     return null
 
   const shouldHideGenericAlert =
-    shouldShowDelegatedVersionArchivingRequestAlert ||
-    shouldShowDelegatedVersionArchivingRequestAcceptedAlert ||
+    shouldShowDelegatedDescriptorArchivingRequestAlert ||
+    shouldShowDelegatedDescriptorArchivingRequestAcceptedAlert ||
     shouldShowDelegatedEServiceArchivingRequestAlert ||
     shouldShowDelegatedEServiceArchivingRequestAcceptedAlert
 
@@ -132,7 +132,7 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
       {visibleGenericAlert && (
         <Alert severity={visibleGenericAlert.severity}>{visibleGenericAlert.content}</Alert>
       )}
-      {shouldShowDelegatedVersionArchivingRequestRejectedAlert && (
+      {shouldShowDelegatedDescriptorArchivingRequestRejectedAlert && (
         <Alert
           severity="error"
           action={
@@ -150,7 +150,7 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
           {t('delegatedDescriptorArchivingRequestRejected')}
         </Alert>
       )}
-      {shouldShowDelegatedVersionArchivingRequestAlert && (
+      {shouldShowDelegatedDescriptorArchivingRequestAlert && (
         <Alert severity="info">
           {t('delegatedDescriptorArchivingRequest', {
             date: delegatedArchivingRequest?.requestedAt
@@ -159,7 +159,7 @@ export const ProviderEServiceDetailsAlerts: React.FC<ProviderEServiceDetailsAler
           })}
         </Alert>
       )}
-      {shouldShowDelegatedVersionArchivingRequestAcceptedAlert && (
+      {shouldShowDelegatedDescriptorArchivingRequestAcceptedAlert && (
         <Alert severity="info">
           {t('archivingDescriptor', {
             date: descriptor.archivingSchedule?.archivableOn

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/__tests__/ProviderEServiceDetailsAlerts.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/__tests__/ProviderEServiceDetailsAlerts.test.tsx
@@ -4,7 +4,7 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ProviderEServiceDetailsAlerts } from '../ProviderEServiceDetailsAlerts'
 import type { ProducerEServiceDescriptor } from '@/api/api.generatedTypes'
-import { renderWithApplicationContext } from '@/utils/testing.utils'
+import { mockUseJwt, renderWithApplicationContext } from '@/utils/testing.utils'
 import {
   createMockEServiceDescriptorProvider,
   createMockEServiceDescriptorProviderAsync,
@@ -22,6 +22,10 @@ const renderAlerts = (
   )
 
 describe('ProviderEServiceDetailsAlerts', () => {
+  beforeEach(() => {
+    mockUseJwt({ jwt: { organizationId: 'delegate-id' } })
+  })
+
   it('renders nothing when descriptor is undefined', () => {
     const { container } = renderAlerts(undefined)
     expect(container).toBeEmptyDOMElement()
@@ -53,9 +57,15 @@ describe('ProviderEServiceDetailsAlerts', () => {
   })
 
   it('renders delegated archiving request info alert when latest request is not rejected', () => {
+    mockUseJwt({ jwt: { organizationId: 'delegate-id' } })
+
     const descriptor = createMockEServiceDescriptorProvider({
       id: 'descriptor-id-1',
       state: 'PUBLISHED',
+      delegation: {
+        delegator: { id: 'delegator-id', name: 'Comune di Milano' },
+        delegate: { id: 'delegate-id', name: 'Comune di Roma' },
+      },
       eservice: {
         delegatedArchivingRequest: {
           requestedAt: '2026-12-01T00:00:00.000Z',
@@ -74,6 +84,8 @@ describe('ProviderEServiceDetailsAlerts', () => {
   })
 
   it('renders delegated archiving request rejection error alert using latest request and opens drawer with rejection reason', async () => {
+    mockUseJwt({ jwt: { organizationId: 'delegate-id' } })
+
     const descriptor = createMockEServiceDescriptorProvider({
       id: 'descriptor-id-1',
       state: 'PUBLISHED',
@@ -126,9 +138,70 @@ describe('ProviderEServiceDetailsAlerts', () => {
     })
   })
 
-  it('renders delegated e-service archiving request info alert when latest request is pending', () => {
+  it('does not render delegated e-service archiving alerts when the user is not the delegate', () => {
+    mockUseJwt({ jwt: { organizationId: 'different-organization-id' } })
+
     const descriptor = createMockEServiceDescriptorProvider({
       state: 'PUBLISHED',
+      delegation: {
+        delegator: { id: 'delegator-id', name: 'Comune di Milano' },
+        delegate: { id: 'delegate-id', name: 'Comune di Roma' },
+      },
+      eservice: {
+        delegatedArchivingRequest: {
+          requestedAt: '2026-12-01T00:00:00.000Z',
+          requesterId: 'requester-id',
+          gracePeriodDays: 30,
+          archivingReason: 'Motivo archiviazione',
+        },
+      },
+    })
+
+    renderAlerts(descriptor)
+
+    expect(screen.queryByText('delegatedEServiceArchivingRequest')).not.toBeInTheDocument()
+    expect(screen.queryByText('delegatedEServiceArchivingRequestRejected')).not.toBeInTheDocument()
+    expect(screen.queryByText('archivingEService')).not.toBeInTheDocument()
+  })
+
+  it('renders delegated descriptor archiving accepted alert when the descriptor is being archived', () => {
+    mockUseJwt({ jwt: { organizationId: 'delegate-id' } })
+
+    const descriptor = createMockEServiceDescriptorProvider({
+      id: 'descriptor-id-1',
+      state: 'ARCHIVING',
+      delegation: {
+        delegator: { id: 'delegator-id', name: 'Comune di Milano' },
+        delegate: { id: 'delegate-id', name: 'Comune di Roma' },
+      },
+      archivingSchedule: { scope: 'DESCRIPTOR', archivableOn: '2026-12-20T00:00:00.000Z' },
+      eservice: {
+        delegatedArchivingRequest: {
+          requestedAt: '2026-12-01T00:00:00.000Z',
+          acceptedAt: '2026-12-02T00:00:00.000Z',
+          descriptorId: 'descriptor-id-1',
+          requesterId: 'requester-id',
+          gracePeriodDays: 30,
+          archivingReason: 'Motivo archiviazione',
+        },
+      },
+    })
+
+    renderAlerts(descriptor)
+
+    expect(screen.getByText('archivingDescriptor')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveClass(/MuiAlert-standardInfo/)
+  })
+
+  it('renders delegated e-service archiving request info alert when latest request is pending', () => {
+    mockUseJwt({ jwt: { organizationId: 'delegate-id' } })
+
+    const descriptor = createMockEServiceDescriptorProvider({
+      state: 'PUBLISHED',
+      delegation: {
+        delegator: { id: 'delegator-id', name: 'Comune di Milano' },
+        delegate: { id: 'delegate-id', name: 'Comune di Roma' },
+      },
       eservice: {
         delegatedArchivingRequest: {
           requestedAt: '2026-12-01T00:00:00.000Z',
@@ -146,9 +219,15 @@ describe('ProviderEServiceDetailsAlerts', () => {
   })
 
   it('renders delegated e-service archiving info alert when descriptor is in ARCHIVING', () => {
+    mockUseJwt({ jwt: { organizationId: 'delegate-id' } })
+
     const descriptor = createMockEServiceDescriptorProvider({
       state: 'ARCHIVING',
       archivingSchedule: { scope: 'ESERVICE', archivableOn: '2026-12-20T00:00:00.000Z' },
+      delegation: {
+        delegator: { id: 'delegator-id', name: 'Comune di Milano' },
+        delegate: { id: 'delegate-id', name: 'Comune di Roma' },
+      },
       eservice: {
         delegatedArchivingRequest: {
           requestedAt: '2026-12-01T00:00:00.000Z',
@@ -166,9 +245,15 @@ describe('ProviderEServiceDetailsAlerts', () => {
   })
 
   it('does not duplicate e-service archiving info alert when descriptor already has archiving alert', () => {
+    mockUseJwt({ jwt: { organizationId: 'delegate-id' } })
+
     const descriptor = createMockEServiceDescriptorProvider({
       state: 'ARCHIVING',
       archivingSchedule: { scope: 'ESERVICE', archivableOn: '2026-12-20T00:00:00.000Z' },
+      delegation: {
+        delegator: { id: 'delegator-id', name: 'Comune di Milano' },
+        delegate: { id: 'delegate-id', name: 'Comune di Roma' },
+      },
       eservice: {
         delegatedArchivingRequest: {
           requestedAt: '2026-12-01T00:00:00.000Z',
@@ -186,6 +271,8 @@ describe('ProviderEServiceDetailsAlerts', () => {
   })
 
   it('renders delegated e-service archiving request rejection error alert and opens drawer with rejection reason', async () => {
+    mockUseJwt({ jwt: { organizationId: 'delegate-id' } })
+
     const descriptor = createMockEServiceDescriptorProvider({
       state: 'PUBLISHED',
       delegation: {

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/__tests__/ProviderEServiceDetailsAlerts.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/__tests__/ProviderEServiceDetailsAlerts.test.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ProviderEServiceDetailsAlerts } from '../ProviderEServiceDetailsAlerts'

--- a/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/__tests__/ProviderEServiceDetailsAlerts.test.tsx
+++ b/src/pages/ProviderEServiceDetailsPage/components/ProviderEServiceDetailsTab/__tests__/ProviderEServiceDetailsAlerts.test.tsx
@@ -163,6 +163,36 @@ describe('ProviderEServiceDetailsAlerts', () => {
     expect(screen.queryByText('archivingEService')).not.toBeInTheDocument()
   })
 
+  it('does not render delegated descriptor archiving alerts when the user is not the delegate', () => {
+    mockUseJwt({ jwt: { organizationId: 'different-organization-id' } })
+
+    const descriptor = createMockEServiceDescriptorProvider({
+      id: 'descriptor-id-1',
+      state: 'PUBLISHED',
+      delegation: {
+        delegator: { id: 'delegator-id', name: 'Comune di Milano' },
+        delegate: { id: 'delegate-id', name: 'Comune di Roma' },
+      },
+      eservice: {
+        delegatedArchivingRequest: {
+          requestedAt: '2026-12-01T00:00:00.000Z',
+          descriptorId: 'descriptor-id-1',
+          requesterId: 'requester-id',
+          gracePeriodDays: 30,
+          archivingReason: 'Motivo archiviazione',
+        },
+      },
+    })
+
+    renderAlerts(descriptor)
+
+    expect(screen.queryByText('delegatedDescriptorArchivingRequest')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('delegatedDescriptorArchivingRequestRejected')
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('archivingDescriptor')).not.toBeInTheDocument()
+  })
+
   it('renders delegated descriptor archiving accepted alert when the descriptor is being archived', () => {
     mockUseJwt({ jwt: { organizationId: 'delegate-id' } })
 


### PR DESCRIPTION
## 🔗 Issue

[PIN-10886](https://pagopa.atlassian.net/browse/PIN-10886)

## 📝 Description / Context

includes two fixes:

- the alerts shown for the delegate flow after archiving requests that are made or rejected must be displayed only to the delegate.
- if there is already a pending archiving request made for a version of the e-service, a new request made directly at the e-service level must also be blocked (when clicking “Archive e-service” in the more options menu).

## 🛠 List of changes

- added isDelegate in conditions in ProviderEServiceDetailsAlerts.tsx
- added block for Archive e-service in useGetProviderEServiceActions.tsx

## 🧪 How to test

follow the archiving request flow as a delegate and then with another user (es. delegator)


[PIN-10886]: https://pagopa.atlassian.net/browse/PIN-10886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ