### PR TITLE
feat: initial reviewer notification commit (PIN-10696)

### DIFF
--- a/__mocks__/data/notification.mocks.ts
+++ b/__mocks__/data/notification.mocks.ts
@@ -25,6 +25,8 @@ const createUserNotificationConfigs = createMockFactory<UserNotificationConfig>(
     clientKeyAndProducerKeychainKeyAddedDeletedToClientUsers: false,
     purposeQuotaAdjustmentRequestToProducer: false,
     purposeOverQuotaStateToConsumer: false,
+    riskAnalysisStateUpdated: false,
+    purposePublication: false,
   },
   inAppNotificationPreference: false,
   emailNotificationPreference: false,
@@ -52,6 +54,8 @@ const createUserNotificationConfigs = createMockFactory<UserNotificationConfig>(
     clientKeyAndProducerKeychainKeyAddedDeletedToClientUsers: false,
     purposeQuotaAdjustmentRequestToProducer: false,
     purposeOverQuotaStateToConsumer: false,
+    riskAnalysisStateUpdated: false,
+    purposePublication: false,
   },
 })
 

--- a/src/pages/NotificationUserConfigPage/__test__/NotificationConfigUserTab.test.tsx
+++ b/src/pages/NotificationUserConfigPage/__test__/NotificationConfigUserTab.test.tsx
@@ -123,6 +123,23 @@ describe('NotificationConfigUserTab', () => {
         within(enableAllSectionButton).queryByText('disableSectionAllNotifications')
       ).toBeInTheDocument()
     })
+
+    it('Should show only risk analysis section for reviewer role', () => {
+      cleanup()
+
+      mockUseJwt({ currentRoles: ['reviewer'] })
+
+      renderComponent('inApp', {
+        inAppNotificationPreference: true,
+      })
+
+      expect(screen.getByTestId('config-section-riskAnalysis')).toBeInTheDocument()
+
+      expect(screen.queryByTestId('config-section-subscriber')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('config-section-provider')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('config-section-delegations')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('config-section-keyAndAttributes')).not.toBeInTheDocument()
+    })
   })
 
   describe('mail', () => {

--- a/src/pages/NotificationUserConfigPage/hooks/useGetNotificationConfigSchema.ts
+++ b/src/pages/NotificationUserConfigPage/hooks/useGetNotificationConfigSchema.ts
@@ -5,6 +5,7 @@ import { match } from 'ts-pattern'
 import React from 'react'
 import { ConsumerIcon, ProviderIcon, MyTenantIcon } from '@/icons'
 import CodeIcon from '@mui/icons-material/Code'
+import AssignmentIcon from '@mui/icons-material/Assignment'
 import { AuthHooks } from '@/api/auth'
 
 export function useGetNotificationConfigSchema(type: NotificationConfigType) {
@@ -267,6 +268,36 @@ export function useGetNotificationConfigSchema(type: NotificationConfigType) {
                 'keyAndAttributes.keys.components.clientKeysAssociationUpdated.description'
               ),
               visibility: ['admin', 'security'], // To define
+            },
+          ],
+        },
+      ],
+    },
+    riskAnalysis: {
+      title: t('riskAnalysis.title'),
+      icon: AssignmentIcon,
+      subsections: [
+        {
+          name: 'riskAnalysisAssignment',
+          title: t('riskAnalysis.riskAnalysisAssignment.title'),
+          components: [
+            {
+              key: 'riskAnalysisStateUpdated',
+              title: t(
+                'riskAnalysis.riskAnalysisAssignment.components.riskAnalysisStateUpdated.label'
+              ),
+              description: t(
+                'riskAnalysis.riskAnalysisAssignment.components.riskAnalysisStateUpdated.description'
+              ),
+              visibility: ['reviewer'],
+            },
+            {
+              key: 'purposePublication',
+              title: t('riskAnalysis.riskAnalysisAssignment.components.purposePublication.label'),
+              description: t(
+                'riskAnalysis.riskAnalysisAssignment.components.purposePublication.description'
+              ),
+              visibility: ['reviewer'],
             },
           ],
         },

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -662,7 +662,7 @@ export const { routes, reactRouterDOMRoutes, hooks, components, utils } = new In
     element: <NotificationsPage />,
     public: false,
     hideSideNav: false,
-    authLevels: ['admin', 'api', 'security'],
+    authLevels: ['admin', 'api', 'security', 'reviewer'],
   })
   .addRoute({
     key: 'NOTIFICATIONS_CONFIG',
@@ -670,7 +670,7 @@ export const { routes, reactRouterDOMRoutes, hooks, components, utils } = new In
     element: <NotificationUserConfigPage />,
     public: false,
     hideSideNav: false,
-    authLevels: ['admin', 'security', 'api'],
+    authLevels: ['admin', 'security', 'api', 'reviewer'],
   })
   .addRoute({
     key: 'SUBSCRIBE_PURPOSE_TEMPLATE_LIST',

--- a/src/static/locales/en/notification.json
+++ b/src/static/locales/en/notification.json
@@ -268,6 +268,22 @@
               }
             }
           }
+        },
+        "riskAnalysis": {
+          "title": "Risk Analysis",
+          "riskAnalysisAssignment": {
+            "title": "Assignment for completion or approval",
+            "components": {
+              "riskAnalysisStateUpdated": {
+                "label": "Status of assignments received",
+                "description": "Notify me when I receive a completed or approved risk analysis, or when one is revoked"
+              },
+              "purposePublication": {
+                "label": "Purpose publication",
+                "description": "Notify me when the administrator publishes a purpose for which I have been assigned the risk analysis"
+              }
+            }
+          }
         }
       },
       "outcome": {

--- a/src/static/locales/it/notification.json
+++ b/src/static/locales/it/notification.json
@@ -269,6 +269,22 @@
               }
             }
           }
+        },
+        "riskAnalysis": {
+          "title": "Analisi del rischio",
+          "riskAnalysisAssignment": {
+            "title": "Assegnazione di compilazione o approvazione",
+            "components": {
+              "riskAnalysisStateUpdated": {
+                "label": "Stato delle assegnazioni ricevute",
+                "description": "Avvisami quando ricevo la compilazione o l’approvazione di un’analisi del rischio o quando mi viene revocata"
+              },
+              "purposePublication": {
+                "label": "Pubblicazione delle finalità",
+                "description": "Avvisami quando l’amministratore pubblica una finalità di cui mi è stata assegnata l’analisi del rischio"
+              }
+            }
+          }
         }
       },
       "outcome": {


### PR DESCRIPTION
🔗 Issue

[PIN-10696](https://pagopa.atlassian.net/browse/PIN-10696)

## 📝 Description / Context

This PR adds a new user notification preference for risk analysis assignment status updates and purpose publication. The new notifications can be enabled by reviewers only.

## 🛠 List of changes

Added the riskAnalysisAssignmentStatus notification configuration.
Restricted the new notification preferences to reviewers.
Added English and Italian translations for the new notifications label and description.
Updated notification mocks and tests to include the new configurations.

## 🧪 How to test

Log in to the application as a reviewer.
Navigate to the user notification configuration page.
Verify that the new Risk analysis status notification option is displayed.
Verify that the new Purpose Publication notification option is displayed.
Verify that the notification options are available only to reviewers.
Enable/disable the notification preferences and verify that the configuration is correctly handled.
Verify that the existing notification preferences are not affected.

[PIN-10696]: https://pagopa.atlassian.net/browse/PIN-10696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ