### PR TITLE
feat: improve download button aria label for better sr user experience (PIN-10900)

### DIFF
--- a/src/components/shared/EserviceTemplate/EServiceTemplateDocumentationSection.tsx
+++ b/src/components/shared/EserviceTemplate/EServiceTemplateDocumentationSection.tsx
@@ -75,6 +75,9 @@ export const EServiceTemplateDocumentationSection: React.FC<
                     component="button"
                     onClick={handleDownloadDocument.bind(null, doc)}
                     startIcon={<AttachFileIcon fontSize="small" />}
+                    aria-label={tCommon('ariaLabels.downloadDocument', {
+                      name: doc.prettyName,
+                    })}
                   >
                     {doc.prettyName}
                   </IconLink>

--- a/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceDocumentationSummarySection.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceDocumentationSummarySection.tsx
@@ -84,6 +84,9 @@ export const ProviderEServiceDocumentationSummarySection: React.FC<
               component="button"
               startIcon={<AttachFileIcon fontSize="small" />}
               onClick={handleDownloadDocument.bind(null, descriptor.interface)}
+              aria-label={tCommon('ariaLabels.downloadDocument', {
+                name: descriptor.interface.prettyName,
+              })}
             >
               {descriptor.interface.prettyName}
             </IconLink>
@@ -107,6 +110,9 @@ export const ProviderEServiceDocumentationSummarySection: React.FC<
                 <IconLink
                   component="button"
                   startIcon={<AttachFileIcon fontSize="small" />}
+                  aria-label={tCommon('ariaLabels.downloadDocument', {
+                    name: descriptor.asyncExchangeCallbackInterface.prettyName,
+                  })}
                   onClick={handleDownloadDocument.bind(
                     null,
                     descriptor.asyncExchangeCallbackInterface

--- a/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceVersionInfoSummarySection.tsx
+++ b/src/pages/ProviderEServiceSummaryPage/components/ProviderEServiceVersionInfoSummarySection.tsx
@@ -12,6 +12,7 @@ import { SummaryInformationContainer } from '@/components/shared/SummaryInformat
 
 export const ProviderEServiceVersionInfoSummarySection: React.FC = () => {
   const { t } = useTranslation('eservice', { keyPrefix: 'summary.versionInfoSummary' })
+  const { t: tCommon } = useTranslation('common')
   const params = useParams<'PROVIDE_ESERVICE_SUMMARY'>()
   const downloadDocument = EServiceDownloads.useDownloadVersionDocument()
 
@@ -47,6 +48,9 @@ export const ProviderEServiceVersionInfoSummarySection: React.FC = () => {
               component="button"
               startIcon={<AttachFileIcon fontSize="small" />}
               onClick={handleDownloadDocument.bind(null, doc)}
+              aria-label={tCommon('ariaLabels.downloadDocument', {
+                name: doc.prettyName,
+              })}
             >
               {doc.prettyName}
             </IconLink>

--- a/src/pages/ProviderEServiceTemplateSummaryPage/components/ProviderEServiceTemplateAdditionalInfoSummarySection.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/components/ProviderEServiceTemplateAdditionalInfoSummarySection.tsx
@@ -18,6 +18,7 @@ export const ProviderEServiceTemplateAdditionalInfoSummarySection: React.FC = ()
   })
   const { t: tSummary } = useTranslation('eserviceTemplate', { keyPrefix: 'summary' })
   const params = useParams<'PROVIDE_ESERVICE_TEMPLATE_SUMMARY'>()
+  const { t: tCommon } = useTranslation('common')
 
   const { data: eserviceTemplate } = useSuspenseQuery(
     EServiceTemplateQueries.getSingle(params.eServiceTemplateId, params.eServiceTemplateVersionId)
@@ -67,6 +68,9 @@ export const ProviderEServiceTemplateAdditionalInfoSummarySection: React.FC = ()
                   key={doc.id}
                   startIcon={<AttachFileIcon fontSize="small" />}
                   onClick={handleDownloadDocument.bind(null, doc)}
+                  aria-label={tCommon('ariaLabels.downloadDocument', {
+                    name: doc.prettyName,
+                  })}
                 >
                   {doc.prettyName}
                 </IconLink>

--- a/src/pages/ProviderEServiceTemplateSummaryPage/components/ProviderEServiceTemplateTechnicalSpecsSummarySection.tsx
+++ b/src/pages/ProviderEServiceTemplateSummaryPage/components/ProviderEServiceTemplateTechnicalSpecsSummarySection.tsx
@@ -53,6 +53,9 @@ export const ProviderEServiceTemplateTechnicalSpecsSummarySection: React.FC = ()
       component="button"
       startIcon={<AttachFileIcon fontSize="small" />}
       onClick={handleDownloadDocument.bind(null, document)}
+      aria-label={tCommon('ariaLabels.downloadDocument', {
+        name: document.prettyName,
+      })}
     >
       {document.prettyName}
     </IconLink>

--- a/src/static/locales/en/common.json
+++ b/src/static/locales/en/common.json
@@ -203,6 +203,6 @@
     "NE": "Not equal to"
   },
   "ariaLabels": {
-    "downloadDocument": "Download document {{name}}"
+    "downloadDocument": "{{name}}, download attached document"
   }
 }

--- a/src/static/locales/it/common.json
+++ b/src/static/locales/it/common.json
@@ -203,6 +203,6 @@
     "NE": "Diverso da"
   },
   "ariaLabels": {
-    "downloadDocument": "Scarica il documento {{name}}"
+    "downloadDocument": "{{name}}, scarica l'allegato"
   }
 }


### PR DESCRIPTION
## 🔗 Issue

[PIN-10900](https://pagopa.atlassian.net/browse/PIN-10900)

## 📝 Description / Context

Improved aria-label download button. Now the screen reader reads the attached file name first and only after the download action. 

## 🧪 How to test
On the provider's e-service details page, navigate with the screen reader in the documentation section.

[PIN-10900]: https://pagopa.atlassian.net/browse/PIN-10900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ