### PR TITLE
fix: allow delegatore to cancel archiving (PIN-10905)

### DIFF
--- a/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
+++ b/src/hooks/__tests__/useGetProviderEServiceActions.test.ts
@@ -10,7 +10,6 @@ import type {
   DelegatedArchivingRequest,
   ProducerEService,
 } from '@/api/api.generatedTypes'
-import { DEFAULT_GRACE_PERIOD_DAYS } from '@/config/constants'
 
 mockUseJwt({ isAdmin: true })
 
@@ -1355,6 +1354,69 @@ describe('useGetProviderEServiceActions slot split (where=detailsPage, admin hap
       'suspendVersion',
       'cancelArchivingVersion',
     ])
+  })
+
+  it('ARCHIVING with DESCRIPTOR scope (DELEGATOR): cancelArchivingVersion in header, no primary', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVING', version: '1' },
+      delegation: {
+        delegator: {
+          id: 'organizationId',
+          name: 'delegator-name',
+        },
+        delegate: {
+          id: 'delegate-id',
+          name: 'delegate-name',
+        },
+      },
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, {
+      archivingSchedule: { scope: 'DESCRIPTOR' },
+    })
+    expect(result.current.primaryAction).toBeUndefined()
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual(['cancelArchivingVersion'])
+  })
+
+  it('ARCHIVING with ESERVICE scope (DELEGATOR): cancelArchivingEservice as primary', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVING', version: '1' },
+      delegation: {
+        delegator: {
+          id: 'organizationId',
+          name: 'delegator-name',
+        },
+        delegate: {
+          id: 'delegate-id',
+          name: 'delegate-name',
+        },
+      },
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, {
+      archivingSchedule: { scope: 'ESERVICE' },
+    })
+    expect(result.current.primaryAction?.label).toBe('cancelArchivingEservice')
+  })
+
+  it('ARCHIVING with DESCRIPTOR scope and ESERVICE archiving (DELEGATOR): cancelArchivingVersion in header, cancelArchivingEservice as primary', () => {
+    const descriptorMock = createMockEServiceProvider({
+      activeDescriptor: { id: 'test-1', state: 'ARCHIVING', version: '1' },
+      delegation: {
+        delegator: {
+          id: 'organizationId',
+          name: 'delegator-name',
+        },
+        delegate: {
+          id: 'delegate-id',
+          name: 'delegate-name',
+        },
+      },
+    })
+    const { result } = renderDetailsPageHook(descriptorMock, {
+      archivingSchedule: { scope: 'DESCRIPTOR' },
+      isEServiceBeingArchived: true,
+    })
+    expect(result.current.primaryAction?.label).toBe('cancelArchivingEservice')
+    expect(result.current.headerInfoActions.map((a) => a.label)).toEqual(['cancelArchivingVersion'])
   })
 
   it('delegate cancel archiving dialog uses delegate-approved variant when state is ARCHIVING, even without acceptedAt', async () => {

--- a/src/hooks/useGetProviderEServiceActions.ts
+++ b/src/hooks/useGetProviderEServiceActions.ts
@@ -1250,6 +1250,31 @@ export function useGetProviderEServiceActions(
     isEServiceBeingArchived,
     isDelegator,
   })
+    .with({ state: 'ARCHIVING', archivingScope: 'ESERVICE', isDelegator: true }, () => ({
+      primary: cancelArchivingEserviceAction,
+      header: [],
+      menu:
+        where === 'detailsPage' ? [...availableAction, ...viewAllVersionsItems] : availableAction,
+    }))
+    .with(
+      {
+        state: 'ARCHIVING',
+        archivingScope: 'DESCRIPTOR',
+        isEServiceBeingArchived: true,
+        isDelegator: true,
+      },
+      () => ({
+        primary: cancelArchivingEserviceAction,
+        header: [cancelArchivingDescriptorAction],
+        menu:
+          where === 'detailsPage' ? [...availableAction, ...viewAllVersionsItems] : availableAction,
+      })
+    )
+    .with({ state: 'ARCHIVING', isDelegator: true }, () => ({
+      primary: undefined,
+      header: [cancelArchivingDescriptorAction],
+      menu: menuWithNewVersion,
+    }))
     .with({ isDelegator: true }, () => ({
       primary: undefined,
       header: [],


### PR DESCRIPTION
## Jira Issue
[PIN-10905](https://pagopa.atlassian.net/browse/PIN-10905)

## Context/Why
- Delegator e-service/archiving process

## Key Changes
 - Restore delegator capability to cancel e-service/version archiving

[PIN-10905]: https://pagopa.atlassian.net/browse/PIN-10905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ