### PR TITLE
PIN-10672: Bump MUI-Italia to 2.7.0 and replace MIStepper

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@mui/system": "5.18.0",
     "@mui/x-date-pickers": "6.20.2",
     "@pagopa/interop-fe-commons": "1.5.3",
-    "@pagopa/mui-italia": "2.4.0",
+    "@pagopa/mui-italia": "2.7.0-RC.3",
     "@tanstack/react-query": "5.51.4",
     "@tanstack/react-query-devtools": "5.51.4",
     "autosuggest-highlight": "3.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,10 +37,10 @@ importers:
         version: 6.20.2(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(date-fns@2.30.0)(dayjs@1.11.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@pagopa/interop-fe-commons':
         specifier: 1.5.3
-        version: 1.5.3(ymetdcksuscyxf43pkvingdoai)
+        version: 1.5.3(n3dkg66ojyhbcaqwzmgwu54pda)
       '@pagopa/mui-italia':
-        specifier: 2.4.0
-        version: 2.4.0(dyvxuajnxmfgebpwpefvcxn5gi)
+        specifier: 2.7.0-RC.3
+        version: 2.7.0-RC.3(dyvxuajnxmfgebpwpefvcxn5gi)
       '@tanstack/react-query':
         specifier: 5.51.4
         version: 5.51.4(react@18.3.1)
@@ -986,8 +986,8 @@ packages:
       react-router-dom: ^6.16.0
       zod: ^4.0.0
 
-  '@pagopa/mui-italia@2.4.0':
-    resolution: {integrity: sha512-yqDRG+ppPWQC7nH/xspzcnkIyYhfBUyAShpO8f63ooFC55fPIV4lzFb2QCU+ENL7aw3GyVlcpuNd7H71c2HAQg==}
+  '@pagopa/mui-italia@2.7.0-RC.3':
+    resolution: {integrity: sha512-9OrgF65zM4f3AU5fVbH+rVYwk2qiGdA8MgSC2cA3/4ZLUIEUA6vuLJ0SEQFIOcG2AHQI6q5q6Lzn5qhGhPTsJg==}
     engines: {node: '>=22.x'}
     peerDependencies:
       '@emotion/react': ^11.14.0
@@ -4619,7 +4619,7 @@ snapshots:
 
   '@open-draft/until@1.0.3': {}
 
-  '@pagopa/interop-fe-commons@1.5.3(ymetdcksuscyxf43pkvingdoai)':
+  '@pagopa/interop-fe-commons@1.5.3(n3dkg66ojyhbcaqwzmgwu54pda)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
@@ -4629,7 +4629,7 @@ snapshots:
       '@mui/material': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mui/system': 5.18.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
       '@mui/x-date-pickers': 6.20.2(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@5.18.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(date-fns@2.30.0)(dayjs@1.11.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@pagopa/mui-italia': 2.4.0(dyvxuajnxmfgebpwpefvcxn5gi)
+      '@pagopa/mui-italia': 2.7.0-RC.3(dyvxuajnxmfgebpwpefvcxn5gi)
       date-fns: 2.30.0
       i18next: 23.16.8
       mixpanel-browser: 2.75.0(@mixpanel/rrweb-utils@2.0.0-alpha.18.3)
@@ -4640,7 +4640,7 @@ snapshots:
       react-router-dom: 6.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod: 4.3.6
 
-  '@pagopa/mui-italia@2.4.0(dyvxuajnxmfgebpwpefvcxn5gi)':
+  '@pagopa/mui-italia@2.7.0-RC.3(dyvxuajnxmfgebpwpefvcxn5gi)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,25 +53,23 @@ function App() {
   if (STAGE === 'UAT') {
     envBannerProps = {
       severity: 'warning',
-      description: t('environmentBanner.content.uat'),
+      children: <>{t('environmentBanner.content.uat')}</>,
     }
   }
 
   if (STAGE === 'ATT') {
     envBannerProps = {
       severity: 'info',
-      description: t('environmentBanner.content.att'),
+      children: <>{t('environmentBanner.content.att')}</>,
     }
   }
 
   return (
     <ThemeProvider theme={theme}>
       {envBannerProps && (
-        <MIAlert
-          variant="header"
-          severity={envBannerProps.severity}
-          description={envBannerProps.description}
-        />
+        <MIAlert variant="header" severity={envBannerProps.severity}>
+          {envBannerProps.children}
+        </MIAlert>
       )}
       <React.Suspense fallback={<FirstLoadingSpinner />}>
         <QueryClientProvider client={queryClient}>

--- a/src/components/shared/Stepper.tsx
+++ b/src/components/shared/Stepper.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Stepper as MUIStepper, Step, StepLabel, Box } from '@mui/material'
+import { Box } from '@mui/material'
+import { MIStepper } from '@pagopa/mui-italia/components/MIStepper'
 import type { StepperStep } from '@/types/common.types'
 
 type StepperProps = {
@@ -10,13 +11,8 @@ type StepperProps = {
 export function Stepper({ steps, activeIndex }: StepperProps) {
   return (
     <Box sx={{ py: 3 }}>
-      <MUIStepper activeStep={activeIndex} alternativeLabel>
-        {steps.map(({ label }) => (
-          <Step key={label}>
-            <StepLabel>{label}</StepLabel>
-          </Step>
-        ))}
-      </MUIStepper>
+      step
+      <MIStepper activeStep={activeIndex} steps={steps.map(({ label }) => ({ label }))} />
     </Box>
   )
 }

--- a/src/components/shared/Stepper.tsx
+++ b/src/components/shared/Stepper.tsx
@@ -11,7 +11,6 @@ type StepperProps = {
 export function Stepper({ steps, activeIndex }: StepperProps) {
   return (
     <Box sx={{ py: 3 }}>
-      step
       <MIStepper activeStep={activeIndex} steps={steps.map(({ label }) => ({ label }))} />
     </Box>
   )


### PR DESCRIPTION
## 🔗 Issue
[PIN-10672
](https://pagopa.atlassian.net/browse/PIN-10672)
## 📝 Description / Context
This PR updates the frontend to MUI-Italia 2.7.0 and replaces the previous MIStepper usage with the current stepper implementation.

The goal is to align with the latest design-system version and improve accessibility/consistency in stepper behavior across the app.

## 🛠 List of changes
Bumped MUI-Italia dependency to version 2.7.0
Updated project lockfile accordingly
Replaced legacy MIStepper integration with the new stepper component usage
Updated related app wiring to keep stepper flows working as expected

## 🧪 How to test

1. Install dependencies and run the app.
2. Navigate to flows that render a stepper and verify:
3. current step is highlighted correctly
4. step transitions work as expected
5. labels/state are shown correctly in each step
6. Run checks:
7. pnpm lint
8. pnpm test
9. Perform a quick accessibility check on stepper interactions (keyboard navigation and announced state).