### PR TITLE
fix: enhance tooltip accessibility in action buttons (A2-2671)

### DIFF
--- a/src/components/shared/HeadSection/ActionsButtons.tsx
+++ b/src/components/shared/HeadSection/ActionsButtons.tsx
@@ -42,7 +42,7 @@ export const ActionsButtons: React.FC<ActionsButtonsProps> = ({ actions }) => {
           return (
             <Wrapper key={i}>
               <Button
-                onClick={action}
+                onClick={disabled ? undefined : action}
                 color={color}
                 startIcon={Icon && <Icon />}
                 onPointerEnter={onPointerEnter}

--- a/src/components/shared/HeadSection/ActionsButtons.tsx
+++ b/src/components/shared/HeadSection/ActionsButtons.tsx
@@ -15,13 +15,26 @@ export const ActionsButtons: React.FC<ActionsButtonsProps> = ({ actions }) => {
     <Stack direction="row" spacing={2} alignItems="center">
       {primaryActions.map(
         (
-          { action, label, color, icon: Icon, tooltip, onPointerEnter, onFocusVisible, ...props },
+          {
+            action,
+            label,
+            color,
+            icon: Icon,
+            tooltip,
+            onPointerEnter,
+            onFocusVisible,
+            disabled,
+            ...props
+          },
           i
         ) => {
+          const isAriaDisabled = Boolean(disabled)
+          const tooltipText = typeof tooltip === 'string' ? tooltip : undefined
+
           const Wrapper = tooltip
             ? ({ children }: { children: React.ReactElement }) => (
-                <Tooltip arrow title={tooltip}>
-                  <span tabIndex={props.disabled ? 0 : undefined}>{children}</span>
+                <Tooltip arrow title={tooltip} describeChild>
+                  <span>{children}</span>
                 </Tooltip>
               )
             : React.Fragment
@@ -30,11 +43,13 @@ export const ActionsButtons: React.FC<ActionsButtonsProps> = ({ actions }) => {
             <Wrapper key={i}>
               <Button
                 onClick={action}
-                variant="text"
                 color={color}
                 startIcon={Icon && <Icon />}
                 onPointerEnter={onPointerEnter}
                 onFocusVisible={onFocusVisible}
+                aria-disabled={isAriaDisabled}
+                aria-description={tooltipText}
+                className={isAriaDisabled ? 'Mui-disabled' : undefined}
                 {...props}
               >
                 {label}

--- a/src/components/shared/HeadSection/__tests__/HeadSection.test.tsx
+++ b/src/components/shared/HeadSection/__tests__/HeadSection.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { HeadSection } from '../HeadSection'
 import type { ActionItemButton } from '@/types/common.types'
 
@@ -84,5 +85,33 @@ describe('HeadSection', () => {
 
     const description = headSection.queryByText('description')
     expect(description).toBeInTheDocument()
+  })
+
+  it('should keep disabled tooltiped action accessible and non-clickable', async () => {
+    const user = userEvent.setup()
+    const action = vi.fn()
+    const tooltip = 'Disabled action tooltip'
+
+    const actions: ActionItemButton[] = [
+      {
+        label: 'disabled action',
+        action,
+        disabled: true,
+        tooltip,
+      },
+    ]
+
+    render(<HeadSection title="title" description="description" actions={actions} />)
+
+    const actionButton = screen.getByRole('button', { name: 'disabled action' })
+    expect(actionButton).toHaveAttribute('aria-disabled', 'true')
+    expect(actionButton).toHaveAccessibleDescription(tooltip)
+
+    await user.tab()
+    expect(actionButton).toHaveFocus()
+    expect(actionButton.parentElement).not.toHaveAttribute('tabindex')
+
+    fireEvent.click(actionButton)
+    expect(action).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## 🔗 Issue

[A2-2671](https://pagopa.atlassian.net/browse/A2-2671)

## 📝 Description / Context

This pull request updates the `ActionsButtons` component to improve accessibility and handling of disabled states for action buttons. The changes ensure that buttons can be properly marked as disabled for assistive technologies and that tooltips are described appropriately.

## 🧪 How to test

- Navigate to the single API Interoperabilità client and ensure no operators are present.
- Go to the Public Keys tab.
- Using a screen reader, navigate over the button.
- Verify Screen Reader: Ensure the tooltip is read correctly. (Note: Previously, focus landed on a <span tabindex="0"> without a role but with an aria-label, violating ARIA specs and causing the tooltip to be read before the button. This should now be fixed).
- Verify DOM: Inspect the element and ensure there is no longer a <span> with tabindex="0" or "-1" without a proper role.



[A2-2671]: https://pagopa.atlassian.net/browse/A2-2671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ